### PR TITLE
Fix of debug_info

### DIFF
--- a/type.cpp
+++ b/type.cpp
@@ -826,7 +826,7 @@ EnumType::GetDIType(llvm::DIDescriptor scope) const {
 
     llvm::DIFile diFile = pos.GetDIFile();
     llvm::DIType diType =
-        m->diBuilder->createEnumerationType(scope, name, diFile, pos.first_line,
+        m->diBuilder->createEnumerationType(diFile, name, diFile, pos.first_line,
                                             32 /* size in bits */,
                                             32 /* align in bits */,
                                             elementArray
@@ -2179,7 +2179,7 @@ StructType::GetDIType(llvm::DIDescriptor scope) const {
     llvm::DIArray elements = m->diBuilder->getOrCreateArray(elementLLVMTypes);
     llvm::DIFile diFile = pos.GetDIFile();
     return m->diBuilder->createStructType(
-        scope,
+        diFile,
         name,
         diFile,
         pos.first_line, // Line number
@@ -2422,7 +2422,7 @@ UndefinedStructType::GetDIType(llvm::DIDescriptor scope) const {
     llvm::DIFile diFile = pos.GetDIFile();
     llvm::DIArray elements;
     return m->diBuilder->createStructType(
-        scope,
+        diFile,
         name,
         diFile,
         pos.first_line, // Line number


### PR DESCRIPTION
These changes fix problem with debug info in LLVM 3.4 with structs and enums.

The reason of problem is that ISPC generates debugInfo type of struct (or enum)
in the scope, where the variable of this type appears.

Ctx.cpp:1586
llvm::DIScope scope = GetDIScope();
llvm::DIType diType = sym->type->GetDIType(scope);

It is always Lexical_Block in some function. It is not right because type can
be declared global or in some function or in some namespace. Struct and enums
are failing because they don't reduce to atomic types. The "Big" fix is to save
declaration place in Type class. But now ISPC doesn't know about it,
for example this doesn't emit an error:

void function_1() { struct Foo {float x;}; uniform Foo myFoo;}
void function_2() {                        uniform Foo myFoo;}

So now all type declarations are global and we can simply change scope
parameter to the current file.

The "Big" fix will be after integration with clang.
