### PR TITLE
code simplification for mandelbrot_task.ispc

### DIFF
--- a/examples/mandelbrot_tasks/mandelbrot_tasks.ispc
+++ b/examples/mandelbrot_tasks/mandelbrot_tasks.ispc
@@ -31,7 +31,9 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
 */
 
+#if 0
 #define _3D_TASKING
+#endif
 
 static inline int
 mandel(float c_re, float c_im, int count) {
@@ -59,25 +61,14 @@ task void
 mandelbrot_scanline(uniform float x0, uniform float dx, 
                     uniform float y0, uniform float dy,
                     uniform int width, uniform int height, 
-#ifdef _3D_TASKING
                     uniform int xspan, uniform int yspan,
-#else
-                    uniform int span,
-#endif
                     uniform int maxIterations, uniform int output[]) {
-#ifdef _3D_TASKING
     const uniform int xstart = taskIndex0 * xspan;
     const uniform int xend   = min(xstart  + xspan, width);
     const uniform int ystart = taskIndex1 * yspan;
     const uniform int yend   = min(ystart  + yspan, height);
 
     foreach (yi = ystart ... yend, xi = xstart ... xend) {
-#else
-    uniform int ystart = taskIndex * span;
-    uniform int yend = min((taskIndex+1) * span, (unsigned int)height);
-
-    foreach (yi = ystart ... yend, xi = 0 ... width) {
-#endif
         float x = x0 + xi * dx;
         float y = y0 + yi * dy;
 
@@ -97,14 +88,12 @@ mandelbrot_ispc(uniform float x0, uniform float y0,
 #ifdef _3D_TASKING
     const uniform int xspan = max(32, programCount*2);  /* make sure it is big enough to avoid false-sharing */
     const uniform int yspan = 16; 
+#else
+    const uniform int xspan = width;
+    const uniform int yspan = 4;
+#endif
 
     launch [width/xspan, height/yspan]
     mandelbrot_scanline(x0, dx, y0, dy, width, height, xspan, yspan,
                           maxIterations, output);
-#else
-    uniform int span = 4;
-
-    launch[height/span] mandelbrot_scanline(x0, dx, y0, dy, width, height, span,
-                                            maxIterations, output);
-#endif
 }


### PR DESCRIPTION
I simplified the kernel, which basically uses 1D tasking as a subset of 2D tasking (with ntaskx = 1). On my Haswell MacbookAir, I see about 1-2% difference between 2D and 1D in both modified and unmodified kernels.  If there is performance hit between modified and unmodified 1D version, I can't see it.

Ilia, would we like to keep this change instead, at least if, after checking on your side, this simplification is as fast as before..

Cheers,
 Evghenii
