### PR TITLE
ISPC_NO_DUMPS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option(ISPC_INCLUDE_EXAMPLES "Generate build targets for the ISPC examples" ON)
 option(ISPC_INCLUDE_TESTS "Generate build targets for the ISPC tests." ON)
 option(ISPC_INCLUDE_UTILS "Generate build targets for the utils." ON)
 option(ISPC_PREPARE_PACKAGE "Generate build targets for ispc package" OFF)
+option(ISPC_NO_DUMPS "Turn off functionality, which requires LLVM dump() functions" OFF)
 
 if (UNIX)
     option(ISPC_STATIC_STDCXX_LINK "Link statically with libstdc++ and libgcc" OFF)
@@ -205,6 +206,10 @@ if (ARM_ENABLED)
 endif()
 if (NVPTX_ENABLED)
     target_compile_definitions(${PROJECT_NAME} PRIVATE ISPC_NVPTX_ENABLED)
+endif()
+
+if (ISPC_NO_DUMPS)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ISPC_NO_DUMPS)
 endif()
 
 # Include directories

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2013, Intel Corporation
+  Copyright (c) 2010-2019, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -1067,8 +1067,10 @@ bool LLVMVectorValuesAllEqual(llvm::Value *v, llvm::Value **splat) {
     bool equal = lVectorValuesAllEqual(v, vectorLength, seenPhis, splat);
 
     Debug(SourcePos(), "LLVMVectorValuesAllEqual(%s) -> %s.", v->getName().str().c_str(), equal ? "true" : "false");
+#ifndef ISPC_NO_DUMPS
     if (g->debugPrint)
         LLVMDumpValue(v);
+#endif
 
     return equal;
 }
@@ -1329,12 +1331,15 @@ bool LLVMVectorIsLinear(llvm::Value *v, int stride) {
     std::vector<llvm::PHINode *> seenPhis;
     bool linear = lVectorIsLinear(v, vectorLength, stride, seenPhis);
     Debug(SourcePos(), "LLVMVectorIsLinear(%s) -> %s.", v->getName().str().c_str(), linear ? "true" : "false");
+#ifndef ISPC_NO_DUMPS
     if (g->debugPrint)
         LLVMDumpValue(v);
+#endif
 
     return linear;
 }
 
+#ifndef ISPC_NO_DUMPS
 static void lDumpValue(llvm::Value *v, std::set<llvm::Value *> &done) {
     if (done.find(v) != done.end())
         return;
@@ -1359,6 +1364,7 @@ void LLVMDumpValue(llvm::Value *v) {
     lDumpValue(v, done);
     fprintf(stderr, "----\n");
 }
+#endif
 
 static llvm::Value *lExtractFirstVectorElement(llvm::Value *v, std::map<llvm::PHINode *, llvm::PHINode *> &phiMap) {
     llvm::VectorType *vt = llvm::dyn_cast<llvm::VectorType>(v->getType());

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2015, Intel Corporation
+  Copyright (c) 2010-2019, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -293,7 +293,9 @@ extern llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, b
 /** This is a utility routine for debugging that dumps out the given LLVM
     value as well as (recursively) all of the other values that it depends
     on. */
+#ifndef ISPC_NO_DUMPS
 extern void LLVMDumpValue(llvm::Value *v);
+#endif
 
 /** Given a vector-typed value, this function returns the value of its
     first element.  Rather than just doing the straightforward thing of

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2016, Intel Corporation
+  Copyright (c) 2010-2019, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -73,6 +73,15 @@ static void lPrintVersion() {
 #else
     printf("Intel(r) SPMD Program Compiler (ispc), %s (build %s @ %s, LLVM %s)\n", ISPC_VERSION, BUILD_VERSION,
            BUILD_DATE, ISPC_LLVM_VERSION_STRING);
+#endif
+
+// The recommended way to build ISPC assumes custom LLVM build with a set of patches.
+// If the default LLVM distribution is used, then the resuling ISPC binary may contain
+// known and already fixed stability and performance problems.
+#ifdef ISPC_NO_DUMPS
+    printf("This version is likely linked against non-recommended LLVM binaries.\n"
+           "For best stability and performance please use official binary distribution from "
+           "http://ispc.github.io/downloads.html");
 #endif
 }
 
@@ -183,8 +192,10 @@ static void devUsage(int ret) {
     printf("        disable-uniform-control-flow\t\tDisable uniform control flow optimizations\n");
     printf("        disable-uniform-memory-optimizations\tDisable uniform-based coherent memory access\n");
     printf("    [--yydebug]\t\t\t\tPrint debugging information during parsing\n");
+#ifndef ISPC_NO_DUMPS
     printf("    [--debug-phase=<value>]\t\tSet optimization phases to dump. "
            "--debug-phase=first,210:220,300,305,310:last\n");
+#endif
 #if ISPC_LLVM_VERSION == ISPC_LLVM_3_4 || ISPC_LLVM_VERSION == ISPC_LLVM_3_5 // 3.4, 3.5
     printf("    [--debug-ir=<value>]\t\tSet optimization phase to generate debugIR after it\n");
 #endif
@@ -698,12 +709,15 @@ int main(int Argc, char *Argv[]) {
                 usage(1);
             }
             hostStubFileName = argv[i];
-        } else if (strncmp(argv[i], "--debug-phase=", 14) == 0) {
+        }
+#ifndef ISPC_NO_DUMPS
+        else if (strncmp(argv[i], "--debug-phase=", 14) == 0) {
             fprintf(stderr, "WARNING: Adding debug phases may change the way PassManager"
                             "handles the phases and it may possibly make some bugs go"
                             "away or introduce the new ones.\n");
             g->debug_stages = ParsingPhases(argv[i] + strlen("--debug-phase="));
         }
+#endif
 
 #if ISPC_LLVM_VERSION == ISPC_LLVM_3_4 || ISPC_LLVM_VERSION == ISPC_LLVM_3_5 // 3.4, 3.5
         else if (strncmp(argv[i], "--debug-ir=", 11) == 0) {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2451,8 +2451,10 @@ void Module::execPreprocessor(const char *infilename, llvm::raw_string_ostream *
     headerOpts.UseBuiltinIncludes = 0;
     headerOpts.UseStandardSystemIncludes = 0;
     headerOpts.UseStandardCXXIncludes = 0;
+#ifndef ISPC_NO_DUMPS
     if (g->debugPrint)
         headerOpts.Verbose = 1;
+#endif
     for (int i = 0; i < (int)g->includePath.size(); ++i) {
         headerOpts.AddPath(g->includePath[i], clang::frontend::Angled,
 #if ISPC_LLVM_VERSION == ISPC_LLVM_3_2

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -361,6 +361,7 @@ void Error(SourcePos p, const char *fmt, ...) {
 }
 
 void Debug(SourcePos p, const char *fmt, ...) {
+#ifndef ISPC_NO_DUMPS
     if (!g->debugPrint || g->quiet)
         return;
 
@@ -368,6 +369,7 @@ void Debug(SourcePos p, const char *fmt, ...) {
     va_start(args, fmt);
     lPrint("Debug", false, p, fmt, args);
     va_end(args);
+#endif
 }
 
 void Warning(SourcePos p, const char *fmt, ...) {


### PR DESCRIPTION
Adding a possibility to build with LLVM distribution, which doesn't have dump() functions enabled