### PR TITLE
Fixed compiler warning

### DIFF
--- a/cbackend.cpp
+++ b/cbackend.cpp
@@ -1495,8 +1495,9 @@ void CWriter::printConstant(Constant *CPV, bool Static) {
         printConstantDataSequential(CDV, Static);
         Out << ")";
       }
+    }
 #endif
-    } else {
+    else {
       assert(isa<UndefValue>(CPV));
       Constant *CZ = Constant::getNullValue(VT->getElementType());
       printType(Out, CPV->getType());


### PR DESCRIPTION
Didn't build for me since I'm using LLVM 3.0. The Brace was on the wrong side of the #endif
