### PR TITLE
Fix for #1588: do not read from stdin by default.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -710,9 +710,9 @@ int main(int Argc, char *Argv[]) {
             g->codegenOptLevel = Globals::CodegenOptLevel::Aggressive;
             if (!strcmp(argv[i], "-O1"))
                 g->opt.disableCoherentControlFlow = true;
-        } else if (!strcmp(argv[i], "-"))
-            ;
-        else if (!strcmp(argv[i], "--nostdlib"))
+        } else if (!strcmp(argv[i], "-")) {
+            file = argv[i];
+        } else if (!strcmp(argv[i], "--nostdlib"))
             g->includeStdlib = false;
         else if (!strcmp(argv[i], "--nocpp"))
             g->runCPP = false;
@@ -794,6 +794,11 @@ int main(int Argc, char *Argv[]) {
     // Emit accumulted errors and warnings, if any.
     // All the rest of errors and warnigns will be processed in regullar way.
     errorHandler.Emit();
+
+    if (file == NULL) {
+        Error(SourcePos(), "No input file were specified. To read text from stdin use \"-\" as file name.");
+        exit(1);
+    }
 
     // Default settings for PS4
     if (g->target_os == TargetOS::ps4) {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -163,8 +163,8 @@ Module::Module(const char *fn) {
         if (IsStdin(filename)) {
             // Unfortunately we can't yet call Error() since the global 'm'
             // variable hasn't been initialized yet.
-            fprintf(stderr, "Can't emit debugging information with no "
-                            "source file on disk.\n");
+            Error(SourcePos(), "Can't emit debugging information with no "
+                               "source file on disk.\n");
             ++errorCount;
             delete diBuilder;
             diBuilder = NULL;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -614,3 +614,11 @@ bool VerifyDataLayoutCompatibility(const std::string &module_dl, const std::stri
 
     return true;
 }
+
+bool IsStdin(const char *filepath) {
+    if (filepath == nullptr || !strcmp(filepath, "-")) {
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -616,7 +616,8 @@ bool VerifyDataLayoutCompatibility(const std::string &module_dl, const std::stri
 }
 
 bool IsStdin(const char *filepath) {
-    if (filepath == nullptr || !strcmp(filepath, "-")) {
+    Assert(filepath != nullptr);
+    if (!strcmp(filepath, "-")) {
         return true;
     } else {
         return false;

--- a/src/util.h
+++ b/src/util.h
@@ -162,3 +162,7 @@ void PrintWithWordBreaks(const char *buf, int indent, int columnWidth, FILE *out
     default.
  */
 int TerminalWidth();
+
+/** Returns true is the filepath represents stdin, otherwise false.
+ */
+bool IsStdin(const char *);

--- a/tests/lit-tests/1588_stdin.ispc
+++ b/tests/lit-tests/1588_stdin.ispc
@@ -1,0 +1,6 @@
+//; RUN: cat %s | %{ispc} - --target=avx2-i32x8
+//; RUN: cat %s | %{ispc} - --nocpp --target=avx2-i32x8
+//; RUN: cat %s | not %{ispc} - -g --nowrap --target=avx2-i32x8 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR
+
+//; CHECK_ERROR: Error: Can't emit debugging information with no source file on disk.
+int i;

--- a/tests/lit-tests/arg_parsing_errors.ispc
+++ b/tests/lit-tests/arg_parsing_errors.ispc
@@ -8,6 +8,7 @@
 //; RUN: not %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 -MT 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_8
 //; RUN: not %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 --dev-stub 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_9
 //; RUN: not %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 --host-stub 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_10
+//; RUN: not %{ispc} --nowrap --target=avx2-i32x8 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_11
 
 //; RUN: not %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 -not-existing-opt --quiet 2>&1 | FileCheck %s --allow-empty -check-prefix=CHECK_ERROR_QUIET
 
@@ -30,6 +31,7 @@
 //; CHECK_ERROR_8: No target name specified after -MT option.
 //; CHECK_ERROR_9: No output file name specified after --dev-stub option.
 //; CHECK_ERROR_10: No output file name specified after --host-stub option.
+//; CHECK_ERROR_11: No input file were specified. To read text from stdin use "-" as file name.
 
 //; CHECK_ERROR_QUIET-NOT: Error
 

--- a/utils/lit/lit/builtin_commands/cat.py
+++ b/utils/lit/lit/builtin_commands/cat.py
@@ -1,0 +1,67 @@
+import getopt
+import sys
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+def convertToCaretAndMNotation(data):
+   newdata = StringIO()
+   if isinstance(data, str):
+       data = bytearray(data)
+
+   for intval in data:
+       if intval == 9 or intval == 10:
+           newdata.write(chr(intval))
+           continue
+       if intval > 127:
+           intval = intval -128
+           newdata.write("M-")
+       if intval < 32:
+           newdata.write("^")
+           newdata.write(chr(intval+64))
+       elif intval == 127:
+           newdata.write("^?")
+       else:
+           newdata.write(chr(intval))
+
+   return newdata.getvalue().encode()
+
+
+def main(argv):
+    arguments = argv[1:]
+    short_options = "v"
+    long_options = ["show-nonprinting"]
+    show_nonprinting = False;
+
+    try:
+        options, filenames = getopt.gnu_getopt(arguments, short_options, long_options)
+    except getopt.GetoptError as err:
+        sys.stderr.write("Unsupported: 'cat':  %s\n" % str(err))
+        sys.exit(1)
+
+    for option, value in options:
+        if option == "-v" or option == "--show-nonprinting":
+            show_nonprinting = True;
+
+    writer = getattr(sys.stdout, 'buffer', None)
+    if writer is None:
+        writer = sys.stdout
+        if sys.platform == "win32":
+            import os, msvcrt
+            msvcrt.setmode(sys.stdout.fileno(),os.O_BINARY)
+    for filename in filenames:
+        try:
+            fileToCat = open(filename,"rb")
+            contents = fileToCat.read()
+            if show_nonprinting:
+                contents = convertToCaretAndMNotation(contents)
+            writer.write(contents)
+            sys.stdout.flush()
+            fileToCat.close()
+        except IOError as error:
+            sys.stderr.write(str(error))
+            sys.exit(1)
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
Change the default behavior from reading from stdin (if input file is not specified on the command line) to require the input file. If it's required to read from stdin, user needs to pass "-" as input file.

What's included in this PR:
 - changing default behavior
 - adding tests

What's not included, but still required by #1588:
 - handle Ctrl+C correctly on stdin on Windows.