### PR TITLE
Fix for #1381 : picked from the llvm commit r324820.

### DIFF
--- a/llvm_patches/5_0_bug1381.patch
+++ b/llvm_patches/5_0_bug1381.patch
@@ -1,0 +1,38 @@
+# This patch is required to fix #1381.
+# Extend inputs with elements smaller than i32 to sint_to_fp/uint_to_fp
+# before type legalization. In this particular case extending bool to 32 bits.
+Index: lib/Target/X86/X86ISelLowering.cpp
+===================================================================
+--- lib/Target/X86/X86ISelLowering.cpp	(revision 348663)
++++ lib/Target/X86/X86ISelLowering.cpp	(working copy)
+@@ -34944,12 +34944,12 @@
+   SDValue Op0 = N->getOperand(0);
+   EVT VT = N->getValueType(0);
+   EVT InVT = Op0.getValueType();
+-  EVT InSVT = InVT.getScalarType();
+   const TargetLowering &TLI = DAG.getTargetLoweringInfo();
+
++  // UINT_TO_FP(vXi1) -> SINT_TO_FP(SEXT(vXi1 to vXi32))
+   // UINT_TO_FP(vXi8) -> SINT_TO_FP(ZEXT(vXi8 to vXi32))
+   // UINT_TO_FP(vXi16) -> SINT_TO_FP(ZEXT(vXi16 to vXi32))
+-  if (InVT.isVector() && (InSVT == MVT::i8 || InSVT == MVT::i16)) {
++  if (InVT.isVector() && InVT.getScalarSizeInBits() < 32) {
+     SDLoc dl(N);
+     EVT DstVT = EVT::getVectorVT(*DAG.getContext(), MVT::i32,
+                                  InVT.getVectorNumElements());
+@@ -34981,14 +34981,11 @@
+   SDValue Op0 = N->getOperand(0);
+   EVT VT = N->getValueType(0);
+   EVT InVT = Op0.getValueType();
+-  EVT InSVT = InVT.getScalarType();
+
+   // SINT_TO_FP(vXi1) -> SINT_TO_FP(SEXT(vXi1 to vXi32))
+   // SINT_TO_FP(vXi8) -> SINT_TO_FP(SEXT(vXi8 to vXi32))
+   // SINT_TO_FP(vXi16) -> SINT_TO_FP(SEXT(vXi16 to vXi32))
+-  if (InVT.isVector() &&
+-      (InSVT == MVT::i8 || InSVT == MVT::i16 ||
+-       (InSVT == MVT::i1 && !DAG.getTargetLoweringInfo().isTypeLegal(InVT)))) {
++  if (InVT.isVector() && InVT.getScalarSizeInBits() < 32) {
+     SDLoc dl(N);
+     EVT DstVT = EVT::getVectorVT(*DAG.getContext(), MVT::i32,
+                                  InVT.getVectorNumElements());

--- a/llvm_patches/6_0_bug1381.patch
+++ b/llvm_patches/6_0_bug1381.patch
@@ -1,0 +1,37 @@
+# This patch is required to fix #1381.
+# Extend inputs with elements smaller than i32 to sint_to_fp/uint_to_fp
+# before type legalization. In this particular case extending bool to 32 bits.
+Index: lib/Target/X86/X86ISelLowering.cpp
+===================================================================
+--- lib/Target/X86/X86ISelLowering.cpp	(revision 348642)
++++ lib/Target/X86/X86ISelLowering.cpp	(working copy)
+@@ -36768,11 +36768,11 @@
+   SDValue Op0 = N->getOperand(0);
+   EVT VT = N->getValueType(0);
+   EVT InVT = Op0.getValueType();
+-  EVT InSVT = InVT.getScalarType();
+
++  // UINT_TO_FP(vXi1) -> SINT_TO_FP(SEXT(vXi1 to vXi32))
+   // UINT_TO_FP(vXi8) -> SINT_TO_FP(ZEXT(vXi8 to vXi32))
+   // UINT_TO_FP(vXi16) -> SINT_TO_FP(ZEXT(vXi16 to vXi32))
+-  if (InVT.isVector() && (InSVT == MVT::i8 || InSVT == MVT::i16)) {
++  if (InVT.isVector() && InVT.getScalarSizeInBits() < 32) {
+     SDLoc dl(N);
+     EVT DstVT = EVT::getVectorVT(*DAG.getContext(), MVT::i32,
+                                  InVT.getVectorNumElements());
+@@ -36802,14 +36802,11 @@
+   SDValue Op0 = N->getOperand(0);
+   EVT VT = N->getValueType(0);
+   EVT InVT = Op0.getValueType();
+-  EVT InSVT = InVT.getScalarType();
+
+   // SINT_TO_FP(vXi1) -> SINT_TO_FP(SEXT(vXi1 to vXi32))
+   // SINT_TO_FP(vXi8) -> SINT_TO_FP(SEXT(vXi8 to vXi32))
+   // SINT_TO_FP(vXi16) -> SINT_TO_FP(SEXT(vXi16 to vXi32))
+-  if (InVT.isVector() &&
+-      (InSVT == MVT::i8 || InSVT == MVT::i16 ||
+-       (InSVT == MVT::i1 && !DAG.getTargetLoweringInfo().isTypeLegal(InVT)))) {
++  if (InVT.isVector() && InVT.getScalarSizeInBits() < 32) {
+     SDLoc dl(N);
+     EVT DstVT = EVT::getVectorVT(*DAG.getContext(), MVT::i32,
+                                  InVT.getVectorNumElements());


### PR DESCRIPTION
This patch is required to fix #1381.
Extend inputs with elements smaller than i32 to sint_to_fp/uint_to_fp
before type legalization. In this particular case extending
bool to 32 bits.

Signed-off-by: Deepak Rajendrakumaran <deepak.rajendrakumaran@intel.com>