### PR TITLE
Add llvm 4.0 as the highest supported llvm version

### DIFF
--- a/ispc_version.h
+++ b/ispc_version.h
@@ -51,9 +51,10 @@
 #define ISPC_LLVM_3_7 30700
 #define ISPC_LLVM_3_8 30800
 #define ISPC_LLVM_3_9 30900
+#define ISPC_LLVM_4_0 40000
 
 #define OLDEST_SUPPORTED_LLVM ISPC_LLVM_3_2
-#define LATEST_SUPPORTED_LLVM ISPC_LLVM_3_9
+#define LATEST_SUPPORTED_LLVM ISPC_LLVM_4_0
 
 #ifdef __ispc__xstr
 #undef __ispc__xstr


### PR DESCRIPTION
Would you mind merging this? The new version was tagged 2 days ago and in the mean time, not much has changed. I couldn't get the whole ISPC project to build against the current svn revision, though. Some cpp source could not be generated from ll files. Maybe it was a fault with my setup, so I made this PR nonetheless. But if there is something seriously wrong about it, it's no problem if you reject this PR.