### PR TITLE
Build fixs for macOS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -70,8 +70,8 @@ cache:
 
 install:
   - cmd: |-
-      cinst winflexbison
-      set FLEX_PATH=%CHOCO_DIR%\lib\winflexbison\tools
+      cinst winflexbison3
+      set FLEX_PATH=%CHOCO_DIR%\lib\winflexbison3\tools
       if exist "%FLEX_PATH%\win_flex.exe" ( cd %FLEX_PATH% && ren win_flex.exe flex.exe )
       if exist "%LLVM_HOME%\bin\" (if exist "%CROSS_TOOLS%\gnuwin32\" set NONEEDDOCKER=rem)
       if "%LLVM_VERSION%" == "latest" set LLVM_VERSION=%LLVM_LATEST%
@@ -83,7 +83,7 @@ install:
       %NONEEDDOCKER% set /p CONTAINER=<container_id.txt
       %NONEEDDOCKER% docker cp %CONTAINER%:%LLVM_HOME%\bin-%LLVM_VERSION% %LLVM_HOME%
       %NONEEDDOCKER% docker cp %CONTAINER%:%CROSS_TOOLS% %CROSS_TOOLS%
-      set PATH=%LLVM_HOME%\bin;C:\Python37\;C:\Python37\Scripts;%CHOCO_DIR%\lib\winflexbison\tools;%PATH%
+      set PATH=%LLVM_HOME%\bin;C:\Python37\;C:\Python37\Scripts;%CHOCO_DIR%\lib\winflexbison3\tools;%PATH%
   - sh: |-
       sudo apt-get install -y flex libc6-dev-i386 g++-multilib lib32stdc++6
       if [ "$LLVM_VERSION" = "latest" ]; then 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ find_package(Python3 REQUIRED)
         message(FATAL_ERROR "Python interpreter is not found")
     endif()
 
-find_package(BISON 2.4 REQUIRED)
+find_package(BISON 3.0 REQUIRED)
     if (BISON_FOUND)
         set(BISON_INPUT src/parse.yy)
         set(BISON_CPP_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/parse.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,15 @@ else()
     endif()
 endif()
 
+if (APPLE AND NOT ISPC_MACOS_SDK_PATH)
+    set(command "xcrun" "--show-sdk-path")
+    execute_process(COMMAND ${command}
+        OUTPUT_VARIABLE ISPC_MACOS_SDK_PATH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  message(STATUS "Using macOS SDK path ${ISPC_MACOS_SDK_PATH}")
+endif()
+
 if (UNIX)
     option(ISPC_STATIC_STDCXX_LINK "Link statically with libstdc++ and libgcc" OFF)
     if (ISPC_PREPARE_PACKAGE AND (NOT APPLE))

--- a/cmake/GenerateBuiltins.cmake
+++ b/cmake/GenerateBuiltins.cmake
@@ -219,7 +219,7 @@ function(builtin_to_cpp bit os_name arch supported_archs supported_oses resultFi
     else()
         add_custom_command(
             OUTPUT ${output}
-            COMMAND ${CLANG_EXECUTABLE} ${target_flags} -m${bit} -emit-llvm -c ${inputFilePath} -o - | \"${LLVM_DIS_EXECUTABLE}\" -
+            COMMAND ${CLANG_EXECUTABLE} ${target_flags} -w -m${bit} -emit-llvm -c ${inputFilePath} -o - | \"${LLVM_DIS_EXECUTABLE}\" -
                 | \"${Python3_EXECUTABLE}\" bitcode2cpp.py c --runtime=${bit} --os=${os_name} --arch=${target_arch} --llvm_as ${LLVM_AS_EXECUTABLE}
                 > ${output}
             DEPENDS ${inputFilePath}

--- a/cmake/GenerateBuiltins.cmake
+++ b/cmake/GenerateBuiltins.cmake
@@ -133,6 +133,8 @@ function(builtin_to_cpp bit os_name arch supported_archs supported_oses resultFi
                 # -I/Users/Shared/android-ndk-r20/sysroot/usr/include -I/Users/Shared/android-ndk-r20/sysroot/usr/include/x86_64-linux-android
                 set(includePath -I${ISPC_ANDROID_NDK_PATH}/sysroot/usr/include -I${ISPC_ANDROID_NDK_PATH}/sysroot/usr/include/x86_64-linux-android)
             endif()
+        elseif (${os_name} STREQUAL "macos")
+            set(includePath -I${ISPC_MACOS_SDK_PATH}/usr/include)
         endif()
     else()
          if (${os_name} STREQUAL "macos")

--- a/common.py
+++ b/common.py
@@ -133,7 +133,7 @@ def error(line, error_type = 1):
 
 def check_tools(m):
     input_tools=[[[1,4],"m4 --version", "bad m4 version"],
-                 [[2,4],"bison --version", "bad bison version"],
+                 [[3,0],"bison --version", "bad bison version"],
                  [[2,5], "flex --version", "bad flex version"]]
     ret = 1 
     for t in range(0,len(input_tools)):

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -37,7 +37,7 @@
 /* one for 'if', one for 'cif' */
 %expect 2
 
-%error-verbose
+%define parse.error verbose
 
 %code requires {
 


### PR DESCRIPTION
* Fix for macOS build: initialize SDK path by default
* Update parse.yy not to use depricated derictive
* No need to see warnings triggered by system includes