### PR TITLE
Fix for #1608/#1609.

### DIFF
--- a/builtins/target-avx512-common-8.ll
+++ b/builtins/target-avx512-common-8.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2019, Intel Corporation
+;;  Copyright (c) 2020, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@
 ;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
 
-define(`MASK',`i8')
+define(`MASK',`i1')
 define(`HAVE_GATHER',`1')
 define(`HAVE_SCATTER',`1')
 
@@ -38,14 +38,8 @@ include(`target-avx512-utils.ll')
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Stub for mask conversion. LLVM's intrinsics want i1 mask, but we use i8
 
-define <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %mask) alwaysinline {
-  %mask_vec_i1 = icmp ne <WIDTH x MASK> %mask, const_vector(MASK, 0)
-  ret <WIDTH x i1> %mask_vec_i1
-}
-
 define i8 @__cast_mask_to_i8 (<WIDTH x MASK> %mask) alwaysinline {
-  %mask_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %mask)
-  %mask_i8 = bitcast <WIDTH x i1> %mask_i1 to i8
+  %mask_i8 = bitcast <WIDTH x i1> %mask to i8
   ret i8 %mask_i8
 }
 
@@ -617,8 +611,7 @@ define void @__masked_store_double(<8 x double>* nocapture, <8 x double> %v, <WI
 define void @__masked_store_blend_i8(<8 x i8>* nocapture, <8 x i8>,
                                      <WIDTH x MASK>) nounwind alwaysinline {
   %v = load PTR_OP_ARGS(`<8 x i8> ')  %0
-  %mask_vec_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %2)
-  %v1 = select <WIDTH x i1> %mask_vec_i1, <8 x i8> %1, <8 x i8> %v
+  %v1 = select <WIDTH x i1> %2, <8 x i8> %1, <8 x i8> %v
   store <8 x i8> %v1, <8 x i8> * %0
   ret void
 }
@@ -626,8 +619,7 @@ define void @__masked_store_blend_i8(<8 x i8>* nocapture, <8 x i8>,
 define void @__masked_store_blend_i16(<8 x i16>* nocapture, <8 x i16>,
                                       <WIDTH x MASK>) nounwind alwaysinline {
   %v = load PTR_OP_ARGS(`<8 x i16> ')  %0
-  %mask_vec_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %2)
-  %v1 = select <WIDTH x i1> %mask_vec_i1, <8 x i16> %1, <8 x i16> %v
+  %v1 = select <WIDTH x i1> %2, <8 x i16> %1, <8 x i16> %v
   store <8 x i16> %v1, <8 x i16> * %0
   ret void
 }
@@ -635,8 +627,7 @@ define void @__masked_store_blend_i16(<8 x i16>* nocapture, <8 x i16>,
 define void @__masked_store_blend_i32(<8 x i32>* nocapture, <8 x i32>,
                                       <WIDTH x MASK>) nounwind alwaysinline {
   %v = load PTR_OP_ARGS(`<8 x i32> ')  %0
-  %mask_vec_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %2)
-  %v1 = select <WIDTH x i1> %mask_vec_i1, <8 x i32> %1, <8 x i32> %v
+  %v1 = select <WIDTH x i1> %2, <8 x i32> %1, <8 x i32> %v
   store <8 x i32> %v1, <8 x i32> * %0
   ret void
 }
@@ -644,8 +635,7 @@ define void @__masked_store_blend_i32(<8 x i32>* nocapture, <8 x i32>,
 define void @__masked_store_blend_float(<8 x float>* nocapture, <8 x float>, 
                                         <WIDTH x MASK>) nounwind alwaysinline {
   %v = load PTR_OP_ARGS(`<8 x float> ')  %0
-  %mask_vec_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %2)
-  %v1 = select <WIDTH x i1> %mask_vec_i1, <8 x float> %1, <8 x float> %v
+  %v1 = select <WIDTH x i1> %2, <8 x float> %1, <8 x float> %v
   store <8 x float> %v1, <8 x float> * %0
   ret void
 }
@@ -653,8 +643,7 @@ define void @__masked_store_blend_float(<8 x float>* nocapture, <8 x float>,
 define void @__masked_store_blend_i64(<8 x i64>* nocapture,
                             <8 x i64>, <WIDTH x MASK>) nounwind alwaysinline {
   %v = load PTR_OP_ARGS(`<8 x i64> ')  %0
-  %mask_vec_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %2)
-  %v1 = select <WIDTH x i1> %mask_vec_i1, <8 x i64> %1, <8 x i64> %v
+  %v1 = select <WIDTH x i1> %2, <8 x i64> %1, <8 x i64> %v
   store <8 x i64> %v1, <8 x i64> * %0
   ret void
 }
@@ -662,8 +651,7 @@ define void @__masked_store_blend_i64(<8 x i64>* nocapture,
 define void @__masked_store_blend_double(<8 x double>* nocapture,
                             <8 x double>, <WIDTH x MASK>) nounwind alwaysinline {
   %v = load PTR_OP_ARGS(`<8 x double> ')  %0
-  %mask_vec_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %2)
-  %v1 = select <WIDTH x i1> %mask_vec_i1, <8 x double> %1, <8 x double> %v
+  %v1 = select <WIDTH x i1> %2, <8 x double> %1, <8 x double> %v
   store <8 x double> %v1, <8 x double> * %0
   ret void
 }

--- a/builtins/target-avx512-common.ll
+++ b/builtins/target-avx512-common.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2015-2019, Intel Corporation
+;;  Copyright (c) 2015-2020, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@
 ;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
 
-define(`MASK',`i8')
+define(`MASK',`i1')
 define(`HAVE_GATHER',`1')
 define(`HAVE_SCATTER',`1')
 
@@ -38,14 +38,8 @@ include(`target-avx512-utils.ll')
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Stub for mask conversion. LLVM's intrinsics want i1 mask, but we use i8
 
-define <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %mask) alwaysinline {
-  %mask_vec_i1 = icmp ne <WIDTH x MASK> %mask, const_vector(MASK, 0)
-  ret <WIDTH x i1> %mask_vec_i1
-}
-
 define i16 @__cast_mask_to_i16 (<WIDTH x MASK> %mask) alwaysinline {
-  %mask_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %mask)
-  %mask_i16 = bitcast <WIDTH x i1> %mask_i1 to i16
+  %mask_i16 = bitcast <WIDTH x i1> %mask to i16
   ret i16 %mask_i16
 }
 
@@ -669,8 +663,7 @@ define void @__masked_store_double(<16 x double>* nocapture, <16 x double> %v, <
 define void @__masked_store_blend_i8(<16 x i8>* nocapture, <16 x i8>, 
                                      <WIDTH x MASK>) nounwind alwaysinline {
   %v = load PTR_OP_ARGS(`<16 x i8> ')  %0
-  %mask_vec_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %2)
-  %v1 = select <WIDTH x i1> %mask_vec_i1, <16 x i8> %1, <16 x i8> %v
+  %v1 = select <WIDTH x i1> %2, <16 x i8> %1, <16 x i8> %v
   store <16 x i8> %v1, <16 x i8> * %0
   ret void
 }
@@ -678,8 +671,7 @@ define void @__masked_store_blend_i8(<16 x i8>* nocapture, <16 x i8>,
 define void @__masked_store_blend_i16(<16 x i16>* nocapture, <16 x i16>, 
                                       <WIDTH x MASK>) nounwind alwaysinline {
   %v = load PTR_OP_ARGS(`<16 x i16> ')  %0
-  %mask_vec_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %2)
-  %v1 = select <WIDTH x i1> %mask_vec_i1, <16 x i16> %1, <16 x i16> %v
+  %v1 = select <WIDTH x i1> %2, <16 x i16> %1, <16 x i16> %v
   store <16 x i16> %v1, <16 x i16> * %0
   ret void
 }
@@ -687,8 +679,7 @@ define void @__masked_store_blend_i16(<16 x i16>* nocapture, <16 x i16>,
 define void @__masked_store_blend_i32(<16 x i32>* nocapture, <16 x i32>, 
                                       <WIDTH x MASK>) nounwind alwaysinline {
   %v = load PTR_OP_ARGS(`<16 x i32> ')  %0
-  %mask_vec_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %2)
-  %v1 = select <WIDTH x i1> %mask_vec_i1, <16 x i32> %1, <16 x i32> %v
+  %v1 = select <WIDTH x i1> %2, <16 x i32> %1, <16 x i32> %v
   store <16 x i32> %v1, <16 x i32> * %0
   ret void
 }
@@ -696,8 +687,7 @@ define void @__masked_store_blend_i32(<16 x i32>* nocapture, <16 x i32>,
 define void @__masked_store_blend_float(<16 x float>* nocapture, <16 x float>, 
                                         <WIDTH x MASK>) nounwind alwaysinline {
   %v = load PTR_OP_ARGS(`<16 x float> ')  %0
-  %mask_vec_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %2)
-  %v1 = select <WIDTH x i1> %mask_vec_i1, <16 x float> %1, <16 x float> %v
+  %v1 = select <WIDTH x i1> %2, <16 x float> %1, <16 x float> %v
   store <16 x float> %v1, <16 x float> * %0
   ret void
 }
@@ -705,8 +695,7 @@ define void @__masked_store_blend_float(<16 x float>* nocapture, <16 x float>,
 define void @__masked_store_blend_i64(<16 x i64>* nocapture,
                             <16 x i64>, <WIDTH x MASK>) nounwind alwaysinline {
   %v = load PTR_OP_ARGS(`<16 x i64> ')  %0
-  %mask_vec_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %2)
-  %v1 = select <WIDTH x i1> %mask_vec_i1, <16 x i64> %1, <16 x i64> %v
+  %v1 = select <WIDTH x i1> %2, <16 x i64> %1, <16 x i64> %v
   store <16 x i64> %v1, <16 x i64> * %0
   ret void
 }
@@ -714,8 +703,7 @@ define void @__masked_store_blend_i64(<16 x i64>* nocapture,
 define void @__masked_store_blend_double(<16 x double>* nocapture,
                             <16 x double>, <WIDTH x MASK>) nounwind alwaysinline {
   %v = load PTR_OP_ARGS(`<16 x double> ')  %0
-  %mask_vec_i1 = call <WIDTH x i1> @__cast_mask_to_i1 (<WIDTH x MASK> %2)
-  %v1 = select <WIDTH x i1> %mask_vec_i1, <16 x double> %1, <16 x double> %v
+  %v1 = select <WIDTH x i1> %2, <16 x double> %1, <16 x double> %v
   store <16 x double> %v1, <16 x double> * %0
   ret void
 }

--- a/builtins/target-avx512-utils.ll
+++ b/builtins/target-avx512-utils.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2015-2019, Intel Corporation
+;;  Copyright (c) 2015-2020, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@
 ;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-define(`MASK',`i8')
+define(`MASK',`i1')
 define(`HAVE_GATHER',`1')
 define(`HAVE_SCATTER',`1')
 

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -759,7 +759,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_dataTypeWidth = 32;
         this->m_vectorWidth = 16;
         this->m_maskingIsFree = true;
-        this->m_maskBitCount = 8;
+        this->m_maskBitCount = 1;
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = this->m_hasScatter = true;
@@ -778,7 +778,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_dataTypeWidth = 32;
         this->m_vectorWidth = 8;
         this->m_maskingIsFree = true;
-        this->m_maskBitCount = 8;
+        this->m_maskBitCount = 1;
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = this->m_hasScatter = true;
@@ -802,7 +802,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_dataTypeWidth = 32;
         this->m_vectorWidth = 16;
         this->m_maskingIsFree = true;
-        this->m_maskBitCount = 8;
+        this->m_maskBitCount = 1;
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = this->m_hasScatter = true;

--- a/tests/lit-tests/1608.ispc
+++ b/tests/lit-tests/1608.ispc
@@ -1,0 +1,16 @@
+//; RUN: %{ispc} %s --target=avx512knl-i32x16 --emit-asm -o - | FileCheck %s --implicit-check-not "vpcmpeqb" -check-prefix=CHECK_AVX512knl16
+//; RUN: %{ispc} %s --target=avx512skx-i32x16 --emit-asm -o - | FileCheck %s --implicit-check-not "vpcmpeqb" -check-prefix=CHECK_AVX512skx16
+//; RUN: %{ispc} %s --target=avx512skx-i32x8 --emit-asm -o - | FileCheck %s --implicit-check-not "vpcmpeqw" --implicit-check-not "vpcmpneqw" -check-prefix=CHECK_AVX512skx8
+// REQUIRES: LLVM_8_0+
+void int_compare(uniform float vin[], uniform int cmp[], uniform float vout[], uniform int count) {
+    foreach (index = 0 ... count) {
+        varying float v = vin[index];
+        varying int c = cmp[index];
+        if (c < 0)
+            v = v * v;
+        else
+            v = sqrt(v);
+
+        vout[index] = v;
+    }
+}

--- a/tests/lit-tests/1609.ispc
+++ b/tests/lit-tests/1609.ispc
@@ -1,0 +1,42 @@
+//; RUN: %{ispc} %s --target=avx512knl-i32x16 --emit-asm -o - | FileCheck %s --implicit-check-not "vpcmpeqb" -check-prefix=CHECK_AVX512knl16
+//; RUN: %{ispc} %s --target=avx512skx-i32x16 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_AVX512skx16
+//; RUN: %{ispc} %s --target=avx512skx-i32x8 --emit-asm -o - | FileCheck %s --implicit-check-not "vptestnmw" -check-prefix=CHECK_AVX512skx8
+// REQUIRES: LLVM_8_0+
+void while_loop_test(uniform float cmp[], uniform float vout[], uniform int count) {
+    foreach (index = 0 ... count) {
+        varying float c = cmp[index];
+// Might have to revisit instructions being checked for.
+
+// CHECK_AVX512knl16: vcmp
+// CHECK_AVX512knl16-NEXT: kortestw
+// CHECK_AVX512knl16: vcmp
+// CHECK_AVX512knl16-NEXT: kortestw
+// CHECK_AVX512knl16:vcmp
+// CHECK_AVX512knl16-NEXT: kortestw
+// CHECK_AVX512knl16: vcmp
+// CHECK_AVX512knl16-NEXT: kortestw
+
+// CHECK_AVX512skx16: vcmp
+// CHECK_AVX512skx16-NEXT: kortestw
+// CHECK_AVX512skx16: vcmp
+// CHECK_AVX512skx16-NEXT: kortestw
+// CHECK_AVX512skx16:vcmp
+// CHECK_AVX512skx16-NEXT: kortestw
+// CHECK_AVX512skx16: vcmp
+// CHECK_AVX512skx16-NEXT: kortestw
+
+// CHECK_AVX512skx8: vcmp
+// CHECK_AVX512skx8-NEXT: kortestb
+// CHECK_AVX512skx8: vcmp
+// CHECK_AVX512skx8-NEXT: kortestb
+// CHECK_AVX512skx8:vcmp
+// CHECK_AVX512skx8-NEXT: kortestb
+// CHECK_AVX512skx8: vcmp
+// CHECK_AVX512skx8-NEXT: kortestb
+        while (c > 1.0) {
+            c = c - 1.0;
+        }
+
+        vout[index] = c;
+    }
+}


### PR DESCRIPTION
Changing avx512 mask to i1 from i8.

i1 is a more natural mask size for avx512. By changing mask size to i1, we can skip constantly converting i8 to i1 for use in intrinsics.