### PR TITLE
Fix C compatibility of ISPCInstrument declaration in export header

### DIFF
--- a/module.cpp
+++ b/module.cpp
@@ -2220,9 +2220,9 @@ Module::writeHeader(const char *fn) {
 
     if (g->emitInstrumentation) {
         fprintf(f, "#define ISPC_INSTRUMENTATION 1\n");
-        fprintf(f, "extern \"C\" {\n");
+        fprintf(f, "#if defined(__cplusplus) && (! defined(__ISPC_NO_EXTERN_C) || !__ISPC_NO_EXTERN_C )\nextern \"C\" {\n#endif // __cplusplus\n");
         fprintf(f, "  void ISPCInstrument(const char *fn, const char *note, int line, uint64_t mask);\n");
-        fprintf(f, "}\n");
+        fprintf(f, "#if defined(__cplusplus) && (! defined(__ISPC_NO_EXTERN_C) || !__ISPC_NO_EXTERN_C )\n} /* end extern C */\n#endif // __cplusplus\n");
     }
 
     // end namespace
@@ -2333,9 +2333,9 @@ Module::writeDispatchHeader(DispatchHeaderInfo *DHI) {
 
       if (g->emitInstrumentation) {
         fprintf(f, "#define ISPC_INSTRUMENTATION 1\n");
-        fprintf(f, "extern \"C\" {\n");
+        fprintf(f, "#if defined(__cplusplus) && (! defined(__ISPC_NO_EXTERN_C) || !__ISPC_NO_EXTERN_C )\nextern \"C\" {\n#endif // __cplusplus\n");
         fprintf(f, "  void ISPCInstrument(const char *fn, const char *note, int line, uint64_t mask);\n");
-        fprintf(f, "}\n");
+        fprintf(f, "#if defined(__cplusplus) && (! defined(__ISPC_NO_EXTERN_C) || !__ISPC_NO_EXTERN_C )\n} /* end extern C */\n#endif // __cplusplus\n");
       }
 
       // end namespace


### PR DESCRIPTION
When compiling with `--instrument` the declaration for ISPCInstrument is not valid C and thus can't be included in a C program since `extern "C"` is not in C. The fix in this PR wraps the `extern "C"` in the same `#if`'s that are used for the `extern "C"` statement on the exported ISPC functions:

```c++
#if defined(__cplusplus) && (! defined(__ISPC_NO_EXTERN_C) || !__ISPC_NO_EXTERN_C )
extern "C" {
#endif // __cplusplus
  void ISPCInstrument(const char *fn, const char *note, int line, uint64_t mask);
#if defined(__cplusplus) && (! defined(__ISPC_NO_EXTERN_C) || !__ISPC_NO_EXTERN_C )
} /* end extern C */
#endif // __cplusplus
```

I noticed this function is written in two places, `Module::writeHeader` and `Module::writeDispatchHeader`, but I'm not sure what the different headers being written here are. For now I've just modified both of them to match. I wasn't sure if ISPCInstrument should be marked extern, I don't think it's necessary but I notice the ISPC exported functions are marked extern, so let me know if that should be changed.