### PR TITLE
Revert "support of LLVM trunk after 201618 revision 'VirtualFileSystem'"

### DIFF
--- a/module.cpp
+++ b/module.cpp
@@ -1979,9 +1979,6 @@ void
 Module::execPreprocessor(const char *infilename, llvm::raw_string_ostream *ostream) const
 {
     clang::CompilerInstance inst;
-#if defined(LLVM_3_5)
-    inst.createVirtualFileSystem();
-#endif
     inst.createFileManager();
 
     llvm::raw_fd_ostream stderrRaw(2, false);


### PR DESCRIPTION
This reverts commit 7fcf4081895159a7e4b1378a23345aa421978b11.
