### PR TITLE
Fix for c++ backend

### DIFF
--- a/cbackend.cpp
+++ b/cbackend.cpp
@@ -149,6 +149,12 @@ namespace {
           for (llvm::BasicBlock::const_iterator II = BB->begin(),
                E = BB->end(); II != E; ++II) {
             const llvm::Instruction &I = *II;
+
+            // Operands of SwitchInsts changed format after 3.1
+            // Seems like there ought to be better way to do what we
+            // want here.  For now, punt on SwitchInsts.
+            if (llvm::isa<llvm::SwitchInst>(&I)) continue;
+            
             // Incorporate the type of the instruction and all its operands.
             incorporateType(I.getType());
             for (llvm::User::const_op_iterator OI = I.op_begin(), OE = I.op_end();


### PR DESCRIPTION
The representation of SwitchInsts changed in LLVM >= 3.2 to use the new range objects.  This causes issues when iterating through the operands of a SwitchInst cast as a User.  The C++ was thus generating spurious type array type declarations when an ISPC program uses the print function of the standard library.  For now, just punt if the search for ArrayTypes finds a SwitchInst.  There is probably a cleaner way to fix this in the future.
