### PR TITLE
Fix for llvm revision 216393

### DIFF
--- a/cbackend.cpp
+++ b/cbackend.cpp
@@ -4945,9 +4945,19 @@ WriteCXXFile(llvm::Module *module, const char *fn, int vectorWidth,
     llvm::sys::fs::OpenFlags flags = llvm::sys::fs::F_None;
 #endif
 
+#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4) || defined(LLVM_3_5)
     std::string error;
+#else // LLVM 3.6+
+    std::error_code error;
+#endif
+
     llvm::tool_output_file *of = new llvm::tool_output_file(fn, error, flags);
+
+#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4) || defined(LLVM_3_5)
     if (error.size()) {
+#else // LLVM 3.6+
+    if (error) {
+#endif
         fprintf(stderr, "Error opening output file \"%s\".\n", fn);
         return false;
     }

--- a/module.cpp
+++ b/module.cpp
@@ -1088,9 +1088,20 @@ Module::writeObjectFileOrAssembly(llvm::TargetMachine *targetMachine,
 
 #endif
 
+#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4) || defined(LLVM_3_5)
     std::string error;
+#else // LLVM 3.6+
+    std::error_code error;
+#endif
+
     llvm::tool_output_file *of = new llvm::tool_output_file(outFileName, error, flags);
+
+#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4) || defined(LLVM_3_5)
     if (error.size()) {
+#else // LLVM 3.6+
+    if (error) {
+#endif
+
         fprintf(stderr, "Error opening output file \"%s\".\n", outFileName);
         return false;
     }


### PR DESCRIPTION
After revision 216393 (https://github.com/llvm-mirror/llvm/commit/8c968628473c7de416e3f468fead20023f33107e) function tool_output_file takes error as std::error_code
