### PR TITLE
Adding <cstdarg> include to main.cpp, which is required for va_arg

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "target_registry.h"
 #include "type.h"
 #include "util.h"
+#include <cstdarg>
 #include <stdio.h>
 #include <stdlib.h>
 #ifdef ISPC_HOST_IS_WINDOWS


### PR DESCRIPTION
Fix for #1643.