### PR TITLE
Trunk38 fixes

### DIFF
--- a/alloy.py
+++ b/alloy.py
@@ -124,6 +124,9 @@ def build_LLVM(version_LLVM, revision, folder, tarball, debug, selfbuild, extra,
     FOLDER_NAME=version_LLVM
     if  version_LLVM == "trunk":
         SVN_PATH="trunk"
+    if  version_LLVM == "3.7":
+        SVN_PATH="branches/release_37"
+        version_LLVM = "3_7"
     if  version_LLVM == "3.6":
         SVN_PATH="tags/RELEASE_361/final"
         version_LLVM = "3_6"
@@ -296,6 +299,7 @@ def unsupported_llvm_targets(LLVM_VERSION):
                        "3.5":["avx512knl-i32x16"],
                        "3.6":["avx512knl-i32x16"],
                        "3.7":[],
+                       "3.8":[],
                        "trunk":[]}   
     return prohibited_list[LLVM_VERSION]
 
@@ -413,8 +417,10 @@ def build_ispc(version_LLVM, make):
             temp = "3_5"
         if version_LLVM == "3.6":
             temp = "3_6"
-        if version_LLVM == "trunk":
+        if version_LLVM == "3.7":
             temp = "3_7"
+        if version_LLVM == "trunk":
+            temp = "3_8"
         os.environ["LLVM_VERSION"] = "LLVM_" + temp
         try_do_LLVM("clean ISPC for building", "msbuild ispc.vcxproj /t:clean", True)
         try_do_LLVM("build ISPC with LLVM version " + version_LLVM + " ", "msbuild ispc.vcxproj /V:m /p:Platform=Win32 /p:Configuration=Release /t:rebuild", True)
@@ -554,7 +560,7 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
             archs.append("x86-64")
         if "native" in only:
             sde_targets_t = []
-        for i in ["3.2", "3.3", "3.4", "3.5", "3.6", "trunk"]:
+        for i in ["3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "trunk"]:
             if i in only:
                 LLVM.append(i)
         if "current" in only:
@@ -833,7 +839,7 @@ def Main():
         if os.environ.get("SMTP_ISPC") == None:
             error("you have no SMTP_ISPC in your environment for option notify", 1)
     if options.only != "":
-        test_only_r = " 3.2 3.3 3.4 3.5 3.6 trunk current build stability performance x86 x86-64 x86_64 -O0 -O2 native debug nodebug "
+        test_only_r = " 3.2 3.3 3.4 3.5 3.6 3.7 trunk current build stability performance x86 x86-64 x86_64 -O0 -O2 native debug nodebug "
         test_only = options.only.split(" ")
         for iterator in test_only:
             if not (" " + iterator + " " in test_only_r):
@@ -943,7 +949,7 @@ if __name__ == '__main__':
     llvm_group = OptionGroup(parser, "Options for building LLVM",
                     "These options must be used with -b option.")
     llvm_group.add_option('--version', dest='version',
-        help='version of llvm to build: 3.2 3.3 3.4 3.5 3.6 trunk. Default: trunk', default="trunk")
+        help='version of llvm to build: 3.2 3.3 3.4 3.5 3.6 3.7 trunk. Default: trunk', default="trunk")
     llvm_group.add_option('--with-gcc-toolchain', dest='gcc_toolchain_path',
          help='GCC install dir to use when building clang. It is important to set when ' +
          'you have alternative gcc installation. Note that otherwise gcc from standard ' +
@@ -984,7 +990,7 @@ if __name__ == '__main__':
     run_group.add_option('--only', dest='only',
         help='set types of tests. Possible values:\n' + 
             '-O0, -O2, x86, x86-64, stability (test only stability), performance (test only performance),\n' +
-            'build (only build with different LLVM), 3.2, 3.3, 3.4, 3.5, 3.6, trunk, native (do not use SDE),\n' +
+            'build (only build with different LLVM), 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, trunk, native (do not use SDE),\n' +
             'current (do not rebuild ISPC), debug (only with debug info), nodebug (only without debug info, default).',
             default="")
     run_group.add_option('--perf_LLVM', dest='perf_llvm',

--- a/builtins/dispatch.ll
+++ b/builtins/dispatch.ll
@@ -148,6 +148,8 @@
 define(`PTR_OP_ARGS',
   ifelse(LLVM_VERSION, LLVM_3_7,
     ``$1 , $1 *'',
+         LLVM_VERSION, LLVM_3_8,
+    ``$1 , $1 *'',
     ``$1 *''
   )
 )

--- a/builtins/util.m4
+++ b/builtins/util.m4
@@ -54,6 +54,8 @@ define(`MASK_HIGH_BIT_ON',
 define(`PTR_OP_ARGS',
   ifelse(LLVM_VERSION, LLVM_3_7,
     ``$1 , $1 *'',
+         LLVM_VERSION, LLVM_3_8,
+    ``$1 , $1 *'',
     ``$1 *''
   )
 )
@@ -1545,7 +1547,7 @@ define <$1 x $2> @__atomic_compare_exchange_$3_global($2* %ptr, <$1 x $2> %cmp,
    %cmp_LANE_ID = extractelement <$1 x $2> %cmp, i32 LANE
    %val_LANE_ID = extractelement <$1 x $2> %val, i32 LANE
 
-  ;; 3.5, 3.6 and 3.7 code is the same since m4 has no OR and AND operators
+  ;; 3.5, 3.6, 3.7 and 3.8 code is the same since m4 has no OR and AND operators
   ifelse(LLVM_VERSION,LLVM_3_5,`
     %r_LANE_ID_t = cmpxchg $2 * %ptr, $2 %cmp_LANE_ID, $2 %val_LANE_ID seq_cst seq_cst
     %r_LANE_ID = extractvalue { $2, i1 } %r_LANE_ID_t, 0
@@ -1553,6 +1555,9 @@ define <$1 x $2> @__atomic_compare_exchange_$3_global($2* %ptr, <$1 x $2> %cmp,
     %r_LANE_ID_t = cmpxchg $2 * %ptr, $2 %cmp_LANE_ID, $2 %val_LANE_ID seq_cst seq_cst
     %r_LANE_ID = extractvalue { $2, i1 } %r_LANE_ID_t, 0
   ',LLVM_VERSION,LLVM_3_7,`
+    %r_LANE_ID_t = cmpxchg $2 * %ptr, $2 %cmp_LANE_ID, $2 %val_LANE_ID seq_cst seq_cst
+    %r_LANE_ID = extractvalue { $2, i1 } %r_LANE_ID_t, 0
+  ',LLVM_VERSION,LLVM_3_8,`
     %r_LANE_ID_t = cmpxchg $2 * %ptr, $2 %cmp_LANE_ID, $2 %val_LANE_ID seq_cst seq_cst
     %r_LANE_ID = extractvalue { $2, i1 } %r_LANE_ID_t, 0
   ',`
@@ -1567,7 +1572,7 @@ define <$1 x $2> @__atomic_compare_exchange_$3_global($2* %ptr, <$1 x $2> %cmp,
 
 define $2 @__atomic_compare_exchange_uniform_$3_global($2* %ptr, $2 %cmp,
                                                        $2 %val) nounwind alwaysinline {                                                           
-  ;; 3.5, 3.6 and 3.7 code is the same since m4 has no OR and AND operators
+  ;; 3.5, 3.6, 3.7 and 3.8 code is the same since m4 has no OR and AND operators
   ifelse(LLVM_VERSION,LLVM_3_5,`
    %r_t = cmpxchg $2 * %ptr, $2 %cmp, $2 %val seq_cst seq_cst
    %r = extractvalue { $2, i1 } %r_t, 0
@@ -1575,6 +1580,9 @@ define $2 @__atomic_compare_exchange_uniform_$3_global($2* %ptr, $2 %cmp,
    %r_t = cmpxchg $2 * %ptr, $2 %cmp, $2 %val seq_cst seq_cst
    %r = extractvalue { $2, i1 } %r_t, 0
   ',LLVM_VERSION,LLVM_3_7,`
+   %r_t = cmpxchg $2 * %ptr, $2 %cmp, $2 %val seq_cst seq_cst
+   %r = extractvalue { $2, i1 } %r_t, 0
+  ',LLVM_VERSION,LLVM_3_8,`
    %r_t = cmpxchg $2 * %ptr, $2 %cmp, $2 %val seq_cst seq_cst
    %r = extractvalue { $2, i1 } %r_t, 0
   ',`

--- a/ispc.h
+++ b/ispc.h
@@ -41,7 +41,7 @@
 #include "ispc_version.h"
 
 #if ISPC_LLVM_VERSION < OLDEST_SUPPORTED_LLVM || ISPC_LLVM_VERSION > LATEST_SUPPORTED_LLVM
-#error "Only LLVM 3.2, 3.3, 3.4, 3.5, 3.6 and 3.7 development branch are supported"
+#error "Only LLVM 3.2, 3.3, 3.4, 3.5, 3.6, 3.7 and 3.8 development branch are supported"
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/ispc_version.h
+++ b/ispc_version.h
@@ -49,9 +49,10 @@
 #define ISPC_LLVM_3_5 30500
 #define ISPC_LLVM_3_6 30600
 #define ISPC_LLVM_3_7 30700
+#define ISPC_LLVM_3_8 30800
 
 #define OLDEST_SUPPORTED_LLVM ISPC_LLVM_3_2
-#define LATEST_SUPPORTED_LLVM ISPC_LLVM_3_7
+#define LATEST_SUPPORTED_LLVM ISPC_LLVM_3_8
 
 #ifdef __ispc__xstr
 #undef __ispc__xstr


### PR DESCRIPTION
Added LLVM 3.7 version in alloy.py with temporary repository + some additional changes for compiling trunk 3.8.