### PR TITLE
Fixing floating point negation

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1010,11 +1010,13 @@ static llvm::Value *lEmitNegate(Expr *arg, SourcePos pos, FunctionEmitContext *c
         return NULL;
 
     // Negate by subtracting from zero...
-    llvm::Value *zero = lLLVMConstantValue(type, g->ctx, 0.);
     ctx->SetDebugPos(pos);
-    if (type->IsFloatType())
+    if (type->IsFloatType()) {
+        llvm::Value *zero = llvm::ConstantFP::getZeroValueForNegation(type->LLVMType(g->ctx));
         return ctx->BinaryOperator(llvm::Instruction::FSub, zero, argVal, LLVMGetName(argVal, "_negate"));
+    }
     else {
+        llvm::Value *zero = lLLVMConstantValue(type, g->ctx, 0.);
         AssertPos(pos, type->IsIntType());
         return ctx->BinaryOperator(llvm::Instruction::Sub, zero, argVal, LLVMGetName(argVal, "_negate"));
     }

--- a/tests/FNeg.ispc
+++ b/tests/FNeg.ispc
@@ -1,0 +1,72 @@
+export uniform int width() { return programCount; }
+
+uniform float Neg(uniform float inVal) {
+    return -inVal;
+}
+
+void test_uni(uniform float RET[]) {
+    uniform float val;
+    unsigned int signBit;
+    uniform float retval;
+    RET[programIndex] = 0;
+
+    val = 0.0;
+    signBit = signbits(val);
+    if (signBit != 0)
+        RET[programIndex] = 1;
+    retval = Neg(val);
+    signBit = signbits(retval);
+    if (signBit == 0)
+        RET[programIndex] = 1;
+ 
+    val = -0.0;
+    signBit = signbits(val);
+    if (signBit == 0)
+        RET[programIndex] = 1;
+    retval = Neg(val);
+    signBit = signbits(retval);
+    if (signBit != 0)
+        RET[programIndex] = 1;
+
+}
+
+float Neg(float inVal) {
+    return -inVal;
+}
+
+
+void test_vary(uniform float RET[]) {
+    double val;
+    unsigned int signBit;
+    double retval;
+    RET[programIndex] = 0;
+
+    val = 0.0;
+    signBit = signbits(val);
+    if (signBit != 0)
+        RET[programIndex] = 1;
+    retval = Neg(val);
+    signBit = signbits(retval);
+    if (signBit == 0)
+        RET[programIndex] = 1;
+
+    val = -0.0;
+    signBit = signbits(val);
+    if (signBit == 0)
+        RET[programIndex] = 1;
+    retval = Neg(val);
+    signBit = signbits(retval);
+    if (signBit != 0)
+        RET[programIndex] = 1;
+
+}
+
+export void f_v(uniform float RET[]) {
+
+    test_vary(RET);
+    test_uni(RET);
+
+}
+
+export void result(uniform float RET[]) { RET[programIndex] = 0; }
+


### PR DESCRIPTION
There are 2 issues here-
1. We were not creating negative 0
2. Code was not optimal for certain fma scenarios-

A pattern like -c+a* b was not creating optimal code. We ended up creating additional assembly code to create 0 and subtract
xorps	%xmm1, %xmm1, %xmm1
vsubps	(%rcx), %ymm1, %ymm1
vfmadd231ps	(%rdx), %ymm0, %ymm1 # ymm1 = (ymm0 * mem) + ymm1

With change, this becomes
vmovups	(%rdx), %ymm1
vfmsub213ps	(%rcx), %ymm0, %ymm1 # ymm1 = (ymm0 * ymm1) - mem

See attached files for test case
[negTestFma.zip](https://github.com/ispc/ispc/files/3474545/negTestFma.zip)

