### PR TITLE
Minor fixes

### DIFF
--- a/cmake/GenerateBuiltins.cmake
+++ b/cmake/GenerateBuiltins.cmake
@@ -219,7 +219,7 @@ function(builtin_to_cpp bit os_name arch supported_archs supported_oses resultFi
     else()
         add_custom_command(
             OUTPUT ${output}
-            COMMAND ${CLANG_EXECUTABLE} ${target_flags} -w -m${bit} -emit-llvm -c ${inputFilePath} -o - | \"${LLVM_DIS_EXECUTABLE}\" -
+            COMMAND ${CLANG_EXECUTABLE} ${target_flags} -w -m${bit} -emit-llvm -c ${inputFilePath} -o - | (\"${LLVM_DIS_EXECUTABLE}\" - || echo "builtins.c compile error")
                 | \"${Python3_EXECUTABLE}\" bitcode2cpp.py c --runtime=${bit} --os=${os_name} --arch=${target_arch} --llvm_as ${LLVM_AS_EXECUTABLE}
                 > ${output}
             DEPENDS ${inputFilePath} bitcode2cpp.py

--- a/examples/tasksys.cpp
+++ b/examples/tasksys.cpp
@@ -121,7 +121,6 @@ using namespace Concurrency;
 #include <semaphore.h>
 #include <sys/param.h>
 #include <sys/stat.h>
-#include <sys/sysctl.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <vector>
@@ -134,7 +133,6 @@ using namespace Concurrency;
 #include <semaphore.h>
 #include <sys/param.h>
 #include <sys/stat.h>
-#include <sys/sysctl.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <vector>


### PR DESCRIPTION
* Removing <sys/sysctl.h> from tasksys.cpp. It's deprecated in latest Linux (Ubuntu 19.10) and is not needed for current version of tasksys.cpp.
* Trigger build fail on build error during builtins.c compilation (fix for #1614 and #1612).