### PR TITLE
Fix unitialized default compiler_exe

### DIFF
--- a/alloy.py
+++ b/alloy.py
@@ -631,7 +631,9 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
                     print_debug("Warning: target " + stability.target + " is not supported in LLVM " + LLVM[i] + "\n", False, stability_log)
                     continue
 
+                # *always* specify default values for global variables on each loop iteration
                 stability.wrapexe = ""
+                stability.compiler_exe = ""
                 # choosing right compiler for a given target
                 # sometimes clang++ is not avaluable. if --ispc-build-compiler = gcc we will pass in g++ compiler
                 if options.ispc_build_compiler == "gcc":


### PR DESCRIPTION
- Apparently the uninitialized compiler_exe var was set to 'icpc' on 3.4 knl testing and remained so on 3.5, 3.6 and 3.7 producing errors (mostly because of icpc's internal errors). Now the default compiler (clang, if available) will be used again with non-knc/knl targets.