### PR TITLE
New templated API for __setzero() __undef() and __smear()

### DIFF
--- a/examples/intrinsics/generic-16.h
+++ b/examples/intrinsics/generic-16.h
@@ -271,7 +271,8 @@ static FORCEINLINE TYPE NAME(TYPE a, int32_t b) {                   \
 }
 
 #define SMEAR(VTYPE, NAME, STYPE)                                  \
-static FORCEINLINE VTYPE __smear_##NAME(STYPE v) {                 \
+template <class RetVecType> VTYPE __smear_##NAME(STYPE);           \
+template <> FORCEINLINE VTYPE __smear_##NAME<VTYPE>(STYPE v) {     \
     VTYPE ret;                                                     \
     for (int i = 0; i < 16; ++i)                                   \
         ret.v[i] = v;                                              \
@@ -279,7 +280,8 @@ static FORCEINLINE VTYPE __smear_##NAME(STYPE v) {                 \
 }
 
 #define SETZERO(VTYPE, NAME)                                       \
-static FORCEINLINE VTYPE __setzero_##NAME() {                      \
+template <class RetVecType> VTYPE __setzero_##NAME();              \
+template <> FORCEINLINE VTYPE __setzero_##NAME<VTYPE>() {          \
     VTYPE ret;                                                     \
     for (int i = 0; i < 16; ++i)                                   \
         ret.v[i] = 0;                                              \
@@ -287,7 +289,8 @@ static FORCEINLINE VTYPE __setzero_##NAME() {                      \
 }
 
 #define UNDEF(VTYPE, NAME)                                         \
-static FORCEINLINE VTYPE __undef_##NAME() {                        \
+template <class RetVecType> VTYPE __undef_##NAME();                \
+template <> FORCEINLINE VTYPE __undef_##NAME<VTYPE>() {            \
     return VTYPE();                                                \
 }
 
@@ -416,18 +419,20 @@ template <int ALIGN> static FORCEINLINE void __store(__vec16_i1 *p, __vec16_i1 v
     *ptr = v.v;
 }
 
-static FORCEINLINE __vec16_i1 __smear_i1(int v) {
+template <class RetVecType> __vec16_i1 __smear_i1(int i);
+template <> FORCEINLINE __vec16_i1 __smear_i1<__vec16_i1>(int v) {
     return __vec16_i1(v, v, v, v, v, v, v, v, 
                       v, v, v, v, v, v, v, v);
 }
 
-static FORCEINLINE __vec16_i1 __setzero_i1() {
+template <class RetVecType> __vec16_i1 __setzero_i1();
+template <> FORCEINLINE __vec16_i1 __setzero_i1<__vec16_i1>() {
     return __vec16_i1(0, 0, 0, 0, 0, 0, 0, 0, 
                       0, 0, 0, 0, 0, 0, 0, 0);
 }
 
-
-static FORCEINLINE __vec16_i1 __undef_i1() {
+template <class RetVecType> __vec16_i1 __undef_i1();
+template <> FORCEINLINE __vec16_i1 __undef_i1<__vec16_i1>() {
     return __vec16_i1();
 }
 

--- a/examples/intrinsics/generic-32.h
+++ b/examples/intrinsics/generic-32.h
@@ -336,15 +336,17 @@ static FORCEINLINE TYPE NAME(TYPE a, int32_t b) {                   \
 }
 
 #define SMEAR(VTYPE, NAME, STYPE)                                  \
-static FORCEINLINE VTYPE __smear_##NAME(STYPE v) {                 \
+template <class RetVecType> VTYPE __smear_##NAME(STYPE);           \
+template <> FORCEINLINE VTYPE __smear_##NAME<VTYPE>(STYPE v) {     \
     VTYPE ret;                                                     \
     for (int i = 0; i < 32; ++i)                                   \
         ret.v[i] = v;                                              \
     return ret;                                                    \
 }
 
-#define SETZERO(VTYPE, NAME)                   \
-static FORCEINLINE VTYPE __setzero_##NAME() {  \
+#define SETZERO(VTYPE, NAME)                                       \
+template <class RetVecType> VTYPE __setzero_##NAME();              \
+template <> FORCEINLINE VTYPE __setzero_##NAME<VTYPE>() {          \
     VTYPE ret;                                                     \
     for (int i = 0; i < 32; ++i)                                   \
         ret.v[i] = 0;                                              \
@@ -352,7 +354,8 @@ static FORCEINLINE VTYPE __setzero_##NAME() {  \
 }
 
 #define UNDEF(VTYPE, NAME)                                         \
-static FORCEINLINE VTYPE __undef_##NAME() {                        \
+template <class RetVecType> VTYPE __undef_##NAME();                \
+template <> FORCEINLINE VTYPE __undef_##NAME<VTYPE>() {                 \
     return VTYPE();                                                \
 }
 
@@ -481,21 +484,24 @@ template <int ALIGN> static FORCEINLINE void __store(__vec32_i1 *p, __vec32_i1 v
     *ptr = v.v;
 }
 
-static FORCEINLINE __vec32_i1 __smear_i1(int v) {
+template <class RetVecType> __vec32_i1 __smear_i1(int i);
+template <> FORCEINLINE __vec32_i1 __smear_i1<__vec32_i1>(int v) {
     return __vec32_i1(v, v, v, v, v, v, v, v, 
                       v, v, v, v, v, v, v, v,
                       v, v, v, v, v, v, v, v,
                       v, v, v, v, v, v, v, v);
 }
 
-static FORCEINLINE __vec32_i1 __setzero_i1() {
+template <class RetVecType> __vec32_i1 __setzero_i1();
+template <> FORCEINLINE __vec32_i1 __setzero_i1<__vec32_i1>() {
     return __vec32_i1(0, 0, 0, 0, 0, 0, 0, 0, 
                       0, 0, 0, 0, 0, 0, 0, 0,
                       0, 0, 0, 0, 0, 0, 0, 0,
                       0, 0, 0, 0, 0, 0, 0, 0);
 }
 
-static FORCEINLINE __vec32_i1 __undef_i1() {
+template <class RetVecType> __vec32_i1 __undef_i1();
+template <> FORCEINLINE __vec32_i1 __undef_i1<__vec32_i1>() {
     return __vec32_i1();
 }
 

--- a/examples/intrinsics/generic-64.h
+++ b/examples/intrinsics/generic-64.h
@@ -461,7 +461,8 @@ static FORCEINLINE TYPE NAME(TYPE a, int32_t b) {                   \
 }
 
 #define SMEAR(VTYPE, NAME, STYPE)                                  \
-static FORCEINLINE VTYPE __smear_##NAME(STYPE v) {                 \
+template <class RetVecType> VTYPE __smear_##NAME(STYPE);           \
+template <> FORCEINLINE VTYPE __smear_##NAME<VTYPE>(STYPE v) {          \
     VTYPE ret;                                                     \
     for (int i = 0; i < 64; ++i)                                   \
         ret.v[i] = v;                                              \
@@ -469,7 +470,8 @@ static FORCEINLINE VTYPE __smear_##NAME(STYPE v) {                 \
 }
 
 #define SETZERO(VTYPE, NAME)                                       \
-static FORCEINLINE VTYPE __setzero_##NAME() {                      \
+template <class RetVecType> VTYPE __setzero_##NAME();              \
+template <> FORCEINLINE VTYPE __setzero_##NAME<VTYPE>() {               \
     VTYPE ret;                                                     \
     for (int i = 0; i < 64; ++i)                                   \
         ret.v[i] = 0;                                              \
@@ -477,7 +479,8 @@ static FORCEINLINE VTYPE __setzero_##NAME() {                      \
 }
 
 #define UNDEF(VTYPE, NAME)                                         \
-static FORCEINLINE VTYPE __undef_##NAME(VTYPE retType) {           \
+template <class RetVecType> VTYPE __undef_##NAME();                \
+template <> FORCEINLINE VTYPE __undef_##NAME<VTYPE>() {                 \
     return VTYPE();                                                \
 }
 
@@ -606,7 +609,8 @@ template <int ALIGN> static FORCEINLINE void __store(__vec64_i1 *p, __vec64_i1 v
     *ptr = v.v;
 }
 
-static FORCEINLINE __vec64_i1 __smear_i1(int v) {
+template <class RetVecType> __vec64_i1 __smear_i1(int i);
+template <> FORCEINLINE __vec64_i1 __smear_i1<__vec64_i1>(int v) {
     return __vec64_i1(v, v, v, v, v, v, v, v, 
                       v, v, v, v, v, v, v, v,
                       v, v, v, v, v, v, v, v,
@@ -617,7 +621,8 @@ static FORCEINLINE __vec64_i1 __smear_i1(int v) {
                       v, v, v, v, v, v, v, v);
 }
 
-static FORCEINLINE __vec64_i1 __setzero_i1() {
+template <class RetVecType> __vec64_i1 __setzero_i1();
+template <> FORCEINLINE __vec64_i1 __setzero_i1<__vec64_i1>() {
     return __vec64_i1(0, 0, 0, 0, 0, 0, 0, 0, 
                       0, 0, 0, 0, 0, 0, 0, 0,
                       0, 0, 0, 0, 0, 0, 0, 0,
@@ -628,7 +633,8 @@ static FORCEINLINE __vec64_i1 __setzero_i1() {
                       0, 0, 0, 0, 0, 0, 0, 0);
 }
 
-static FORCEINLINE __vec64_i1 __undef_i1() {
+template <class RetVecType> __vec64_i1 __undef_i1();
+template <> FORCEINLINE __vec64_i1 __undef_i1<__vec64_i1>() {
     return __vec64_i1();
 }
 

--- a/examples/intrinsics/sse4.h
+++ b/examples/intrinsics/sse4.h
@@ -322,15 +322,18 @@ template <int ALIGN> static FORCEINLINE void __store(__vec4_i1 *p, __vec4_i1 val
     _mm_storeu_ps((float *)(&p->v), value.v);
 }
 
-static FORCEINLINE __vec4_i1 __smear_i1(int v) {
+template <class RetVecType> __vec4_i1 __smear_i1(int v);
+template <> FORCEINLINE __vec4_i1 __smear_i1<__vec4_i1>(int v) {
     return __vec4_i1(v, v, v, v);
 }
 
-static FORCEINLINE __vec4_i1 __setzero_i1() {
+template <class RetVecType> __vec4_i1 __setzero_i1();
+template <> FORCEINLINE __vec4_i1 __setzero_i1<__vec4_i1>() {
     return __vec4_i1(_mm_setzero_ps());
 }
 
-static FORCEINLINE __vec4_i1 __undef_i1() {
+template <class RetVecType> __vec4_i1 __undef_i1();
+template <> FORCEINLINE __vec4_i1 __undef_i1<__vec4_i1>() {
     return __vec4_i1();
 }
 
@@ -560,15 +563,18 @@ static FORCEINLINE void __insert_element(__vec4_i8 *v, int index, int8_t val) {
     ((int8_t *)v)[index] = val;
 }
 
-static FORCEINLINE __vec4_i8 __smear_i8(int8_t v) {
+template <class RetVecType> __vec4_i8 __smear_i8(int8_t v);
+template <> FORCEINLINE __vec4_i8 __smear_i8<__vec4_i8>(int8_t v) {
     return _mm_set1_epi8(v);
 }
 
-static FORCEINLINE __vec4_i8 __setzero_i8() {
+template <class RetVecType> __vec4_i8 __setzero_i8();
+template <> FORCEINLINE __vec4_i8 __setzero_i8<__vec4_i8>() {
     return _mm_set1_epi8(0);
 }
 
-static FORCEINLINE __vec4_i8 __undef_i8() {
+template <class RetVecType> __vec4_i8 __undef_i8();
+template <> FORCEINLINE __vec4_i8 __undef_i8<__vec4_i8>() {
     return __vec4_i8();
 }
 
@@ -829,15 +835,18 @@ static FORCEINLINE void __insert_element(__vec4_i16 *v, int index, int16_t val) 
     ((int16_t *)v)[index] = val;
 }
 
-static FORCEINLINE __vec4_i16 __smear_i16(int16_t v) {
+template <class RetVecType> __vec4_i16 __smear_i16(int16_t v);
+template <> FORCEINLINE __vec4_i16 __smear_i16<__vec4_i16>(int16_t v) {
     return _mm_set1_epi16(v);
 }
 
-static FORCEINLINE __vec4_i16 __setzero_i16() {
+template <class RetVecType> __vec4_i16 __setzero_i16();
+template <> FORCEINLINE __vec4_i16 __setzero_i16<__vec4_i16>() {
     return _mm_set1_epi16(0);
 }
 
-static FORCEINLINE __vec4_i16 __undef_i16() {
+template <class RetVecType> __vec4_i16 __undef_i16();
+template <> FORCEINLINE __vec4_i16 __undef_i16<__vec4_i16>() {
     return __vec4_i16();
 }
 
@@ -1076,15 +1085,18 @@ static FORCEINLINE __vec4_i32 __select(__vec4_i1 mask, __vec4_i32 a, __vec4_i32 
                                           _mm_castsi128_ps(a.v), mask.v));
 }
 
-static FORCEINLINE __vec4_i32 __smear_i32(int32_t v) {
+template <class RetVecType> __vec4_i32 __smear_i32(int32_t v);
+template <> FORCEINLINE __vec4_i32 __smear_i32<__vec4_i32>(int32_t v) {
     return _mm_set1_epi32(v);
 }
 
-static FORCEINLINE __vec4_i32 __setzero_i32() {
+template <class RetVecType> __vec4_i32 __setzero_i32();
+template <> FORCEINLINE __vec4_i32 __setzero_i32<__vec4_i32>() {
     return _mm_castps_si128(_mm_setzero_ps());
 }
 
-static FORCEINLINE __vec4_i32 __undef_i32() {
+template <class RetVecType> __vec4_i32 __undef_i32();
+template <> FORCEINLINE __vec4_i32 __undef_i32<__vec4_i32>() {
     return __vec4_i32();
 }
 
@@ -1347,15 +1359,18 @@ static FORCEINLINE __vec4_i64 __select(__vec4_i1 mask, __vec4_i64 a, __vec4_i64 
     return __vec4_i64(_mm_castpd_si128(r0), _mm_castpd_si128(r1));
 }
 
-static FORCEINLINE __vec4_i64 __smear_i64(int64_t v) {
+template <class RetVecType> __vec4_i64 __smear_i64(int64_t v);
+template <> FORCEINLINE __vec4_i64 __smear_i64<__vec4_i64>(int64_t v) {
     return __vec4_i64(v, v, v, v);
 }
 
-static FORCEINLINE __vec4_i64 __setzero_i64() {
+template <class RetVecType> __vec4_i64 __setzero_i64();
+template <> FORCEINLINE __vec4_i64 __setzero_i64<__vec4_i64>() {
     return __vec4_i64(0, 0, 0, 0);
 }
 
-static FORCEINLINE __vec4_i64 __undef_i64() {
+template <class RetVecType> __vec4_i64 __undef_i64();
+template <> FORCEINLINE __vec4_i64 __undef_i64<__vec4_i64>() {
     return __vec4_i64();
 }
 
@@ -1465,15 +1480,18 @@ static FORCEINLINE __vec4_f __select(__vec4_i1 mask, __vec4_f a, __vec4_f b) {
     return _mm_blendv_ps(b.v, a.v, mask.v);
 }
 
-static FORCEINLINE __vec4_f __smear_float(float v) {
+template <class RetVecType> __vec4_f __smear_float(float v);
+template <> FORCEINLINE __vec4_f __smear_float<__vec4_f>(float v) {
     return _mm_set1_ps(v);
 }
 
-static FORCEINLINE __vec4_f __setzero_float() {
+template <class RetVecType> __vec4_f __setzero_float();
+template <> FORCEINLINE __vec4_f __setzero_float<__vec4_f>() {
     return _mm_setzero_ps();
 }
 
-static FORCEINLINE __vec4_f __undef_float() {
+template <class RetVecType> __vec4_f __undef_float();
+template <> FORCEINLINE __vec4_f __undef_float<__vec4_f>() {
     return __vec4_f();
 }
 
@@ -1614,15 +1632,18 @@ static FORCEINLINE __vec4_d __select(__vec4_i1 mask, __vec4_d a, __vec4_d b) {
     return __vec4_d(r0, r1);
 }
 
-static FORCEINLINE __vec4_d __smear_double(double v) {
+template <class RetVecType> __vec4_d __smear_double(double v);
+template <> FORCEINLINE __vec4_d __smear_double<__vec4_d>(double v) {
     return __vec4_d(_mm_set1_pd(v), _mm_set1_pd(v));
 }
 
-static FORCEINLINE __vec4_d __setzero_double() {
+template <class RetVecType> __vec4_d __setzero_double();
+template <> FORCEINLINE __vec4_d __setzero_double<__vec4_d>() {
     return __vec4_d(_mm_setzero_pd(), _mm_setzero_pd());
 }
 
-static FORCEINLINE __vec4_d __undef_double() {
+template <class RetVecType> __vec4_d __undef_double();
+template <> FORCEINLINE __vec4_d __undef_double<__vec4_d>() {
     return __vec4_d();
 }
 
@@ -1722,11 +1743,11 @@ static FORCEINLINE __vec4_i16 __cast_sext(__vec4_i16, __vec4_i8 val) {
 }
 
 static FORCEINLINE __vec4_i8 __cast_sext(__vec4_i8, __vec4_i1 v) {
-    return __select(v, __smear_i8(0xff), __setzero_i8());
+    return __select(v, __smear_i8<__vec4_i8>(0xff), __setzero_i8<__vec4_i8>());
 }
 
 static FORCEINLINE __vec4_i16 __cast_sext(__vec4_i16, __vec4_i1 v) {
-    return __select(v, __smear_i16(0xffff), __setzero_i16());
+    return __select(v, __smear_i16<__vec4_i16>(0xffff), __setzero_i16<__vec4_i16>());
 }
 
 static FORCEINLINE __vec4_i32 __cast_sext(__vec4_i32, __vec4_i1 v) {
@@ -1786,11 +1807,11 @@ static FORCEINLINE __vec4_i16 __cast_zext(__vec4_i16, __vec4_i8 val) {
 }
 
 static FORCEINLINE __vec4_i8 __cast_zext(__vec4_i8, __vec4_i1 v) {
-    return __select(v, __smear_i8(1), __setzero_i8());
+    return __select(v, __smear_i8<__vec4_i8>(1), __setzero_i8<__vec4_i8>());
 }
 
 static FORCEINLINE __vec4_i16 __cast_zext(__vec4_i16, __vec4_i1 v) {
-    return __select(v, __smear_i16(1), __setzero_i16());
+    return __select(v, __smear_i16<__vec4_i16>(1), __setzero_i16<__vec4_i16>());
 }
 
 static FORCEINLINE __vec4_i32 __cast_zext(__vec4_i32, __vec4_i1 v) {
@@ -1798,7 +1819,7 @@ static FORCEINLINE __vec4_i32 __cast_zext(__vec4_i32, __vec4_i1 v) {
 }
 
 static FORCEINLINE __vec4_i64 __cast_zext(__vec4_i64, __vec4_i1 v) {
-    return __select(v, __smear_i64(1), __setzero_i64());
+    return __select(v, __smear_i64<__vec4_i64>(1), __setzero_i64<__vec4_i64>());
 }
 
 // truncations
@@ -1958,11 +1979,11 @@ static FORCEINLINE __vec4_d __cast_uitofp(__vec4_d, __vec4_i64 val) {
 }
 
 static FORCEINLINE __vec4_f __cast_uitofp(__vec4_f, __vec4_i1 v) {
-    return __select(v, __smear_float(1.), __setzero_float());
+    return __select(v, __smear_float<__vec4_f>(1.), __setzero_float<__vec4_f>());
 }
 
 static FORCEINLINE __vec4_d __cast_uitofp(__vec4_d, __vec4_i1 v) {
-    return __select(v, __smear_double(1.), __setzero_double());
+    return __select(v, __smear_double<__vec4_d>(1.), __setzero_double<__vec4_d>());
 }
 
 // float/double to signed int
@@ -2897,7 +2918,7 @@ lGatherBaseOffsets32(RetVec, RetScalar, unsigned char *p, uint32_t scale,
     RetScalar r[4];
 #if 1
     // "Fast gather" trick...
-    offsets = __select(mask, offsets, __setzero_i32());
+    offsets = __select(mask, offsets, __setzero_i32<__vec4_i32>());
 
     int offset = scale * _mm_extract_epi32(offsets.v, 0);
     RetScalar *ptr = (RetScalar *)(p + offset);
@@ -2954,7 +2975,7 @@ lGatherBaseOffsets64(RetVec, RetScalar, unsigned char *p, uint32_t scale,
     RetScalar r[4];
 #if 1
     // "Fast gather" trick...
-    offsets = __select(mask, offsets, __setzero_i64());
+    offsets = __select(mask, offsets, __setzero_i64<__vec4_i64>());
 
     int64_t offset = scale * _mm_extract_epi64(offsets.v[0], 0);
     RetScalar *ptr = (RetScalar *)(p + offset);

--- a/stmt.cpp
+++ b/stmt.cpp
@@ -2207,7 +2207,7 @@ ForeachUniqueStmt::EmitCode(FunctionEmitContext *ctx) const {
         // lane's value of the varying expression is the same as the value
         // we've selected to process this time through--i.e.:
         // oldMask & (smear(element) == exprValue)
-        llvm::Value *uniqueSmear = ctx->SmearUniform(uniqueValue, "unique_semar");
+        llvm::Value *uniqueSmear = ctx->SmearUniform(uniqueValue, "unique_smear");
         llvm::Value *matchingLanes = NULL;
         if (uniqueValue->getType()->isFloatingPointTy())
             matchingLanes = 

--- a/type.cpp
+++ b/type.cpp
@@ -1060,12 +1060,12 @@ PointerType::Mangle() const {
         return "";
     }
 
-    std::string ret = variability.MangleString() + std::string("<");
+    std::string ret = variability.MangleString() + std::string("_3C_"); // <
     if (isSlice || isFrozen)  ret += "-";
     if (isSlice) ret += "s";
     if (isFrozen) ret += "f";
     if (isSlice || isFrozen)  ret += "-";
-    return ret + baseType->Mangle() + std::string(">");
+    return ret + baseType->Mangle() + std::string("_3E_"); // >
 }
 
 
@@ -1636,7 +1636,7 @@ std::string
 VectorType::Mangle() const {
     std::string s = base->Mangle();
     char buf[16];
-    sprintf(buf, "<%d>", numElements);
+    sprintf(buf, "_3C_%d_3E_", numElements); // "<%d>"
     return s + std::string(buf);
 }
 
@@ -1789,7 +1789,7 @@ lMangleStructName(const std::string &name, Variability variability) {
         n += buf;
         break;
     default:
-        FATAL("Unexpected varaibility in lMangleStructName()");
+        FATAL("Unexpected variability in lMangleStructName()");
     }
     
     // And stuff the name at the end....
@@ -2049,7 +2049,7 @@ std::string
 StructType::Mangle() const {
     return lMangleStruct(variability, isConst, name);
 }
-    
+
 
 std::string
 StructType::GetCDeclaration(const std::string &n) const {


### PR DESCRIPTION
These functions are templated based on their return type.  Tried hard to avoid changing the ABI in spite of a rework of the internal mangling of names.

JL
