### PR TITLE
Fixed the last useless step in foreach_tiled in some cases

### DIFF
--- a/stmt.cpp
+++ b/stmt.cpp
@@ -1988,7 +1988,13 @@ ForeachStmt::EmitCode(FunctionEmitContext *ctx) const {
         }
 
         ctx->StoreInst(LLVMFalse, stepIndexAfterMaskedBodyPtr);
-        ctx->BranchInst(bbMaskedBody);
+
+        // check to see if counter != end, otherwise, the next step is not necessary
+        llvm::Value *counter = ctx->LoadInst(uniformCounterPtrs[nDims-1], "counter");
+        llvm::Value *atEnd =
+            ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_NE,
+                         counter, endVals[nDims-1], "at_end");
+        ctx->BranchInst(bbMaskedBody, bbReset[nDims-1], atEnd);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/tests/foreach-32.ispc
+++ b/tests/foreach-32.ispc
@@ -1,0 +1,29 @@
+export uniform int width() { return programCount; }
+
+export void f_f(uniform float RET[], uniform float aFOO[]) {
+#define A_BEGIN 11
+#define A_END   14
+#define B_BEGIN 28
+#define B_END   31
+#define C_BEGIN 0
+#define C_END   8
+    uniform int t = 0;
+
+    foreach_tiled (i = A_BEGIN ... A_END, j = B_BEGIN ... B_END, k = C_BEGIN ... C_END) {
+        t++;
+    }
+
+    //the comparison with the expected number of iterations
+    if (programCount == 4)
+        RET[programIndex] = t - 24;
+    else if (programCount == 8)
+        RET[programIndex] = t - 16;
+    else if (programCount == 16)
+        RET[programIndex] = t - 8;
+    else
+        RET[programIndex] = t; //this case is still unknown, error in general
+}
+
+export void result(uniform float RET[]) {
+    RET[programIndex] = 0;
+}


### PR DESCRIPTION
This basic block runs only on the last step. Therefore, this check during mask calculation is not very expensive. 