### PR TITLE
Fix bug in cbackend

### DIFF
--- a/cbackend.cpp
+++ b/cbackend.cpp
@@ -4199,8 +4199,9 @@ void CWriter::visitCallInst(llvm::CallInst &I) {
 #else /* LLVM 3.3+ */
   const llvm::AttributeSet &PAL = I.getAttributes();
 #endif
+
   bool hasByVal = I.hasByValArgument();
-  bool isStructRet = I.hasStructRetAttr();
+  bool isStructRet = (I.getNumArgOperands() > 0) && I.hasStructRetAttr();
   if (isStructRet) {
     writeOperandDeref(I.getArgOperand(0));
     Out << " = ";


### PR DESCRIPTION
"I.hasStructRetAttr()" will throw an assertion, if "I" has zero arguments.