### PR TITLE
Change python to python2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,45 +308,45 @@ objs/lex.o: objs/lex.cpp $(HEADERS) objs/parse.cc
 
 objs/builtins-dispatch.cpp: builtins/dispatch.ll builtins/util.m4 builtins/util-nvptx.m4 builtins/svml.m4 $(wildcard builtins/*common.ll)
 	@echo Creating C++ source from builtins definition file $<
-	@m4 -Ibuiltins/ -DLLVM_VERSION=$(LLVM_VERSION) -DBUILD_OS=UNIX $< | python bitcode2cpp.py $< > $@
+	@m4 -Ibuiltins/ -DLLVM_VERSION=$(LLVM_VERSION) -DBUILD_OS=UNIX $< | python2 bitcode2cpp.py $< > $@
 
 objs/builtins-%-32bit.cpp: builtins/%.ll builtins/util.m4 builtins/util-nvptx.m4 builtins/svml.m4 $(wildcard builtins/*common.ll)
 	@echo Creating C++ source from builtins definition file $< \(32 bit version\)
-	@m4 -Ibuiltins/ -DLLVM_VERSION=$(LLVM_VERSION) -DBUILD_OS=UNIX -DRUNTIME=32 $< | python bitcode2cpp.py $< 32bit > $@
+	@m4 -Ibuiltins/ -DLLVM_VERSION=$(LLVM_VERSION) -DBUILD_OS=UNIX -DRUNTIME=32 $< | python2 bitcode2cpp.py $< 32bit > $@
 
 objs/builtins-%-64bit.cpp: builtins/%.ll builtins/util.m4 builtins/util-nvptx.m4 builtins/svml.m4 $(wildcard builtins/*common.ll)
 	@echo Creating C++ source from builtins definition file $< \(64 bit version\)
-	@m4 -Ibuiltins/ -DLLVM_VERSION=$(LLVM_VERSION) -DBUILD_OS=UNIX -DRUNTIME=64 $< | python bitcode2cpp.py $< 64bit > $@
+	@m4 -Ibuiltins/ -DLLVM_VERSION=$(LLVM_VERSION) -DBUILD_OS=UNIX -DRUNTIME=64 $< | python2 bitcode2cpp.py $< 64bit > $@
 
 objs/builtins-c-32.cpp: builtins/builtins.c
 	@echo Creating C++ source from builtins definition file $<
-	@$(CLANG) -m32 -emit-llvm -c $< -o - | llvm-dis - | python bitcode2cpp.py c 32 > $@
+	@$(CLANG) -m32 -emit-llvm -c $< -o - | llvm-dis - | python2 bitcode2cpp.py c 32 > $@
 
 objs/builtins-c-64.cpp: builtins/builtins.c
 	@echo Creating C++ source from builtins definition file $<
-	@$(CLANG) -m64 -emit-llvm -c $< -o - | llvm-dis - | python bitcode2cpp.py c 64 > $@
+	@$(CLANG) -m64 -emit-llvm -c $< -o - | llvm-dis - | python2 bitcode2cpp.py c 64 > $@
 
 objs/stdlib_mask1_ispc.cpp: stdlib.ispc
 	@echo Creating C++ source from $< for mask1
 	@$(CLANG) -E -x c -DISPC_MASK_BITS=1 -DISPC=1 -DPI=3.14159265358979 $< -o - | \
-		python stdlib2cpp.py mask1 > $@
+		python2 stdlib2cpp.py mask1 > $@
 
 objs/stdlib_mask8_ispc.cpp: stdlib.ispc
 	@echo Creating C++ source from $< for mask8
 	@$(CLANG) -E -x c -DISPC_MASK_BITS=8 -DISPC=1 -DPI=3.14159265358979 $< -o - | \
-		python stdlib2cpp.py mask8 > $@
+		python2 stdlib2cpp.py mask8 > $@
 
 objs/stdlib_mask16_ispc.cpp: stdlib.ispc
 	@echo Creating C++ source from $< for mask16
 	@$(CLANG) -E -x c -DISPC_MASK_BITS=16 -DISPC=1 -DPI=3.14159265358979 $< -o - | \
-		python stdlib2cpp.py mask16 > $@
+		python2 stdlib2cpp.py mask16 > $@
 
 objs/stdlib_mask32_ispc.cpp: stdlib.ispc
 	@echo Creating C++ source from $< for mask32
 	@$(CLANG) -E -x c -DISPC_MASK_BITS=32 -DISPC=1 -DPI=3.14159265358979 $< -o - | \
-		python stdlib2cpp.py mask32 > $@
+		python2 stdlib2cpp.py mask32 > $@
 
 objs/stdlib_mask64_ispc.cpp: stdlib.ispc
 	@echo Creating C++ source from $< for mask64
 	@$(CLANG) -E -x c -DISPC_MASK_BITS=64 -DISPC=1 -DPI=3.14159265358979 $< -o - | \
-		python stdlib2cpp.py mask64 > $@
+		python2 stdlib2cpp.py mask64 > $@

--- a/alloy.py
+++ b/alloy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 #  Copyright (c) 2013-2014, Intel Corporation
 #  All rights reserved.

--- a/bitcode2cpp.py
+++ b/bitcode2cpp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import string

--- a/check_env.py
+++ b/check_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 #  Copyright (c) 2013, Intel Corporation
 #  All rights reserved.

--- a/common.py
+++ b/common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 #  Copyright (c) 2013, Intel Corporation 
 #  All rights reserved.

--- a/perf.py
+++ b/perf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 #  Copyright (c) 2013, Intel Corporation
 #  All rights reserved.

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 #  Copyright (c) 2013, Intel Corporation
 #  All rights reserved.

--- a/stdlib2cpp.py
+++ b/stdlib2cpp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 

--- a/tt_dump_read.py
+++ b/tt_dump_read.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 #  Copyright (c) 2014, Intel Corporation 
 #  All rights reserved.


### PR DESCRIPTION
This PR changes the makefile and shebangs follow [PEP 394](http://legacy.python.org/dev/peps/pep-0394/) making it possible to compile ispc on systems that do not default to `python2`.

A possible downside is that older systems might not implement PEP 394 and thus might not have `python2`. I'm unsure how this would work with Windows as well.