### PR TITLE
Fix branch tests for breaks and returns.

### DIFF
--- a/ctx.cpp
+++ b/ctx.cpp
@@ -841,6 +841,9 @@ FunctionEmitContext::jumpIfAllLoopLanesAreDone(llvm::BasicBlock *target) {
     if (breakLanesPtr == NULL) {
         llvm::Value *continued = LoadInst(continueLanesPtr,
                                           "continue_lanes");
+        continued = BinaryOperator(llvm::Instruction::And,
+                                   continued, GetFunctionMask(),
+                                   "continued&func");
         allDone = MasksAllEqual(continued, blockEntryMask);
     }
     else {
@@ -860,6 +863,10 @@ FunctionEmitContext::jumpIfAllLoopLanesAreDone(llvm::BasicBlock *target) {
             finishedLanes = BinaryOperator(llvm::Instruction::Or, finishedLanes,
                                            continued, "returned|breaked|continued");
         }
+        
+        finishedLanes = BinaryOperator(llvm::Instruction::And,
+                                       finishedLanes, GetFunctionMask(),
+                                       "finished&func");
 
         // Do we match the mask at loop or switch statement entry?
         allDone = MasksAllEqual(finishedLanes, blockEntryMask);

--- a/stmt.cpp
+++ b/stmt.cpp
@@ -374,6 +374,7 @@ lEmitIfStatements(FunctionEmitContext *ctx, Stmt *stmts, const char *trueOrFalse
 
 /** Returns true if the "true" block for the if statement consists of a
     single 'break' statement, and the "false" block is empty. */
+/*
 static bool
 lCanApplyBreakOptimization(Stmt *trueStmts, Stmt *falseStmts) {
     if (falseStmts != NULL) {
@@ -392,7 +393,7 @@ lCanApplyBreakOptimization(Stmt *trueStmts, Stmt *falseStmts) {
     else
         return false;
 }
-
+*/
 
 void
 IfStmt::EmitCode(FunctionEmitContext *ctx) const {


### PR DESCRIPTION
Breaks/continues/returns were testing based off of the Internal Mask instead of the Full Mask.  
