### PR TITLE
Fix for #1595.

### DIFF
--- a/llvm_patches/8_0_9_0_Fix_for_1595.patch
+++ b/llvm_patches/8_0_9_0_Fix_for_1595.patch
@@ -1,0 +1,15 @@
+# Fix for ISPC issue 1595 and related llvm bug 43857.
+# Fixing crash in constant propagation pass when returning nested structs.
+Index: lib/Transforms/IPO/IPConstantPropagation.cpp
+===================================================================
+--- lib/Transforms/IPO/IPConstantPropagation.cpp
++++ lib/Transforms/IPO/IPConstantPropagation.cpp
+@@ -232,7 +232,7 @@ static bool PropagateConstantReturn(Function &F) {
+       // Find the index of the retval to replace with
+       int index = -1;
+       if (ExtractValueInst *EV = dyn_cast<ExtractValueInst>(Ins))
+-        if (EV->hasIndices())
++        if (EV->getNumIndices() == 1)
+           index = *EV->idx_begin();
+ 
+       // If this use uses a specific return value, and we have a replacement,

--- a/tests/lit-tests/1595.ispc
+++ b/tests/lit-tests/1595.ispc
@@ -1,0 +1,29 @@
+// RUN: %{ispc} %s > %t 2>&1
+// REQUIRES: LLVM_8_0+
+
+struct Vec3f {
+};
+
+inline uniform float signedDist(uniform const Vec3f& pt) {
+    return 0;
+}
+
+struct TriangleVerts
+{
+    Vec3f v0;
+    Vec3f v1;
+    Vec3f v2;
+};
+
+uniform TriangleVerts get_triangle_verts()
+{
+    uniform TriangleVerts tri;
+    return tri;
+}
+
+void csClosestPoint()
+{
+    uniform TriangleVerts tri = get_triangle_verts();
+
+    uniform const float d0 = signedDist(tri.v0);
+}


### PR DESCRIPTION
Porting llvm fix to fix returning nested structs in IR during
constant propagation pass.