### PR TITLE
Fixed =/== error for KNC intrinsic implementation of __all()

### DIFF
--- a/examples/intrinsics/knc.h
+++ b/examples/intrinsics/knc.h
@@ -478,7 +478,7 @@ static FORCEINLINE bool __any(__vec16_i1 mask) {
 }
 
 static FORCEINLINE bool __all(__vec16_i1 mask) {
-    return (mask=0xFFFF);
+    return (mask==0xFFFF);
 }
 
 static FORCEINLINE bool __none(__vec16_i1 mask) {


### PR DESCRIPTION
Fixed logic error in KNC intrinsic implementation of checking to see if all fields of the mask are on.
