### PR TITLE
Set of minor changes

### DIFF
--- a/builtins/builtins.c
+++ b/builtins/builtins.c
@@ -196,6 +196,7 @@ done:
     fflush(stdout);
 }
 
+#ifdef ISPC_NVPTX_ENABLED
 /* this is print for PTX target only */
 int __puts_nvptx(const char *);
 void __do_print_nvptx(const char *format, const char *types, int width, uint64_t mask, void **args) {
@@ -269,6 +270,7 @@ void __do_print_nvptx(const char *format, const char *types, int width, uint64_t
     __puts_nvptx("---nvptx printing is not support---\n");
 #endif
 }
+#endif
 
 int __num_cores() {
 #if defined(_MSC_VER) || defined(__MINGW32__)

--- a/fail_db.txt
+++ b/fail_db.txt
@@ -410,6 +410,8 @@
 % End of anonymous namespace bug
 
 % Windows specific fails. transcendentals-10-0.ispc is not expected to work anywhere except Linux.
+.\tests\transcendentals-10-0.ispc compfail     x86           sse4 Windows LLVM 9.0         cl -O2 *
+.\tests\transcendentals-10-0.ispc compfail     x86           sse4 Windows LLVM 8.0         cl -O2 *
 .\tests\transcendentals-10-0.ispc compfail     x86           sse4 Windows LLVM 7.0         cl -O2 *
 .\tests\transcendentals-10-0.ispc compfail     x86           sse4 Windows LLVM 6.0         cl -O2 *
 .\tests\transcendentals-10-0.ispc compfail     x86           sse4 Windows LLVM 5.0         cl -O2 *

--- a/src/ispc_version.h
+++ b/src/ispc_version.h
@@ -38,7 +38,9 @@
 #ifndef ISPC_VERSION_H
 #define ISPC_VERSION_H
 
-#define ISPC_VERSION "1.11.1dev"
+#define ISPC_VERSION_MAJOR 1
+#define ISPC_VERSION_MINOR 12
+#define ISPC_VERSION "1.12.0dev"
 #include "llvm/Config/llvm-config.h"
 
 #define ISPC_LLVM_VERSION (LLVM_VERSION_MAJOR * 10000 + LLVM_VERSION_MINOR * 100)

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2522,8 +2522,12 @@ void Module::execPreprocessor(const char *infilename, llvm::raw_string_ostream *
     if (g->opt.forceAlignedMemory)
         opts.addMacroDef("ISPC_FORCE_ALIGNED_MEMORY");
 
-    opts.addMacroDef("ISPC_MAJOR_VERSION=1");
-    opts.addMacroDef("ISPC_MINOR_VERSION=4");
+    constexpr int buf_size = 25;
+    char ispc_major[buf_size], ispc_minor[buf_size];
+    snprintf(ispc_major, buf_size, "ISPC_MAJOR_VERSION=%d", ISPC_VERSION_MAJOR);
+    snprintf(ispc_minor, buf_size, "ISPC_MINOR_VERSION=%d", ISPC_VERSION_MINOR);
+    opts.addMacroDef(ispc_major);
+    opts.addMacroDef(ispc_minor);
 
     if (g->includeStdlib) {
         if (g->opt.disableAsserts)

--- a/tests/lit-tests/noinline.ispc
+++ b/tests/lit-tests/noinline.ispc
@@ -4,6 +4,6 @@ noinline int bar(uniform int a[]) {
 }
 
 export  void foo(uniform int a[]) {
-// CHECK: callq	bar___un_3C_uni_3E
+// CHECK: callq	{{.?}}bar___un_3C_uni_3E
     a[programIndex] = bar(a);
 }


### PR DESCRIPTION
* update ISPC_MAJOR_VERSION and ISPC_MINOR_VERSION with version change
* change the version string to 1.12.0dev, as the next version is going to be 1.12.0
* fix noinline.ispc lit test on Mac
* update faildb for Windows
* add missing ifdef for __puts_nvptx()