### PR TITLE
Added cstdlib include

### DIFF
--- a/examples/mandelbrot/mandelbrot.cpp
+++ b/examples/mandelbrot/mandelbrot.cpp
@@ -43,6 +43,7 @@
 #include "../timing.h"
 #include "mandelbrot_ispc.h"
 #include <string.h>
+#include <cstdlib>
 using namespace ispc;
 
 extern void mandelbrot_serial(float x0, float y0, float x1, float y1,


### PR DESCRIPTION
the atoi and other functions were not transitively included under clang/llvm3.5 - macports on OSX 10.9

```
make
/bin/mkdir -p objs/
ispc -O2 --arch=x86-64 --target=sse2-i32x4,sse4-i32x8,avx1-i32x16,avx2-i32x16 mandelbrot.ispc -o objs/mandelbrot_ispc.o -h objs/mandelbrot_ispc.h
clang++ mandelbrot.cpp -Iobjs/ -O2 -m64 -c -o objs/mandelbrot.o
mandelbrot.cpp:82:27: error: use of undeclared identifier 'atof'
            float scale = atof(argv[1] + 8);
                          ^
mandelbrot.cpp:89:34: error: use of undeclared identifier 'atoi'
            test_iterations[i] = atoi(argv[argc - 2 + i]);
                                 ^
2 errors generated.
```
