### PR TITLE
Fix to track LLVM 3.4 ToT changes

### DIFF
--- a/ctx.cpp
+++ b/ctx.cpp
@@ -344,6 +344,14 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym,
             AssertPos(currentPos, diSubprogramType.Verify());
         }
 
+#if defined(LLVM_3_4)
+        Assert(diSubprogramType.isCompositeType());
+        llvm::DICompositeType diSubprogramType_n =
+            static_cast<llvm::DICompositeType>(diSubprogramType);
+#else
+        llvm::DIType diSubprogramType_n = diSubprogramType;
+#endif
+
         std::string mangledName = llvmFunction->getName();
         if (mangledName == funSym->name)
             mangledName = "";
@@ -356,7 +364,7 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym,
         diSubprogram =
             m->diBuilder->createFunction(diFile /* scope */, funSym->name,
                                          mangledName,        diFile,
-                                         firstLine,          diSubprogramType,
+                                         firstLine,          diSubprogramType_n,
                                          isStatic,           true, /* is defn */
                                          firstLine,
                                          flags,

--- a/type.cpp
+++ b/type.cpp
@@ -2879,7 +2879,11 @@ FunctionType::GetDIType(llvm::DIDescriptor scope) const {
     for (int i = 0; i < GetNumParameters(); ++i) {
         const Type *t = GetParameterType(i);
         if (t == NULL)
+#if defined(LLVM_3_4)
+            return llvm::DICompositeType();
+#else
             return llvm::DIType();
+#endif
         retArgTypes.push_back(t->GetDIType(scope));
     }
 


### PR DESCRIPTION
changes to support createFunction() with DICompositeType argument in LLVM_3_4
