### PR TITLE
Fix to acos.ispc test

### DIFF
--- a/tests/acos.ispc
+++ b/tests/acos.ispc
@@ -6,7 +6,7 @@ bool ok(float x, float ref) { return (abs(x - ref) < 1e-6) || abs((x-ref)/ref) <
 
 export void f_v(uniform float RET[]) {
     uniform float vals[8] = { 0, 1, 0.5, -1, -.87, -.25, 1e-3, -.99999999 };
-    uniform float r[programCount];
+    uniform float r[8];
     foreach (i = 0 ... 8)
         r[i] = cos(acos(vals[i % 8]));
 


### PR DESCRIPTION
Fixed test to mirror asin.ispc and no longer fail.
