### PR TITLE
Add an alloy.py option to build ispc binary with g++

### DIFF
--- a/alloy.py
+++ b/alloy.py
@@ -677,7 +677,7 @@ def Main():
     # gcc and g++ options are equal and added for ease of use 
     if options.ispc_build_compiler != "clang" and \
        options.ispc_build_compiler != "gcc":   
-        error("unknow option for --ispc-compiler: " + options.ispc_build_compiler, 1)
+        error("unknow option for --ispc-build-compiler: " + options.ispc_build_compiler, 1)
         parser.print_help()
         exit(0)
 


### PR DESCRIPTION
This will add an option '--ispc-compiler' to the 'alloy.py' which allows building ispc binary with g++ instead of clang. Possible options are: 'clang', 'g++', 'gcc', with 'g++' and 'gcc' being equal. Clang is still a default option. Also, 'check_isa.cpp' is now being compiled with g++, as clang may not be the option on every machine.
