### PR TITLE
Fixed default compiler value from ' ' to None

### DIFF
--- a/alloy.py
+++ b/alloy.py
@@ -633,7 +633,7 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
 
                 # *always* specify default values for global variables on each loop iteration
                 stability.wrapexe = ""
-                stability.compiler_exe = ""
+                stability.compiler_exe = None
                 # choosing right compiler for a given target
                 # sometimes clang++ is not avaluable. if --ispc-build-compiler = gcc we will pass in g++ compiler
                 if options.ispc_build_compiler == "gcc":


### PR DESCRIPTION
- 'run_tests.py' does not recognize ' ' as a request to automatically choose a compiler. It should be 'None' instead