### PR TITLE
Fix for bug #361

### DIFF
--- a/module.cpp
+++ b/module.cpp
@@ -332,6 +332,15 @@ Module::CompileFile() {
             }
             fclose(f);
         }
+		else {
+			// Check stdin to EOF (it can be empty, so we need to exit)
+			char c = getchar();
+			if (c == EOF){
+				perror("empty stdin");
+				return 1;
+			}
+			ungetc(c, stdin);
+		}
 
         std::string buffer;
         llvm::raw_string_ostream os(buffer);


### PR DESCRIPTION
Fixed https://github.com/ispc/ispc/issues/361
If we call ispc with no file and empty stdin we will have correct message about it. No fail in preprocessor.
But I don't sure about correct behavior, maybe we need to create empty file if it has been setted?
