### PR TITLE
Patches for llvm 7.0 support

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2017, Intel Corporation
+Copyright (c) 2010-2018, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2010-2016, Intel Corporation
+#  Copyright (c) 2010-2018, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,7 @@ llvm_patches folder. You can build LLVM manually, or run our scripts, which \n
 will do all the work for you. Do the following: \n
 1. Create a folder, where LLVM will reside and set LLVM_HOME variable to its \n
   path. \n
-2. Set ISPC_HOME variable to your ISPC location (probably current folder).
+2. Set ISPC_HOME variable to your ISPC location (probably current folder). \n
 3. Run alloy.py tool to checkout and build LLVM: \n
   alloy.py -b --version=3.8 \n
 4. Add $$LLVM_HOME/bin-3.8/bin path to your PATH. \n

--- a/alloy.py
+++ b/alloy.py
@@ -138,7 +138,7 @@ def checkout_LLVM(component, use_git, version_LLVM, revision, target_dir, from_v
         SVN_PATH="trunk"
         GIT_BRANCH="master"
     elif  version_LLVM == "6_0":
-        SVN_PATH="tags/RELEASE_600/final"
+        SVN_PATH="branches/release_60"
         GIT_BRANCH="release_60"
     elif  version_LLVM == "5_0":
         SVN_PATH="tags/RELEASE_501/final"

--- a/alloy.py
+++ b/alloy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-#  Copyright (c) 2013-2017, Intel Corporation
+#  Copyright (c) 2013-2018, Intel Corporation
 #  All rights reserved.
 # 
 #  Redistribution and use in source and binary forms, with or without
@@ -137,8 +137,11 @@ def checkout_LLVM(component, use_git, version_LLVM, revision, target_dir, from_v
     if  version_LLVM == "trunk":
         SVN_PATH="trunk"
         GIT_BRANCH="master"
+    elif  version_LLVM == "6_0":
+        SVN_PATH="tags/RELEASE_600/final"
+        GIT_BRANCH="release_60"
     elif  version_LLVM == "5_0":
-        SVN_PATH="tags/RELEASE_500/final"
+        SVN_PATH="tags/RELEASE_501/final"
         GIT_BRANCH="release_50"
     elif  version_LLVM == "4_0":
         SVN_PATH="tags/RELEASE_401/final"
@@ -554,8 +557,10 @@ def build_ispc(version_LLVM, make):
             temp = "4_0"
         if version_LLVM == "5.0":
             temp = "5_0"
-        if version_LLVM == "trunk":
+        if version_LLVM == "6.0":
             temp = "6_0"
+        if version_LLVM == "trunk":
+            temp = "7_0"
         os.environ["LLVM_VERSION"] = "LLVM_" + temp
         try_do_LLVM("clean ISPC for building", "msbuild ispc.vcxproj /t:clean", True)
         try_do_LLVM("build ISPC with LLVM version " + version_LLVM + " ", "msbuild ispc.vcxproj /V:m /p:Platform=Win32 /p:Configuration=Release /t:rebuild", True)
@@ -695,7 +700,7 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
             archs.append("x86-64")
         if "native" in only:
             sde_targets_t = []
-        for i in ["3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0", "5.0", "trunk"]:
+        for i in ["3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0", "5.0", "6.0", "trunk"]:
             if i in only:
                 LLVM.append(i)
         if "current" in only:
@@ -981,7 +986,7 @@ def Main():
         if os.environ.get("SMTP_ISPC") == None:
             error("you have no SMTP_ISPC in your environment for option notify", 1)
     if options.only != "":
-        test_only_r = " 3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 4.0 5.0 trunk current build stability performance x86 x86-64 x86_64 -O0 -O2 native debug nodebug "
+        test_only_r = " 3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 4.0 5.0 6.0 trunk current build stability performance x86 x86-64 x86_64 -O0 -O2 native debug nodebug "
         test_only = options.only.split(" ")
         for iterator in test_only:
             if not (" " + iterator + " " in test_only_r):
@@ -1094,7 +1099,7 @@ if __name__ == '__main__':
     llvm_group = OptionGroup(parser, "Options for building LLVM",
                     "These options must be used with -b option.")
     llvm_group.add_option('--version', dest='version',
-        help='version of llvm to build: 3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 4.0 5.0 trunk. Default: trunk', default="trunk")
+        help='version of llvm to build: 3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 4.0 5.0 6.0 trunk. Default: trunk', default="trunk")
     llvm_group.add_option('--with-gcc-toolchain', dest='gcc_toolchain_path',
          help='GCC install dir to use when building clang. It is important to set when ' +
          'you have alternative gcc installation. Note that otherwise gcc from standard ' +
@@ -1137,7 +1142,7 @@ if __name__ == '__main__':
     run_group.add_option('--only', dest='only',
         help='set types of tests. Possible values:\n' + 
             '-O0, -O2, x86, x86-64, stability (test only stability), performance (test only performance),\n' +
-            'build (only build with different LLVM), 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 5.0, trunk, native (do not use SDE),\n' +
+            'build (only build with different LLVM), 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 5.0, 6.0, trunk, native (do not use SDE),\n' +
             'current (do not rebuild ISPC), debug (only with debug info), nodebug (only without debug info, default).',
             default="")
     run_group.add_option('--perf_LLVM', dest='perf_llvm',

--- a/builtins/dispatch.ll
+++ b/builtins/dispatch.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2011-2017, Intel Corporation
+;;  Copyright (c) 2011-2018, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -157,6 +157,8 @@ define(`PTR_OP_ARGS',
          LLVM_VERSION, LLVM_5_0,
     ``$1 , $1 *'',
          LLVM_VERSION, LLVM_6_0,
+    ``$1 , $1 *'',
+         LLVM_VERSION, LLVM_7_0,
     ``$1 , $1 *'',
     ``$1 *''
   )

--- a/builtins/target-knl.ll
+++ b/builtins/target-knl.ll
@@ -42,7 +42,7 @@ ifelse(LLVM_VERSION, LLVM_3_7,
          LLVM_VERSION, LLVM_5_0,
     `include(`target-avx512-common.ll')',
          LLVM_VERSION, LLVM_6_0,
-    `include(`target-avx512-common.ll')'
+    `include(`target-avx512-common.ll')',
          LLVM_VERSION, LLVM_7_0,
     `include(`target-avx512-common.ll')'
   )
@@ -74,7 +74,7 @@ ifelse(LLVM_VERSION, LLVM_3_7,
          LLVM_VERSION, LLVM_5_0,
     rcp_rsqrt_varying_float_knl(),
          LLVM_VERSION, LLVM_6_0,
-    rcp_rsqrt_varying_float_knl()
+    rcp_rsqrt_varying_float_knl(),
          LLVM_VERSION, LLVM_7_0,
     rcp_rsqrt_varying_float_knl()
   )

--- a/builtins/target-knl.ll
+++ b/builtins/target-knl.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2015-2017, Intel Corporation
+;;  Copyright (c) 2015-2018, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -43,6 +43,8 @@ ifelse(LLVM_VERSION, LLVM_3_7,
     `include(`target-avx512-common.ll')',
          LLVM_VERSION, LLVM_6_0,
     `include(`target-avx512-common.ll')'
+         LLVM_VERSION, LLVM_7_0,
+    `include(`target-avx512-common.ll')'
   )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -72,6 +74,8 @@ ifelse(LLVM_VERSION, LLVM_3_7,
          LLVM_VERSION, LLVM_5_0,
     rcp_rsqrt_varying_float_knl(),
          LLVM_VERSION, LLVM_6_0,
+    rcp_rsqrt_varying_float_knl()
+         LLVM_VERSION, LLVM_7_0,
     rcp_rsqrt_varying_float_knl()
   )
 

--- a/builtins/target-skx.ll
+++ b/builtins/target-skx.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2016-2017, Intel Corporation
+;;  Copyright (c) 2016-2018, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,8 @@ ifelse(LLVM_VERSION, LLVM_3_8,
          LLVM_VERSION, LLVM_5_0,
     `include(`target-avx512-common.ll')',
          LLVM_VERSION, LLVM_6_0,
+    `include(`target-avx512-common.ll')'
+         LLVM_VERSION, LLVM_7_0,
     `include(`target-avx512-common.ll')'
   )
 
@@ -92,6 +94,8 @@ ifelse(LLVM_VERSION, LLVM_3_8,
          LLVM_VERSION, LLVM_5_0,
     rcp_rsqrt_varying_float_skx(),
          LLVM_VERSION, LLVM_6_0,
+    rcp_rsqrt_varying_float_skx()
+         LLVM_VERSION, LLVM_7_0,
     rcp_rsqrt_varying_float_skx()
   )
 

--- a/builtins/target-skx.ll
+++ b/builtins/target-skx.ll
@@ -41,7 +41,7 @@ ifelse(LLVM_VERSION, LLVM_3_8,
          LLVM_VERSION, LLVM_5_0,
     `include(`target-avx512-common.ll')',
          LLVM_VERSION, LLVM_6_0,
-    `include(`target-avx512-common.ll')'
+    `include(`target-avx512-common.ll')',
          LLVM_VERSION, LLVM_7_0,
     `include(`target-avx512-common.ll')'
   )
@@ -94,7 +94,7 @@ ifelse(LLVM_VERSION, LLVM_3_8,
          LLVM_VERSION, LLVM_5_0,
     rcp_rsqrt_varying_float_skx(),
          LLVM_VERSION, LLVM_6_0,
-    rcp_rsqrt_varying_float_skx()
+    rcp_rsqrt_varying_float_skx(),
          LLVM_VERSION, LLVM_7_0,
     rcp_rsqrt_varying_float_skx()
   )

--- a/builtins/util-nvptx.m4
+++ b/builtins/util-nvptx.m4
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2017, Intel Corporation
+;;  Copyright (c) 2010-2018, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without

--- a/builtins/util.m4
+++ b/builtins/util.m4
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2017, Intel Corporation
+;;  Copyright (c) 2010-2018, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -64,6 +64,8 @@ define(`PTR_OP_ARGS',
     ``$1 , $1 *'',
          LLVM_VERSION, LLVM_6_0,
     ``$1 , $1 *'',
+         LLVM_VERSION, LLVM_7_0,
+    ``$1 , $1 *'',
     ``$1 *''
   )
 )
@@ -81,6 +83,8 @@ define(`MdORi64',
     ``i64'',
     LLVM_VERSION, LLVM_6_0,
     ``i64'',
+    LLVM_VERSION, LLVM_7_0,
+    ``i64'',
     ``double''
   )
 )
@@ -95,6 +99,8 @@ define(`MfORi32',
     LLVM_VERSION, LLVM_5_0,
     ``i32'',
     LLVM_VERSION, LLVM_6_0,
+    ``i32'',
+    LLVM_VERSION, LLVM_7_0,
     ``i32'',
     ``float''
   )
@@ -1613,6 +1619,9 @@ define <$1 x $2> @__atomic_compare_exchange_$3_global($2* %ptr, <$1 x $2> %cmp,
   ',LLVM_VERSION,LLVM_6_0,`
     %r_LANE_ID_t = cmpxchg $2 * %ptr, $2 %cmp_LANE_ID, $2 %val_LANE_ID seq_cst seq_cst
     %r_LANE_ID = extractvalue { $2, i1 } %r_LANE_ID_t, 0
+  ',LLVM_VERSION,LLVM_7_0,`
+    %r_LANE_ID_t = cmpxchg $2 * %ptr, $2 %cmp_LANE_ID, $2 %val_LANE_ID seq_cst seq_cst
+    %r_LANE_ID = extractvalue { $2, i1 } %r_LANE_ID_t, 0
   ',`
     %r_LANE_ID = cmpxchg $2 * %ptr, $2 %cmp_LANE_ID, $2 %val_LANE_ID seq_cst
   ')
@@ -1648,6 +1657,9 @@ define $2 @__atomic_compare_exchange_uniform_$3_global($2* %ptr, $2 %cmp,
    %r_t = cmpxchg $2 * %ptr, $2 %cmp, $2 %val seq_cst seq_cst
    %r = extractvalue { $2, i1 } %r_t, 0
   ',LLVM_VERSION,LLVM_6_0,`
+   %r_t = cmpxchg $2 * %ptr, $2 %cmp, $2 %val seq_cst seq_cst
+   %r = extractvalue { $2, i1 } %r_t, 0
+  ',LLVM_VERSION,LLVM_7_0,`
    %r_t = cmpxchg $2 * %ptr, $2 %cmp, $2 %val seq_cst seq_cst
    %r = extractvalue { $2, i1 } %r_t, 0
   ',`

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -5172,7 +5172,7 @@ countries.
 
 * Other names and brands may be claimed as the property of others.
 
-Copyright(C) 2011-2017, Intel Corporation. All rights reserved.
+Copyright(C) 2011-2018, Intel Corporation. All rights reserved.
 
 
 Optimization Notice

--- a/docs/perfguide.rst
+++ b/docs/perfguide.rst
@@ -786,7 +786,7 @@ countries.
 
 * Other names and brands may be claimed as the property of others.
 
-Copyright(C) 2011-2017, Intel Corporation. All rights reserved.
+Copyright(C) 2011-2018, Intel Corporation. All rights reserved.
 
 
 Optimization Notice

--- a/docs/template-news.txt
+++ b/docs/template-news.txt
@@ -57,7 +57,7 @@
 %(body)s
 </div>
     <div class="clearfix"></div>
-    <div id="footer"> &copy; 2011-2017 <strong>Intel Corporation</strong> | Valid <a href="http://validator.w3.org/check?uri=referer">XHTML</a> | <a href="http://jigsaw.w3.org/css-validator/check/referer">CSS</a> | ClearBlue  by: <a href="http://www.themebin.com/">ThemeBin</a>
+    <div id="footer"> &copy; 2011-2018 <strong>Intel Corporation</strong> | Valid <a href="http://validator.w3.org/check?uri=referer">XHTML</a> | <a href="http://jigsaw.w3.org/css-validator/check/referer">CSS</a> | ClearBlue  by: <a href="http://www.themebin.com/">ThemeBin</a>
       <!-- Please Do Not remove this link, thank u -->
       </div>
       </div>

--- a/docs/template-perf.txt
+++ b/docs/template-perf.txt
@@ -57,7 +57,7 @@
 %(body)s
 </div>
     <div class="clearfix"></div>
-    <div id="footer"> &copy; 2011-2017 <strong>Intel Corporation</strong> | Valid <a href="http://validator.w3.org/check?uri=referer">XHTML</a> | <a href="http://jigsaw.w3.org/css-validator/check/referer">CSS</a> | ClearBlue  by: <a href="http://www.themebin.com/">ThemeBin</a>
+    <div id="footer"> &copy; 2011-2018 <strong>Intel Corporation</strong> | Valid <a href="http://validator.w3.org/check?uri=referer">XHTML</a> | <a href="http://jigsaw.w3.org/css-validator/check/referer">CSS</a> | ClearBlue  by: <a href="http://www.themebin.com/">ThemeBin</a>
       <!-- Please Do Not remove this link, thank u -->
       </div>
       </div>

--- a/docs/template.txt
+++ b/docs/template.txt
@@ -57,7 +57,7 @@
 %(body)s
 </div>
     <div class="clearfix"></div>
-    <div id="footer"> &copy; 2011-2017 <strong>Intel Corporation</strong> | Valid <a href="http://validator.w3.org/check?uri=referer">XHTML</a> | <a href="http://jigsaw.w3.org/css-validator/check/referer">CSS</a> | ClearBlue  by: <a href="http://www.themebin.com/">ThemeBin</a>
+    <div id="footer"> &copy; 2011-2018 <strong>Intel Corporation</strong> | Valid <a href="http://validator.w3.org/check?uri=referer">XHTML</a> | <a href="http://jigsaw.w3.org/css-validator/check/referer">CSS</a> | ClearBlue  by: <a href="http://www.themebin.com/">ThemeBin</a>
       <!-- Please Do Not remove this link, thank u -->
       </div>
       </div>

--- a/ispc.cpp
+++ b/ispc.cpp
@@ -60,9 +60,14 @@
   #include <llvm/IR/Instructions.h>
 #endif
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_3_6 // LLVM 3.6+
-  #include <llvm/Target/TargetSubtargetInfo.h>
-  #if ISPC_LLVM_VERSION >= ISPC_LLVM_3_7 // LLVM 3.7+
-    #include <llvm/Target/TargetLowering.h>
+  #if ISPC_LLVM_VERSION >= ISPC_LLVM_6_0
+    #include <llvm/CodeGen/TargetSubtargetInfo.h>
+    #include <llvm/CodeGen/TargetLowering.h>
+  #else
+    #include <llvm/Target/TargetSubtargetInfo.h>
+    #if ISPC_LLVM_VERSION >= ISPC_LLVM_3_7 // LLVM 3.7+
+      #include <llvm/Target/TargetLowering.h>
+    #endif
   #endif
 #endif
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_3_5 // LLVM 3.5+

--- a/ispc.h
+++ b/ispc.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2017, Intel Corporation
+  Copyright (c) 2010-2018, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 #include "ispc_version.h"
 
 #if ISPC_LLVM_VERSION < OLDEST_SUPPORTED_LLVM || ISPC_LLVM_VERSION > LATEST_SUPPORTED_LLVM
-#error "Only LLVM 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 5.0 and 6.0 development branch are supported"
+#error "Only LLVM 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 5.0, 6.0 and 7.0 development branch are supported"
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/ispc_version.h
+++ b/ispc_version.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2015-2017, Intel Corporation
+  Copyright (c) 2015-2018, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -54,9 +54,10 @@
 #define ISPC_LLVM_4_0 40000
 #define ISPC_LLVM_5_0 50000
 #define ISPC_LLVM_6_0 60000
+#define ISPC_LLVM_7_0 70000
 
 #define OLDEST_SUPPORTED_LLVM ISPC_LLVM_3_2
-#define LATEST_SUPPORTED_LLVM ISPC_LLVM_6_0
+#define LATEST_SUPPORTED_LLVM ISPC_LLVM_7_0
 
 #ifdef __ispc__xstr
 #undef __ispc__xstr


### PR DESCRIPTION
The changes of this commit are completely analogue to the changes
introduced in 6dc0ccc404c877531f06b42881272f15f4209b17 (aside from some additional 2017->2018 bumps)

Please note that there isn't a RELEASE_600 tag on llvm.org yet (see
https://llvm.org/svn/llvm-project/llvm/tags/). Therefore, the change in
alloy.py is a bit ahead of time as of now.