### PR TITLE
Fail_db.txt update after LLVM bug 40891 fix in trunk

### DIFF
--- a/fail_db.txt
+++ b/fail_db.txt
@@ -516,10 +516,6 @@
 
 
 % LLVM 9.0 fails
-./tests/pmuls-vi64.ispc compfail     x86    avx1-i32x16   Linux LLVM 9.0 clang++9.0 -O0 *
-./tests/pmulus-vi64.ispc compfail     x86    avx1-i32x16   Linux LLVM 9.0 clang++9.0 -O0 *
-./tests/pmuls-vi64.ispc compfail     x86  avx1.1-i32x16   Linux LLVM 9.0 clang++9.0 -O0 *
-./tests/pmulus-vi64.ispc compfail     x86  avx1.1-i32x16   Linux LLVM 9.0 clang++9.0 -O0 *
 ./tests/cfor-gs-double-improve-multidim-2.ispc runfail     x86     avx2-i32x8   Linux LLVM 9.0 clang++9.0 -O2 *
 ./tests/cfor-gs-improve-multidim-2.ispc runfail     x86     avx2-i32x8   Linux LLVM 9.0 clang++9.0 -O2 *
 ./tests/gs-double-improve-multidim-2.ispc runfail     x86     avx2-i32x8   Linux LLVM 9.0 clang++9.0 -O2 *
@@ -534,8 +530,6 @@
 ./tests/gs-improve-multidim-2.ispc runfail     x86    avx2-i32x16   Linux LLVM 9.0 clang++9.0 -O2 *
 ./tests/gs-improve-unif.ispc runfail     x86    avx2-i32x16   Linux LLVM 9.0 clang++9.0 -O2 *
 ./tests/struct-test-118.ispc runfail     x86    avx2-i32x16   Linux LLVM 9.0 clang++9.0 -O2 *
-./tests/pmuls-vi64.ispc compfail     x86    avx2-i32x16   Linux LLVM 9.0 clang++9.0 -O0 *
-./tests/pmulus-vi64.ispc compfail     x86    avx2-i32x16   Linux LLVM 9.0 clang++9.0 -O0 *
 ./tests/cfor-gs-double-improve-multidim-2.ispc runfail     x86     avx2-i64x4   Linux LLVM 9.0 clang++9.0 -O2 *
 ./tests/cfor-gs-improve-multidim-2.ispc runfail     x86     avx2-i64x4   Linux LLVM 9.0 clang++9.0 -O2 *
 ./tests/gs-double-improve-multidim-2.ispc runfail     x86     avx2-i64x4   Linux LLVM 9.0 clang++9.0 -O2 *


### PR DESCRIPTION
Update for: #1430 (9.0/8.0 fails)