### PR TITLE
fixed ISPC compilation fail caused by LLVM DIBuilder API change

### DIFF
--- a/builtins.cpp
+++ b/builtins.cpp
@@ -921,18 +921,22 @@ lDefineConstantInt(const char *name, int val, llvm::Module *module,
         // FIXME? DWARF says that this (and programIndex below) should
         // have the DW_AT_artifical attribute.  It's not clear if this
         // matters for anything though.
-        llvm::DIGlobalVariable var =
+
 #if !defined(LLVM_3_2) && !defined(LLVM_3_3) && !defined(LLVM_3_4) && !defined(LLVM_3_5)// LLVM 3.6+
-            m->diBuilder->createGlobalVariable(file,
+        llvm::Constant *sym_const_storagePtr = llvm::dyn_cast<llvm::Constant>(sym->storagePtr);
+        Assert(sym_const_storagePtr);
+        llvm::DIGlobalVariable var = m->diBuilder->createGlobalVariable(
+                                               file,
                                                name,
                                                name,
                                                file,
                                                0 /* line */,
                                                diType,
                                                true /* static */,
-                                               sym->storagePtr);
+                                               sym_const_storagePtr);
 #else
-            m->diBuilder->createGlobalVariable(name,
+        llvm::DIGlobalVariable var = m->diBuilder->createGlobalVariable(
+                                               name,
                                                file,
                                                0 /* line */,
                                                diType,
@@ -992,18 +996,21 @@ lDefineProgramIndex(llvm::Module *module, SymbolTable *symbolTable) {
         llvm::DIFile file;
         llvm::DIType diType = sym->type->GetDIType(file);
         Assert(diType.Verify());
-        llvm::DIGlobalVariable var =
 #if !defined(LLVM_3_2) && !defined(LLVM_3_3) && !defined(LLVM_3_4) && !defined(LLVM_3_5)// LLVM 3.6+
-            m->diBuilder->createGlobalVariable(file,
+        llvm::Constant *sym_const_storagePtr = llvm::dyn_cast<llvm::Constant>(sym->storagePtr);
+        Assert(sym_const_storagePtr);
+        llvm::DIGlobalVariable var = m->diBuilder->createGlobalVariable(
+                                               file,
                                                sym->name.c_str(),
                                                sym->name.c_str(),
                                                file,
                                                0 /* line */,
                                                diType,
                                                false /* static */,
-                                               sym->storagePtr);
+                                               sym_const_storagePtr);
 #else
-            m->diBuilder->createGlobalVariable(sym->name.c_str(),
+        llvm::DIGlobalVariable var = m->diBuilder->createGlobalVariable(
+                                               sym->name.c_str(),
                                                file,
                                                0 /* line */,
                                                diType,

--- a/module.cpp
+++ b/module.cpp
@@ -607,18 +607,21 @@ Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *initE
 
     if (diBuilder) {
         llvm::DIFile file = pos.GetDIFile();
-        llvm::DIGlobalVariable var =
 #if !defined(LLVM_3_2) && !defined(LLVM_3_3) && !defined(LLVM_3_4) && !defined(LLVM_3_5)// LLVM 3.6+
-            diBuilder->createGlobalVariable(file,
+        llvm::Constant *sym_const_storagePtr = llvm::dyn_cast<llvm::Constant>(sym->storagePtr);
+        Assert(sym_const_storagePtr);
+        llvm::DIGlobalVariable var = diBuilder->createGlobalVariable(
+                                            file,
                                             name,
                                             name,
                                             file,
                                             pos.first_line,
                                             sym->type->GetDIType(file),
                                             (sym->storageClass == SC_STATIC),
-                                            sym->storagePtr);
+                                            sym_const_storagePtr);
 #else
-            diBuilder->createGlobalVariable(name,
+        llvm::DIGlobalVariable var = diBuilder->createGlobalVariable(
+                                            name,
                                             file,
                                             pos.first_line,
                                             sym->type->GetDIType(file),


### PR DESCRIPTION
fixed ISPC compilation fail caused by the change of llvm::Value to llvm::Constant in DIBuilder member functions (LLVM commit 222070, https://llvm.org/svn/llvm-project/llvm/trunk@222070)

TODO:
The testing has revealed 7 new runfails and 126 new compfails (comparing to only 40 compfails before the build failure). Need to examine and fix those compfails (the 93 new ones are on generic-4 and generic-16 and 40 old ones are on sse2-i32x4)

Details:
x86          sse2-i32x4   Linux LLVM 3.6 clang++3.6 -O2. Fails: 20, New fails: 20.
x86-64     sse2-i32x4   Linux LLVM 3.6 clang++3.6 -O2. Fails: 20, New fails: 20.
x86-64     generic-4     Linux LLVM 3.6 clang++3.6 -O2. Fails: 16, New fails: 16. 
x86-64     generic-4     Linux LLVM 3.6 clang++3.6 -O0. Fails: 34, New fails: 34.
x86-64     generic-16   Linux LLVM 3.6 clang++3.6 -O2. Fails: 10, New fails: 10.
x86-64     generic-16   Linux LLVM 3.6 clang++3.6 -O0. Fails: 33, New fails: 33.
