### PR TITLE
passing icpc compiler for knc target

### DIFF
--- a/alloy.py
+++ b/alloy.py
@@ -438,9 +438,7 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
         LLVM = []
         targets = []
         sde_targets = []
-# sometimes clang++ is not avaluable. if --ispc-build-compiler = gcc we will pass in g++ compiler
-        if options.ispc_build_compiler == "gcc":
-            stability.compiler_exe = "g++"
+
 # parsing option only, update parameters of run
         if "-O2" in only:
             opts.append(False)
@@ -521,6 +519,14 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
             for j in range(0,len(targets)):
                 stability.target = targets[j]
                 stability.wrapexe = ""
+                # choosing right compiler for a given target
+                # sometimes clang++ is not avaluable. if --ispc-build-compiler = gcc we will pass in g++ compiler
+                if options.ispc_build_compiler == "gcc":
+                    stability.compiler_exe = "g++"
+                # but 'knc' target is supported only by icpc, so set explicitly
+                if "knc" in targets[j]:
+                    stability.compiler_exe = "icpc"
+                # now set archs for targets
                 if "generic" in targets[j]:
                     arch = gen_archs
                 elif "knc" in targets[j]:

--- a/run_tests.py
+++ b/run_tests.py
@@ -589,7 +589,7 @@ def run_tests(options1, args, print_version):
             options.compiler_exe = "cl.exe"
         else:
             options.compiler_exe = "clang++"
- 
+
     # checks the required compiler otherwise prints an error message
     PATH_dir = string.split(os.getenv("PATH"), os.pathsep) 
     compiler_exists = False


### PR DESCRIPTION
When passed in g++ compiler it overrode icpc compiler set for knc target. Now the compiler is chosen based on tested target.
