### PR TITLE
Fix crash when compiling an empty `do {} while (false)` loop

### DIFF
--- a/stmt.cpp
+++ b/stmt.cpp
@@ -1076,7 +1076,7 @@ void DoStmt::EmitCode(FunctionEmitContext *ctx) const {
     // scope around the statements in the list.  So if the body is just a
     // single statement (and thus not a statement list), we need a new
     // scope, but we don't want two scopes in the StmtList case.
-    if (!llvm::dyn_cast<StmtList>(bodyStmts))
+    if (!bodyStmts || !llvm::dyn_cast<StmtList>(bodyStmts))
         ctx->StartScope();
 
     ctx->AddInstrumentationPoint("do loop body");
@@ -1118,7 +1118,7 @@ void DoStmt::EmitCode(FunctionEmitContext *ctx) const {
             ctx->BranchInst(btest);
     }
     // End the scope we started above, if needed.
-    if (!llvm::dyn_cast<StmtList>(bodyStmts))
+    if (!bodyStmts || !llvm::dyn_cast<StmtList>(bodyStmts))
         ctx->EndScope();
 
     // Now emit code for the loop test.

--- a/tests/empty-do-while.ispc
+++ b/tests/empty-do-while.ispc
@@ -1,0 +1,10 @@
+export uniform int width() { return programCount; }
+
+export void f_f(uniform float RET[], uniform float aFOO[]) {
+    do {} while (false);
+    RET[programIndex] = (float)programIndex;
+}
+
+export void result(uniform float RET[]) {
+    RET[programIndex] = (float)programIndex;
+}


### PR DESCRIPTION
Hi there,

Apparently, the LLVM dynamic cast isn't protected against casting null pointers. The following code snippet crashes ISPC:

```
export void Kernel()
{
	do {} while (false);
}
```

The fix is trivial - check if the pointer isn't null before attempting the cast.

This is on LLVM 6.0, I should mention.