### PR TITLE
Fixing MIC performance issue, which showed up when we switched to

### DIFF
--- a/cbackend.cpp
+++ b/cbackend.cpp
@@ -3286,10 +3286,16 @@ void CWriter::visitBinaryOperator(llvm::Instruction &I) {
       if ((I.getOpcode() == llvm::Instruction::Shl ||
            I.getOpcode() == llvm::Instruction::LShr ||
            I.getOpcode() == llvm::Instruction::AShr)) {
-          if (LLVMVectorValuesAllEqual(I.getOperand(1))) {
-              Out << "__extract_element(";
-              writeOperand(I.getOperand(1));
-              Out << ", 0) ";
+          llvm::Value *splat = NULL;
+          if (LLVMVectorValuesAllEqual(I.getOperand(1), &splat)) {
+              if (splat) {
+                  // Avoid __extract_element(splat(value), 0), if possible.
+                  writeOperand(splat);
+              } else {
+                  Out << "__extract_element(";
+                  writeOperand(I.getOperand(1));
+                  Out << ", 0) ";
+              }
           }
           else
               writeOperand(I.getOperand(1));

--- a/llvmutil.h
+++ b/llvmutil.h
@@ -228,7 +228,8 @@ extern llvm::Constant *LLVMMaskAllOff;
 /** Tests to see if all of the elements of the vector in the 'v' parameter
     are equal.  Like lValuesAreEqual(), this is a conservative test and may
     return false for arrays where the values are actually all equal.  */
-extern bool LLVMVectorValuesAllEqual(llvm::Value *v);
+extern bool LLVMVectorValuesAllEqual(llvm::Value *v,
+                                     llvm::Value **splat = NULL);
 
 /** Given vector of integer-typed values, this function returns true if it
     can determine that the elements of the vector have a step of 'stride'


### PR DESCRIPTION
LLVM 3.4 (due to more aggressive optimizations): vector of _the same_
constants should be generated as scalar value in cpp file, instead of
__extract_element(splat(value), 0).
I.e. <2,2,2,2> should appear in cpp as 2, but not
__extract_element(splat(2), 0);
