### PR TITLE
Knl int8 mask

### DIFF
--- a/builtins.cpp
+++ b/builtins.cpp
@@ -445,6 +445,8 @@ lSetInternalFunctions(llvm::Module *module) {
         "__broadcast_i32",
         "__broadcast_i64",
         "__broadcast_i8",
+        "__cast_mask_to_i1",
+        "__cast_mask_to_i16",
         "__ceil_uniform_double",
         "__ceil_uniform_float",
         "__ceil_varying_double",
@@ -482,6 +484,8 @@ lSetInternalFunctions(llvm::Module *module) {
         "__extract_float",
         "__extract_double",
 //#endif /* ISPC_NVPTX_ENABLED */
+        "__extract_mask_low",
+        "__extract_mask_hi",
         "__fastmath",
         "__float_to_half_uniform",
         "__float_to_half_varying",

--- a/ispc.cpp
+++ b/ispc.cpp
@@ -934,7 +934,7 @@ Target::Target(const char *arch, const char *cpu, const char *isa, bool pic, boo
         // ?? this->m_dataTypeWidth = 32;
         this->m_vectorWidth = 16;
         this->m_maskingIsFree = true;
-        this->m_maskBitCount = 1;
+        this->m_maskBitCount = 8;
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = this->m_hasScatter = true;
@@ -954,7 +954,7 @@ Target::Target(const char *arch, const char *cpu, const char *isa, bool pic, boo
         // ?? this->m_dataTypeWidth = 32;
         this->m_vectorWidth = 16;
         this->m_maskingIsFree = true;
-        this->m_maskBitCount = 1;
+        this->m_maskBitCount = 8;
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = this->m_hasScatter = true;

--- a/lex.ll
+++ b/lex.ll
@@ -637,14 +637,14 @@ lParseInteger(bool dotdotdot) {
             // No u or l suffix
             // If we're compiling to an 8-bit mask target and the constant
             // fits into 8 bits, return an 8-bit int.
-            if (g->target->getMaskBitCount() == 8) {
+            if (g->target->getDataTypeWidth() == 8) {
                 if (yylval.intVal <= 0x7fULL)
                     return TOKEN_INT8_CONSTANT;
                 else if (yylval.intVal <= 0xffULL)
                     return TOKEN_UINT8_CONSTANT;
             }
             // And similarly for 16-bit masks and constants
-            if (g->target->getMaskBitCount() == 16) {
+            if (g->target->getDataTypeWidth() == 16) {
                 if (yylval.intVal <= 0x7fffULL)
                     return TOKEN_INT16_CONSTANT;
                 else if (yylval.intVal <= 0xffffULL)


### PR DESCRIPTION
Switching AVX-512 implementation to use i8x32 mask instead of i1x32 to be able to address elements of varying bool in memory.