### PR TITLE
Changed LLVM 3.5 svn download path to 'final'

### DIFF
--- a/alloy.py
+++ b/alloy.py
@@ -110,8 +110,7 @@ def build_LLVM(version_LLVM, revision, folder, tarball, debug, selfbuild, extra,
     if  version_LLVM == "trunk":
         SVN_PATH="trunk"
     if  version_LLVM == "3.5":
-        # SVN_PATH=tags/RELEASE_35/rc1
-        SVN_PATH="branches/release_35"
+        SVN_PATH="tags/RELEASE_350/final"
         version_LLVM = "3_5"
     if  version_LLVM == "3.4":
         SVN_PATH="tags/RELEASE_34/dot2-final"


### PR DESCRIPTION
The LLVM 3.5 is released, so the download path is changed to http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_350/final (instead of 3.5 trunk)
