### PR TITLE
Fix to respect uniform/varying qualifiers inside of typedefs.

### DIFF
--- a/sym.cpp
+++ b/sym.cpp
@@ -214,6 +214,17 @@ SymbolTable::LookupType(const char *name) const {
     return NULL;
 }
 
+bool
+SymbolTable::ContainsType(const Type *type) const {
+    TypeMapType::const_iterator iter = types.begin();
+    while (iter != types.end()) {
+        if (iter->second == type) {
+            return true;
+        }
+        iter++;
+    }
+    return false;
+}
 
 std::vector<std::string>
 SymbolTable::ClosestVariableOrFunctionMatch(const char *str) const {

--- a/sym.h
+++ b/sym.h
@@ -219,6 +219,12 @@ public:
         @return Pointer to the Type, if found; otherwise NULL is returned.
     */
     const Type *LookupType(const char *name) const;
+    
+    /** Look for a type given a pointer.
+
+        @return True if found, False otherwise.
+    */
+    bool ContainsType(const Type * type) const;
 
     /** This method returns zero or more strings with the names of symbols
         in the symbol table that nearly (but not exactly) match the given


### PR DESCRIPTION
ISPC is incorrectly handling typedefs:

typedef uniform int\* uniform uintuptr;
uintuptr a = NULL;

In the example above, a has type "uniform int \* varying" instead of "uniform int \* uniform".  This patch checks to see if a custom type in a declaration has type qualifiers, and if so, appropriately modifies the declaration to respect them.

A check is also added to make sure that something now isn't both uniform and varying, as the parser can't detect it.

"varying uintuptr a" will result in an error.
