### PR TITLE
Fix 32-bit samples on Mac OS X.

### DIFF
--- a/examples/timing.h
+++ b/examples/timing.h
@@ -43,9 +43,15 @@ extern "C" {
 #endif /* __cplusplus */
     __inline__ uint64_t rdtsc() {
         uint32_t low, high;
+#ifdef __x86_64
         __asm__ __volatile__ (
             "xorl %%eax,%%eax \n    cpuid"
             ::: "%rax", "%rbx", "%rcx", "%rdx" );
+#else
+        __asm__ __volatile__ (
+            "xorl %%eax,%%eax \n    cpuid"
+            ::: "%eax", "%ebx", "%ecx", "%edx" );
+#endif
         __asm__ __volatile__ (
                               "rdtsc" : "=a" (low), "=d" (high));
         return (uint64_t)high << 32 | low;


### PR DESCRIPTION
On Mac OS X and Linux rdtsc() didn't save and restore 32-bit registers.

This patch fixes issue #87.
