### PR TITLE
Build fail fix for ISPC with LLVM 3.6 (current trunk)

### DIFF
--- a/builtins.cpp
+++ b/builtins.cpp
@@ -835,12 +835,23 @@ lDefineConstantInt(const char *name, int val, llvm::Module *module,
         // have the DW_AT_artifical attribute.  It's not clear if this
         // matters for anything though.
         llvm::DIGlobalVariable var =
+#if !defined(LLVM_3_2) && !defined(LLVM_3_3) && !defined(LLVM_3_4) && !defined(LLVM_3_5)// LLVM 3.6+
+            m->diBuilder->createGlobalVariable(file,
+                                               name,
+                                               name,
+                                               file,
+                                               0 /* line */,
+                                               diType,
+                                               true /* static */,
+                                               sym->storagePtr);
+#else
             m->diBuilder->createGlobalVariable(name,
                                                file,
                                                0 /* line */,
                                                diType,
                                                true /* static */,
                                                sym->storagePtr);
+#endif
         Assert(var.Verify());
     }
 }
@@ -895,12 +906,23 @@ lDefineProgramIndex(llvm::Module *module, SymbolTable *symbolTable) {
         llvm::DIType diType = sym->type->GetDIType(file);
         Assert(diType.Verify());
         llvm::DIGlobalVariable var =
+#if !defined(LLVM_3_2) && !defined(LLVM_3_3) && !defined(LLVM_3_4) && !defined(LLVM_3_5)// LLVM 3.6+
+            m->diBuilder->createGlobalVariable(file,
+                                               sym->name.c_str(),
+                                               sym->name.c_str(),
+                                               file,
+                                               0 /* line */,
+                                               diType,
+                                               false /* static */,
+                                               sym->storagePtr);
+#else
             m->diBuilder->createGlobalVariable(sym->name.c_str(),
                                                file,
                                                0 /* line */,
                                                diType,
                                                false /* static */,
                                                sym->storagePtr);
+#endif    
         Assert(var.Verify());
     }
 }

--- a/ctx.cpp
+++ b/ctx.cpp
@@ -1606,8 +1606,14 @@ FunctionEmitContext::EmitVariableDebugInfo(Symbol *sym) {
                                           diType,
                                           true /* preserve through opts */);
     AssertPos(currentPos, var.Verify());
+#if !defined(LLVM_3_2) && !defined(LLVM_3_3) && !defined(LLVM_3_4) && !defined(LLVM_3_5)// LLVM 3.6+
+    llvm::DIExpression E = m->diBuilder->createExpression();
+    llvm::Instruction *declareInst =
+        m->diBuilder->insertDeclare(sym->storagePtr, var, E, bblock);
+#else
     llvm::Instruction *declareInst =
         m->diBuilder->insertDeclare(sym->storagePtr, var, bblock);
+#endif
     AddDebugPos(declareInst, &sym->pos, &scope);
 }
 
@@ -1633,8 +1639,14 @@ FunctionEmitContext::EmitFunctionParameterDebugInfo(Symbol *sym, int argNum) {
                                           flags,
                                           argNum+1);
     AssertPos(currentPos, var.Verify());
+#if !defined(LLVM_3_2) && !defined(LLVM_3_3) && !defined(LLVM_3_4) && !defined(LLVM_3_5)// LLVM 3.6+
+    llvm::DIExpression E =  m->diBuilder->createExpression();
+    llvm::Instruction *declareInst =
+        m->diBuilder->insertDeclare(sym->storagePtr, var, E, bblock);
+#else
     llvm::Instruction *declareInst =
         m->diBuilder->insertDeclare(sym->storagePtr, var, bblock);
+#endif
     AddDebugPos(declareInst, &sym->pos, &scope);
 }
 

--- a/module.cpp
+++ b/module.cpp
@@ -558,12 +558,23 @@ Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *initE
     if (diBuilder) {
         llvm::DIFile file = pos.GetDIFile();
         llvm::DIGlobalVariable var =
+#if !defined(LLVM_3_2) && !defined(LLVM_3_3) && !defined(LLVM_3_4) && !defined(LLVM_3_5)// LLVM 3.6+
+            diBuilder->createGlobalVariable(file,
+                                            name,
+                                            name,
+                                            file,
+                                            pos.first_line,
+                                            sym->type->GetDIType(file),
+                                            (sym->storageClass == SC_STATIC),
+                                            sym->storagePtr);
+#else
             diBuilder->createGlobalVariable(name,
                                             file,
                                             pos.first_line,
                                             sym->type->GetDIType(file),
                                             (sym->storageClass == SC_STATIC),
                                             sym->storagePtr);
+#endif
         Assert(var.Verify());
     }
 }


### PR DESCRIPTION
Build fails because of the new interface for 'DIBuilder::insertDeclare' and 'DIBuilder::createGlobalVariable' in LLVM 3.6 (ids: 076fd5dfc1f0600183bbc7db974dc7b39086136d and bc88cfc3512326d6c8f8dbf3c15d880c0e21feb0 correspondingly)
