### PR TITLE
Add error messages for structs containing nested undefined structs

### DIFF
--- a/type.cpp
+++ b/type.cpp
@@ -1956,6 +1956,25 @@ StructType::IsConstType() const {
 }
 
 
+bool
+StructType::IsDefined() const {
+  for (int i = 0; i < GetElementCount(); i++) {
+    const Type *t = GetElementType(i);
+    const UndefinedStructType *ust = CastType<UndefinedStructType>(t);
+    if (ust != NULL) {
+      return false;
+    }
+    const StructType *st = CastType<StructType>(t);
+    if (st != NULL) {
+      if (!st->IsDefined()) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+
 const Type *
 StructType::GetBaseType() const {
     return this;

--- a/type.h
+++ b/type.h
@@ -81,15 +81,15 @@ struct Variability {
 /** Enumerant that records each of the types that inherit from the Type
     baseclass. */
 enum TypeId {
-    ATOMIC_TYPE,
-    ENUM_TYPE,
-    POINTER_TYPE,
-    ARRAY_TYPE,
-    VECTOR_TYPE,
-    STRUCT_TYPE,
-    UNDEFINED_STRUCT_TYPE,
-    REFERENCE_TYPE,
-    FUNCTION_TYPE
+  ATOMIC_TYPE,           // 0
+  ENUM_TYPE,             // 1
+  POINTER_TYPE,          // 2
+  ARRAY_TYPE,            // 3
+  VECTOR_TYPE,           // 4
+  STRUCT_TYPE,           // 5
+  UNDEFINED_STRUCT_TYPE, // 6
+  REFERENCE_TYPE,        // 7
+  FUNCTION_TYPE          // 8
 };
 
 
@@ -675,6 +675,7 @@ public:
     bool IsIntType() const;
     bool IsUnsignedType() const;
     bool IsConstType() const;
+    bool IsDefined() const;
 
     const Type *GetBaseType() const;
     const StructType *GetAsVaryingType() const;


### PR DESCRIPTION
ISPC wasn't properly issuing errors for accessing a member in a struct that is unsized due to containing an unsized member.  A similar lack of errors existed for allocating such structs.  New, handy error messages have been added, replacing the previous behavior of LLVM asserts triggering.
