### PR TITLE
Fixed VC2010 warning

### DIFF
--- a/builtins.cpp
+++ b/builtins.cpp
@@ -180,7 +180,7 @@ lCreateISPCSymbol(llvm::Function *func, SymbolTable *symbolTable) {
             FunctionType *funcType = new FunctionType(returnType, argTypes, noPos);
             // set NULL default arguments
             std::vector<ConstExpr *> defaults;
-            for (int j = 0; j < ftype->getNumParams(); ++j)
+            for (unsigned int j = 0; j < ftype->getNumParams(); ++j)
                 defaults.push_back(NULL);
             funcType->SetArgumentDefaults(defaults);
 


### PR DESCRIPTION
Fixed VC2010 warning: builtins.cpp(183): warning C4018: '<' : signed/unsigned mismatch
Type of control variable changed to 'unsigned int' like in line 167.
