### PR TITLE
Add --no-omit-frame-pointer option.

### DIFF
--- a/ispc.cpp
+++ b/ispc.cpp
@@ -1025,6 +1025,8 @@ Target::Target(const char *arch, const char *cpu, const char *isa, bool pic, boo
         if (g->opt.disableFMA == false)
             options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
 #if ISPC_LLVM_VERSION <= ISPC_LLVM_3_6
+        if (g->NoOmitFramePointer)
+            options.NoFramePointerElim = true;
 #ifdef ISPC_IS_WINDOWS
         if (strcmp("x86", arch) == 0) {
             // Workaround for issue #503 (LLVM issue 14646).
@@ -1443,6 +1445,7 @@ Globals::Globals() {
     runCPP = true;
     debugPrint = false;
     printTarget = false;
+    NoOmitFramePointer = false;
     debugIR = -1;
     disableWarnings = false;
     warningsAsErrors = false;

--- a/ispc.h
+++ b/ispc.h
@@ -562,6 +562,9 @@ struct Globals {
     /** When \c true, target ISA will be printed during ispc's execution. */
     bool printTarget;
 
+    /** When \c true, LLVM won't omit frame pointer. */
+    bool NoOmitFramePointer;
+
     /** Indicates which stages of optimization we want to dump. */
     std::set<int> debug_stages;
 

--- a/main.cpp
+++ b/main.cpp
@@ -143,6 +143,7 @@ devUsage(int ret) {
     printf("\nusage (developer options): ispc\n");
     printf("    [--debug]\t\t\t\tPrint information useful for debugging ispc\n");
     printf("    [--print-target]\t\t\tPrint target's information\n");
+    printf("    [--no-omit-frame-pointer]\t\tDisable frame pointer omission. It may be useful for profiling\n");
     printf("    [--fuzz-test]\t\t\tRandomly perturb program input to test error conditions\n");
     printf("    [--fuzz-seed=<value>]\t\tSeed value for RNG for fuzz testing\n");
     printf("    [--opt=<option>]\t\t\tSet optimization option\n");
@@ -374,6 +375,8 @@ int main(int Argc, char *Argv[]) {
 #endif
         else if (!strcmp(argv[i], "--print-target"))
             g->printTarget = true;
+        else if (!strcmp(argv[i], "--no-omit-frame-pointer"))
+            g->NoOmitFramePointer = true;
         else if (!strcmp(argv[i], "--instrument"))
             g->emitInstrumentation = true;
         else if (!strcmp(argv[i], "-g")) {

--- a/module.cpp
+++ b/module.cpp
@@ -495,6 +495,12 @@ Module::CompileFile() {
         fclose(f);
     }
 
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_3_7 // LLVM 3.7+
+    if (g->NoOmitFramePointer)
+        for (llvm::Function& f : *module)
+            f.addFnAttr("no-frame-pointer-elim", "true");
+#endif
+
     ast->GenerateIR();
 
     if (diBuilder)


### PR DESCRIPTION
LLVM omits frame pointer by default. New option was added to disable it. (see #1137)