### PR TITLE
ISPC AO example: fix for non-square output images

### DIFF
--- a/examples/aobench/ao.ispc
+++ b/examples/aobench/ao.ispc
@@ -220,6 +220,10 @@ static void ao_scanlines(uniform int y0, uniform int y1, uniform int w,
         // Figure out x,y pixel in NDC
         float px =  (x + du - (w / 2.0f)) / (w / 2.0f);
         float py = -(y + dv - (h / 2.0f)) / (h / 2.0f);
+
+		// Scale NDC based on width/height ratio, supporting non-square image output
+		px *= (float)w / (float)h;
+
         float ret = 0.f;
         Ray ray;
         Isect isect;

--- a/examples/aobench/ao.ispc
+++ b/examples/aobench/ao.ispc
@@ -221,8 +221,8 @@ static void ao_scanlines(uniform int y0, uniform int y1, uniform int w,
         float px =  (x + du - (w / 2.0f)) / (w / 2.0f);
         float py = -(y + dv - (h / 2.0f)) / (h / 2.0f);
 
-		// Scale NDC based on width/height ratio, supporting non-square image output
-		px *= (float)w / (float)h;
+        // Scale NDC based on width/height ratio, supporting non-square image output
+        px *= (float)w / (float)h;
 
         float ret = 0.f;
         Ray ray;

--- a/examples/aobench/ao_serial.cpp
+++ b/examples/aobench/ao_serial.cpp
@@ -273,8 +273,8 @@ static void ao_scanlines(int y0, int y1, int w, int h, int nsubsamples,
                     float px = (x + (u / (float)nsubsamples) - (w / 2.0f)) / (w / 2.0f);
                     float py = -(y + (v / (float)nsubsamples) - (h / 2.0f)) / (h / 2.0f);
 
-					// Scale NDC based on width/height ratio, supporting non-square image output
-					px *= (float)w / (float)h;
+                    // Scale NDC based on width/height ratio, supporting non-square image output
+                    px *= (float)w / (float)h;
 
                     float ret = 0.f;
                     Ray ray;

--- a/examples/aobench/ao_serial.cpp
+++ b/examples/aobench/ao_serial.cpp
@@ -272,6 +272,10 @@ static void ao_scanlines(int y0, int y1, int w, int h, int nsubsamples,
                 for (int v = 0; v < nsubsamples; ++v) {
                     float px = (x + (u / (float)nsubsamples) - (w / 2.0f)) / (w / 2.0f);
                     float py = -(y + (v / (float)nsubsamples) - (h / 2.0f)) / (h / 2.0f);
+
+					// Scale NDC based on width/height ratio, supporting non-square image output
+					px *= (float)w / (float)h;
+
                     float ret = 0.f;
                     Ray ray;
                     Isect isect;

--- a/examples/aobench_instrumented/ao_instrumented.ispc
+++ b/examples/aobench_instrumented/ao_instrumented.ispc
@@ -258,6 +258,10 @@ static void ao_scanlines(uniform int y0, uniform int y1, uniform int w,
             // Figure out x,y pixel in NDC
             float px =  (x + du - (w / 2.0f)) / (w / 2.0f);
             float py = -(y + dv - (h / 2.0f)) / (h / 2.0f);
+
+			// Scale NDC based on width/height ratio, supporting non-square image output
+			px *= (float)w / (float)h;
+
             float ret = 0.f;
             Ray ray;
             Isect isect;

--- a/examples/aobench_instrumented/ao_instrumented.ispc
+++ b/examples/aobench_instrumented/ao_instrumented.ispc
@@ -259,8 +259,8 @@ static void ao_scanlines(uniform int y0, uniform int y1, uniform int w,
             float px =  (x + du - (w / 2.0f)) / (w / 2.0f);
             float py = -(y + dv - (h / 2.0f)) / (h / 2.0f);
 
-			// Scale NDC based on width/height ratio, supporting non-square image output
-			px *= (float)w / (float)h;
+            // Scale NDC based on width/height ratio, supporting non-square image output
+            px *= (float)w / (float)h;
 
             float ret = 0.f;
             Ray ray;


### PR DESCRIPTION
Hi,

The following change allows for non-deformed, non-square image output.

Before (1024x768):
![image](https://cloud.githubusercontent.com/assets/1844966/26753879/7b012e86-4870-11e7-915c-b6964da641d9.png)

After (1024x768):
![image](https://cloud.githubusercontent.com/assets/1844966/26753876/62319b3e-4870-11e7-999d-f80f9d24389b.png)

Also (768x1024):
![image](https://cloud.githubusercontent.com/assets/1844966/26753888/a4e882ee-4870-11e7-8273-e108c8183185.png)

Regards,

-Colin