### PR TITLE
Typo and warning fix

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -905,7 +905,7 @@ lCheckForStructParameters(const FunctionType *ftype, SourcePos pos) {
     for (int i = 0; i < ftype->GetNumParameters(); ++i) {
         const Type *type = ftype->GetParameterType(i);
         if (CastType<StructType>(type) != NULL) {
-            Error(pos, "Passing structs to/from application functions by value"
+            Error(pos, "Passing structs to/from application functions by value "
                 "is currently not supported. Use a reference, a const reference, "
                 "a pointer, or a const pointer to the struct instead.");
             return;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2016, Intel Corporation
+  Copyright (c) 2010-2018, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -1296,18 +1296,18 @@ Module::writeOutput(OutputType outputType, OutputFlags flags, const char *outFil
                   fileType = "header";
               break;
           case Deps:
-            break;
+              break;
           case DevStub:
-            if (strcasecmp(suffix, "c") && strcasecmp(suffix, "cc") &&
-                strcasecmp(suffix, "c++") && strcasecmp(suffix, "cxx") &&
-                strcasecmp(suffix, "cpp"))
-              fileType = "dev-side offload stub";
+              if (strcasecmp(suffix, "c") && strcasecmp(suffix, "cc") &&
+                  strcasecmp(suffix, "c++") && strcasecmp(suffix, "cxx") &&
+                  strcasecmp(suffix, "cpp"))
+                  fileType = "dev-side offload stub";
               break;
           case HostStub:
-            if (strcasecmp(suffix, "c") && strcasecmp(suffix, "cc") &&
-                strcasecmp(suffix, "c++") && strcasecmp(suffix, "cxx") &&
-                strcasecmp(suffix, "cpp"))
-              fileType = "host-side offload stub";
+              if (strcasecmp(suffix, "c") && strcasecmp(suffix, "cc") &&
+                  strcasecmp(suffix, "c++") && strcasecmp(suffix, "cxx") &&
+                  strcasecmp(suffix, "cpp"))
+                  fileType = "host-side offload stub";
               break;
           default:
             Assert(0 /* swtich case not handled */);


### PR DESCRIPTION
* Fix typo in error message.
* Fix warning when compiled with GCC7.