### PR TITLE
fix LLVM_VERSION for minor versions != 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ endif
 ARCH_TYPE = $(shell arch)
 
 LLVM_CXXFLAGS=$(shell $(LLVM_CONFIG) --cppflags)
-LLVM_VERSION=LLVM_$(shell $(LLVM_CONFIG) --version | sed -e s/\\./_/ -e s/svn// -e s/\.0//)
+LLVM_VERSION=LLVM_$(shell $(LLVM_CONFIG) --version | sed -e 's/svn//' -e 's/\./_/' -e 's/\..*//')
 LLVM_VERSION_DEF=-D$(LLVM_VERSION)
 
 LLVM_COMPONENTS = engine ipo bitreader bitwriter instrumentation linker


### PR DESCRIPTION
llvm version 3.4.2 got converted to 3_4.2 and not 3_4 as intended.

see https://bugs.gentoo.org/show_bug.cgi?id=515114
