### PR TITLE
Add dump-file and debug-llvm options

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1472,6 +1472,7 @@ Globals::Globals() {
     includeStdlib = true;
     runCPP = true;
     debugPrint = false;
+    dumpFile = false;
     printTarget = false;
     NoOmitFramePointer = false;
     debugIR = -1;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -566,6 +566,9 @@ struct Globals {
     /** Indicates which stages of optimization we want to dump. */
     std::set<int> debug_stages;
 
+    /** Whether to dump IR to file. */
+    bool dumpFile;
+
     /** Indicates after which optimization we want to generate
         DebugIR information. */
     int debugIR;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,10 +46,10 @@
 #else
 #include <unistd.h>
 #endif // ISPC_IS_WINDOWS
+#include <llvm/Support/Debug.h>
 #include <llvm/Support/Signals.h>
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Support/TargetSelect.h>
-#include <llvm/Support/Debug.h>
 
 #ifdef ISPC_IS_WINDOWS
 #define strcasecmp stricmp
@@ -729,8 +729,7 @@ int main(int Argc, char *Argv[]) {
                             "handles the phases and it may possibly make some bugs go"
                             "away or introduce the new ones.\n");
             g->debug_stages = ParsingPhases(argv[i] + strlen("--debug-phase="));
-        }
-        else if (strncmp(argv[i], "--dump-file", 11) == 0)
+        } else if (strncmp(argv[i], "--dump-file", 11) == 0)
             g->dumpFile = true;
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -725,6 +725,8 @@ int main(int Argc, char *Argv[]) {
                             "away or introduce the new ones.\n");
             g->debug_stages = ParsingPhases(argv[i] + strlen("--debug-phase="));
         }
+        else if (strncmp(argv[i], "--dump-file", 11) == 0)
+            g->dumpFile = true;
 #endif
 
 #if ISPC_LLVM_VERSION == ISPC_LLVM_3_4 || ISPC_LLVM_VERSION == ISPC_LLVM_3_5 // 3.4, 3.5

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,6 +178,7 @@ static void devUsage(int ret) {
     lPrintVersion();
     printf("\nusage (developer options): ispc\n");
     printf("    [--debug]\t\t\t\tPrint information useful for debugging ispc\n");
+    printf("    [--debug-llvm]\t\t\tEnable LLVM debugging information (dumps to stderr)\n");
     printf("    [--print-target]\t\t\tPrint target's information\n");
     printf("    [--fuzz-test]\t\t\tRandomly perturb program input to test error conditions\n");
     printf("    [--fuzz-seed=<value>]\t\tSeed value for RNG for fuzz testing\n");
@@ -196,6 +197,7 @@ static void devUsage(int ret) {
 #ifndef ISPC_NO_DUMPS
     printf("    [--debug-phase=<value>]\t\tSet optimization phases to dump. "
            "--debug-phase=first,210:220,300,305,310:last\n");
+    printf("    [--dump-file]\t\t\tDump module IR to file(s) in current directory\n");
 #endif
 #if ISPC_LLVM_VERSION == ISPC_LLVM_3_4 || ISPC_LLVM_VERSION == ISPC_LLVM_3_5 // 3.4, 3.5
     printf("    [--debug-ir=<value>]\t\tSet optimization phase to generate debugIR after it\n");
@@ -371,7 +373,7 @@ static int ParsingPhaseName(char *stage) {
 
 static std::set<int> ParsingPhases(char *stages) {
     std::set<int> phases;
-    auto len = strnlen_s(stages, 100);
+    auto len = strnlen(stages, 100);
     Assert(len && len < 100 && "phases string is too long!");
     int begin = ParsingPhaseName(stages);
     int end = begin;
@@ -515,8 +517,8 @@ int main(int Argc, char *Argv[]) {
             usage(1);
         } else if (!strcmp(argv[i], "--debug"))
             g->debugPrint = true;
-	else if (!strcmp(argv[i], "--debug-llvm"))
-	    llvm::DebugFlag = true;
+        else if (!strcmp(argv[i], "--debug-llvm"))
+            llvm::DebugFlag = true;
 #ifdef ISPC_IS_WINDOWS
         else if (!strcmp(argv[i], "--dllexport"))
             g->dllExport = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,7 @@
 #include <llvm/Support/Signals.h>
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Support/TargetSelect.h>
+#include <llvm/Support/Debug.h>
 
 #ifdef ISPC_IS_WINDOWS
 #define strcasecmp stricmp
@@ -514,6 +515,8 @@ int main(int Argc, char *Argv[]) {
             usage(1);
         } else if (!strcmp(argv[i], "--debug"))
             g->debugPrint = true;
+	else if (!strcmp(argv[i], "--debug-llvm"))
+	    llvm::DebugFlag = true;
 #ifdef ISPC_IS_WINDOWS
         else if (!strcmp(argv[i], "--dllexport"))
             g->dllExport = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -370,8 +370,8 @@ static int ParsingPhaseName(char *stage) {
 
 static std::set<int> ParsingPhases(char *stages) {
     std::set<int> phases;
-    /* ensure the string is NUL terminated */
-    stages[sizeof(stages) - 1] = '\0';
+    auto len = strnlen_s(stages, 100);
+    Assert(len && len < 100 && "phases string is too long!");
     int begin = ParsingPhaseName(stages);
     int end = begin;
 

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -491,7 +491,8 @@ void DebugPassManager::add(llvm::Pass *P, int stage = -1) {
 #if ISPC_LLVM_VERSION <= ISPC_LLVM_3_9
                 snprintf(buf, sizeof(buf), "\n\n*****LLVM IR after phase %d: %s*****\n\n", number, P->getPassName());
 #else // LLVM 4.0+
-                snprintf(buf, sizeof(buf), "\n\n*****LLVM IR after phase %d: %s*****\n\n", number, P->getPassName().data());
+                snprintf(buf, sizeof(buf), "\n\n*****LLVM IR after phase %d: %s*****\n\n", number,
+                         P->getPassName().data());
 #endif
                 PM.add(CreateDebugPass(buf));
             }
@@ -4420,7 +4421,7 @@ static llvm::Pass *CreateDebugPass(char *output) { return new DebugPass(output);
 class DebugPassFile : public llvm::ModulePass {
   public:
     static char ID;
-    DebugPassFile(int number, llvm::StringRef name) : ModulePass(ID), pnum(number), pname(name) { }
+    DebugPassFile(int number, llvm::StringRef name) : ModulePass(ID), pnum(number), pname(name) {}
 
 #if ISPC_LLVM_VERSION <= ISPC_LLVM_3_9
     const char *getPassName() const { return "Dump LLVM IR"; }
@@ -4431,7 +4432,7 @@ class DebugPassFile : public llvm::ModulePass {
     bool doInitialization(llvm::Module &m);
 
   private:
-    void run(llvm::Module& m, bool init);
+    void run(llvm::Module &m, bool init);
     int pnum;
     llvm::StringRef pname;
 };
@@ -4441,8 +4442,7 @@ char DebugPassFile::ID = 0;
 /**
  * Strips all non-alphanumeric characters from given string.
  */
-std::string sanitize(std::string in)
-{
+std::string sanitize(std::string in) {
     llvm::Regex r("[^[:alnum:]]");
     while (r.match(in))
         in = r.sub("", in);

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -145,6 +145,10 @@
 #ifndef PRIu64
 #define PRIu64 "llu"
 #endif
+#ifndef ISPC_NO_DUMPS
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/Regex.h>
+#endif
 
 static llvm::Pass *CreateIntrinsicsOptPass();
 static llvm::Pass *CreateInstructionSimplifyPass();
@@ -159,6 +163,7 @@ static llvm::Pass *CreateMakeInternalFuncsStaticPass();
 
 #ifndef ISPC_NO_DUMPS
 static llvm::Pass *CreateDebugPass(char *output);
+static llvm::Pass *CreateDebugPassFile(int number, llvm::StringRef name);
 #endif
 
 static llvm::Pass *CreateReplaceStdlibShiftPass();
@@ -479,13 +484,17 @@ void DebugPassManager::add(llvm::Pass *P, int stage = -1) {
 #ifndef ISPC_NO_DUMPS
         if (g->debug_stages.find(number) != g->debug_stages.end()) {
             // adding dump of LLVM IR after optimization
-            char buf[100];
+            if (g->dumpFile) {
+                PM.add(CreateDebugPassFile(number, P->getPassName()));
+            } else {
+                char buf[100];
 #if ISPC_LLVM_VERSION <= ISPC_LLVM_3_9
-            snprintf(buf, sizeof(buf), "\n\n*****LLVM IR after phase %d: %s*****\n\n", number, P->getPassName());
+                snprintf(buf, sizeof(buf), "\n\n*****LLVM IR after phase %d: %s*****\n\n", number, P->getPassName());
 #else // LLVM 4.0+
-            snprintf(buf, sizeof(buf), "\n\n*****LLVM IR after phase %d: %s*****\n\n", number, P->getPassName().data());
+                snprintf(buf, sizeof(buf), "\n\n*****LLVM IR after phase %d: %s*****\n\n", number, P->getPassName().data());
 #endif
-            PM.add(CreateDebugPass(buf));
+                PM.add(CreateDebugPass(buf));
+            }
         }
 #endif
 
@@ -4399,6 +4408,67 @@ bool DebugPass::runOnModule(llvm::Module &module) {
 }
 
 static llvm::Pass *CreateDebugPass(char *output) { return new DebugPass(output); }
+#endif
+
+//////////////////////////////////////////////////////////////////////////
+// DebugPassFile
+
+/** This pass is added in list of passes after optimizations which
+    we want to debug and print dump of LLVM IR to file.
+ */
+#ifndef ISPC_NO_DUMPS
+class DebugPassFile : public llvm::ModulePass {
+  public:
+    static char ID;
+	DebugPassFile(int number, llvm::StringRef name) : ModulePass(ID), pnum(number), pname(name) { }
+
+#if ISPC_LLVM_VERSION <= ISPC_LLVM_3_9
+    const char *getPassName() const { return "Dump LLVM IR"; }
+#else // LLVM 4.0+
+    llvm::StringRef getPassName() const { return "Dump LLVM IR"; }
+#endif
+    bool runOnModule(llvm::Module &m);
+    bool doInitialization(llvm::Module &m);
+
+  private:
+    void run(llvm::Module& m, bool init);
+    int pnum;
+    llvm::StringRef pname;
+};
+
+char DebugPassFile::ID = 0;
+
+/**
+ * Strips all non-alphanumeric characters from given string.
+ */
+std::string sanitize(std::string in)
+{
+    llvm::Regex r("[^[:alnum:]]");
+    while (r.match(in))
+        in = r.sub("", in);
+    return in;
+}
+
+void DebugPassFile::run(llvm::Module &module, bool init) {
+    std::error_code EC;
+    char fname[100];
+    snprintf(fname, sizeof(fname), "%s_%d_%s.ll", init ? "init" : "ir", pnum, sanitize(pname).c_str());
+    llvm::raw_fd_ostream OS(fname, EC, llvm::sys::fs::F_None);
+    Assert(!EC && "IR dump file creation failed!");
+    module.print(OS, 0);
+}
+
+bool DebugPassFile::runOnModule(llvm::Module &module) {
+    run(module, false);
+    return true;
+}
+
+bool DebugPassFile::doInitialization(llvm::Module &module) {
+    run(module, true);
+    return true;
+}
+
+static llvm::Pass *CreateDebugPassFile(int number, llvm::StringRef name) { return new DebugPassFile(number, name); }
 #endif
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -4420,7 +4420,7 @@ static llvm::Pass *CreateDebugPass(char *output) { return new DebugPass(output);
 class DebugPassFile : public llvm::ModulePass {
   public:
     static char ID;
-	DebugPassFile(int number, llvm::StringRef name) : ModulePass(ID), pnum(number), pname(name) { }
+    DebugPassFile(int number, llvm::StringRef name) : ModulePass(ID), pnum(number), pname(name) { }
 
 #if ISPC_LLVM_VERSION <= ISPC_LLVM_3_9
     const char *getPassName() const { return "Dump LLVM IR"; }


### PR DESCRIPTION
1. Added --dump-file option to dump module IR to file after each pass (after doInitialization and runOnModule)
2. Added --debug-llvm option to turn on llvm debug info dumps
3. Fixed --debug-phase=first:last option interpretation