### PR TITLE
Fix for the bug with gcc4.7: incorrect usage of ArrayRef

### DIFF
--- a/cbackend.cpp
+++ b/cbackend.cpp
@@ -4831,7 +4831,11 @@ MaskOpsCleanupPass::runOnBasicBlock(llvm::BasicBlock &bb) {
         if (bop->getOpcode() == llvm::Instruction::Xor) {
             // Check for XOR with all-true values
             if (lIsAllTrue(bop->getOperand(1))) {
-                llvm::ArrayRef<llvm::Value *> arg(bop->getOperand(0));
+                llvm::Value *val = bop->getOperand(0);
+                // Note that ArrayRef takes reference to an object, which must live
+                // long enough, so passing return value of getOperand directly is
+                // incorrect and it actually causes crashes with gcc 4.7 and later.
+                llvm::ArrayRef<llvm::Value *> arg(val);
                 llvm::CallInst *notCall = llvm::CallInst::Create(notFunc, arg,
                                                      bop->getName());
                 ReplaceInstWithInst(iter, notCall);


### PR DESCRIPTION
This fixes big number of comp fails for generic-4 target when ISPC is built by gcc 4.7 with optimizations. gcc 4.2 and other compilers are not affected.

Before the fix I had 166 comp fails / 37 run fails with generic-4 (gcc4.7) and only 2 comp fails / 38 run fails when ISPC built with clang.
After the fix, it’s the same for clang and gcc4.7: 2 comp fails / 38 run fails.

The fix itself looks pretty stupid from the first glance, but this actually fixes incorrect usage of LLVM interface. ArrayRef expects as a parameter “(const T &OneElt)”. I.e. it expects a reference to an object, it doesn’t own the object, but expects that it lives long enough and it keeps a reference. The old code provided _temporary value_, which live range was not long enough. So compiler may optimize it away. gcc4.7 at O2 does optimize this temporary object, while other compilers don’t (at the moment).
