### PR TITLE
Add assignments to Uniform as an unsafe thing when checking to run with ...

### DIFF
--- a/ast.cpp
+++ b/ast.cpp
@@ -477,6 +477,20 @@ lCheckAllOffSafety(ASTNode *node, void *data) {
         return false;
     }
 
+    /*
+      Don't allow turning if/else to straight-line-code if we 
+      assign to a uniform.
+    */
+    AssignExpr *ae;
+    if ((ae = dynamic_cast<AssignExpr *>(node)) != NULL) {
+      if (ae->GetType()) {
+        if (ae->GetType()->IsUniformType()) {
+          *okPtr = false;
+          return false;
+        }
+      }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
...mask all off

The following program printing 10 drives programmers crazy and should be disallowed:

export void doit() {
     int a = 0;
     uniform int b = 0;
     if (a == 0) {
       ++b;
     }
     else {
       b = 10;
     }
     print("b: %\n", b);
}