### PR TITLE
Fix for #1596.

### DIFF
--- a/src/expr.h
+++ b/src/expr.h
@@ -78,9 +78,11 @@ class Expr : public ASTNode {
 
     /** If this is a constant expression that can be converted to a
         constant of the given type, this method should return the
-        corresponding llvm::Constant value.  Otherwise it should return
-        NULL. */
-    virtual llvm::Constant *GetConstant(const Type *type) const;
+        corresponding llvm::Constant value and a flag denoting if it's
+        valid for multi-target compilation for use as an initializer of
+        a global variable. Otherwise it should return the llvm::constant
+        value as NULL. */
+    virtual std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
     /** This method should perform early optimizations of the expression
         (constant folding, etc.) and return a pointer to the resulting
@@ -167,7 +169,7 @@ class BinaryExpr : public Expr {
     Expr *Optimize();
     Expr *TypeCheck();
     int EstimateCost() const;
-    llvm::Constant *GetConstant(const Type *type) const;
+    std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
     const Op op;
     Expr *arg0, *arg1;
@@ -246,7 +248,7 @@ class ExprList : public Expr {
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
     void Print() const;
-    llvm::Constant *GetConstant(const Type *type) const;
+    std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
     ExprList *Optimize();
     ExprList *TypeCheck();
     int EstimateCost() const;
@@ -426,7 +428,7 @@ class ConstExpr : public Expr {
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
     void Print() const;
-    llvm::Constant *GetConstant(const Type *type) const;
+    std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
     Expr *TypeCheck();
     Expr *Optimize();
@@ -491,7 +493,7 @@ class TypeCastExpr : public Expr {
     Expr *Optimize();
     int EstimateCost() const;
     Symbol *GetBaseSymbol() const;
-    llvm::Constant *GetConstant(const Type *type) const;
+    std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
     const Type *type;
     Expr *expr;
@@ -585,7 +587,7 @@ class AddressOfExpr : public Expr {
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
-    llvm::Constant *GetConstant(const Type *type) const;
+    std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
     Expr *expr;
 };
@@ -606,7 +608,7 @@ class SizeOfExpr : public Expr {
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
-    llvm::Constant *GetConstant(const Type *type) const;
+    std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
     /* One of expr or type should be non-NULL (but not both of them).  The
        SizeOfExpr returns the size of whichever one of them isn't NULL. */
@@ -653,7 +655,7 @@ class FunctionSymbolExpr : public Expr {
     Expr *Optimize();
     void Print() const;
     int EstimateCost() const;
-    llvm::Constant *GetConstant(const Type *type) const;
+    std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
     /** Given the types of the function arguments, in the presence of
         function overloading, this method resolves which actual function
@@ -721,7 +723,7 @@ class NullPointerExpr : public Expr {
     const Type *GetType() const;
     Expr *TypeCheck();
     Expr *Optimize();
-    llvm::Constant *GetConstant(const Type *type) const;
+    std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
     void Print() const;
     int EstimateCost() const;
 };

--- a/src/expr.h
+++ b/src/expr.h
@@ -167,6 +167,7 @@ class BinaryExpr : public Expr {
     Expr *Optimize();
     Expr *TypeCheck();
     int EstimateCost() const;
+    llvm::Constant *GetConstant(const Type *type) const;
 
     const Op op;
     Expr *arg0, *arg1;
@@ -605,6 +606,7 @@ class SizeOfExpr : public Expr {
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
+    llvm::Constant *GetConstant(const Type *type) const;
 
     /* One of expr or type should be non-NULL (but not both of them).  The
        SizeOfExpr returns the size of whichever one of them isn't NULL. */

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1324,8 +1324,15 @@ static bool lGenericTypeLayoutIndeterminate(llvm::Type *type) {
     return true;
 }
 
+bool Target::IsGenericTypeLayoutIndeterminate(llvm::Type *type) {
+    bool ret = false;
+    if (m_isa == Target::GENERIC && lGenericTypeLayoutIndeterminate(type) == true)
+        ret = true;
+    return ret;
+}
+
 llvm::Value *Target::SizeOf(llvm::Type *type, llvm::BasicBlock *insertAtEnd) {
-    if (m_isa == Target::GENERIC && lGenericTypeLayoutIndeterminate(type)) {
+    if (IsGenericTypeLayoutIndeterminate(type)) {
         llvm::Value *index[1] = {LLVMInt32(1)};
         llvm::PointerType *ptrType = llvm::PointerType::get(type, 0);
         llvm::Value *voidPtr = llvm::ConstantPointerNull::get(ptrType);
@@ -1346,7 +1353,7 @@ llvm::Value *Target::SizeOf(llvm::Type *type, llvm::BasicBlock *insertAtEnd) {
 }
 
 llvm::Value *Target::StructOffset(llvm::Type *type, int element, llvm::BasicBlock *insertAtEnd) {
-    if (m_isa == Target::GENERIC && lGenericTypeLayoutIndeterminate(type) == true) {
+    if (IsGenericTypeLayoutIndeterminate(type)) {
         llvm::Value *indices[2] = {LLVMInt32(0), LLVMInt32(element)};
         llvm::PointerType *ptrType = llvm::PointerType::get(type, 0);
         llvm::Value *voidPtr = llvm::ConstantPointerNull::get(ptrType);
@@ -1379,13 +1386,6 @@ void Target::markFuncWithTargetAttr(llvm::Function *func) {
     if (m_tf_attributes) {
         func->addAttributes(llvm::AttributeList::FunctionIndex, *m_tf_attributes);
     }
-}
-
-bool Target::IsGenericTypeLayoutIndeterminate(llvm::Type *type) {
-    bool ret = false;
-    if (m_isa == Target::GENERIC && lGenericTypeLayoutIndeterminate(type) == true)
-        ret = true;
-    return ret;
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -1441,6 +1441,7 @@ Globals::Globals() {
     enableFuzzTest = false;
     fuzzTestSeed = -1;
     mangleFunctionsWithTarget = false;
+    isMultiTargetCompilation = false;
 
     ctx = new llvm::LLVMContext;
 

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1381,6 +1381,13 @@ void Target::markFuncWithTargetAttr(llvm::Function *func) {
     }
 }
 
+bool Target::IsGenericTypeLayoutIndeterminate(llvm::Type *type) {
+    bool ret = false;
+    if (m_isa == Target::GENERIC && lGenericTypeLayoutIndeterminate(type) == true)
+        ret = true;
+    return ret;
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // Opt
 

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -214,6 +214,8 @@ class Target {
     /** Mark LLVM function with target specific attribute, if required. */
     void markFuncWithTargetAttr(llvm::Function *func);
 
+    bool IsGenericTypeLayoutIndeterminate(llvm::Type *type);
+
     const llvm::Target *getTarget() const { return m_target; }
 
     // Note the same name of method for 3.1 and 3.2+, this allows

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -214,6 +214,7 @@ class Target {
     /** Mark LLVM function with target specific attribute, if required. */
     void markFuncWithTargetAttr(llvm::Function *func);
 
+    /* Check if target is GENERIC and internally calls lGenericTypeLayoutIndeterminate */
     bool IsGenericTypeLayoutIndeterminate(llvm::Type *type);
 
     const llvm::Target *getTarget() const { return m_target; }
@@ -626,6 +627,9 @@ struct Globals {
 
     /** Lines for which warnings are turned off. */
     std::map<std::pair<int, std::string>, bool> turnOffWarnings;
+
+    /* If true, we are compiling for more than one target. */
+    bool isMultiTargetCompilation;
 };
 
 enum {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -914,6 +914,9 @@ int main(int Argc, char *Argv[]) {
         Warning(SourcePos(), "--dllexport switch will be ignored, as the target OS is not Windows.");
     }
 
+    if (targets.size() > 1)
+        g->isMultiTargetCompilation = true;
+
     if ((ot == Module::Asm) && (intelAsmSyntax != NULL)) {
         std::vector<const char *> Args(3);
         Args[0] = "ispc (LLVM option parsing)";

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -2360,7 +2360,8 @@ lGetConstantInt(Expr *expr, int *value, SourcePos pos, const char *usage) {
     if (expr == NULL)
         return false;
 
-    llvm::Constant *cval = expr->GetConstant(expr->GetType());
+    std::pair<llvm::Constant *, bool> cValPair = expr->GetConstant(expr->GetType());
+    llvm::Constant *cval = cValPair.first;
     if (cval == NULL) {
         Error(pos, "%s must be a compile-time constant.", usage);
         return false;

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -194,7 +194,8 @@ void DeclStmt::EmitCode(FunctionEmitContext *ctx) const {
                     initExpr = ::Optimize(initExpr);
                 }
 
-                cinit = initExpr->GetConstant(sym->type);
+                std::pair<llvm::Constant *, bool> cinitPair = initExpr->GetConstant(sym->type);
+                cinit = cinitPair.first;
                 if (cinit == NULL)
                     Error(initExpr->pos,
                           "Initializer for static variable "

--- a/tests/1596.ispc
+++ b/tests/1596.ispc
@@ -1,0 +1,20 @@
+static uniform int sz = sizeof(uniform int);
+
+static uniform int a = 7;
+static uniform int * uniform pa = &a;
+static const uniform int * uniform parr[] = {NULL, &a, &a};
+
+static const uniform int b[] = {2, 9, 3, 4, 8, 5, 6, 3};
+static const uniform int * uniform pb[] = {NULL, b + 5, b};
+static const uniform int * uniform pb1[] = {NULL, b, b};
+
+export uniform int width() { return programCount; }
+
+export void f_v(uniform float RET[]) {
+
+    RET[programIndex] = *pa * *parr[2] * *pb[1] * *pb1[2];
+    //print("\n Calc Val = % Orig Val = % \n", *pa * *parr[2] * *pb[1] * *pb1[2], 7 * 7 * 5 * 2);
+
+}
+
+export void result(uniform float RET[]) { RET[programIndex] = 490; }

--- a/tests/1596.ispc
+++ b/tests/1596.ispc
@@ -1,20 +1,37 @@
 static uniform int sz = sizeof(uniform int);
 
 static uniform int a = 7;
-static uniform int * uniform pa = &a;
-static const uniform int * uniform parr[] = {NULL, &a, &a};
+static uniform int *uniform pa = &a;
+static const uniform int *uniform parr[] = {NULL, &a, &a};
 
 static const uniform int b[] = {2, 9, 3, 4, 8, 5, 6, 3};
-static const uniform int * uniform pb[] = {NULL, b + 5, b};
-static const uniform int * uniform pb1[] = {NULL, b, b};
+static const uniform int *uniform pb[] = {NULL, b + 5, b};
+static const uniform int *uniform pb1[] = {NULL, b, b};
+
+uniform int sVar = sizeof(varying int64);
+
+uniform int ii[2][3][4] = {{{1, 2, 3, 4}, {1, 2, 3, 4}, {1, 2, 3, 4}}, {{1, 2, 3, 4}, {1, 2, 3, 4}, {1, 2, 3, 4}}};
+uniform int *uniform aaa = &ii[1][2][3];
+
+static uniform int sVar_loc_global = sizeof(varying int8);
 
 export uniform int width() { return programCount; }
 
 export void f_v(uniform float RET[]) {
-
-    RET[programIndex] = *pa * *parr[2] * *pb[1] * *pb1[2];
-    //print("\n Calc Val = % Orig Val = % \n", *pa * *parr[2] * *pb[1] * *pb1[2], 7 * 7 * 5 * 2);
-
+    static uniform int sVar_loc = sizeof(varying int8);
+    RET[programIndex] = (1 * *pa) + (2 * *parr[2]) + (3 * *pb[1]) + (4 * *pb1[2]) + (5 * *aaa) + (6 * sz) + (7 * sVar) + (8 * sVar_loc) + (9 * sVar_loc_global);
 }
 
-export void result(uniform float RET[]) { RET[programIndex] = 490; }
+// Expected Values
+// *pa = 7
+// *parr[2] = 7
+// *pb[1] = 5
+// *pb1[2] = 2
+// *aaa = 4
+// sz = 4
+// sVar = 8 * WIDTH
+// sVar_loc = 1 * WIDTH
+// sVar_loc_global = 1 * WIDTH
+export void result(uniform float RET[]) {
+    RET[programIndex] = (1 * 7) + (2 * 7) + (3 * 5) + (4 * 2) + (5 * 4) + (6 * 4) + (7 * (8 * programCount)) + (8 * (1 * programCount)) + (9 * (1 * programCount));
+}

--- a/tests/lit-tests/1596.ispc
+++ b/tests/lit-tests/1596.ispc
@@ -1,0 +1,23 @@
+// RUN: %{ispc} %s > %t 2>&1
+uniform int sz = sizeof(uniform int);
+
+static uniform float a = 1.0;
+static uniform float * uniform pa = &a;
+static const uniform float * uniform parr[] = {NULL, &a, &a};
+
+static const uniform float b[] = {0.,4., 3., 2., 1.};
+static const uniform float * uniform pb[] = {NULL, b+3, b};
+static const uniform float * uniform pb1[] = {NULL, b, b};
+
+varying float i = 80;
+varying float p_foo[] = {1, 4, 3, 2, 4, 3, 3, 3};
+varying float * uniform au = &p_foo[0];
+
+
+varying float usevals() {
+
+    varying float * varying av = au + i + *pa * *parr[1] * *pb[2] * *pb1[1];
+    return *av  ;
+}
+
+

--- a/tests/lit-tests/1596.ispc
+++ b/tests/lit-tests/1596.ispc
@@ -1,23 +1,28 @@
-// RUN: %{ispc} %s > %t 2>&1
+//; RUN: %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 2>&1 | FileCheck %s -check-prefix=CHECK_SINGLE
+//; RUN: not %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8,sse2-i32x4 2>&1 | FileCheck %s -check-prefix=CHECK_MULTI
+//; CHECK_SINGLE: Initializer for global variable "sz_var" is a constant for single-target compilation but not for multi-target compilation.
+//; CHECK_MULTI: Initializer for global variable "sz_var" is not a constant for multi-target compilation
 uniform int sz = sizeof(uniform int);
 
 static uniform float a = 1.0;
-static uniform float * uniform pa = &a;
-static const uniform float * uniform parr[] = {NULL, &a, &a};
+static uniform float *uniform pa = &a;
+static const uniform float *uniform parr[] = {NULL, &a, &a};
 
-static const uniform float b[] = {0.,4., 3., 2., 1.};
-static const uniform float * uniform pb[] = {NULL, b+3, b};
-static const uniform float * uniform pb1[] = {NULL, b, b};
+static const uniform float b[] = {0., 4., 3., 2., 1.};
+static const uniform float *uniform pb[] = {NULL, b + 3, b};
+static const uniform float *uniform pb1[] = {NULL, b, b};
 
 varying float i = 80;
 varying float p_foo[] = {1, 4, 3, 2, 4, 3, 3, 3};
-varying float * uniform au = &p_foo[0];
+varying float *uniform au = &p_foo[0];
 
+uniform int sz_var = sizeof(varying int);
+
+uniform int ii[2][3][4] = {{{1, 2, 3, 4}, {1, 2, 3, 4}, {1, 2, 3, 4}}, {{1, 2, 3, 4}, {1, 2, 3, 4}, {1, 2, 3, 4}}};
+uniform int *uniform aaa = &ii[1][2][3];
 
 varying float usevals() {
 
-    varying float * varying av = au + i + *pa * *parr[1] * *pb[2] * *pb1[1];
-    return *av  ;
+    varying float *varying av = au + i + *pa * *parr[1] * *pb[2] * *pb1[1] + *aaa;
+    return *av;
 }
-
-


### PR DESCRIPTION
This mostly has logic to identify compile time constants
which are global addresses and their variants.

Enables following initializations -
uniform int sz = sizeof(uniform int);

static uniform float a = 1.0;
static uniform float * uniform pa = &a;
static const uniform float * uniform parr[] = {NULL, &a, &a};

static const uniform float b[] = {0.,4., 3., 2., 1.};
static const uniform float * uniform pb[] = {NULL, b+3, b};
