### PR TITLE
Packed_store_active2

### DIFF
--- a/builtins.cpp
+++ b/builtins.cpp
@@ -488,6 +488,7 @@ lSetInternalFunctions(llvm::Module *module) {
         "__num_cores",
         "__packed_load_active",
         "__packed_store_active",
+        "__packed_store_active2",
         "__popcnt_int32",
         "__popcnt_int64",
         "__prefetch_read_uniform_1",

--- a/stdlib.ispc
+++ b/stdlib.ispc
@@ -1209,6 +1209,13 @@ packed_store_active(uniform unsigned int a[],
     return __packed_store_active(a, vals, (UIntMaskType)__mask);
 }
 
+static inline uniform int
+packed_store_active2(uniform unsigned int a[],
+                    unsigned int vals) {
+    return __packed_store_active2(a, vals, (UIntMaskType)__mask);
+}
+
+
 static inline uniform int 
 packed_load_active(uniform int a[], varying int * uniform vals) {
     return __packed_load_active(a, vals, (IntMaskType)__mask);
@@ -1218,6 +1225,12 @@ static inline uniform int
 packed_store_active(uniform int a[], int vals) {
     return __packed_store_active(a, vals, (IntMaskType)__mask);
 }
+
+static inline uniform int
+packed_store_active2(uniform int a[], int vals) {
+    return __packed_store_active2(a, vals, (IntMaskType)__mask);
+}
+
 
 ///////////////////////////////////////////////////////////////////////////
 // System information

--- a/tests/packed-store2-1.ispc
+++ b/tests/packed-store2-1.ispc
@@ -1,0 +1,16 @@
+
+export uniform int width() { return programCount; }
+
+export void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform int pack[2+programCount];
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    packed_store_active2(&pack[2], a);
+    RET[programIndex] = pack[programIndex]; 
+}
+
+export void result(uniform float RET[]) {
+    RET[programIndex] = programIndex-1;
+    RET[0] = RET[1] = 0;
+}

--- a/tests/packed-store2-2.ispc
+++ b/tests/packed-store2-2.ispc
@@ -1,0 +1,21 @@
+
+export uniform int width() { return programCount; }
+
+export void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform int pack[2+programCount];
+    uniform int number;
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    if ((int)a & 1)
+        number = packed_store_active2(&pack[2], a);
+    pack[2+number] = 0;
+    RET[programIndex] = pack[programIndex]; 
+}
+
+export void result(uniform float RET[]) {
+    RET[programIndex] = 0;
+    uniform int val = 1;
+    for (uniform int i = 2; i < 2+programCount/2; ++i, val += 2)
+        RET[i] = val;
+}

--- a/tests/packed-store2-3.ispc
+++ b/tests/packed-store2-3.ispc
@@ -1,0 +1,17 @@
+
+export uniform int width() { return programCount; }
+
+export void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform int pack[2+programCount];
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    uniform int count = 0;
+    if ((int)a & 1)
+        count += packed_store_active2(&pack[2], a);
+    RET[programIndex] = count;
+}
+
+export void result(uniform float RET[]) {
+    RET[programIndex] = (programCount == 1) ? 1 : programCount/2;
+}

--- a/tests/packed-store2.ispc
+++ b/tests/packed-store2.ispc
@@ -1,0 +1,15 @@
+
+export uniform int width() { return programCount; }
+
+export void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform unsigned int pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    packed_store_active2(pack, (unsigned int)a);
+    RET[programIndex] = pack[programIndex]; 
+}
+
+export void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}


### PR DESCRIPTION
These changes add new builtin "packed_store_active2". Its semantics are the same as in packed_store_array, but it has some performance improvements. We change the main loop where we copy elements only under the condition of    corresponding mask element is on to the "always write" method when we copy all elements but change their positions only if corresponding mask element is on. Also we added zext instruction to remove unused cltq instructions in asm code.

This implementation has some limitations: 1. you should keep array with incremented length. 2. you can operate with arrays with length less than 2^32.
