### PR TITLE
Tweak to sse4.h intrinsics include file.

### DIFF
--- a/examples/intrinsics/sse4.h
+++ b/examples/intrinsics/sse4.h
@@ -51,9 +51,6 @@
 #define FORCEINLINE __attribute__((always_inline)) inline
 #endif
 
-#undef FORCEINLINE
-#define FORCEINLINE
-
 typedef float __vec1_f;
 typedef double __vec1_d;
 typedef int8_t __vec1_i8;
@@ -3986,3 +3983,7 @@ static FORCEINLINE uint64_t __atomic_cmpxchg(uint64_t *p, uint64_t cmpval,
     return __sync_val_compare_and_swap(p, cmpval, newval);
 #endif
 }
+
+#undef FORCEINLINE
+
+


### PR DESCRIPTION
Moved some preprocessor directives so inlining works.  Otherwise, executables with multiple ISPC->CPP files would not compile due to multiple definitions.
