### PR TITLE
Implement GCC-style makefile dependency rule generation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -129,7 +129,7 @@ usage(int ret) {
     printf("    [-MMM <filename>]\t\t\tWrite #include dependencies to given file.\n");
     printf("    [-M]\t\t\t\tOutput a rule suitable for `make' describing the dependencies of the main source file to stdout.\n");
     printf("    [-MF <filename>]\t\t\tWhen used with `-M', specifies a file to write the dependencies to.\n");
-	printf("    [-MT <filename>]\t\t\tWhen used with `-M', changes the target of the rule emitted by dependency generation.\n");
+    printf("    [-MT <filename>]\t\t\tWhen used with `-M', changes the target of the rule emitted by dependency generation.\n");
     printf("    [--no-omit-frame-pointer]\t\tDisable frame pointer omission. It may be useful for profiling\n");
     printf("    [--nostdlib]\t\t\tDon't make the ispc standard library available\n");
     printf("    [--nocpp]\t\t\t\tDon't run the C preprocessor\n");
@@ -457,7 +457,7 @@ int main(int Argc, char *Argv[]) {
     const char *outFileName = NULL;
     const char *includeFileName = NULL;
     const char *depsFileName = NULL;
-	const char *depsTargetName = NULL;
+    const char *depsTargetName = NULL;
     const char *hostStubFileName = NULL;
     const char *devStubFileName = NULL;
     // Initiailize globals early so that we can set various option values

--- a/module.cpp
+++ b/module.cpp
@@ -2002,8 +2002,7 @@ Module::writeDeps(const char *fn, bool generateMakeRule, const char *tn) {
     for (std::set<std::string>::const_iterator it=registeredDependencies.begin();
          it != registeredDependencies.end();
          ++it) {
-      // As this is preprocessor output, these paths come escaped.
-      unescaped = *it;
+      unescaped = *it;  // As this is preprocessor output, paths come escaped.
       lUnescapeStringInPlace(unescaped);
       fprintf(file," %s \\\n",unescaped.c_str());
     }
@@ -3174,6 +3173,7 @@ Module::CompileAndOutput(const char *srcFile,
                          const char *headerFileName,
                          const char *includeFileName,
                          const char *depsFileName,
+                         const char *depsTargetName,
                          const char *hostStubFileName,
                          const char *devStubFileName)
 {
@@ -3237,7 +3237,9 @@ Module::CompileAndOutput(const char *srcFile,
                     return 1;
             if (depsFileName != NULL || (outputFlags & Module::OutputDepsToStdout)) {
               std::string targetName;
-              if (outFileName)
+			  if (depsTargetName)
+                targetName = depsTargetName;
+              else if (outFileName)
                 targetName = outFileName;
               else if (srcFile) {
                 targetName = srcFile;

--- a/module.cpp
+++ b/module.cpp
@@ -3242,7 +3242,7 @@ Module::CompileAndOutput(const char *srcFile,
                     return 1;
             if (depsFileName != NULL || (outputFlags & Module::OutputDepsToStdout)) {
               std::string targetName;
-			  if (depsTargetName)
+              if (depsTargetName)
                 targetName = depsTargetName;
               else if (outFileName)
                 targetName = outFileName;

--- a/module.cpp
+++ b/module.cpp
@@ -1225,7 +1225,7 @@ Module::AddExportedTypes(const std::vector<std::pair<const Type *,
 
 
 bool
-Module::writeOutput(OutputType outputType, const char *outFileName,
+Module::writeOutput(OutputType outputType, OutputFlags flags, const char *outFileName,
                     const char *includeFileName, DispatchHeaderInfo *DHI) {
     if (diBuilder && (outputType != Header) && (outputType != Deps))
         lStripUnusedDebugInfo(module);
@@ -1245,74 +1245,77 @@ Module::writeOutput(OutputType outputType, const char *outFileName,
     &&  module && llvm::verifyModule(*module))
         FATAL("Resulting module verification failed!");
 
+    if (outFileName)
+    {
     // First, issue a warning if the output file suffix and the type of
     // file being created seem to mismatch.  This can help catch missing
     // command-line arguments specifying the output file type.
-    const char *suffix = strrchr(outFileName, '.');
-    if (suffix != NULL) {
-        ++suffix;
-        const char *fileType = NULL;
-        switch (outputType) {
-        case Asm:
+      const char *suffix = strrchr(outFileName, '.');
+      if (suffix != NULL) {
+          ++suffix;
+          const char *fileType = NULL;
+          switch (outputType) {
+          case Asm:
 #ifdef ISPC_NVPTX_ENABLED
-          if (g->target->getISA() == Target::NVPTX)
-          {
-            if (strcasecmp(suffix, "ptx"))
-                fileType = "assembly";
-          }
-          else
+            if (g->target->getISA() == Target::NVPTX)
+            {
+              if (strcasecmp(suffix, "ptx"))
+                  fileType = "assembly";
+            }
+            else
 #endif /* ISPC_NVPTX_ENABLED */
-            if (strcasecmp(suffix, "s"))
-                fileType = "assembly";
-            break;
-        case Bitcode:
+              if (strcasecmp(suffix, "s"))
+                  fileType = "assembly";
+              break;
+          case Bitcode:
 #ifdef ISPC_NVPTX_ENABLED
-          if (g->target->getISA() == Target::NVPTX)
-          {
-            if (strcasecmp(suffix, "ll"))
-                fileType = "LLVM assembly";
-          }
-          else
+            if (g->target->getISA() == Target::NVPTX)
+            {
+              if (strcasecmp(suffix, "ll"))
+                  fileType = "LLVM assembly";
+            }
+            else
 #endif /* ISPC_NVPTX_ENABLED */
-            if (strcasecmp(suffix, "bc"))
-                fileType = "LLVM bitcode";
+              if (strcasecmp(suffix, "bc"))
+                  fileType = "LLVM bitcode";
+              break;
+          case Object:
+              if (strcasecmp(suffix, "o") && strcasecmp(suffix, "obj"))
+                  fileType = "object";
+              break;
+          case CXX:
+              if (strcasecmp(suffix, "c") && strcasecmp(suffix, "cc") &&
+                  strcasecmp(suffix, "c++") && strcasecmp(suffix, "cxx") &&
+                  strcasecmp(suffix, "cpp"))
+                  fileType = "c++";
+              break;
+          case Header:
+              if (strcasecmp(suffix, "h") && strcasecmp(suffix, "hh") &&
+                  strcasecmp(suffix, "hpp"))
+                  fileType = "header";
+              break;
+          case Deps:
             break;
-        case Object:
-            if (strcasecmp(suffix, "o") && strcasecmp(suffix, "obj"))
-                fileType = "object";
-            break;
-        case CXX:
+          case DevStub:
             if (strcasecmp(suffix, "c") && strcasecmp(suffix, "cc") &&
                 strcasecmp(suffix, "c++") && strcasecmp(suffix, "cxx") &&
                 strcasecmp(suffix, "cpp"))
-                fileType = "c++";
-            break;
-        case Header:
-            if (strcasecmp(suffix, "h") && strcasecmp(suffix, "hh") &&
-                strcasecmp(suffix, "hpp"))
-                fileType = "header";
-            break;
-        case Deps:
-          break;
-        case DevStub:
-          if (strcasecmp(suffix, "c") && strcasecmp(suffix, "cc") &&
-              strcasecmp(suffix, "c++") && strcasecmp(suffix, "cxx") &&
-              strcasecmp(suffix, "cpp"))
-            fileType = "dev-side offload stub";
-            break;
-        case HostStub:
-          if (strcasecmp(suffix, "c") && strcasecmp(suffix, "cc") &&
-              strcasecmp(suffix, "c++") && strcasecmp(suffix, "cxx") &&
-              strcasecmp(suffix, "cpp"))
-            fileType = "host-side offload stub";
-            break;
-        default:
-          Assert(0 /* swtich case not handled */);
-          return 1;
-        }
-        if (fileType != NULL)
-            Warning(SourcePos(), "Emitting %s file, but filename \"%s\" "
-                    "has suffix \"%s\"?", fileType, outFileName, suffix);
+              fileType = "dev-side offload stub";
+              break;
+          case HostStub:
+            if (strcasecmp(suffix, "c") && strcasecmp(suffix, "cc") &&
+                strcasecmp(suffix, "c++") && strcasecmp(suffix, "cxx") &&
+                strcasecmp(suffix, "cpp"))
+              fileType = "host-side offload stub";
+              break;
+          default:
+            Assert(0 /* swtich case not handled */);
+            return 1;
+          }
+          if (fileType != NULL)
+              Warning(SourcePos(), "Emitting %s file, but filename \"%s\" "
+                      "has suffix \"%s\"?", fileType, outFileName, suffix);
+      }
     }
 
     if (outputType == Header) {
@@ -1322,7 +1325,7 @@ Module::writeOutput(OutputType outputType, const char *outFileName,
         return writeHeader(outFileName);
     }
     else if (outputType == Deps)
-      return writeDeps(outFileName);
+      return writeDeps(outFileName, 0 != (flags & GenerateMakeRuleForDeps), includeFileName);
     else if (outputType == HostStub)
       return writeHostStub(outFileName);
     else if (outputType == DevStub)
@@ -1956,18 +1959,27 @@ lIsExternC(const Symbol *sym) {
 
 
 bool
-Module::writeDeps(const char *fn) {
-  std::cout << "writing dependencies to file " << fn << std::endl;
-  FILE *file = fopen(fn,"w");
+Module::writeDeps(const char *fn, bool generateMakeRule, const char *tn) {
+  if (fn)	// We may be passed nullptr for stdout output.
+    std::cout << "writing dependencies to file " << fn << std::endl;
+  FILE *file = fn ? fopen(fn,"w") : stdout;
   if (!file) {
     perror("fopen");
     return false;
   }
 
-  for (std::set<std::string>::const_iterator it=registeredDependencies.begin();
-       it != registeredDependencies.end();
-       ++it)
-    fprintf(file,"%s\n",it->c_str());
+  if (generateMakeRule) {
+    fprintf(file,"%s:", tn);
+    for (std::set<std::string>::const_iterator it=registeredDependencies.begin();
+         it != registeredDependencies.end();
+         ++it)
+      fprintf(file," %s \\\n",it->c_str());
+  } else {
+    for (std::set<std::string>::const_iterator it=registeredDependencies.begin();
+         it != registeredDependencies.end();
+         ++it)
+      fprintf(file,"%s\n",it->c_str());
+  }
   return true;
 }
 
@@ -3123,7 +3135,7 @@ Module::CompileAndOutput(const char *srcFile,
                          const char *arch,
                          const char *cpu,
                          const char *target,
-                         bool generatePIC,
+                         OutputFlags outputFlags,
                          OutputType outputType,
                          const char *outFileName,
                          const char *headerFileName,
@@ -3134,7 +3146,7 @@ Module::CompileAndOutput(const char *srcFile,
 {
     if (target == NULL || strchr(target, ',') == NULL) {
         // We're only compiling to a single target
-        g->target = new Target(arch, cpu, target, generatePIC, g->printTarget);
+        g->target = new Target(arch, cpu, target, 0 != (outputFlags & GeneratePIC), g->printTarget);
         if (!g->target->isValid())
             return 1;
 
@@ -3185,19 +3197,31 @@ Module::CompileAndOutput(const char *srcFile,
             }
 
             if (outFileName != NULL)
-                if (!m->writeOutput(outputType, outFileName, includeFileName))
+                if (!m->writeOutput(outputType, outputFlags, outFileName, includeFileName))
                     return 1;
             if (headerFileName != NULL)
-                if (!m->writeOutput(Module::Header, headerFileName))
+                if (!m->writeOutput(Module::Header, outputFlags, headerFileName))
                     return 1;
-            if (depsFileName != NULL)
-              if (!m->writeOutput(Module::Deps,depsFileName))
+            if (depsFileName != NULL || (outputFlags & Module::OutputDepsToStdout)) {
+              std::string targetName;
+              if (outFileName)
+                targetName = outFileName;
+              else if (srcFile) {
+                targetName = srcFile;
+                size_t dot = targetName.find_last_of('.');
+                if (dot != std::string::npos)
+                  targetName.erase(dot, std::string::npos);
+                targetName.append(".o");
+              } else
+                targetName = "a.out";
+              if (!m->writeOutput(Module::Deps,outputFlags,depsFileName,targetName.c_str()))
                 return 1;
+            }
             if (hostStubFileName != NULL)
-              if (!m->writeOutput(Module::HostStub,hostStubFileName))
+              if (!m->writeOutput(Module::HostStub,outputFlags,hostStubFileName))
                 return 1;
             if (devStubFileName != NULL)
-              if (!m->writeOutput(Module::DevStub,devStubFileName))
+              if (!m->writeOutput(Module::DevStub,outputFlags,devStubFileName))
                 return 1;
         }
         else
@@ -3278,7 +3302,7 @@ Module::CompileAndOutput(const char *srcFile,
         std::string treatGenericAsSmth = "";
 
         for (unsigned int i = 0; i < targets.size(); ++i) {
-            g->target = new Target(arch, cpu, targets[i].c_str(), generatePIC, g->printTarget);
+            g->target = new Target(arch, cpu, targets[i].c_str(), 0 != (outputFlags & GeneratePIC), g->printTarget);
             if (!g->target->isValid())
                 return 1;
 
@@ -3316,13 +3340,13 @@ Module::CompileAndOutput(const char *srcFile,
                         !g->target->getTreatGenericAsSmth().empty()) {
                         targetOutFileName = lGetTargetFileName(outFileName,
                                                 g->target->getTreatGenericAsSmth().c_str(), true);
-                        if (!m->writeOutput(CXX, targetOutFileName.c_str(), includeFileName))
+                        if (!m->writeOutput(CXX, outputFlags, targetOutFileName.c_str(), includeFileName))
                             return 1;
                     }
                     else {
                         const char *isaName = g->target->GetISAString();
                         targetOutFileName = lGetTargetFileName(outFileName, isaName, false);
-                        if (!m->writeOutput(outputType, targetOutFileName.c_str()))
+                        if (!m->writeOutput(outputType, outputFlags, targetOutFileName.c_str()))
                             return 1;
                     }
                 }
@@ -3352,10 +3376,10 @@ Module::CompileAndOutput(const char *srcFile,
               std::string targetHeaderFileName =
                 lGetTargetFileName(headerFileName, isaName, false);
               // write out a header w/o target name for the first target only
-              if (!m->writeOutput(Module::Header, headerFileName, "", &DHI)) {
+              if (!m->writeOutput(Module::Header, outputFlags, headerFileName, "", &DHI)) {
                 return 1;
               }
-              if (!m->writeOutput(Module::Header, targetHeaderFileName.c_str())) {
+              if (!m->writeOutput(Module::Header, outputFlags, targetHeaderFileName.c_str())) {
                 return 1;
               }
               if (i == targets.size()-1) {
@@ -3384,7 +3408,7 @@ Module::CompileAndOutput(const char *srcFile,
         }
         Assert(firstTargetMachine != NULL);
 
-        g->target = new Target(arch, cpu, firstISA, generatePIC, false, treatGenericAsSmth);
+        g->target = new Target(arch, cpu, firstISA, 0 != (outputFlags & GeneratePIC), false, treatGenericAsSmth);
         if (!g->target->isValid()) {
             return 1;
         }
@@ -3400,7 +3424,7 @@ Module::CompileAndOutput(const char *srcFile,
         }
 
         if (depsFileName != NULL)
-            if (!m->writeOutput(Module::Deps, depsFileName))
+            if (!m->writeOutput(Module::Deps, outputFlags, depsFileName))
                 return 1;
 
         delete g->target;

--- a/module.h
+++ b/module.h
@@ -208,7 +208,7 @@ inline Module::OutputFlags& operator|=(Module::OutputFlags& lhs, const __underly
 inline Module::OutputFlags& operator&=(Module::OutputFlags& lhs, const __underlying_type(Module::OutputFlags) rhs) {
   return lhs = (Module::OutputFlags)((__underlying_type(Module::OutputFlags))lhs & rhs);
 }
-inline constexpr Module::OutputFlags operator|(const Module::OutputFlags lhs, const __underlying_type(Module::OutputFlags) rhs) {
+inline Module::OutputFlags operator|(const Module::OutputFlags lhs, const Module::OutputFlags rhs) {
   return (Module::OutputFlags)((__underlying_type(Module::OutputFlags))lhs | rhs);
 }
 

--- a/module.h
+++ b/module.h
@@ -186,10 +186,11 @@ private:
         output. */
     bool writeOutput(OutputType ot, OutputFlags flags, const char *filename,
                      const char *includeFileName = NULL,
+                     const char *sourceFileName = NULL,
                      DispatchHeaderInfo *DHI = 0);
     bool writeHeader(const char *filename);
     bool writeDispatchHeader(DispatchHeaderInfo *DHI);
-    bool writeDeps(const char *filename, bool generateMakeRule, const char *targetName = NULL);
+    bool writeDeps(const char *filename, bool generateMakeRule, const char *targetName = NULL, const char *srcFilename = NULL);
     bool writeDevStub(const char *filename);
     bool writeHostStub(const char *filename);
     bool writeObjectFileOrAssembly(OutputType outputType, const char *filename);

--- a/module.h
+++ b/module.h
@@ -106,6 +106,13 @@ public:
                       HostStub  /** generate host-side offload stubs */
     };
 
+    enum OutputFlags { NoFlags = 0,
+                       GeneratePIC = 0x1,
+                       GenerateFlatDeps = 0x2,         /** Dependencies will be output as a flat list. */
+                       GenerateMakeRuleForDeps = 0x4,  /** Dependencies will be output in a make rule format instead of a flat list. */
+                       OutputDepsToStdout = 0x8,       /** Dependency information will be output to stdout instead of file. */
+    };
+
     /** Compile the given source file, generating assembly, object file, or
         LLVM bitcode output, as well as (optionally) a header file with
         declarations of functions and types used in the ispc/application
@@ -138,7 +145,7 @@ public:
      */
     static int CompileAndOutput(const char *srcFile, const char *arch,
                                 const char *cpu, const char *targets,
-                                bool generatePIC,
+                                OutputFlags outputFlags,
                                 OutputType outputType,
                                 const char *outFileName,
                                 const char *headerFileName,
@@ -176,12 +183,12 @@ private:
         true on success, false if there has been an error.  The given
         filename may be NULL, indicating that output should go to standard
         output. */
-    bool writeOutput(OutputType ot, const char *filename,
+    bool writeOutput(OutputType ot, OutputFlags flags, const char *filename,
                      const char *includeFileName = NULL,
                      DispatchHeaderInfo *DHI = 0);
     bool writeHeader(const char *filename);
     bool writeDispatchHeader(DispatchHeaderInfo *DHI);
-    bool writeDeps(const char *filename);
+    bool writeDeps(const char *filename, bool generateMakeRule, const char *targetName = NULL);
     bool writeDevStub(const char *filename);
     bool writeHostStub(const char *filename);
     bool writeObjectFileOrAssembly(OutputType outputType, const char *filename);
@@ -192,5 +199,15 @@ private:
 
     void execPreprocessor(const char *infilename, llvm::raw_string_ostream* ostream) const;
 };
+
+inline Module::OutputFlags& operator|=(Module::OutputFlags& lhs, const __underlying_type(Module::OutputFlags) rhs) {
+  return lhs = (Module::OutputFlags)((__underlying_type(Module::OutputFlags))lhs | rhs);
+}
+inline Module::OutputFlags& operator&=(Module::OutputFlags& lhs, const __underlying_type(Module::OutputFlags) rhs) {
+  return lhs = (Module::OutputFlags)((__underlying_type(Module::OutputFlags))lhs & rhs);
+}
+inline constexpr Module::OutputFlags operator|(const Module::OutputFlags lhs, const __underlying_type(Module::OutputFlags) rhs) {
+  return (Module::OutputFlags)((__underlying_type(Module::OutputFlags))lhs | rhs);
+}
 
 #endif // ISPC_MODULE_H

--- a/module.h
+++ b/module.h
@@ -151,6 +151,7 @@ public:
                                 const char *headerFileName,
                                 const char *includeFileName,
                                 const char *depsFileName,
+                                const char *depsTargetName,
                                 const char *hostStubFileName,
                                 const char *devStubFileName);
 


### PR DESCRIPTION
Hello there,

Here's a little change that I found useful in my own work.

This commit adds handling of commandline options `-M` and `-MF` in a way inspired by what GCC does (inspired, as in, the switch names and semantics have been borrowed from GCC).
`-M` generates a makefile-compatible target rule for the current output object (or the canonical `a.out`, if nothing is specified), and outputs it to `stdout`.
`-MF <filename>` puts the output in `<filename>` instead.
`-MT <target name>` allows overriding the name of the target in the rule generated by `-M`.
The functionality of `-MMM` remains unchanged, apart from the fact that a subsequent `-MF` may alter the filename.
In order to achieve this, a new bitflag type `Module::OutputFlags` is introduced. It replaces the `generatePIC` boolean and is added as a new argument in several places.

Example output from running `ispc.exe -M "D:\projects\ispc\examples\deferred\kernels.ispc" -MF "D:\projects\ispc\examples\deferred\kernels.ispc.d" -MT foo.bar` on Windows:
```
foo.bar: D:\projects\ispc\examples\deferred/deferred.h \
 D:\projects\ispc\examples\deferred\kernels.ispc \

```
This can be directly included in a makefile that e.g. has a target `all` which depends on `foo.bar`.

Regards,

Leszek