### PR TITLE
Added fix for ispc on ARM

### DIFF
--- a/builtins/target-neon-16.ll
+++ b/builtins/target-neon-16.ll
@@ -524,3 +524,4 @@ rcpd_decl()
 
 transcendetals_decl()
 trigonometry_decl()
+saturation_arithmetic()

--- a/builtins/target-neon-32.ll
+++ b/builtins/target-neon-32.ll
@@ -494,3 +494,4 @@ rcpd_decl()
 
 transcendetals_decl()
 trigonometry_decl()
+saturation_arithmetic()

--- a/builtins/target-neon-8.ll
+++ b/builtins/target-neon-8.ll
@@ -590,3 +590,4 @@ rcpd_decl()
 
 transcendetals_decl()
 trigonometry_decl()
+saturation_arithmetic()

--- a/examples/timing.h
+++ b/examples/timing.h
@@ -54,6 +54,19 @@ __inline__ uint64_t rdtsc() {
   return (1000000ull * tv.tv_sec + tv.tv_usec) * 1000ull;
 }
 
+#include <sys/time.h>
+static inline double rtc(void)
+{
+  struct timeval Tvalue;
+  double etime;
+  struct timezone dummy;
+
+  gettimeofday(&Tvalue,&dummy);
+  etime =  (double) Tvalue.tv_sec +
+    1.e-6*((double) Tvalue.tv_usec);
+  return etime;
+}
+
 #else // __arm__
 
 #ifdef WIN32


### PR DESCRIPTION
ISPC and examples are now can be build on ARM. When using IPSC on arm it reports:

    Warning: Module DataLayout is incompatible with library DataLayout: 
            Module DL: e-p:32:32:32-S64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f16:16:16-f32:32:32-f64:64:64-f128:128:128-v64:64:64-v128:64:128-a0:0:64-n32 
            Library DL: e-p:32:32:32-S32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f16:16:16-f32:32:32-f64:32:64-f128:128:128-v64:32:64-v128:32:128-a0:0:64-n32 
         
