### PR TITLE
Fixes to build with ToT / M4 Macro Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,8 @@ LLVM_LIBS=$(shell $(LLVM_CONFIG) --libs)
 CLANG=clang
 CLANG_LIBS = -lclangFrontend -lclangDriver \
              -lclangSerialization -lclangParse -lclangSema \
-             -lclangAnalysis -lclangAST -lclangLex -lclangBasic
-ifneq ($(shell $(LLVM_CONFIG) --version), 3.0)
-  CLANG_LIBS += -lclangEdit
-endif
+             -lclangAnalysis -lclangAST -lclangBasic \
+             -lclangEdit -lclangLex
 
 ISPC_LIBS=$(shell $(LLVM_CONFIG) --ldflags) $(CLANG_LIBS) $(LLVM_LIBS) \
 	-lpthread

--- a/builtins/util.m4
+++ b/builtins/util.m4
@@ -3295,7 +3295,7 @@ check_neighbors:
   %castvec = bitcast <$1 x $2> %vec to <$1 x $4>
   %castvr = call <$1 x $4> @__rotate_i$6(<$1 x $4> %castvec, i32 1)
   %vr = bitcast <$1 x $4> %castvr to <$1 x $2>
-  %eq = $5 eq <$1 x $2> %vec, %vr
+  %eq = $5 $7 <$1 x $2> %vec, %vr
   ifelse(MASK,i32, `
     %eq32 = sext <$1 x i1> %eq to <$1 x i32>
     %eqmm = call i64 @__movmsk(<$1 x i32> %eq32)', `
@@ -3310,7 +3310,7 @@ check_neighbors:
   %v`'i = extractelement <$1 x $2> %vec, i32 i')
 
   forloop(i, 0, eval($1-2), `
-  %eq`'i = $5 eq $2 %v`'i, %v`'eval(i+1)')
+  %eq`'i = $5 $7 $2 %v`'i, %v`'eval(i+1)')
 
   %and0 = and i1 %eq0, %eq1
   forloop(i, 1, eval($1-3), `
@@ -3330,10 +3330,10 @@ not_all_equal:
 ')
 
 define(`reduce_equal', `
-reduce_equal_aux($1, i32, int32, i32, icmp, 32)
-reduce_equal_aux($1, float, float, i32, fcmp, 32)
-reduce_equal_aux($1, i64, int64, i64, icmp, 64)
-reduce_equal_aux($1, double, double, i64, fcmp, 64)
+reduce_equal_aux($1, i32, int32, i32, icmp, 32, eq)
+reduce_equal_aux($1, float, float, i32, fcmp, 32, oeq)
+reduce_equal_aux($1, i64, int64, i64, icmp, 64, eq)
+reduce_equal_aux($1, double, double, i64, fcmp, 64, oeq)
 ')
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cbackend.cpp
+++ b/cbackend.cpp
@@ -51,7 +51,11 @@
 #include "llvm/Pass.h"
 #include "llvm/PassManager.h"
 #if !defined(LLVM_3_1)
-  #include "llvm/TypeFinder.h"
+  #if defined(LLVM_3_2)
+    #include "llvm/TypeFinder.h"
+  #else // LLVM_3_3 +
+    #include "llvm/IR/TypeFinder.h"
+  #endif
 #endif // LLVM_3_2 +
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/SmallString.h"

--- a/module.cpp
+++ b/module.cpp
@@ -91,10 +91,11 @@
 #else
   #if defined(LLVM_3_2)
     #include <llvm/DataLayout.h>
+    #include <llvm/TargetTransformInfo.h>
   #else // LLVM 3.3+
     #include <llvm/IR/DataLayout.h>
+    #include <llvm/Analysis/TargetTransformInfo.h>
   #endif
-  #include <llvm/TargetTransformInfo.h>
 #endif
 #include <llvm/Analysis/Verifier.h>
 #include <llvm/Support/CFG.h>

--- a/opt.cpp
+++ b/opt.cpp
@@ -79,7 +79,7 @@
   #include <llvm/DataLayout.h>
 #else // LLVM 3.3+
   #include <llvm/IR/DataLayout.h>
-  #include <llvm/TargetTransformInfo.h>
+  #include <llvm/Analysis/TargetTransformInfo.h>
 #endif
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Analysis/Verifier.h>
@@ -426,8 +426,7 @@ Optimize(llvm::Module *module, int optLevel) {
     optPM.add(new llvm::TargetTransformInfo(targetMachine->getScalarTargetTransformInfo(),
                                             targetMachine->getVectorTargetTransformInfo()));
   #else // LLVM 3.3+
-    optPM.add(llvm::createNoTTIPass(targetMachine->getScalarTargetTransformInfo(),
-                                    targetMachine->getVectorTargetTransformInfo()));
+    targetMachine->addAnalysisPasses(optPM);
   #endif
 #endif
 


### PR DESCRIPTION
Various header files/APIs have changed.
Cleaned up library link order in Makefile to build with ToT.
Fixed M4 macro to emit legal LLVM IR: fcmp oeq instead of fcmp eq
