### PR TITLE
Fixed compiler warning in expression type caster

### DIFF
--- a/expr.cpp
+++ b/expr.cpp
@@ -6614,7 +6614,7 @@ TypeCastExpr::TypeCheck() {
         return this;
 
     if (Type::Equal(fromType, AtomicType::Void) ||
-        fromType->IsVaryingType() && toType->IsUniformType()) {
+        (fromType->IsVaryingType() && toType->IsUniformType())) {
         Error(pos, "Can't type cast from type \"%s\" to type \"%s\"",
               fromType->GetString().c_str(), toType->GetString().c_str());
         return NULL;


### PR DESCRIPTION
I just forked and built ispc and got a compiler warning for parens on an a || b && c expression. -> a || (b && c)
Specifically:

if (cast from void || cast from varying && cast to uniform)
    error;
