### PR TITLE
LLVM trunk build fail fix (MDNode interface change)

### DIFF
--- a/cbackend.cpp
+++ b/cbackend.cpp
@@ -152,11 +152,7 @@ namespace {
           incorporateValue(Aliasee);
       }
 
-#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4) || defined(LLVM_3_5)
       llvm::SmallVector<std::pair<unsigned, llvm::MDNode*>, 4> MDForInst;
-#else // LLVM 3.6+
-      llvm::SmallVector<std::pair<unsigned, llvm::Value*>, 4> MDForInst;
-#endif
 
       // Get types from functions.
       for (llvm::Module::const_iterator FI = M.begin(), E = M.end(); FI != E; ++FI) {

--- a/opt.cpp
+++ b/opt.cpp
@@ -185,11 +185,8 @@ lCopyMetadata(llvm::Value *vto, const llvm::Instruction *from) {
     if (!to)
         return;
 
-#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4) || defined(LLVM_3_5)
     llvm::SmallVector<std::pair<unsigned int, llvm::MDNode *>, 8> metadata;
-#else // LLVM 3.6+
-    llvm::SmallVector<std::pair<unsigned int, llvm::Value *>, 8> metadata;
-#endif
+
     from->getAllMetadata(metadata);
     for (unsigned int i = 0; i < metadata.size(); ++i)
         to->setMetadata(metadata[i].first, metadata[i].second);
@@ -219,19 +216,12 @@ lCopyMetadata(llvm::Value *vto, const llvm::Instruction *from) {
 */
 static bool
 lGetSourcePosFromMetadata(const llvm::Instruction *inst, SourcePos *pos) {
-#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4) || defined(LLVM_3_5)    
     llvm::MDNode *filename = inst->getMetadata("filename");
     llvm::MDNode *first_line = inst->getMetadata("first_line");
     llvm::MDNode *first_column = inst->getMetadata("first_column");
     llvm::MDNode *last_line = inst->getMetadata("last_line");
     llvm::MDNode *last_column = inst->getMetadata("last_column");
-#else // LLVM 3.6+
-    llvm::MDNode *filename = inst->getMDNode("filename");
-    llvm::MDNode *first_line = inst->getMDNode("first_line");
-    llvm::MDNode *first_column = inst->getMDNode("first_column");
-    llvm::MDNode *last_line = inst->getMDNode("last_line");
-    llvm::MDNode *last_column = inst->getMDNode("last_column");
-#endif
+
     if (!filename || !first_line || !first_column || !last_line || !last_column)
         return false;
 


### PR DESCRIPTION
Several LLVM functions accepting MDNode type were changed, as well as MDNode type itself. This commit fixes ISPC build fail caused by these changes
