### PR TITLE
Fixed AVX-512 IR incompatibility issue

### DIFF
--- a/builtins.cpp
+++ b/builtins.cpp
@@ -1332,6 +1332,7 @@ DefineStdlib(SymbolTable *symbolTable, llvm::LLVMContext *ctx, llvm::Module *mod
         }
         break;
     }
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_3_7 // LLVM 3.7+
     case Target::KNL_AVX512: {
         switch (g->target->getVectorWidth()) {
         case 16:
@@ -1347,6 +1348,7 @@ DefineStdlib(SymbolTable *symbolTable, llvm::LLVMContext *ctx, llvm::Module *mod
         }
         break;
     }
+#endif
     case Target::GENERIC: {
         switch (g->target->getVectorWidth()) {
         case 4:

--- a/builtins/target-knl.ll
+++ b/builtins/target-knl.ll
@@ -30,5 +30,13 @@
 ;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
 
 define(`WIDTH',`16')
-include(`target-avx512-common.ll')
+
+
+ifelse(LLVM_VERSION, LLVM_3_7,
+    `include(`target-avx512-common.ll')',
+         LLVM_VERSION, LLVM_3_8,
+    `include(`target-avx512-common.ll')'
+  )
+
+
 ;;saturation_arithmetic_novec()


### PR DESCRIPTION
- The IR has changed significantly since LLVM 3.7. However, AVX-512 target is supported only with 3.7 and older, so there is no need to build it against old LLVM versions