### PR TITLE
Fix for revision

### DIFF
--- a/ConstantsScanner.h
+++ b/ConstantsScanner.h
@@ -1,0 +1,97 @@
+//==- llvm/Analysis/ConstantsScanner.h - Iterate over constants -*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This class implements an iterator to walk through the constants referenced by
+// a method.  This is used by the Bitcode & Assembly writers to build constant
+// pools.
+//
+//===----------------------------------------------------------------------===//
+
+// It is file which is needed for cbackend.cpp. It was removed in LLVM_232397 revision.
+
+#ifndef LLVM_ANALYSIS_CONSTANTSSCANNER_H
+#define LLVM_ANALYSIS_CONSTANTSSCANNER_H
+
+#include "llvm/IR/InstIterator.h"
+
+namespace llvm {
+
+class Constant;
+
+class constant_iterator : public std::iterator<std::forward_iterator_tag,
+                                               const Constant, ptrdiff_t> {
+  const_inst_iterator InstI;                // Method instruction iterator
+  unsigned OpIdx;                           // Operand index
+
+  bool isAtConstant() const {
+    assert(!InstI.atEnd() && OpIdx < InstI->getNumOperands() &&
+           "isAtConstant called with invalid arguments!");
+    return isa<Constant>(InstI->getOperand(OpIdx));
+  }
+
+public:
+  constant_iterator(const Function *F) : InstI(inst_begin(F)), OpIdx(0) {
+    // Advance to first constant... if we are not already at constant or end
+    if (InstI != inst_end(F) &&                            // InstI is valid?
+        (InstI->getNumOperands() == 0 || !isAtConstant())) // Not at constant?
+      operator++();
+  }
+
+  constant_iterator(const Function *F, bool) // end ctor
+      : InstI(inst_end(F)),
+        OpIdx(0) {}
+
+  bool operator==(const constant_iterator &x) const {
+    return OpIdx == x.OpIdx && InstI == x.InstI;
+  }
+  bool operator!=(const constant_iterator &x) const { return !(*this == x); }
+
+  pointer operator*() const {
+    assert(isAtConstant() && "Dereferenced an iterator at the end!");
+    return cast<Constant>(InstI->getOperand(OpIdx));
+  }
+  pointer operator->() const { return **this; }
+
+  constant_iterator &operator++() { // Preincrement implementation
+    ++OpIdx;
+    do {
+      unsigned NumOperands = InstI->getNumOperands();
+      while (OpIdx < NumOperands && !isAtConstant()) {
+        ++OpIdx;
+      }
+
+      if (OpIdx < NumOperands) return *this;  // Found a constant!
+      ++InstI;
+      OpIdx = 0;
+    } while (!InstI.atEnd());
+
+    return *this;  // At the end of the method
+  }
+
+  constant_iterator operator++(int) { // Postincrement
+    constant_iterator tmp = *this;
+    ++*this;
+    return tmp;
+  }
+
+  bool atEnd() const { return InstI.atEnd(); }
+};
+
+inline constant_iterator constant_begin(const Function *F) {
+  return constant_iterator(F);
+}
+
+inline constant_iterator constant_end(const Function *F) {
+  return constant_iterator(F, true);
+}
+
+} // End llvm namespace
+
+#endif
+

--- a/ConstantsScanner.h
+++ b/ConstantsScanner.h
@@ -18,7 +18,11 @@
 #ifndef LLVM_ANALYSIS_CONSTANTSSCANNER_H
 #define LLVM_ANALYSIS_CONSTANTSSCANNER_H
 
-#include "llvm/IR/InstIterator.h"
+#if defined(LLVM_3_4)
+  #include "llvm/Support/InstIterator.h"
+#else
+  #include "llvm/IR/InstIterator.h"
+#endif
 
 namespace llvm {
 

--- a/cbackend.cpp
+++ b/cbackend.cpp
@@ -65,7 +65,11 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/Analysis/ConstantsScanner.h"
+#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4) || defined(LLVM_3_5) || defined(LLVM_3_6)
+  #include "llvm/Analysis/ConstantsScanner.h"
+#else
+  #include "ConstantsScanner.h"
+#endif
 #if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4) || defined(LLVM_3_5)
   #include "llvm/Analysis/FindUsedTypes.h"
 #endif

--- a/cbackend.cpp
+++ b/cbackend.cpp
@@ -65,11 +65,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/STLExtras.h"
-#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4) || defined(LLVM_3_5) || defined(LLVM_3_6)
-  #include "llvm/Analysis/ConstantsScanner.h"
-#else
-  #include "ConstantsScanner.h"
-#endif
+#include "ConstantsScanner.h"
 #if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4) || defined(LLVM_3_5)
   #include "llvm/Analysis/FindUsedTypes.h"
 #endif


### PR DESCRIPTION
Header ConstantsScanner.h was removed from LLVM, so we need to have our own for cbackend.cpp (https://github.com/llvm-mirror/llvm/commit/bf71e29ec5008c9ac9abc264a4fc405b99b91e23)