### PR TITLE
 [NFC] Fix for llvm upstream change 328717 

### DIFF
--- a/cbackend.cpp
+++ b/cbackend.cpp
@@ -93,6 +93,9 @@
 #include "llvm/CodeGen/IntrinsicLowering.h"
 //#include "llvm/Target/Mangler.h"
 #include "llvm/Transforms/Scalar.h"
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_7_0
+  #include "llvm/Transforms/Utils.h"
+#endif
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCInstrInfo.h"
@@ -1629,7 +1632,7 @@ void CWriter::printConstant(llvm::Constant *CPV, bool Static) {
       Out << "\"";
       //const uint64_t *Ptr64 = CPV->getUniqueInteger().getRawData();
       const uint64_t *Ptr64 = CI->getValue().getRawData();
-      for (int i = 0; i < Ty->getPrimitiveSizeInBits(); i++) {
+      for (unsigned i = 0; i < Ty->getPrimitiveSizeInBits(); i++) {
         Out << ((Ptr64[i / (sizeof (uint64_t) * 8)] >> (i % (sizeof (uint64_t) * 8))) & 1);
       }
       Out << "\"";

--- a/opt.cpp
+++ b/opt.cpp
@@ -99,6 +99,9 @@
 #include <llvm/ADT/SmallSet.h>
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/IPO.h>
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_7_0
+  #include "llvm/Transforms/Utils.h"
+#endif
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #include <llvm/Target/TargetOptions.h>
 #if ISPC_LLVM_VERSION == ISPC_LLVM_3_2


### PR DESCRIPTION
cbackend.cpp uses createLowerInvokePass
opt.cpp uses createPromoteMemoryToRegisterPass

These functions were moved to the named header with commit 328717, which will
be part of the llvm 7.0 release.
Phabricator url: https://reviews.llvm.org/rL328717

This commit also fixes a signed/unsigned comparison warning in cbackend.cpp.
With these changed applied, ispc builds against llvm trunk from yesterday (April 9)