### PR TITLE
Changes in perf.py functionality, unification of examples, correction build warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,10 @@ CXX=g++
 CPP=cpp
 OPT=-O2
 CXXFLAGS=$(OPT) $(LLVM_CXXFLAGS) -I. -Iobjs/ -I$(CLANG_INCLUDE)  \
-	-Wall $(LLVM_VERSION_DEF) \
-	-DBUILD_DATE="\"$(BUILD_DATE)\"" -DBUILD_VERSION="\"$(BUILD_VERSION)\""
+	$(LLVM_VERSION_DEF) \
+	-Wall \
+	-DBUILD_DATE="\"$(BUILD_DATE)\"" -DBUILD_VERSION="\"$(BUILD_VERSION)\"" \
+	-Werror -Wno-sign-compare
 ifneq ($(ARM_ENABLED), 0)
     CXXFLAGS+=-DISPC_ARM_ENABLED
 endif

--- a/examples/aobench/ao.cpp
+++ b/examples/aobench/ao.cpp
@@ -138,7 +138,7 @@ int main(int argc, char **argv)
     }
 
     // Report results and save image
-    printf("[aobench ispc]:\t\t\t[%.3f] M cycles (%d x %d image)\n", 
+    printf("[aobench ispc]:\t\t\t[%.3f] million cycles (%d x %d image)\n", 
            minTimeISPC, width, height);
     savePPM("ao-ispc.ppm", width, height); 
 
@@ -158,7 +158,7 @@ int main(int argc, char **argv)
     }
 
     // Report results and save image
-    printf("[aobench ispc + tasks]:\t\t[%.3f] M cycles (%d x %d image)\n", 
+    printf("[aobench ispc + tasks]:\t\t[%.3f] million cycles (%d x %d image)\n", 
            minTimeISPCTasks, width, height);
     savePPM("ao-ispc-tasks.ppm", width, height); 
 
@@ -176,7 +176,7 @@ int main(int argc, char **argv)
     }
 
     // Report more results, save another image...
-    printf("[aobench serial]:\t\t[%.3f] M cycles (%d x %d image)\n", minTimeSerial, 
+    printf("[aobench serial]:\t\t[%.3f] million cycles (%d x %d image)\n", minTimeSerial, 
            width, height);
     printf("\t\t\t\t(%.2fx speedup from ISPC, %.2fx speedup from ISPC + tasks)\n", 
            minTimeSerial / minTimeISPC, minTimeSerial / minTimeISPCTasks);

--- a/examples/deferred/main.cpp
+++ b/examples/deferred/main.cpp
@@ -130,7 +130,7 @@ int main(int argc, char** argv) {
     printf("\t\t\t\t(%.2fx speedup from static ISPC, %.2fx from Cilk+ISPC)\n", 
            serialCycles/ispcCycles, serialCycles/dynamicCilkCycles);
 #else
-    printf("\t\t\t\t(%.2fx speedup from ISPC)\n", serialCycles/ispcCycles);
+    printf("\t\t\t\t(%.2fx speedup from ISPC + tasks)\n", serialCycles/ispcCycles);
 #endif // __cilk
 
     DeleteInputData(input);

--- a/examples/mandelbrot/mandelbrot.cpp
+++ b/examples/mandelbrot/mandelbrot.cpp
@@ -109,7 +109,7 @@ int main() {
         minSerial = std::min(minSerial, dt);
     }
 
-    printf("[mandelbrot serial]:\t\t[%.3f] millon cycles\n", minSerial);
+    printf("[mandelbrot serial]:\t\t[%.3f] million cycles\n", minSerial);
     writePPM(buf, width, height, "mandelbrot-serial.ppm");
 
     printf("\t\t\t\t(%.2fx speedup from ISPC)\n", minSerial/minISPC);

--- a/examples/mandelbrot_tasks/mandelbrot_tasks.cpp
+++ b/examples/mandelbrot_tasks/mandelbrot_tasks.cpp
@@ -137,7 +137,7 @@ int main(int argc, char *argv[]) {
         minSerial = std::min(minSerial, dt);
     }
 
-    printf("[mandelbrot serial]:\t\t[%.3f] millon cycles\n", minSerial);
+    printf("[mandelbrot serial]:\t\t[%.3f] million cycles\n", minSerial);
     writePPM(buf, width, height, "mandelbrot-serial.ppm");
 
     printf("\t\t\t\t(%.2fx speedup from ISPC + tasks)\n", minSerial/minISPC);

--- a/examples/noise/noise.cpp
+++ b/examples/noise/noise.cpp
@@ -106,7 +106,7 @@ int main() {
         minSerial = std::min(minSerial, dt);
     }
 
-    printf("[noise serial]:\t\t\t[%.3f] millon cycles\n", minSerial);
+    printf("[noise serial]:\t\t\t[%.3f] million cycles\n", minSerial);
     writePPM(buf, width, height, "noise-serial.ppm");
 
     printf("\t\t\t\t(%.2fx speedup from ISPC)\n", minSerial/minISPC);

--- a/examples/perf.py
+++ b/examples/perf.py
@@ -10,12 +10,22 @@ import glob
 import string
 import platform
 
+def print_debug(line):
+    if options.silent == False:
+        sys.stdout.write(line)
+
+def print_file(line):
+    if options.output != "":
+        output = open(options.output, 'w')
+        output.writelines(line)
+        output.close()
+
 def build_test():
     global build_log
     global is_windows
     if is_windows == False:
         os.system("make clean >> "+build_log)
-        return os.system("make >> "+build_log+" 2>> "+build_log)
+        return os.system("make CXX="+ref_compiler+" CC="+refc_compiler+" >> "+build_log+" 2>> "+build_log)
     else:
         os.system("msbuild /t:clean >> " + build_log)
         return os.system("msbuild /V:m /p:Platform=x64 /p:Configuration=Release /p:TargetDir=.\ /t:rebuild >> " + build_log)
@@ -30,7 +40,7 @@ def execute_test(command):
     return r
 
 #gathers all tests results and made an item test from answer structure
-def run_test(command, c1, c2, test):
+def run_test(command, c1, c2, test, b_serial):
     global perf_temp
     if build_test() != 0:
         sys.stdout.write("ERROR: Compilation fails\n")
@@ -40,11 +50,13 @@ def run_test(command, c1, c2, test):
         return
     tasks = [] #list of results with tasks, it will be test[2]
     ispc = [] #list of results without tasks, it will be test[1]
+    absolute_tasks = []  #list of absolute results with tasks, it will be test[4]
+    absolute_ispc = [] #list of absolute results without tasks, ut will be test[3]
+    serial = [] #list serial times, it will be test[5]
     j = 1
     for line in open(perf_temp): # we take test output
         if "speedup" in line: # we are interested only in lines with speedup
             if j == c1: # we are interested only in lines with c1 numbers
-                sys.stdout.write(line)
                 line = line.expandtabs(0)
                 line = line.replace("("," ")
                 line = line.split(",")
@@ -57,9 +69,42 @@ def run_test(command, c1, c2, test):
                         ispc.append(number)
                 c1 = c1 + c2
             j+=1
+        if "million cycles" in line:
+            if j == c1:
+                line = line.replace("]","[")
+                line = line.split("[")
+                number = float(line[3])
+                if "tasks" in line[1]:
+                    absolute_tasks.append(number)
+                else:
+                    if "ispc" in line[1]:
+                        absolute_ispc.append(number)
+                if "serial" in line[1]:
+                    serial.append(number)
+
+    if len(ispc) != 0:
+        if len(tasks) != 0:
+            print_debug("ISPC speedup / ISPC + tasks speedup / ISPC time / ISPC + tasks time / serial time\n")
+            for i in range(0,len(serial)):
+                print_debug("%10s   /\t%10s\t    /%9s  /    %10s\t    /%10s\n" %
+                    (ispc[i], tasks[i], absolute_ispc[i], absolute_tasks[i], serial[i]))
+        else:
+            print_debug("ISPC speedup / ISPC time / serial time\n")
+            for i in range(0,len(serial)):
+                print_debug("%10s   /%9s  /%10s\n" % (ispc[i], absolute_ispc[i], serial[i]))
+    else:
+        if len(tasks) != 0:
+            print_debug("ISPC + tasks speedup / ISPC + tasks time / serial time\n")
+            for i in range(0,len(serial)):
+                print_debug("%10s\t     /    %10s\t /%10s\n" % (tasks[i], absolute_tasks[i], serial[i]))
+
     test[1] = test[1] + ispc
     test[2] = test[2] + tasks
-
+    test[3] = test[3] + absolute_ispc
+    test[4] = test[4] + absolute_tasks
+    if b_serial == True:
+        #if we concatenate outputs we should use only the first serial answer.
+        test[5] = test[5] + serial
 
 def cpu_get():
     p = open("/proc/stat", 'r')
@@ -113,30 +158,57 @@ def geomean(par):
 #test[0] - name of test
 #test[1] - list of results without tasks
 #test[2] - list of results with tasks
-#test[1] or test[2] may be empty
+#test[3] - list of absolute results without tasks
+#test[4] - list of absolute results with tasks
+#test[5] - list of absolute time without ISPC (serial)
+#test[1..4] may be empty
 def print_answer(answer):
-    sys.stdout.write("Name of test:\t\tISPC:\tISPC + tasks:\n")
-    max_t = [0,0]
-    diff_t = [0,0]
-    geomean_t = [0,0]
-    list_of_max = [[],[]]
+    filelist = []
+    print_debug("--------------------------------------------------------------------------\n")
+    print_debug("test name:\t    ISPC speedup: ISPC + tasks speedup: | " + 
+        "ISPC time:    ISPC + tasks time:  serial:\n")
+    filelist.append("test name,ISPC speedup,diff," +
+        "ISPC + tasks speedup,diff,ISPC time,diff,ISPC + tasks time,diff,serial,diff\n")
+    max_t = [0,0,0,0,0]
+    diff_t = [0,0,0,0,0]
+    geomean_t = [0,0,0,0,0]
+    list_of_max = [[],[],[],[],[]]
     for i in range(len(answer)):
-        for t in range(1,3):
+        for t in range(1,6):
             if len(answer[i][t]) == 0:
                 max_t[t-1] = "n/a"
                 diff_t[t-1] = "n/a"
             else:
-                list_of_max[t-1].append(max(answer[i][t]))
-                max_t[t-1] = str(max(answer[i][t]))
-                diff_t[t-1] = str(max(answer[i][t]) - min(answer[i][t]))
-        sys.stdout.write("%s:\n" % answer[i][0])
-        sys.stdout.write("\t\tmax:\t%s\t%s\n" % (max_t[0], max_t[1]))
-        sys.stdout.write("\t\tdiff:\t%s\t%s\n" % (diff_t[0], diff_t[1]))
+                if t < 3:
+                    mm = max(answer[i][t])
+                else:
+                    mm = min(answer[i][t])
+                max_t[t-1] = '%.2f' % mm
+                list_of_max[t-1].append(mm)
+                diff_t[t-1] = '%.2f' % (max(answer[i][t]) - min(answer[i][t]))
+        print_debug("%s:\n" % answer[i][0])
+        print_debug("\t\tmax:\t%5s\t\t%10s\t|%10s\t%10s\t%10s\n" %
+            (max_t[0], max_t[1], max_t[2], max_t[3], max_t[4]))
+        print_debug("\t\tdiff:\t%5s\t\t%10s\t|%10s\t%10s\t%10s\n" %
+            (diff_t[0], diff_t[1], diff_t[2], diff_t[3], diff_t[4]))
+        for t in range(0,5):
+            if max_t[t] == "n/a":
+                max_t[t] = ""
+            if diff_t[t] == "n/a":
+                diff_t[t] = ""
+        filelist.append(answer[i][0] + "," +
+                        max_t[0] + "," + diff_t[0] + "," +  max_t[1] + "," + diff_t[1] + "," +
+                        max_t[2] + "," + diff_t[2] + "," +  max_t[3] + "," + diff_t[3] + "," +
+                        max_t[4] + "," + diff_t[4] + "\n")
+    for i in range(0,5):
+        geomean_t[i] = geomean(list_of_max[i])
+    print_debug("---------------------------------------------------------------------------------\n")
+    print_debug("Geomean:\t\t%5s\t\t%10s\t|%10s\t%10s\t%10s\n" %
+        (geomean_t[0], geomean_t[1], geomean_t[2], geomean_t[3], geomean_t[4]))
+    filelist.append("Geomean," + str(geomean_t[0]) + ",," + str(geomean_t[1])
+        + ",," + str(geomean_t[2]) + ",," + str(geomean_t[3]) + ",," + str(geomean_t[4]) + "\n")
+    print_file(filelist)
 
-    geomean_t[0] = geomean(list_of_max[0])
-    geomean_t[1] = geomean(list_of_max[1])
-    sys.stdout.write("---------------------------------------------\n")
-    sys.stdout.write("Geomean:\t\t%s\t%s\n" % (geomean_t[0], geomean_t[1]))
 
 ###Main###
 # parsing options
@@ -147,6 +219,12 @@ parser.add_option('-c', '--config', dest='config',
     help='config file of tests', default="./perf.ini")
 parser.add_option('-p', '--path', dest='path',
     help='path to examples directory', default="./")
+parser.add_option('-s', '--silent', dest='silent',
+    help='silent mode, only table output', default=False, action="store_true")
+parser.add_option('-o', '--output', dest='output',
+    help='output file for script reading', default="")
+parser.add_option('--compiler', dest='compiler',
+    help='reference compiler', default="")
 (options, args) = parser.parse_args()
 
 global is_windows
@@ -174,6 +252,14 @@ ref_compiler_exists = False
 if is_windows == False:
     compiler = "ispc"
     ref_compiler = "g++"
+    refc_compiler = "gcc"
+    if options.compiler != "":
+        if options.compiler == "clang" or options.compiler == "clang++":
+            ref_compiler = "clang++"
+            refc_compiler = "clang"
+        if options.compiler == "icc" or options.compiler == "icpc":
+            ref_compiler = "icpc"
+            refc_compiler = "icc"
 else:
     compiler = "ispc.exe"
     ref_compiler = "cl.exe"
@@ -222,12 +308,27 @@ perf_temp = pwd + "perf_temp"
 
 i = 0
 answer = []
-sys.stdout.write("Okey go go go!\n\n")
+print_debug("Okey go go go!\n\n")
+os.system(compiler + " --version >" + build_log)
+version = open(build_log)
+print_debug("Using test compiler: " + version.readline())
+version.close()
+
+if is_windows == False:
+    os.system(ref_compiler + " --version >" + build_log)
+else:
+    os.system(ref_compiler + " 2>" + build_log + " 1>&2")
+
+version = open(build_log)
+print_debug("Using reference compiler: " + version.readline())
+version.close()
+
+
 # loop for all tests
 while i < length-2:
     # we read name of test
-    sys.stdout.write("%s" % lines[i])
-    test = [lines[i][:-1],[],[]]
+    print_debug("%s" % lines[i])
+    test = [lines[i][:-1],[],[],[],[],[]]
     # read location of test
     folder = lines[i+1]
     folder = folder[:-1]
@@ -257,10 +358,10 @@ while i < length-2:
         c2 = 1
     next_line = lines[i+3]
     if next_line[0] == "^":  #we should concatenate result of this test with previous one
-        run_test(command, c1, c2, answer[len(answer)-1])
+        run_test(command, c1, c2, answer[len(answer)-1], False)
         i = i+1
     else: #we run this test and append it's result to answer structure
-        run_test(command, c1, c2, test)
+        run_test(command, c1, c2, test, True)
         answer.append(test)
     # preparing next loop iteration
     os.chdir(pwd)

--- a/examples/stencil/stencil.cpp
+++ b/examples/stencil/stencil.cpp
@@ -130,7 +130,7 @@ int main() {
         minTimeSerial = std::min(minTimeSerial, dt);
     }
 
-    printf("[stencil serial]:\t\t[%.3f] millon cycles\n", minTimeSerial);
+    printf("[stencil serial]:\t\t[%.3f] million cycles\n", minTimeSerial);
 
     printf("\t\t\t\t(%.2fx speedup from ISPC, %.2fx speedup from ISPC + tasks)\n", 
            minTimeSerial / minTimeISPC, minTimeSerial / minTimeISPCTasks);

--- a/examples/volume_rendering/volume.cpp
+++ b/examples/volume_rendering/volume.cpp
@@ -204,7 +204,7 @@ int main(int argc, char *argv[]) {
         minSerial = std::min(minSerial, dt);
     }
 
-    printf("[volume serial]:\t\t[%.3f] millon cycles\n", minSerial);
+    printf("[volume serial]:\t\t[%.3f] million cycles\n", minSerial);
     writePPM(image, width, height, "volume-serial.ppm");
 
     printf("\t\t\t\t(%.2fx speedup from ISPC, %.2fx speedup from ISPC + tasks)\n", 

--- a/main.cpp
+++ b/main.cpp
@@ -328,7 +328,6 @@ int main(int Argc, char *Argv[]) {
     // as we're parsing below
     g = new Globals;
 
-    bool debugSet = false, optSet = false;
     Module::OutputType ot = Module::Object;
     bool generatePIC = false;
     const char *arch = NULL, *cpu = NULL, *target = NULL;
@@ -371,7 +370,6 @@ int main(int Argc, char *Argv[]) {
             g->emitInstrumentation = true;
         else if (!strcmp(argv[i], "-g")) {
             g->generateDebuggingSymbols = true;
-            debugSet = true;
         }
         else if (!strcmp(argv[i], "--emit-asm"))
             ot = Module::Asm;
@@ -496,12 +494,10 @@ int main(int Argc, char *Argv[]) {
         }
         else if (!strcmp(argv[i], "-O0")) {
             g->opt.level = 0;
-            optSet = true;
         }
         else if (!strcmp(argv[i], "-O") ||  !strcmp(argv[i], "-O1") ||
                  !strcmp(argv[i], "-O2") || !strcmp(argv[i], "-O3")) {
             g->opt.level = 1;
-            optSet = true;
         }
         else if (!strcmp(argv[i], "-"))
             ;


### PR DESCRIPTION
Changes in Makefile and main.cpp are to delete build warnings and not to allow them in the future.
Changes in examples are to unify them.
Changes in perf.py are to print absolute numbers, add silent and reference compiler options and add excel-friendly output.
