### PR TITLE
Static link

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -83,10 +83,14 @@ build:
   project: c:\\projects\\ispc\\build\\ispc.vcxproj
   verbosity: minimal
 
-test_script:
+after_build:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - msbuild c:\\projects\\ispc\\build\\check_isa.vcxproj /t:Rebuild
+
+test_script:
   - set PATH=%ISPC_HOME%\build\bin\%configuration%;%PATH%
   - cd %ISPC_HOME%
+  - check_isa.exe
   - python perf.py -n 1 -g "Visual Studio 15 Win64"
   - if "%LLVM_VERSION%"=="7.0" ( python run_tests.py -a x86 )
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,10 +98,11 @@ matrix:
 script:
     - mkdir build_$LLVM_VERSION && cd build_$LLVM_VERSION
     - cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR ../
-      # Build ispc and examples
-    - make ispc -j4
-      # We need to have ispc binary in ISPC_HOME to run the tests
-    - cp $ISPC_HOME/build_$LLVM_VERSION/bin/ispc $ISPC_HOME && cd $ISPC_HOME
+      # Build ispc and check_isa utility
+    - make ispc check_isa -j4
+      # Add ispc to the PATH
+    - export PATH=$ISPC_HOME/build_$LLVM_VERSION/bin:$PATH && cd $ISPC_HOME
+    - check_isa
     - ./check_env.py
       # Run examples
     - ./perf.py -n 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,14 @@ else()
     endif()
 endif()
 
+# Build target for utility checking host ISA
+if (NOT ISPC_PREPARE_PACKAGE)
+    add_executable(check_isa "")
+    target_sources(check_isa PRIVATE check_isa.cpp)
+    set_target_properties(check_isa PROPERTIES FOLDER "Utils")
+    install (TARGETS check_isa DESTINATION bin)
+endif()
+
 if (ISPC_INCLUDE_EXAMPLES AND NOT ISPC_PREPARE_PACKAGE)
     add_subdirectory(examples)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,11 @@ option(ISPC_PREPARE_PACKAGE "Generate build targets for ispc package" OFF)
 
 if (UNIX)
     option(ISPC_STATIC_STDCXX_LINK "Link statically with libstdc++ and libgcc" OFF)
+    if (ISPC_PREPARE_PACKAGE)
+        option(ISPC_STATIC_LINK "Link statically" ON)
+    else()
+        option(ISPC_STATIC_LINK "Link statically" OFF)
+    endif()
     option(ISPC_USE_ASAN "Build ispc with address sanitizer instrumentation using clang compiler" OFF)
 endif()
 
@@ -232,6 +237,10 @@ endif()
 
 if (ISPC_STATIC_STDCXX_LINK)
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-static-libgcc -static-libstdc++")
+endif()
+
+if (ISPC_STATIC_LINK)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-static")
 endif()
 
 if (ISPC_USE_ASAN)


### PR DESCRIPTION
Added option to link ISPC statically. Verified on different versions of fedora, ubuntu and centos.
Now when package is created, ISPC is built statically by default.
Also added build and run of check_isa utility.