### PR TITLE
Fix build with LLVM top-of-tree, fix warnings, remove LLVM 3.0 support

### DIFF
--- a/builtins.cpp
+++ b/builtins.cpp
@@ -50,7 +50,7 @@
 #if defined(LLVM_3_2)
   #include <llvm/Attributes.h>
 #endif
-#if defined(LLVM_3_0) || defined(LLVM_3_1) || defined(LLVM_3_2)
+#if defined(LLVM_3_1) || defined(LLVM_3_2)
   #include <llvm/LLVMContext.h>
   #include <llvm/Module.h>
   #include <llvm/Type.h>

--- a/ctx.cpp
+++ b/ctx.cpp
@@ -46,7 +46,7 @@
 #include "sym.h"
 #include <map>
 #include <llvm/Support/Dwarf.h>
-#if defined(LLVM_3_0) || defined(LLVM_3_1) || defined(LLVM_3_2)
+#if defined(LLVM_3_1) || defined(LLVM_3_2)
   #include <llvm/Metadata.h>
   #include <llvm/Module.h>
   #include <llvm/Instructions.h>
@@ -358,9 +358,7 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym,
                                          mangledName,        diFile,
                                          firstLine,          diSubprogramType,
                                          isStatic,           true, /* is defn */
-#ifndef LLVM_3_0
                                          firstLine,
-#endif // !LLVM_3_0
                                          flags,
                                          isOptimized,        llvmFunction);
         AssertPos(currentPos, diSubprogram.Verify());
@@ -1384,11 +1382,7 @@ FunctionEmitContext::MasksAllEqual(llvm::Value *v1, llvm::Value *v2) {
 
 llvm::Value *
 FunctionEmitContext::GetStringPtr(const std::string &str) {
-#ifdef LLVM_3_0
-    llvm::Constant *lstr = llvm::ConstantArray::get(*g->ctx, str);
-#else
     llvm::Constant *lstr = llvm::ConstantDataArray::getString(*g->ctx, str);
-#endif
     llvm::GlobalValue::LinkageTypes linkage = llvm::GlobalValue::InternalLinkage;
     llvm::Value *lstrPtr = new llvm::GlobalVariable(*m->module, lstr->getType(),
                                                     true /*isConst*/, 
@@ -1438,11 +1432,7 @@ FunctionEmitContext::I1VecToBoolVec(llvm::Value *b) {
 
 static llvm::Value *
 lGetStringAsValue(llvm::BasicBlock *bblock, const char *s) {
-#ifdef LLVM_3_0
-    llvm::Constant *sConstant = llvm::ConstantArray::get(*g->ctx, s);
-#else
     llvm::Constant *sConstant = llvm::ConstantDataArray::getString(*g->ctx, s);
-#endif
     llvm::Value *sPtr = new llvm::GlobalVariable(*m->module, sConstant->getType(), 
                                                  true /* const */,
                                                  llvm::GlobalValue::InternalLinkage,

--- a/ctx.h
+++ b/ctx.h
@@ -40,14 +40,14 @@
 
 #include "ispc.h"
 #include <map>
-#if defined(LLVM_3_0) || defined(LLVM_3_1) || defined(LLVM_3_2)
+#if defined(LLVM_3_1) || defined(LLVM_3_2)
   #include <llvm/InstrTypes.h>
   #include <llvm/Instructions.h>
 #else
   #include <llvm/IR/InstrTypes.h>
   #include <llvm/IR/Instructions.h>
 #endif
-#if defined(LLVM_3_0) || defined(LLVM_3_1)
+#if defined(LLVM_3_1)
   #include <llvm/Analysis/DebugInfo.h>
   #include <llvm/Analysis/DIBuilder.h>
 #else

--- a/expr.cpp
+++ b/expr.cpp
@@ -56,7 +56,7 @@
 #include <list>
 #include <set>
 #include <stdio.h>
-#if defined(LLVM_3_0) || defined(LLVM_3_1) || defined(LLVM_3_2)
+#if defined(LLVM_3_1) || defined(LLVM_3_2)
   #include <llvm/Module.h>
   #include <llvm/Type.h>
   #include <llvm/Instructions.h>

--- a/func.cpp
+++ b/func.cpp
@@ -46,7 +46,7 @@
 #include "util.h"
 #include <stdio.h>
 
-#if defined(LLVM_3_0) || defined(LLVM_3_1) || defined(LLVM_3_2)
+#if defined(LLVM_3_1) || defined(LLVM_3_2)
   #include <llvm/LLVMContext.h>
   #include <llvm/Module.h>
   #include <llvm/Type.h>
@@ -310,7 +310,7 @@ Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function,
         // isn't worth the code bloat / overhead.
         bool checkMask = (type->isTask == true) || 
             (
-#if defined(LLVM_3_0) || defined(LLVM_3_1)
+#if defined(LLVM_3_1)
               (function->hasFnAttr(llvm::Attribute::AlwaysInline) == false)
 #elif defined(LLVM_3_2)
               (function->getFnAttributes().hasAttribute(llvm::Attributes::AlwaysInline) == false)
@@ -453,7 +453,7 @@ Function::GenerateIR() {
                     functionName += std::string("_") + g->target.GetISAString();
                 llvm::Function *appFunction = 
                     llvm::Function::Create(ftype, linkage, functionName.c_str(), m->module);
-#if defined(LLVM_3_0) || defined(LLVM_3_1)
+#if defined(LLVM_3_1)
                 appFunction->setDoesNotThrow(true);
 #else
                 appFunction->setDoesNotThrow();

--- a/ispc.cpp
+++ b/ispc.cpp
@@ -48,7 +48,7 @@
   #include <sys/types.h>
   #include <unistd.h>
 #endif
-#if defined(LLVM_3_0) || defined(LLVM_3_1) || defined(LLVM_3_2)
+#if defined(LLVM_3_1) || defined(LLVM_3_2)
   #include <llvm/LLVMContext.h>
   #include <llvm/Module.h>
   #include <llvm/Instructions.h>
@@ -57,7 +57,7 @@
   #include <llvm/IR/Module.h>
   #include <llvm/IR/Instructions.h>
 #endif
-#if defined(LLVM_3_0) || defined(LLVM_3_1)
+#if defined(LLVM_3_1)
   #include <llvm/Analysis/DebugInfo.h>
   #include <llvm/Analysis/DIBuilder.h>
 #else
@@ -67,7 +67,7 @@
 #include <llvm/Support/Dwarf.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
-#if defined(LLVM_3_0) || defined(LLVM_3_1)
+#if defined(LLVM_3_1)
   #include <llvm/Target/TargetData.h>
 #elif defined(LLVM_3_2)
   #include <llvm/DataLayout.h>
@@ -348,13 +348,10 @@ Target::GetTarget(const char *arch, const char *cpu, const char *isa,
         t->attributes = "+avx,+popcnt,+cmov,+f16c,+rdrand";
         t->maskingIsFree = false;
         t->maskBitCount = 32;
-#if !defined(LLVM_3_0)
-        // LLVM 3.1+ only
         t->hasHalf = true;
-  #if !defined(LLVM_3_1)
+#if !defined(LLVM_3_1)
         // LLVM 3.2+ only
         t->hasRand = true;
-  #endif
 #endif
     }
     else if (!strcasecmp(isa, "avx1.1-x2")) {
@@ -364,16 +361,12 @@ Target::GetTarget(const char *arch, const char *cpu, const char *isa,
         t->attributes = "+avx,+popcnt,+cmov,+f16c,+rdrand";
         t->maskingIsFree = false;
         t->maskBitCount = 32;
-#if !defined(LLVM_3_0)
-        // LLVM 3.1+ only
         t->hasHalf = true;
-  #if !defined(LLVM_3_1)
+#if !defined(LLVM_3_1)
         // LLVM 3.2+ only
         t->hasRand = true;
-  #endif
 #endif
     }
-#ifndef LLVM_3_0
     else if (!strcasecmp(isa, "avx2")) {
         t->isa = Target::AVX2;
         t->nativeVectorWidth = 8;
@@ -410,7 +403,6 @@ Target::GetTarget(const char *arch, const char *cpu, const char *isa,
         t->hasGather = true;
 #endif
     }
-#endif // !LLVM_3_0
     else {
         fprintf(stderr, "Target ISA \"%s\" is unknown.  Choices are: %s\n", 
                 isa, SupportedTargetISAs());
@@ -419,7 +411,7 @@ Target::GetTarget(const char *arch, const char *cpu, const char *isa,
 
     if (!error) {
         llvm::TargetMachine *targetMachine = t->GetTargetMachine();
-#if defined(LLVM_3_0) || defined(LLVM_3_1)
+#if defined(LLVM_3_1)
         const llvm::TargetData *targetData = targetMachine->getTargetData();
         t->is32Bit = (targetData->getPointerSize() == 4);
 #else
@@ -456,9 +448,7 @@ Target::SupportedTargetArchs() {
 const char *
 Target::SupportedTargetISAs() {
     return "sse2, sse2-x2, sse4, sse4-x2, avx, avx-x2"
-#ifndef LLVM_3_0
         ", avx1.1, avx1.1-x2, avx2, avx2-x2"
-#endif // !LLVM_3_0
         ", generic-1, generic-4, generic-8, generic-16, generic-32";
 }
 
@@ -467,11 +457,7 @@ std::string
 Target::GetTripleString() const {
     llvm::Triple triple;
     // Start with the host triple as the default
-#ifdef LLVM_3_0
-    triple.setTriple(llvm::sys::getHostTriple());
-#else
     triple.setTriple(llvm::sys::getDefaultTargetTriple());
-#endif
 
     // And override the arch in the host triple based on what the user
     // specified.  Here we need to deal with the fact that LLVM uses one
@@ -496,11 +482,6 @@ Target::GetTargetMachine() const {
 
     llvm::Reloc::Model relocModel = generatePIC ? llvm::Reloc::PIC_ : 
                                                   llvm::Reloc::Default;
-#ifdef LLVM_3_0
-    std::string featuresString = attributes;
-    llvm::TargetMachine *targetMachine = 
-        target->createTargetMachine(triple, cpu, featuresString, relocModel);
-#else
     std::string featuresString = attributes;
     llvm::TargetOptions options;
 #if !defined(LLVM_3_1)
@@ -510,7 +491,6 @@ Target::GetTargetMachine() const {
     llvm::TargetMachine *targetMachine = 
         target->createTargetMachine(triple, cpu, featuresString, options,
                                     relocModel);
-#endif // !LLVM_3_0
     Assert(targetMachine != NULL);
 
     targetMachine->setAsmVerbosityDefault(true);
@@ -595,7 +575,7 @@ Target::SizeOf(llvm::Type *type,
                                           "sizeof_int", insertAtEnd);
     }
 
-#if defined(LLVM_3_0) || defined(LLVM_3_1)
+#if defined(LLVM_3_1)
     const llvm::TargetData *td = GetTargetMachine()->getTargetData();
     Assert(td != NULL);
     uint64_t bitSize = td->getTypeSizeInBits(type);
@@ -642,7 +622,7 @@ Target::StructOffset(llvm::Type *type, int element,
         return NULL;
     }
 
-#if defined(LLVM_3_0) || defined(LLVM_3_1)
+#if defined(LLVM_3_1)
     const llvm::TargetData *td = GetTargetMachine()->getTargetData();
     Assert(td != NULL);
     const llvm::StructLayout *sl = td->getStructLayout(structType);

--- a/ispc.h
+++ b/ispc.h
@@ -40,8 +40,8 @@
 
 #define ISPC_VERSION "1.3.1dev"
 
-#if !defined(LLVM_3_0) && !defined(LLVM_3_1) && !defined(LLVM_3_2) && !defined(LLVM_3_3)
-#error "Only LLVM 3.0, 3.1, 3.2 and the 3.3 development branch are supported"
+#if !defined(LLVM_3_1) && !defined(LLVM_3_2) && !defined(LLVM_3_3)
+#error "Only LLVM 3.1, 3.2 and the 3.3 development branch are supported"
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/llvmutil.h
+++ b/llvmutil.h
@@ -38,7 +38,7 @@
 #ifndef ISPC_LLVMUTIL_H
 #define ISPC_LLVMUTIL_H 1
 
-#if defined(LLVM_3_0) || defined(LLVM_3_1) || defined(LLVM_3_2)
+#if defined(LLVM_3_1) || defined(LLVM_3_2)
   #include <llvm/LLVMContext.h>
   #include <llvm/Type.h>
   #include <llvm/DerivedTypes.h>

--- a/main.cpp
+++ b/main.cpp
@@ -62,9 +62,7 @@ static void
 lPrintVersion() {
     printf("Intel(r) SPMD Program Compiler (ispc), %s (build %s @ %s, LLVM %s)\n", 
            ISPC_VERSION, BUILD_VERSION, BUILD_DATE, 
-#if defined(LLVM_3_0)
-           "3.0"
-#elif defined(LLVM_3_1)
+#if defined(LLVM_3_1)
            "3.1"
 #elif defined(LLVM_3_2)
            "3.2"

--- a/parse.yy
+++ b/parse.yy
@@ -83,10 +83,10 @@ struct ForeachDimension;
 #include "util.h"
 
 #include <stdio.h>
-#if !defined(LLVM_3_0) && !defined(LLVM_3_1) && !defined(LLVM_3_2)
-  #include <llvm/IR/Constants.h>
-#else
+#if defined(LLVM_3_1) || defined(LLVM_3_2)
   #include <llvm/Constants.h>
+#else
+  #include <llvm/IR/Constants.h>
 #endif
 
 #define UNIMPLEMENTED \

--- a/stmt.cpp
+++ b/stmt.cpp
@@ -48,7 +48,7 @@
 #include <stdio.h>
 #include <map>
 
-#if defined(LLVM_3_0) || defined(LLVM_3_1) || defined(LLVM_3_2)
+#if defined(LLVM_3_1) || defined(LLVM_3_2)
   #include <llvm/Module.h>
   #include <llvm/Type.h>
   #include <llvm/Instructions.h>

--- a/type.cpp
+++ b/type.cpp
@@ -43,14 +43,14 @@
 
 #include <stdio.h>
 #include <map>
-#if defined(LLVM_3_0) || defined(LLVM_3_1) || defined(LLVM_3_2)
+#if defined(LLVM_3_1) || defined(LLVM_3_2)
   #include <llvm/Value.h>
   #include <llvm/Module.h>
 #else
   #include <llvm/IR/Value.h>
   #include <llvm/IR/Module.h>
 #endif
-#if defined(LLVM_3_0) || defined(LLVM_3_1)
+#if defined(LLVM_3_1)
   #include <llvm/Analysis/DebugInfo.h>
   #include <llvm/Analysis/DIBuilder.h>
 #else
@@ -820,7 +820,7 @@ EnumType::GetDIType(llvm::DIDescriptor scope) const {
                                             32 /* size in bits */,
                                             32 /* align in bits */,
                                             elementArray
-#if !defined(LLVM_3_0) && !defined(LLVM_3_1)
+#if !defined(LLVM_3_1)
                                             , llvm::DIType()
 #endif
                                             );
@@ -2626,7 +2626,7 @@ ReferenceType::GetDIType(llvm::DIDescriptor scope) const {
     }
 
     llvm::DIType diTargetType = targetType->GetDIType(scope);
-#if defined(LLVM_3_0) || defined(LLVM_3_1)
+#if defined(LLVM_3_1)
     return m->diBuilder->createReferenceType(diTargetType);
 #else
     return m->diBuilder->createReferenceType(llvm::dwarf::DW_TAG_reference_type,

--- a/type.h
+++ b/type.h
@@ -40,7 +40,7 @@
 
 #include "ispc.h"
 #include "util.h"
-#if defined(LLVM_3_0) || defined(LLVM_3_1) || defined(LLVM_3_2)
+#if defined(LLVM_3_1) || defined(LLVM_3_2)
   #include <llvm/Type.h>
   #include <llvm/DerivedTypes.h>
 #else


### PR DESCRIPTION
There are three commits here.
1. A whole bunch of header files have moved and some APIs have changed in the new llvm 3.3 development branch.  These changes get ispc building again.
2. The second one just fixes some compiler warnings (all cosmetic)
3. The third removes support for building with LLVM 3.0.  You may or may not want to take this, but it cleans up the code in a few places and generally removes cruft.  Now that LLVM 3.2 has been released, it seems reasonable to demand LLVM 3.1 or higher, especially since 3.0's support for AVX is much less good than 3.1 and 3.2
