### PR TITLE
Changing overload rules to match C++ behavior

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -2935,7 +2935,9 @@ of a function, ``ispc`` uses the following model to choose the best function:
 each conversion of two types has its cost. ``ispc`` tries to find conversion
 with the smallest cost. When ``ispc`` can't find any conversion it means that
 this function is not suitable. Then ``ispc`` sums costs for all arguments and
-chooses the function with the smallest final cost.
+chooses the function with the smallest final cost. If the chosen function 
+has some arguments which costs are bigger than their costs in other function
+this treats as ambiguous.
 Costs of type conversions placed from small to big:
 
 1. Parameter types match exactly.

--- a/expr.h
+++ b/expr.h
@@ -635,7 +635,8 @@ private:
     static int computeOverloadCost(const FunctionType *ftype,
                                    const std::vector<const Type *> &argTypes,
                                    const std::vector<bool> *argCouldBeNULL,
-                            const std::vector<bool> *argIsConstant);
+                                   const std::vector<bool> *argIsConstant,
+                                   int * cost);
 
     /** Name of the function that is being called. */
     std::string name;

--- a/tests/array-mixed-unif-vary-indexing-2.ispc
+++ b/tests/array-mixed-unif-vary-indexing-2.ispc
@@ -16,7 +16,7 @@ export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
     else
         x[a][b-1] = 1;
 
-    a = min(a, 46);
+    a = min(a, 46.f);
 
     RET[programIndex] = x[3][a];
 }

--- a/tests/array-mixed-unif-vary-indexing.ispc
+++ b/tests/array-mixed-unif-vary-indexing.ispc
@@ -10,7 +10,7 @@ export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
         for (uniform int j = 0; j < 47; ++j)
             x[i][j] = 2+b-5;
 
-    a = min(a,46);
+    a = min(a,46.f);
     x[a][b-1] = 0;
     RET[programIndex] = x[2][a];
 }

--- a/tests/array-multidim-gather-scatter.ispc
+++ b/tests/array-multidim-gather-scatter.ispc
@@ -11,7 +11,7 @@ export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
 
     uniform int index[4] = { 0, 1, 2, 4 };
     float v = index[programIndex & 0x3];
-    x[min(a,39)][v] = 0;
+    x[min(a,39.f)][v] = 0;
     RET[programIndex] = x[v+1][v];
 }
 

--- a/tests/func-overload-max.ispc
+++ b/tests/func-overload-max.ispc
@@ -4,7 +4,7 @@ export uniform int width() { return programCount; }
 
 export void f_f(uniform float RET[], uniform float aFOO[]) {
     float a = 1. / aFOO[programIndex]; 
-    RET[programIndex] = max(0, a); 
+    RET[programIndex] = max(0.f, a); 
 }
 
 export void result(uniform float RET[]) {

--- a/tests/funcptr-uniform-10.ispc
+++ b/tests/funcptr-uniform-10.ispc
@@ -16,7 +16,7 @@ export void f_f(uniform float RET[], uniform float aFOO[]) {
     uniform FuncType func[] = { bar, foo };
     float a = aFOO[programIndex]; 
     float b = aFOO[0]-1; // == 0
-    func[min(a, 0)] = foo;
+    func[min(a, 0.f)] = foo;
     RET[programIndex] = func[0](a, b);
 }
 

--- a/tests/goto-4.ispc
+++ b/tests/goto-4.ispc
@@ -9,7 +9,7 @@ export void f_f(uniform float RET[], uniform float aFOO[]) {
  encore:
     ++RET[programIndex];
     if (any(a != 0)) {
-        a = max(a-1, 0);
+        a = max(a-1, 0.f);
         goto encore;
     }
 }

--- a/tests/max-float-1.ispc
+++ b/tests/max-float-1.ispc
@@ -6,7 +6,7 @@ export uniform int width() { return programCount; }
 export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
     float a = aFOO[programIndex];
     RET[programIndex] = max(3 * a, 10.f);
-    RET[width()-1] = max(b, 100);
+    RET[width()-1] = max(b, 100.f);
 }
 
 

--- a/tests/max-float-2.ispc
+++ b/tests/max-float-2.ispc
@@ -6,7 +6,7 @@ export uniform int width() { return programCount; }
 export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
     float a = aFOO[programIndex];
     RET[programIndex] = max(-10 * (a-3), .1f);
-    RET[width() - 1] = max(-10 * b, 2);
+    RET[width() - 1] = max(-10 * b, 2.f);
 }
 
 export void result(uniform float RET[]) {

--- a/tests/min-float-1.ispc
+++ b/tests/min-float-1.ispc
@@ -6,7 +6,7 @@ export uniform int width() { return programCount; }
 export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
     float a = aFOO[programIndex];
     RET[programIndex] = min(3 * a, 10.f);
-    RET[width()-1] = min(b, 100);
+    RET[width()-1] = min(b, 100.f);
 }
 
 

--- a/tests/min-float-2.ispc
+++ b/tests/min-float-2.ispc
@@ -6,7 +6,7 @@ export uniform int width() { return programCount; }
 export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
     float a = aFOO[programIndex];
     RET[programIndex] = min(-10 * (a-3), .1f);
-    RET[width() - 1] = min(-10 * b, 2);
+    RET[width() - 1] = min(-10 * b, 2.f);
 }
 
 export void result(uniform float RET[]) {

--- a/tests/typedef-2.ispc
+++ b/tests/typedef-2.ispc
@@ -19,7 +19,7 @@ export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
     for (uniform int i = 0; i < 16; ++i)
         for (uniform int j = 0; j < 16; ++j)
             bar.foo[i].x[j] = b;
-    RET[programIndex] = bar.foo[min(15, a-1)].x[min(15, a-1)];
+    RET[programIndex] = bar.foo[min(15.f, a-1)].x[min(15.f, a-1)];
 }
 
 export void result(uniform float RET[]) { RET[programIndex] = 5; }


### PR DESCRIPTION
Emit a warning when the best overload match has some number of no-best matching parameters.
