### PR TITLE
correction of --instrument option support

### DIFF
--- a/bitcode2cpp.py
+++ b/bitcode2cpp.py
@@ -45,7 +45,7 @@ for i in range(0, len(data), 1):
             sys.stdout.write("\n")
 
 sys.stdout.write("0x00 };\n\n")
-sys.stdout.write("int builtins_bitcode_" + name + "_length = " + str(i+1) + ";\n")
+sys.stdout.write("int builtins_bitcode_" + name + "_length = " + str(len(data)) + ";\n")
 
 as_out.wait()
 

--- a/ctx.cpp
+++ b/ctx.cpp
@@ -1414,7 +1414,7 @@ FunctionEmitContext::ProgramIndexVector(bool is32bits) {
 
 llvm::Value *
 FunctionEmitContext::GetStringPtr(const std::string &str) {
-    llvm::Constant *lstr = llvm::ConstantDataArray::getString(*g->ctx, str);
+    llvm::Constant *lstr = llvm::ConstantDataArray::getString(*g->ctx, str, false);
     llvm::GlobalValue::LinkageTypes linkage = llvm::GlobalValue::InternalLinkage;
     llvm::Value *lstrPtr = new llvm::GlobalVariable(*m->module, lstr->getType(),
                                                     true /*isConst*/,
@@ -1464,11 +1464,13 @@ FunctionEmitContext::I1VecToBoolVec(llvm::Value *b) {
 
 static llvm::Value *
 lGetStringAsValue(llvm::BasicBlock *bblock, const char *s) {
-    llvm::Constant *sConstant = llvm::ConstantDataArray::getString(*g->ctx, s);
+    llvm::Constant *sConstant = llvm::ConstantDataArray::getString(*g->ctx, s, false);
+    std::string var_name = "_";
+    var_name = var_name + s;
     llvm::Value *sPtr = new llvm::GlobalVariable(*m->module, sConstant->getType(),
                                                  true /* const */,
                                                  llvm::GlobalValue::InternalLinkage,
-                                                 sConstant, s);
+                                                 sConstant, var_name.c_str());
     llvm::Value *indices[2] = { LLVMInt32(0), LLVMInt32(0) };
     llvm::ArrayRef<llvm::Value *> arrayRef(&indices[0], &indices[2]);
     return llvm::GetElementPtrInst::Create(sPtr, arrayRef, "sptr", bblock);

--- a/examples/aobench_instrumented/instrument.cpp
+++ b/examples/aobench_instrumented/instrument.cpp
@@ -60,7 +60,7 @@ int countbits(int i) {
 // Callback function that ispc compiler emits calls to when --instrument
 // command-line flag is given while compiling.
 void
-ISPCInstrument(const char *fn, const char *note, int line, int mask) {
+ISPCInstrument(const char *fn, const char *note, int line, uint64_t mask) {
     char sline[16];
     sprintf(sline, "%04d", line);
     std::string s = std::string(fn) + std::string("(") + std::string(sline) +

--- a/examples/aobench_instrumented/instrument.h
+++ b/examples/aobench_instrumented/instrument.h
@@ -28,7 +28,7 @@
    PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
    LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #ifndef INSTRUMENT_H
@@ -36,8 +36,8 @@
 
 #include <stdint.h>
 
-extern "C" { 
-    void ISPCInstrument(const char *fn, const char *note, int line, int mask);
+extern "C" {
+    void ISPCInstrument(const char *fn, const char *note, int line, uint64_t mask);
 }
 
 void ISPCPrintInstrument();


### PR DESCRIPTION
Summary of these changes:
- we should call function getString with third parameter "false". This function puts our string in string map and it can add null at the end of this. But when we try to read something from string map we search for string without null.
- when we put first parameter in ISPCInstrument function we shouldn't name it's value as filename. Because it will have a conflict in string table with filename. So I added a "_" before this name. It doesn't influence on user interface of this function.
- we should change the type of fourth parameter of function ISPCInstrument in our examples because ispc produces another one.
- in file bitcode2cpp.py i+1 == len(data) but it is better to use len.

These changes were tested on linux.
