### PR TITLE
Fix bugs with exported varyings.

### DIFF
--- a/type.cpp
+++ b/type.cpp
@@ -456,15 +456,9 @@ AtomicType::GetCDeclaration(const std::string &name) const {
         ret += name;
     }
 
-    if (variability == Variability::Varying ||
-        variability == Variability::SOA) {
+    if (variability == Variability::SOA) {
         char buf[32];
-        // get program count
-        // g->mangleFunctionsNamesWithTarget - hack check for void *
-        int vWidth = (variability == Variability::Varying) ? 
-                        g->target->getVectorWidth() :
-                        variability.soaWidth;
-        sprintf(buf, "[%d]", vWidth);
+        sprintf(buf, "[%d]", variability.soaWidth);
         ret += buf;
     }
 
@@ -1096,19 +1090,26 @@ PointerType::GetCDeclaration(const std::string &name) const {
     }
 
     std::string ret = baseType->GetCDeclaration("");
+    
+    bool baseIsBasicVarying = (IsBasicType(baseType)) && (baseType->IsVaryingType());
+    
+    if (baseIsBasicVarying) ret += std::string("(");
     ret += std::string(" *");
     if (isConst) ret += " const";
     ret += std::string(" ");
     ret += name;
+    if (baseIsBasicVarying) ret += std::string(")");
 
-    if (variability == Variability::SOA ||
-        variability == Variability::Varying) {
-        int vWidth = (variability == Variability::Varying) ?
-            g->target->getVectorWidth() :
-            variability.soaWidth;
+    if (variability == Variability::SOA) {
         char buf[32];
-        sprintf(buf, "[%d]", vWidth);
+        sprintf(buf, "[%d]", variability.soaWidth);
         ret += buf;
+    }
+    if (baseIsBasicVarying) {
+      int vWidth = g->target->getVectorWidth();
+      char buf[32];
+      sprintf(buf, "[%d]", vWidth);
+      ret += buf;
     }
 
     return ret;
@@ -1890,6 +1891,10 @@ StructType::StructType(const std::string &n, const llvm::SmallVector<const Type 
     }
 }
 
+const std::string 
+StructType::GetCStructName() const {
+  return lMangleStructName(name, variability);
+}
 
 Variability
 StructType::GetVariability() const  {
@@ -2078,7 +2083,7 @@ std::string
 StructType::GetCDeclaration(const std::string &n) const {
     std::string ret;
     if (isConst) ret += "const ";
-    ret += std::string("struct ") + name;
+    ret += std::string("struct ") + GetCStructName();
     if (lShouldPrintName(n)) {
         ret += std::string(" ") + n;
 

--- a/type.h
+++ b/type.h
@@ -714,7 +714,8 @@ public:
     const SourcePos &GetElementPosition(int i) const { return elementPositions[i]; }
 
     /** Returns the name of the structure type.  (e.g. struct Foo -> "Foo".) */
-    const std::string &GetStructName() const { return name; }
+    const std::string &GetStructName() const  { return name; }
+    const std::string GetCStructName() const;
 
 private:
     static bool checkIfCanBeSOA(const StructType *st);


### PR DESCRIPTION
Change up exported varyings implementation (Simpler and shorter!)

Structs in header files now emitted using mangled names that embed vectorlength and variability in struct C++ struct name.
Fix C++ declaration of pointers to arrays.
