### PR TITLE
Avoid double spaces in error messages to get same messages on Win and Unix

### DIFF
--- a/decl.cpp
+++ b/decl.cpp
@@ -157,7 +157,7 @@ DeclSpecs::GetBaseType(SourcePos pos) const {
             return NULL;
         }
         else if (soaWidth <= 0 || (soaWidth & (soaWidth - 1)) != 0) {
-            Error(pos, "soa<%d> width illegal.  Value must be positive power "
+            Error(pos, "soa<%d> width illegal. Value must be positive power "
                   "of two.", soaWidth);
             return NULL;
         }

--- a/parse.yy
+++ b/parse.yy
@@ -567,7 +567,7 @@ rate_qualified_type_specifier
                 $$ = NULL;
             }
             else if (soaWidth <= 0 || (soaWidth & (soaWidth - 1)) != 0) {
-                Error(@1, "soa<%d> width illegal.  Value must be positive power "
+                Error(@1, "soa<%d> width illegal. Value must be positive power "
                       "of two.", soaWidth);
                 $$ = NULL;
             }


### PR DESCRIPTION
Unix version of ISPC has sophisticated logic for parsing and printing error messages, while on Windows it's printed "as is" - see lPrintWithWordBreaks() for more details.

One thing, which Unix version does, is skipping more than one space between words. And this causes difference in output in Windows and Unix, which in turn causes tests_errors/soa-2.ispc to fail on Windows because of error message not matched the expected message.
