### PR TITLE
Support of knl-generic-16 target

### DIFF
--- a/func.cpp
+++ b/func.cpp
@@ -515,8 +515,14 @@ Function::GenerateIR() {
                 llvm::FunctionType *ftype = type->LLVMFunctionType(g->ctx, true);
                 llvm::GlobalValue::LinkageTypes linkage = llvm::GlobalValue::ExternalLinkage;
                 std::string functionName = sym->name;
-                if (g->mangleFunctionsWithTarget)
-                    functionName += std::string("_") + g->target->GetISAString();
+                if (g->mangleFunctionsWithTarget) {
+                    // If we treat knl as generic, we should have appropriate mangling
+                    if (g->target->getISA() == Target::GENERIC &&
+                        g->target->getTreatGenericAsKNL())
+                        functionName += std::string("_") + "knl_generic";
+                    else
+                        functionName += std::string("_") + g->target->GetISAString();
+                }
 #ifdef ISPC_NVPTX_ENABLED
                 if (g->target->getISA() == Target::NVPTX)
                 {

--- a/ispc.cpp
+++ b/ispc.cpp
@@ -416,12 +416,13 @@ public:
 };
 
 
-Target::Target(const char *arch, const char *cpu, const char *isa, bool pic) :
+Target::Target(const char *arch, const char *cpu, const char *isa, bool pic, bool genAsKNL) :
     m_target(NULL),
     m_targetMachine(NULL),
     m_dataLayout(NULL),
     m_valid(false),
     m_isa(SSE2),
+    m_treatGenericAsKNL(genAsKNL),
     m_arch(""),
     m_is32Bit(true),
     m_cpu(""),
@@ -660,8 +661,15 @@ Target::Target(const char *arch, const char *cpu, const char *isa, bool pic) :
         CPUfromISA = CPU_Generic;
     }
     else if (!strcasecmp(isa, "generic-16") ||
-             !strcasecmp(isa, "generic-x16")) {
+             !strcasecmp(isa, "generic-x16") ||
+             // We treat knl-generic-16 as generic-16, but with special name mangling
+             !strcasecmp(isa, "knl-generic-16") ||
+             !strcasecmp(isa, "knl-generic-x16")) {
         this->m_isa = Target::GENERIC;
+        if (!strcasecmp(isa, "knl-generic-16") ||
+            !strcasecmp(isa, "knl-generic-x16"))
+            // It is used for appropriate name mangling and dispatch function during multitarget compilation
+            this->m_treatGenericAsKNL = true;
         this->m_nativeVectorWidth = 16;
         this->m_nativeVectorAlignment = 64;
         this->m_vectorWidth = 16;
@@ -1065,7 +1073,7 @@ Target::SupportedTargets() {
         "avx1.1-i32x8, avx1.1-i32x16, avx1.1-i64x4 "
         "avx2-i32x8, avx2-i32x16, avx2-i64x4, "
         "generic-x1, generic-x4, generic-x8, generic-x16, "
-        "generic-x32, generic-x64"
+        "generic-x32, generic-x64, knl-generic-x16"
 #ifdef ISPC_ARM_ENABLED
         ", neon-i8x16, neon-i16x8, neon-i32x4"
 #endif

--- a/ispc.h
+++ b/ispc.h
@@ -196,7 +196,7 @@ public:
     /** Initializes the given Target pointer for a target of the given
         name, if the name is a known target.  Returns true if the
         target was initialized and false if the name is unknown. */
-    Target(const char *arch, const char *cpu, const char *isa, bool pic);
+    Target(const char *arch, const char *cpu, const char *isa, bool pic, bool genAsKNL = false);
 
     /** Returns a comma-delimited string giving the names of the currently
         supported compilation targets. */
@@ -254,6 +254,8 @@ public:
     bool isValid() const {return m_valid;}
 
     ISA getISA() const {return m_isa;}
+
+    bool getTreatGenericAsKNL() const {return m_treatGenericAsKNL;} 
 
     std::string getArch() const {return m_arch;}
 
@@ -315,6 +317,10 @@ private:
 
     /** Instruction set being compiled to. */
     ISA m_isa;
+
+    /** The variable is needed to distinguish native knl from one supported through generic */
+    // TODO: it as a kludge. Fix it.
+    bool m_treatGenericAsKNL;
 
     /** Target system architecture.  (e.g. "x86-64", "x86"). */
     std::string m_arch;


### PR DESCRIPTION
Now we have knl-generic-16 target. It is always processed as generic-x16 during code generation, but in multiple target compilation it is forced to emit c++ file.