### PR TITLE
Fix to match LLVM trunk

### DIFF
--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2020, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -168,7 +168,7 @@ static bool lCreateISPCSymbol(llvm::Function *func, SymbolTable *symbolTable) {
     noPos.name = "__stdlib";
 
     const llvm::FunctionType *ftype = func->getFunctionType();
-    std::string name = func->getName();
+    std::string name = std::string(func->getName());
 
     if (name.size() < 3 || name[0] != '_' || name[1] != '_')
         return false;

--- a/src/cbackend.cpp
+++ b/src/cbackend.cpp
@@ -1883,7 +1883,7 @@ std::string CWriter::GetValueName(const llvm::Value *Operand) {
         return CBEMangle(Operand->getName().str().c_str());
     }
 
-    std::string Name = Operand->getName();
+    std::string Name = std::string(Operand->getName());
 
     if (Name.empty()) { // Assign unique names to local temporaries.
         unsigned &No = AnonValueNumbers[Operand];
@@ -2495,7 +2495,7 @@ bool CWriter::doInitialization(llvm::Module &M) {
             continue;
 
         // Don't redeclare ispc's own intrinsics
-        std::string name = I->getName();
+        std::string name = std::string(I->getName());
         if (name.size() > 2 && name[0] == '_' && name[1] == '_')
             continue;
 

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -314,7 +314,7 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::F
         llvm::DISubroutineType *diSubprogramType_n = llvm::cast<llvm::DISubroutineType>(diSubprogramType);
         llvm::DINode::DIFlags flags = llvm::DINode::FlagPrototyped;
 
-        std::string mangledName = llvmFunction->getName();
+        std::string mangledName = std::string(llvmFunction->getName());
         if (mangledName == funSym->name)
             mangledName = "";
 

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2020, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -1509,7 +1509,7 @@ llvm::Value *LLVMShuffleVectors(llvm::Value *v1, llvm::Value *v2, int32_t shuf[]
 const char *LLVMGetName(llvm::Value *v, const char *s) {
     if (v == NULL)
         return s;
-    std::string ret = v->getName();
+    std::string ret = std::string(v->getName());
     ret += s;
     return strdup(ret.c_str());
 }

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -4261,7 +4261,7 @@ std::string sanitize(std::string in) {
 void DebugPassFile::run(llvm::Module &module, bool init) {
     std::error_code EC;
     char fname[100];
-    snprintf(fname, sizeof(fname), "%s_%d_%s.ll", init ? "init" : "ir", pnum, sanitize(pname).c_str());
+    snprintf(fname, sizeof(fname), "%s_%d_%s.ll", init ? "init" : "ir", pnum, sanitize(std::string(pname)).c_str());
     llvm::raw_fd_ostream OS(fname, EC, llvm::sys::fs::F_None);
     Assert(!EC && "IR dump file creation failed!");
     module.print(OS, 0);


### PR DESCRIPTION
Fix after LLVM change requiring explicit conversion from StringRef to std::string

LLVM commit: llvm/llvm-project@777180a32b61