### PR TITLE
This will make 'alloy_build' shorter

### DIFF
--- a/alloy.py
+++ b/alloy.py
@@ -90,7 +90,6 @@ def try_do_LLVM(text, command, from_validation):
             msg = MIMEMultipart()
             attach_mail_file(msg, alloy_build, "alloy_build.log", 400)
             attach_mail_file(msg, stability_log, "stability.log")
-            attach_mail_file(msg, stability.in_file, "run_tests_log.log")
             send_mail("Error while executing " + command + ". Examine logs  for more information.", msg)
         error("can't " + text, 1)
     print_debug("DONE.\n", from_validation, alloy_build)


### PR DESCRIPTION
This merge will add 'tail' feature to the attach_mail_file function and cut down 'alloy_build.log' to 100 lines in case there were no errors and 400 lines otherwise. It will also most likely fix the bug when no 'run_tests.log' was being sent in case of build failure. Yet no 'stability.log' will be sent in case of build failure.
