### PR TITLE
Fixed VC2010 warnings caused by implicit conversion from 'long' to 'char'.

### DIFF
--- a/lex.ll
+++ b/lex.ll
@@ -393,12 +393,12 @@ lEscapeChar(char *str, char *pChar, SourcePos *pos)
         // octal constants \012
         case '0': case '1': case '2': case '3': case '4':
         case '5': case '6': case '7':
-            *pChar = strtol(str, &tail, 8);
+            *pChar = (char)strtol(str, &tail, 8);
             str = tail - 1;
             break;
         // hexidecimal constant \xff
         case 'x':
-            *pChar = strtol(str, &tail, 16);
+            *pChar = (char)strtol(str, &tail, 16);
             str = tail - 1;
             break;
         default:


### PR DESCRIPTION
Fixed VC2010 warnings caused by implicit conversion from 'long' to 'char':

lex.ll(397): warning C4244: '=' : conversion from 'long' to 'char', possible loss of data
lex.ll(402): warning C4244: '=' : conversion from 'long' to 'char', possible loss of data

by explicit cast to 'char'.

See: http://msdn.microsoft.com/en-us/library/w4z2wdyc(v=vs.80).aspx

long strtol(
   const char _nptr,
   char *_endptr,
   int base 
);
