### PR TITLE
Removed dead code optimization from -O0

### DIFF
--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -467,7 +467,6 @@ void Optimize(llvm::Module *module, int optLevel) {
         optPM.add(CreateIsCompileTimeConstantPass(true));
         optPM.add(llvm::createFunctionInliningPass());
         optPM.add(CreateMakeInternalFuncsStaticPass());
-        optPM.add(llvm::createCFGSimplificationPass());
         optPM.add(llvm::createGlobalDCEPass());
     } else {
         llvm::PassRegistry *registry = llvm::PassRegistry::getPassRegistry();


### PR DESCRIPTION
Until the "volatile" keyword is in ispc, I can't have ispc removing variables I need in code for spacing reasons.