### PR TITLE
Fix ISPC with LLVM TOT build problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,10 @@ objs/cbackend.o: cbackend.cpp
 	@echo Compiling $<
 	@$(CXX) -fno-rtti -fno-exceptions $(CXXFLAGS) -o $@ -c $<
 
+objs/opt.o: opt.cpp
+	@echo Compiling $<
+	@$(CXX) -fno-rtti $(CXXFLAGS) -o $@ -c $<
+
 objs/%.o: objs/%.cpp
 	@echo Compiling $<
 	@$(CXX) $(CXXFLAGS) -o $@ -c $<

--- a/ispc.h
+++ b/ispc.h
@@ -40,8 +40,8 @@
 
 #define ISPC_VERSION "1.3.1dev"
 
-#if !defined(LLVM_3_0) && !defined(LLVM_3_1) && !defined(LLVM_3_2)
-#error "Only LLVM 3.0, 3.1, and the 3.2 development branch are supported"
+#if !defined(LLVM_3_0) && !defined(LLVM_3_1) && !defined(LLVM_3_2) && !defined(LLVM_3_3)
+#error "Only LLVM 3.0, 3.1, 3.2 and the 3.3 development branch are supported"
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/main.cpp
+++ b/main.cpp
@@ -68,6 +68,8 @@ lPrintVersion() {
            "3.1"
 #elif defined(LLVM_3_2)
            "3.2"
+#elif defined(LLVM_3_3)
+           "3.3"
 #else
 #error "Unhandled LLVM version"
 #endif 

--- a/module.cpp
+++ b/module.cpp
@@ -1757,9 +1757,9 @@ Module::execPreprocessor(const char *infilename, llvm::raw_string_ostream *ostre
     clang::TextDiagnosticPrinter *diagPrinter =
         new clang::TextDiagnosticPrinter(stderrRaw, clang::DiagnosticOptions());
 #else
-    clang::DiagnosticOptions diagOptions;
+    clang::DiagnosticOptions *diagOptions = new clang::DiagnosticOptions();
     clang::TextDiagnosticPrinter *diagPrinter =
-        new clang::TextDiagnosticPrinter(stderrRaw, &diagOptions);
+        new clang::TextDiagnosticPrinter(stderrRaw, diagOptions);
 #endif
     llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs> diagIDs(new clang::DiagnosticIDs);
 #if defined(LLVM_3_0) || defined(LLVM_3_1)
@@ -1767,7 +1767,7 @@ Module::execPreprocessor(const char *infilename, llvm::raw_string_ostream *ostre
         new clang::DiagnosticsEngine(diagIDs, diagPrinter);
 #else
     clang::DiagnosticsEngine *diagEngine = 
-        new clang::DiagnosticsEngine(diagIDs, &diagOptions, diagPrinter);
+        new clang::DiagnosticsEngine(diagIDs, diagOptions, diagPrinter);
 #endif
     inst.setDiagnostics(diagEngine);
 


### PR DESCRIPTION
Add -fno-rtti to the build of opt.o in ISPC; add LLVM version 3.3; allocate the diagOptions on the heap so  it can be deleted by the diagPrinter. 
