### PR TITLE
Disable dump calls if methods not exported by llvm

### DIFF
--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -1177,11 +1177,11 @@ lVectorValuesAllEqual(llvm::Value *v, int vectorLength,
 
 #if 0
     fprintf(stderr, "all equal: ");
-    v->dump();
+    llvm_dump(*v);
     fprintf(stderr, "\n");
     llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(v);
     if (inst) {
-        inst->getParent()->dump();
+        llvm_dump(*inst->getParent());
         fprintf(stderr, "\n");
         fprintf(stderr, "\n");
     }
@@ -1469,11 +1469,11 @@ lVectorIsLinear(llvm::Value *v, int vectorLength, int stride,
 
 #if 0
     fprintf(stderr, "linear check: ");
-    v->dump();
+    llvm_dump(*v);
     fprintf(stderr, "\n");
     llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(v);
     if (inst) {
-        inst->getParent()->dump();
+        llvm_dump(*inst->getParent());
         fprintf(stderr, "\n");
         fprintf(stderr, "\n");
     }
@@ -1516,7 +1516,7 @@ lDumpValue(llvm::Value *v, std::set<llvm::Value *> &done) {
         return;
 
     fprintf(stderr, "  ");
-    v->dump();
+    llvm_dump(*v);
     done.insert(v);
 
     if (inst == NULL)

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -57,6 +57,13 @@
 #define PTYPE(p) (llvm::cast<llvm::PointerType>((p)->getType()->getScalarType())->getElementType())
 #endif
 
+template<typename T> void inline llvm_dump(const T& v) {
+#if ISPC_LLVM_VERSION < ISPC_LLVM_5_0 || defined(LLVM_ENABLE_DUMP)
+    v.dump();
+#endif
+    (void)v;
+}
+
 namespace llvm {
     class PHINode;
     class InsertElementInst;

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -173,7 +173,7 @@ static llvm::Pass *CreatePromoteLocalToPrivatePass();
                   strlen(getenv("FUNC"))))) {                           \
         fprintf(stderr, "Start of " NAME "\n");                \
         fprintf(stderr, "---------------\n");                  \
-        bb.dump();                                             \
+        llvm_dump(bb);                                             \
         fprintf(stderr, "---------------\n\n");                \
     } else /* eat semicolon */
 
@@ -184,7 +184,7 @@ static llvm::Pass *CreatePromoteLocalToPrivatePass();
                   strlen(getenv("FUNC"))))) {                           \
         fprintf(stderr, "End of " NAME " %s\n", modifiedAny ? "** CHANGES **" : ""); \
         fprintf(stderr, "---------------\n");                  \
-        bb.dump();                                             \
+        llvm_dump(bb);                                             \
         fprintf(stderr, "---------------\n\n");                \
     } else /* eat semicolon */
 
@@ -433,7 +433,7 @@ lGetMask(llvm::Value *factor, uint64_t *mask) {
             llvm::TargetMachine *targetMachine = g->target->GetTargetMachine();
             const llvm::TargetData *td = targetMachine->getTargetData();
             llvm::Constant *c = llvm::ConstantFoldConstantExpression(ce, td);
-            c->dump();
+            llvm_dump(*c);
             factor = c;
         }
         // else we should be able to handle it above...
@@ -537,7 +537,7 @@ void
 Optimize(llvm::Module *module, int optLevel) {
     if (g->debugPrint) {
         printf("*** Code going into optimization ***\n");
-        module->dump();
+        llvm_dump(*module);
     }
     DebugPassManager optPM;
     optPM.add(llvm::createVerifierPass(),0);
@@ -932,7 +932,7 @@ Optimize(llvm::Module *module, int optLevel) {
 
     if (g->debugPrint) {
         printf("\n*****\nFINAL OUTPUT\n*****\n");
-        module->dump();
+        llvm_dump(*module);
     }
 
 }
@@ -2016,7 +2016,7 @@ lExtractOffsetVector248Scale(llvm::Value **vec) {
 static llvm::Value *
 lExtractUniforms(llvm::Value **vec, llvm::Instruction *insertBefore) {
     fprintf(stderr, " lextract: ");
-    (*vec)->dump();
+    llvm_dump(*(*vec));
     fprintf(stderr, "\n");
 
     if (llvm::isa<llvm::ConstantVector>(*vec) ||
@@ -2101,11 +2101,11 @@ lExtractUniformsFromOffset(llvm::Value **basePtr, llvm::Value **offsetVector,
                            llvm::Value *offsetScale,
                            llvm::Instruction *insertBefore) {
 #if 1
-    (*basePtr)->dump();
+    llvm_dump(*(*basePtr));
     printf("\n");
-    (*offsetVector)->dump();
+    llvm_dump(*(*offsetVector));
     printf("\n");
-    offsetScale->dump();
+    llvm_dump(*offsetScale);
     printf("-----\n");
 #endif
 
@@ -4863,7 +4863,7 @@ bool
 DebugPass::runOnModule(llvm::Module &module) {
     fprintf(stderr, "%s", str_output);
     fflush(stderr);
-    module.dump();
+    llvm_dump(module);
     return true;
 }
 


### PR DESCRIPTION
Since llvm 5.0 the various dump methods are only exported if LLVM_ENABLE_DUMP is set. Since the methods are always present in the header files calling them leads to undefined references during linking.