### PR TITLE
Fixing build for llvm trunk and 10.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2019, Intel Corporation
+#  Copyright (c) 2018-2020, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -185,6 +185,10 @@ endif()
 
 set(CLANG_LIBRARY_LIST clangFrontend clangDriver clangSerialization clangParse clangSema clangAnalysis clangAST clangBasic clangEdit clangLex)
 set(LLVM_COMPONENTS engine ipo bitreader bitwriter instrumentation linker option)
+
+if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "10.0.0")
+    list(APPEND LLVM_COMPONENTS frontendopenmp)
+endif()
 
 list(APPEND LLVM_COMPONENTS x86)
 if (ARM_ENABLED)

--- a/alloy.py
+++ b/alloy.py
@@ -129,12 +129,16 @@ def checkout_LLVM(component, use_git, version_LLVM, revision, target_dir, from_v
         error("Trying to checkout unidentified component: " + component, 1)
 
     # Identify the version
-    # An example of using branch (instead of final tag) is the foolowing (for 9.0):
+    # An example of using branch (instead of final tag) is the following (for 9.0):
     # svn: "branches/release_90/"
     # git: "origin/release/9.x"
     if  version_LLVM == "trunk":
         SVN_PATH="UNSUPPORTED"
         GIT_TAG="master"
+    elif  version_LLVM == "10_0":
+        SVN_PATH="UNSUPPORTED"
+        # Update tag when 10.0 releases
+        GIT_TAG="origin/release/10.x"
     elif  version_LLVM == "9_0":
         SVN_PATH="UNSUPPORTED"
         GIT_TAG="llvmorg-9.0.1"
@@ -645,7 +649,7 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
     print_debug("Folder: " + os.environ["ISPC_HOME"] + "\n", False, "")
     date = datetime.datetime.now()
     print_debug("Date: " + date.strftime('%H:%M %d/%m/%Y') + "\n", False, "")
-    newest_LLVM="9.0"
+    newest_LLVM="10.0"
     msg_additional_info = ""
 # *** *** ***
 # Stability validation run
@@ -698,7 +702,7 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
             archs.append("x86-64")
         if "native" in only:
             sde_targets_t = []
-        for i in ["6.0", "7.0", "8.0", "9.0", "trunk"]:
+        for i in ["6.0", "7.0", "8.0", "9.0", "10.0", "trunk"]:
             if i in only:
                 LLVM.append(i)
         if "current" in only:
@@ -974,7 +978,7 @@ def Main():
         if os.environ.get("SMTP_ISPC") == None:
             error("you have no SMTP_ISPC in your environment for option notify", 1)
     if options.only != "":
-        test_only_r = " 6.0 7.0 8.0 9.0 trunk current build stability performance x86 x86-64 x86_64 -O0 -O2 native debug nodebug "
+        test_only_r = " 6.0 7.0 8.0 9.0 10.0 trunk current build stability performance x86 x86-64 x86_64 -O0 -O2 native debug nodebug "
         test_only = options.only.split(" ")
         for iterator in test_only:
             if not (" " + iterator + " " in test_only_r):
@@ -1093,7 +1097,7 @@ if __name__ == '__main__':
     llvm_group = OptionGroup(parser, "Options for building LLVM",
                     "These options must be used with -b option.")
     llvm_group.add_option('--version', dest='version',
-        help='version of llvm to build: 6.0 7.0 8.0 9.0 trunk. Default: trunk', default="trunk")
+        help='version of llvm to build: 6.0 7.0 8.0 9.0 10.0 trunk. Default: trunk', default="trunk")
     llvm_group.add_option('--with-gcc-toolchain', dest='gcc_toolchain_path',
          help='GCC install dir to use when building clang. It is important to set when ' +
          'you have alternative gcc installation. Note that otherwise gcc from standard ' +
@@ -1137,7 +1141,7 @@ if __name__ == '__main__':
     run_group.add_option('--only', dest='only',
         help='set types of tests. Possible values:\n' + 
             '-O0, -O2, x86, x86-64, stability (test only stability), performance (test only performance),\n' +
-            'build (only build with different LLVM), 6.0, 7.0, 8.0, 9.0, trunk, native (do not use SDE),\n' +
+            'build (only build with different LLVM), 6.0, 7.0, 8.0, 9.0, 10.0, trunk, native (do not use SDE),\n' +
             'current (do not rebuild ISPC), debug (only with debug info), nodebug (only without debug info, default).',
             default="")
     run_group.add_option('--perf_LLVM', dest='perf_llvm',

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2020, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -42,7 +42,7 @@
 #include "target_registry.h"
 
 #if ISPC_LLVM_VERSION < OLDEST_SUPPORTED_LLVM || ISPC_LLVM_VERSION > LATEST_SUPPORTED_LLVM
-#error "Only LLVM 6.0 - 9.0 and 10.0 development branch are supported"
+#error "Only LLVM 6.0 - 10.0 and 11.0 development branch are supported"
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/src/ispc_version.h
+++ b/src/ispc_version.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2015-2019, Intel Corporation
+  Copyright (c) 2015-2020, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -50,9 +50,10 @@
 #define ISPC_LLVM_8_0 80000
 #define ISPC_LLVM_9_0 90000
 #define ISPC_LLVM_10_0 100000
+#define ISPC_LLVM_11_0 110000
 
 #define OLDEST_SUPPORTED_LLVM ISPC_LLVM_6_0
-#define LATEST_SUPPORTED_LLVM ISPC_LLVM_10_0
+#define LATEST_SUPPORTED_LLVM ISPC_LLVM_11_0
 
 #ifdef __ispc__xstr
 #undef __ispc__xstr

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2020, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -47,6 +47,7 @@
 #else
 #include <unistd.h>
 #endif // ISPC_HOST_IS_WINDOWS
+#include <llvm/Support/CommandLine.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/Signals.h>
 #include <llvm/Support/TargetRegistry.h>

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2020, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -934,9 +934,15 @@ bool Module::writeObjectFileOrAssembly(llvm::TargetMachine *targetMachine, llvm:
                                        const char *outFileName) {
     // Figure out if we're generating object file or assembly output, and
     // set binary output for object files
+#if ISPC_LLVM_VERSION <= ISPC_LLVM_9_0
     llvm::TargetMachine::CodeGenFileType fileType =
         (outputType == Object) ? llvm::TargetMachine::CGFT_ObjectFile : llvm::TargetMachine::CGFT_AssemblyFile;
     bool binary = (fileType == llvm::TargetMachine::CGFT_ObjectFile);
+#else // LLVM 10.0+
+    llvm::CodeGenFileType fileType = (outputType == Object) ? llvm::CGFT_ObjectFile : llvm::CGFT_AssemblyFile;
+    bool binary = (fileType == llvm::CGFT_ObjectFile);
+#endif
+
     llvm::sys::fs::OpenFlags flags = binary ? llvm::sys::fs::F_None : llvm::sys::fs::F_Text;
 
     std::error_code error;
@@ -1896,7 +1902,12 @@ void Module::execPreprocessor(const char *infilename, llvm::raw_string_ostream *
     inst.setTarget(target);
     inst.createSourceManager(inst.getFileManager());
 
+#if ISPC_LLVM_VERSION <= ISPC_LLVM_9_0
     clang::FrontendInputFile inputFile(infilename, clang::InputKind::Unknown);
+#else // LLVM 10.0+
+    clang::FrontendInputFile inputFile(infilename, clang::InputKind());
+#endif
+
     inst.InitializeSourceManager(inputFile);
 
     // Don't remove comments in the preprocessor, so that we can accurately

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2020, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -1820,10 +1820,14 @@ llvm::DIType *StructType::GetDIType(llvm::DIScope *scope) const {
     llvm::DINodeArray elements = m->diBuilder->getOrCreateArray(elementLLVMTypes);
     llvm::DIFile *diFile = pos.GetDIFile();
     return m->diBuilder->createStructType(diFile, name, diFile,
-                                          pos.first_line,             // Line number
-                                          layout->getSizeInBits(),    // Size in bits
+                                          pos.first_line,          // Line number
+                                          layout->getSizeInBits(), // Size in bits
+#if ISPC_LLVM_VERSION <= ISPC_LLVM_9_0
                                           layout->getAlignment() * 8, // Alignment in bits
-                                          llvm::DINode::FlagZero,     // Flags
+#else                                                                 // LLVM 10.0+
+                                          layout->getAlignment().value() * 8, // Alignment in bits
+#endif
+                                          llvm::DINode::FlagZero, // Flags
                                           NULL, elements);
 }
 


### PR DESCRIPTION
Main Changes are-
1. Updated latest llvm version to 11.0
     a. Since 10.0 has branched but released, using the temporary branch in alloy. Has to update this once 10.0 official release happens
2. LLVM moved openmp to a new library - frontendopenmp. Modified Cmake to add this
3. Changes in headers caused us to add some new headers
4. setjmp and longjmp deprecated and removed. From what I understand they have not been supported for a while now. Hence the complete removal.
5. BasicBlockPass removed in llvm. switched to FunctionPass
6. Alignment no longer use integer values. have to use llvm::MaybeAlign