### PR TITLE
#469: Fix for multi-target compilation

### DIFF
--- a/ispc.cpp
+++ b/ispc.cpp
@@ -551,10 +551,9 @@ Target::GetTripleString() const {
     return triple.str();
 }
 
-
 const char *
-Target::GetISAString() const {
-    switch (m_isa) {
+Target::ISAToString(ISA isa) {
+    switch (isa) {
     case Target::SSE2:
         return "sse2";
     case Target::SSE4:
@@ -568,9 +567,14 @@ Target::GetISAString() const {
     case Target::GENERIC:
         return "generic";
     default:
-        FATAL("Unhandled target in GetISAString()");
+        FATAL("Unhandled target in ISAToString()");
     }
     return "";
+}
+
+const char *
+Target::GetISAString() const {
+    return ISAToString(m_isa);
 }
 
 

--- a/ispc.h
+++ b/ispc.h
@@ -169,6 +169,14 @@ extern void DoAssertPos(SourcePos pos, const char *file, int line, const char *e
 */
 class Target {
 public:
+    /** Enumerator giving the instruction sets that the compiler can
+        target.  These should be ordered from "worse" to "better" in that
+        if a processor supports multiple target ISAs, then the most
+        flexible/performant of them will apear last in the enumerant.  Note
+        also that __best_available_isa() needs to be updated if ISAs are
+        added or the enumerant values are reordered.  */
+    enum ISA { SSE2, SSE4, AVX, AVX11, AVX2, GENERIC, NUM_ISAS };
+
     /** Initializes the given Target pointer for a target of the given
         name, if the name is a known target.  Returns true if the
         target was initialized and false if the name is unknown. */
@@ -194,6 +202,9 @@ public:
         target. */
     llvm::TargetMachine *GetTargetMachine() const {return m_targetMachine;}
 
+    /** Convert ISA enum to string */
+    static const char *ISAToString(Target::ISA isa);
+
     /** Returns a string like "avx" encoding the target. */
     const char *GetISAString() const;
 
@@ -209,14 +220,6 @@ public:
 
     /** Mark LLVM function with target specific attribute, if required. */
     void markFuncWithTargetAttr(llvm::Function* func);
-
-    /** Enumerator giving the instruction sets that the compiler can
-        target.  These should be ordered from "worse" to "better" in that
-        if a processor supports multiple target ISAs, then the most
-        flexible/performant of them will apear last in the enumerant.  Note
-        also that __best_available_isa() needs to be updated if ISAs are
-        added or the enumerant values are reordered.  */
-    enum ISA { SSE2, SSE4, AVX, AVX11, AVX2, GENERIC, NUM_ISAS };
 
     const llvm::Target *getTarget() const {return m_target;}
 


### PR DESCRIPTION
Fix is required for multi-target compilation. This is a regression after redesigning Target class. But an old behavior was incorrect anyway, as incorrect target information was supplied to dispatch module via g->target.

We also need to improve our testing to catch such things during testing.
