### PR TITLE
Fixed CPU name retrieval

### DIFF
--- a/ispc.cpp
+++ b/ispc.cpp
@@ -352,7 +352,7 @@ public:
         return CPUs.str();
     }
 
-    std::string GetDefaultNameFromType(CPUtype type) {
+    std::string &GetDefaultNameFromType(CPUtype type) {
         Assert((type > CPU_None) && (type < sizeofCPUtype));
         return names[type][0];
     }


### PR DESCRIPTION
It`s necessary to pass the result by reference instead of creating a new object: otherwise, its data might be used beyond the point of its disposal.