### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ set (ISPC_TARGETS
         avx512knl-i32x16
         avx512skx-i32x16
         generic-1 generic-4 generic-8 generic-16 generic-32 generic-64)
-if (${LLVM_VERSION_NUMBER} GREATER_EQUAL "8.0.0")
+if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "8.0.0")
     list(APPEND ISPC_TARGETS avx512skx-i32x8)
 endif()
 

--- a/cmake/LLVMConfig.cmake
+++ b/cmake/LLVMConfig.cmake
@@ -97,14 +97,15 @@ function(run_llvm_config output_var)
     set(${output_var} ${${output_var}} PARENT_SCOPE)
 endfunction()
 
-run_llvm_config(CXX_FLAGS "--cxxflags")
-# Check LLVM_ENABLE_DUMP flag
-if (${LLVM_VERSION} GREATER_EQUAL "LLVM_5_0")
-    string(FIND CXX_FLAGS "LLVM_ENABLE_DUMP" ENABLED_DUMP)
-    if (NOT ${ENABLED_DUMP} GREATER -1)
-        message(FATAL_ERROR "LLVM was built without DLLVM_ENABLE_DUMP enabled")
-    endif()
+run_llvm_config(LLVM_VERSION_NUMBER "--version")
+message(STATUS "Detected LLVM version: ${LLVM_VERSION_NUMBER}")
+
+run_llvm_config(ASSERTIONS "--assertion-mode")
+if (NOT ${ASSERTIONS} STREQUAL "ON")
+    message(WARNING "LLVM was built without assertions enabled (-DLLVM_ENABLE_ASSERTIONS=OFF). This disables dumps, which are required for ISPC to be fully functional.")
 endif()
+
+run_llvm_config(CXX_FLAGS "--cxxflags")
 # Check DNDEBUG flag
 if (NOT CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
     string(FIND CXX_FLAGS "NDEBUG" NDEBUG_DEF)
@@ -121,9 +122,6 @@ if (NOT CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
         endforeach()
     endif()
 endif()
-
-run_llvm_config(LLVM_VERSION_NUMBER "--version")
-message(STATUS "Detected LLVM version: ${LLVM_VERSION_NUMBER}")
 
 function(get_llvm_libfiles resultList)
     run_llvm_config(LLVM_LIBS "--libfiles" ${ARGN})


### PR DESCRIPTION
* properly compare LLVM versions
* correctly detect LLVM build without asserts/dumps.