### PR TITLE
Increase number of input args supported to 512

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,7 +63,7 @@
 #endif
 #endif // ISPC_IS_WINDOWS
 
-#define MAX_NUM_ARGS (128)
+#define MAX_NUM_ARGS (512)
 
 static void lPrintVersion() {
 #ifdef ISPC_IS_WINDOWS


### PR DESCRIPTION
Custom build systems on large projects send down many folders as includes. Increase number ISPC supports to 512 to support this.