### PR TITLE
Allow command-line arguments to be passed in a file

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -286,13 +286,15 @@ static void lAddArgsFromFactory(ArgFactory &Args, int &argc, char *argv[MAX_NUM_
 /** Parse an open file for arguments and add them to the argc/argv passed as parameters */
 static void lAddArgsFromFile(FILE *file, int &argc, char *argv[MAX_NUM_ARGS])
 {
-    lAddArgsFromFactory(FileArgFactory(file), argc, argv);
+    FileArgFactory args(file);
+    lAddArgsFromFactory(args, argc, argv);
 }
 
 /** Parse a string for arguments and add them to the argc/argv passed as parameters */
 static void lAddArgsFromString(const char *string, int &argc, char *argv[MAX_NUM_ARGS])
 {
-    lAddArgsFromFactory(StringArgFactory(string), argc, argv);
+    StringArgFactory args(string);
+    lAddArgsFromFactory(args, argc, argv);
 }
 
 /** Add a single argument to the argc/argv passed as parameters. If the argument is of the


### PR DESCRIPTION
For reasons that I won't go into, I need to pass a large number of arguments to ISPC and the resulting command line can exceed the command-line length limit on Windows. Hence, I have implemented a patch to the command-line handling that allows some or all command-line arguments to be specified in a file.

This change takes the gcc format of `@<filename>`. If `<filename>` does not exist or cannot be opened, the argument is accepted as-is. The file (or `ISPC_ARGS`) is itself allowed to contain another `@<filename>` argument.

The content of the file is split into arguments in essentially the same way as was used for `ISPC_ARGS`. It does not (yet) support any method of escaping or quoting to allow white space within an argument. These arguments then replace the original `@<filename>`.

This also now polices that maximum number of arguments allowed rather than corrupting memory!

This change successfully builds and passes all tests on Windows but I have no way to test the Linux build. I also have not update the usage instructions with this change.