### PR TITLE
Fix for llvm revision 216239

### DIFF
--- a/ctx.cpp
+++ b/ctx.cpp
@@ -1555,7 +1555,7 @@ FunctionEmitContext::StartScope() {
         // Revision 216239 in LLVM removes support of DWARF discriminator
         // as the last argument
                                              currentPos.first_column);
-#endif
+#endif // LLVM 3.2, 3.3, 3.4 and 3.6+
         AssertPos(currentPos, lexicalBlock.Verify());
         debugScopes.push_back(lexicalBlock);
     }


### PR DESCRIPTION
After revision 216239(https://github.com/llvm-mirror/llvm/commit/c7260209a8cf404c461483da8dee33fad84bbf18) function createLexicalBlock takes only 4 arguments.
