### PR TITLE
Explicit isa in tests

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -264,13 +264,15 @@ def run_test(filename):
                 else:
                     gcc_arch = '-m64'
 
+                gcc_isa=""
                 if options.target == 'sse2' or options.target == 'sse2-x2':
                     gcc_isa = '-msse3'
                 if options.target == 'sse4' or options.target == 'sse4-x2' or options.target == 'generic-4':
                     gcc_isa = '-msse4.2'
-                if options.target == 'avx' or options.target == 'avx-x2' or options.target == 'generic-16':
+                if options.target == 'avx' or options.target == 'avx-x2' or options.target == 'generic-8':
                     gcc_isa = '-mavx'
-                if options.target == 'generic-16' or options.target == 'generic-32' or options.target == 'generic-64':
+                if (options.target == 'generic-16' or options.target == 'generic-32' or options.target == 'generic-64') \
+                        and (options.include_file.find("knc.h")!=-1 or options.include_file.find("knc2x.h")!=-1):
                     gcc_isa = '-mmic'
 
                 cc_cmd = "%s -O2 -I. %s %s test_static.cpp -DTEST_SIG=%d %s -o %s" % \


### PR DESCRIPTION
KNC does not support SSE or AVX intructions.
When compiling for MIC, ICC needs to be passed the -mmic compiler flag and none of the flags corresponding to unsupported ISA extensions.

The current run_tests.py script uses -msse4.2 by default, which is a problem when trying to run tests on KNC.  This patch changes run_tests.py to pick the ISA requested from the compiler based on the target passed to the script.
