### PR TITLE
Removed visitUnwindInst function to remove dependency on UnwindInst

### DIFF
--- a/cbackend.cpp
+++ b/cbackend.cpp
@@ -437,9 +437,6 @@ namespace {
     void visitInvokeInst(InvokeInst &I) {
       llvm_unreachable("Lowerinvoke pass didn't work!");
     }
-    void visitUnwindInst(UnwindInst &I) {
-      llvm_unreachable("Lowerinvoke pass didn't work!");
-    }
     void visitResumeInst(ResumeInst &I) {
       llvm_unreachable("DwarfEHPrepare pass didn't work!");
     }


### PR DESCRIPTION
Code no longer builds against head of LLVM branch after revision 149906
removed the unwind instruction.
