### PR TITLE
- Add Silvermont (--cpu=slm) option for llvm 3.4+.

### DIFF
--- a/ispc.cpp
+++ b/ispc.cpp
@@ -149,7 +149,7 @@ static const char *supportedCPUs[] = {
 #endif
     "atom", "penryn", "core2", "corei7", "corei7-avx"
 #if !defined(LLVM_3_1)
-    , "core-avx-i", "core-avx2", "slm"
+    , "core-avx-i", "core-avx2"
 #endif // LLVM 3.2+
 #if !defined(LLVM_3_1) && !defined(LLVM_3_2) && !defined(LLVM_3_3)
     , "slm" 


### PR DESCRIPTION
- Change default Sandybridge isa name to avx1-i32x8 from avx-i32x8,
  to conform with replacement of avx-i32x8 by avx1-i32x8 everywhere else.
- Add "target-cpu" attribute, when using AttrBuilder, to correct a problem
  whereby llvm would switch from the command line cpu setting
  to the native (auto-detected) cpu setting on second and subsequent
  functions. e.g. if I wanted to build for Silvermont on a Sandy Bridge
  machine, ispc/llvm would correctly use Silvermont and turn on the
  Silvermont scheduler. For the second and subsequent functions,
  it would auto-detect Sandy Bridge, but still run the Silvermont
  scheduler.
