### PR TITLE
Fix build with LLVM top-of-tree.

### DIFF
--- a/ctx.cpp
+++ b/ctx.cpp
@@ -332,7 +332,11 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym,
         diFile = funcStartPos.GetDIFile();
         AssertPos(currentPos, diFile.Verify());
 
+#if defined(LLVM_3_1) || defined(LLVM_3_2) || defined(LLVM_3_3)
         llvm::DIScope scope = llvm::DIScope(m->diBuilder->getCU());
+#else // LLVM_3_4+
+        llvm::DIScope scope = llvm::DIScope(m->diCompileUnit);
+#endif
         AssertPos(currentPos, scope.Verify());
 
         const FunctionType *functionType = function->GetType();

--- a/module.cpp
+++ b/module.cpp
@@ -307,6 +307,9 @@ Module::Module(const char *fn) {
             sprintf(producerString, "ispc version %s (built on %s)",
                     ISPC_VERSION, __DATE__);
 #endif
+#if !defined(LLVM_3_1) && !defined(LLVM_3_2) && !defined(LLVM_3_3)
+            diCompileUnit = 
+#endif // LLVM_3_4+            
             diBuilder->createCompileUnit(llvm::dwarf::DW_LANG_C99,  /* lang */
                                          name,  /* filename */
                                          directory, /* directory */

--- a/module.h
+++ b/module.h
@@ -41,6 +41,9 @@
 
 #include "ispc.h"
 #include "ast.h"
+#if !defined(LLVM_3_1) && !defined(LLVM_3_2) && !defined(LLVM_3_3)
+  #include <llvm/DebugInfo.h>
+#endif
 
 namespace llvm
 {
@@ -152,6 +155,10 @@ public:
 
     /** The diBuilder manages generating debugging information */
     llvm::DIBuilder *diBuilder;
+
+#if !defined(LLVM_3_1) && !defined(LLVM_3_2) && !defined(LLVM_3_3)
+    llvm::DICompileUnit diCompileUnit;
+#endif // LLVM_3_4+
 
 private:
     const char *filename;


### PR DESCRIPTION
The DIBuilder::getCU() method has been removed; we now just store the
compilation unit returned when we call DIBuilder::createCompileUnit.
