### PR TITLE
Fix synchronization issue in run_tests.py.

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -503,7 +503,11 @@ def file_check(results, host, target):
         opt = "-O2"
 # Detect LLVM version
     temp1 = common.take_lines(host.ispc_exe + " --version", "first")
-    llvm_version = temp1[-12:-4]
+    temp2 = re.search('LLVM [0-9]*\.[0-9]*', temp1)
+    if temp2 != None:
+        llvm_version = temp2.group()
+    else:
+        llvm_version = "unknown LLVM"
 # Detect compiler version
     if OS != "Windows":
         temp1 = common.take_lines(options.compiler_exe + " --version", "first")


### PR DESCRIPTION
The pattern with checking Queue.empty() and doing Queue.get() without critical
section leads to dead locks. So, options are: use critical section or different
mechanism to pull the new job. This solution uses "STOP" markers in the Queue.
So, no check for empty queue is needed. The same queue is also used to indicate
that all tests are handled, as it's JoinableQueue. Hence getting rid of extra
Queue for signaling completion.

Also queue for signalling errors is removed. All exception will be reported as
Runtime failures and reported in the log.