### PR TITLE
Fix for #1493

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -155,8 +155,12 @@ static void lPrintFileLineContext(SourcePos p) {
     while ((c = fgetc(f)) != EOF) {
         // Don't print more than three lines of context.  (More than that,
         // and we're probably doing the wrong thing...)
-        if (curLine >= std::max(p.first_line, p.last_line - 2) && curLine <= p.last_line)
+        if (curLine >= std::max(p.first_line, p.last_line - 2) && curLine <= p.last_line) {
+            if (c == '\t')
+                c = ' ';
+
             fputc(c, stderr);
+        }
         if (c == '\n')
             ++curLine;
         if (curLine > p.last_line)


### PR DESCRIPTION
In order to point to the correct code snippet we have to treat tab
as space since during lexing when we calculate the original column number,
tab and spaces are both treated as same.