### PR TITLE
Fix for #503 - avoid omitting frame pointer on Win32

### DIFF
--- a/ispc.cpp
+++ b/ispc.cpp
@@ -441,6 +441,14 @@ Target::Target(const char *arch, const char *cpu, const char *isa, bool pic) :
         if (g->opt.disableFMA == false)
             options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
 #endif // !LLVM_3_1
+
+#ifdef ISPC_IS_WINDOWS
+        if (strcmp("x86", arch) == 0) {
+            // Workaround for issue #503 (LLVM issue 14646).
+            // It's Win32 specific.
+            options.NoFramePointerElim = true;
+        }
+#endif
         m_targetMachine =
             m_target->createTargetMachine(triple, m_cpu, featuresString, options,
                     relocModel);


### PR DESCRIPTION
Tested on Windows and Linux.
