### PR TITLE
Replace old ScalarReplAggregates pass with no longer new SROA pass.

### DIFF
--- a/opt.cpp
+++ b/opt.cpp
@@ -612,9 +612,7 @@ Optimize(llvm::Module *module, int optLevel) {
         optPM.add(llvm::createBasicAAWrapperPass());
 #endif
         optPM.add(llvm::createCFGSimplificationPass());
-        // Here clang has an experimental pass SROAPass instead of
-        // ScalarReplAggregatesPass. We should add it in the future.
-        optPM.add(llvm::createScalarReplAggregatesPass());
+        optPM.add(llvm::createSROAPass());
         optPM.add(llvm::createEarlyCSEPass());
         optPM.add(llvm::createLowerExpectIntrinsicPass());
 


### PR DESCRIPTION
The old pass was being really dumb with a few simple examples.  The "new" hotness of the SROA pass produces better code for these cases.

We probably should've changed this a year ago. ;)