### PR TITLE
[NFC] Fix for llvm upstream change 325155

### DIFF
--- a/module.cpp
+++ b/module.cpp
@@ -1490,7 +1490,11 @@ Module::writeBitcode(llvm::Module *module, const char *outFileName) {
     }
     else
 #endif /* ISPC_NVPTX_ENABLED */
+#if ISPC_LLVM_VERSION < ISPC_LLVM_7_0
       llvm::WriteBitcodeToFile(module, fos);
+#else
+      llvm::WriteBitcodeToFile(*module, fos);
+#endif
 
     return true;
 }


### PR DESCRIPTION
`WriteBitcodeToFile` now takes the module by reference instead of by pointer.

Phabricator: https://reviews.llvm.org/rL325155
GitHub: https://github.com/llvm-mirror/llvm/commit/06d6207c1c631716d4e6310246d198aa9e05c0d0