### PR TITLE
fix for cpuFromIsa

### DIFF
--- a/ispc.cpp
+++ b/ispc.cpp
@@ -274,7 +274,7 @@ Target::Target(const char *arch, const char *cpu, const char *isa, bool pic) :
         this->m_arch = arch;
     }
 
-    const char * cpuFromIsa;
+    const char * cpuFromIsa = "";
 
     // Check default LLVM generated targets
     if (!strcasecmp(isa, "sse2") ||


### PR DESCRIPTION
Otherwise we get errors:

```
$ ./run_tests.py --target=generic-4
Testing ispc: /nfs/home5/evghenii/soft/ispc/ispc
Warning: No generics #include specified; using examples/intrinsics/sse4.h


Using test compiler: Intel(r) SPMD Program Compiler (ispc), 1.7.1dev (build commit 3459c75fbcd47c16 @ 20140708, LLVM 3.4)
Using C/C++ compiler: clang version 3.4 (tags/RELEASE_34/final 199016) (llvm/tags/RELEASE_34/final 199015)

Running 16 jobs in parallel. Running 1314 tests.

Traceback (most recent call last):
      File "./run_tests.py", line 816, in <module>
    L = run_tests(options, args, 1)
  File "./run_tests.py", line 714, in run_tests
    raise OSError(2, 'Some test subprocess has thrown an exception', '')
OSError: [Errno 2] Some test subprocess has thrown an exception: ''
```

and 

```
$ ./ispc --target=generic-4 tests/test-1.ispc --emit-c++    -o out.cpp
'??I' is not a recognized processor for this target (ignoring processor)
'??I' is not a recognized processor for this target (ignoring processor)
'??I' is not a recognized processor for this target (ignoring processor)
'??I' is not a recognized processor for this target (ignoring processor)
'??I' is not a recognized processor for this target (ignoring processor)
'??I' is not a recognized processor for this target (ignoring processor)
```
