### PR TITLE
Changed the default knc header file from 'knc-i1x16.h' to 'knc.h'

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -601,8 +601,8 @@ def run_tests(options1, args, print_version):
             options.include_file = "examples/intrinsics/generic-64.h"
             options.target = "generic-64"
         elif options.target == "knc":
-            error("No knc #include specified; using examples/intrinsics/knc-i1x16.h\n", 2)
-            options.include_file = "examples/intrinsics/knc-i1x16.h"
+            error("No knc #include specified; using examples/intrinsics/knc.h\n", 2)
+            options.include_file = "examples/intrinsics/knc.h"
  
     if options.compiler_exe == None:
         if (options.target == "knc"): 


### PR DESCRIPTION
Owing to the fact that the 'knc-i1x16.h' header does most of its job via loops and the 'knc.h' is currently under development, it might be more interesting to run the latter during the nightly tests.
