### PR TITLE
Fix build on Fedora 17

### DIFF
--- a/ispc.cpp
+++ b/ispc.cpp
@@ -44,6 +44,8 @@
 #include <windows.h>
 #include <direct.h>
 #define strcasecmp stricmp
+#else
+#include <unistd.h>
 #endif
 #include <llvm/LLVMContext.h>
 #include <llvm/Module.h>

--- a/lex.ll
+++ b/lex.ll
@@ -58,6 +58,8 @@ extern void RegisterDependency(const std::string &fileName);
 
 #ifdef ISPC_IS_WINDOWS
 inline int isatty(int) { return 0; }
+#else
+#include <unistd.h>
 #endif // ISPC_IS_WINDOWS
 
 static int allTokens[] = { 

--- a/main.cpp
+++ b/main.cpp
@@ -43,6 +43,8 @@
 #include <stdlib.h>
 #ifdef ISPC_IS_WINDOWS
   #include <time.h>
+#else
+  #include <unistd.h>
 #endif // ISPC_IS_WINDOWS
 #include <llvm/Support/Signals.h>
 #include <llvm/Support/TargetRegistry.h>


### PR DESCRIPTION
Some modules require an include of unistd.h (e.g. for getcwd and isatty
definitions).

These changes were required to build successfully on a Fedora 17 system,
using GCC 4.7.0 & glibc-headers 2.15.
