### PR TITLE
Fix cast from uniform struct to varying struct.

### DIFF
--- a/ctx.h
+++ b/ctx.h
@@ -481,7 +481,8 @@ public:
         pointer values given by the lvalue.  If the lvalue is not varying,
         then both the mask pointer and the type pointer may be NULL. */
     llvm::Value *LoadInst(llvm::Value *ptr, llvm::Value *mask,
-                          const Type *ptrType, const char *name = NULL);
+                          const Type *ptrType, const char *name = NULL, 
+                          bool one_elem = false);
 
     llvm::Value *LoadInst(llvm::Value *ptr, const char *name = NULL);
 

--- a/expr.cpp
+++ b/expr.cpp
@@ -6786,7 +6786,8 @@ lUniformValueToVarying(FunctionEmitContext *ctx, llvm::Value *value,
 
         for (int i = 0; i < collectionType->GetElementCount(); ++i) {
             llvm::Value *v = ctx->ExtractInst(value, i, "get_element");
-            v = lUniformValueToVarying(ctx, v, collectionType->GetElementType(i));
+            if (collectionType->GetElementType(i)->IsVaryingType())
+                v = lUniformValueToVarying(ctx, v, collectionType->GetElementType(i));
             retValue = ctx->InsertInst(retValue, v, i, "set_element");
         }
         return retValue;

--- a/tests/struct-test-126.ispc
+++ b/tests/struct-test-126.ispc
@@ -1,0 +1,23 @@
+
+export uniform int width() { return programCount; }
+
+
+struct Foo {
+    uniform float x;
+    varying float y;
+};
+
+export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    float a = aFOO[programIndex];
+    uniform Foo struct_1;
+    struct_1.x = b;
+    struct_1.y = aFOO[programIndex];
+    varying Foo struct_2 = struct_1;
+    RET[programIndex] = struct_2.x + struct_2.y;
+}
+
+
+export void result(uniform float RET[]) {
+    RET[programIndex] = 5 + programIndex + 1;
+}
+

--- a/tests/struct-test-127.ispc
+++ b/tests/struct-test-127.ispc
@@ -1,0 +1,37 @@
+
+export uniform int width() { return programCount; }
+
+
+struct Foo {
+    uniform float x;
+    varying float y;
+};
+
+inline varying Foo func(uniform Foo * varying f)
+{
+    return *f;
+}
+
+export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    float a = aFOO[programIndex];
+    uniform Foo struct_1;
+    struct_1.x = b;
+    struct_1.y = aFOO[programIndex];
+
+    uniform Foo * varying ptr = &(struct_1);
+    varying Foo struct_2;
+    struct_2.x = -100;
+    struct_2.y = -150;
+    if (programIndex % 3 == 0)
+        struct_2 = func(ptr);
+    RET[programIndex] = struct_2.x + struct_2.y;
+}
+
+
+export void result(uniform float RET[]) {
+    if (programIndex % 3 == 0)
+        RET[programIndex] = 5 + programIndex + 1;
+    else
+        RET[programIndex] = -145;
+}
+


### PR DESCRIPTION
According to https://ispc.github.io/ispc.html#struct-types, uniform field of varying struct is still uniform, so we don't need cast it to varying. (#1164)