### PR TITLE
Supporting LLVM trunk

### DIFF
--- a/builtins.cpp
+++ b/builtins.cpp
@@ -643,13 +643,21 @@ lSetInternalFunctions(llvm::Module *module) {
 void
 AddBitcodeToModule(const unsigned char *bitcode, int length,
                    llvm::Module *module, SymbolTable *symbolTable) {
-    std::string bcErr;
     llvm::StringRef sb = llvm::StringRef((char *)bitcode, length);
     llvm::MemoryBuffer *bcBuf = llvm::MemoryBuffer::getMemBuffer(sb);
+#if defined(LLVM_3_5)
+    llvm::ErrorOr<llvm::Module *> ModuleOrErr = llvm::parseBitcodeFile(bcBuf, *g->ctx);
+    if (llvm::error_code EC = ModuleOrErr.getError())
+        Error(SourcePos(), "Error parsing stdlib bitcode: %s", EC.message().c_str());
+    else {
+        llvm::Module *bcModule = ModuleOrErr.get();
+#else
+    std::string bcErr;
     llvm::Module *bcModule = llvm::ParseBitcodeFile(bcBuf, *g->ctx, &bcErr);
     if (!bcModule)
         Error(SourcePos(), "Error parsing stdlib bitcode: %s", bcErr.c_str());
     else {
+#endif
         // FIXME: this feels like a bad idea, but the issue is that when we
         // set the llvm::Module's target triple in the ispc Module::Module
         // constructor, we start by calling llvm::sys::getHostTriple() (and

--- a/func.cpp
+++ b/func.cpp
@@ -477,7 +477,11 @@ Function::GenerateIR() {
     }
 
     if (m->errorCount == 0) {
+#if defined (LLVM_3_5)
+        if (llvm::verifyFunction(*function) == true) {
+#else
         if (llvm::verifyFunction(*function, llvm::ReturnStatusAction) == true) {
+#endif
             if (g->debugPrint)
                 function->dump();
             FATAL("Function verificication failed");
@@ -523,8 +527,12 @@ Function::GenerateIR() {
                     emitCode(&ec, appFunction, firstStmtPos);
                     if (m->errorCount == 0) {
                         sym->exportedFunction = appFunction;
+#if defined(LLVM_3_5)
+                        if (llvm::verifyFunction(*appFunction) == true) {
+#else
                         if (llvm::verifyFunction(*appFunction,
                                                  llvm::ReturnStatusAction) == true) {
+#endif
                             if (g->debugPrint)
                                 appFunction->dump();
                             FATAL("Function verificication failed");


### PR DESCRIPTION
These changes allow ISPC to be built with LLVM trunk after r199218, r199569 and r199279 revisions.
