### PR TITLE
Set of LLVM 10.0 patches for avx512skx i8x64 and i16x32 targets (3 st…

### DIFF
--- a/llvm_patches/10_0_i8_shuffle_avx512_i8_i16.patch
+++ b/llvm_patches/10_0_i8_shuffle_avx512_i8_i16.patch
@@ -1,0 +1,31 @@
+# This patch is needed for avx512skx-i8x64 and avx512skx-i16x32 targets.
+
+commit 6bdd63dc28208a597542b0c6bc41093f32417804
+Author: Simon Pilgrim <llvm-dev@redking.me.uk>
+Date:   Thu Feb 27 13:52:16 2020 +0000
+
+    [X86] createVariablePermute - handle case where recursive createVariablePermute call fails
+
+    Account for the case where a recursive createVariablePermute call with a wider vector type fails.
+
+    Original test case from @craig.topper (Craig Topper)
+
+diff --git a/llvm/lib/Target/X86/X86ISelLowering.cpp b/llvm/lib/Target/X86/X86ISelLowering.cpp
+index 1f132bc768c..1cc9c7b16d7 100644
+--- lib/Target/X86/X86ISelLowering.cpp
++++ lib/Target/X86/X86ISelLowering.cpp
+@@ -9631,9 +9631,11 @@ static SDValue createVariablePermute(MVT VT, SDValue SrcVec, SDValue IndicesVec,
+       IndicesVT = EVT(VT).changeVectorElementTypeToInteger();
+       IndicesVec = widenSubVector(IndicesVT.getSimpleVT(), IndicesVec, false,
+                                   Subtarget, DAG, SDLoc(IndicesVec));
+-      return extractSubVector(
+-          createVariablePermute(VT, SrcVec, IndicesVec, DL, DAG, Subtarget), 0,
+-          DAG, DL, SizeInBits);
++      SDValue NewSrcVec =
++          createVariablePermute(VT, SrcVec, IndicesVec, DL, DAG, Subtarget);
++      if (NewSrcVec)
++        return extractSubVector(NewSrcVec, 0, DAG, DL, SizeInBits);
++      return SDValue();
+     } else if (SrcVec.getValueSizeInBits() < SizeInBits) {
+       // Widen smaller SrcVec to match VT.
+       SrcVec = widenSubVector(VT, SrcVec, false, Subtarget, DAG, SDLoc(SrcVec));

--- a/llvm_patches/10_0_k_reg_mov_avx512_i8_i16.patch
+++ b/llvm_patches/10_0_k_reg_mov_avx512_i8_i16.patch
@@ -1,0 +1,47 @@
+# This patch is needed for avx512skx-i8x64 and avx512skx-i16x32 targets.
+
+# This is combination of two commits:
+#  - 0cd6712a7af0fa2702b5d4cc733500eb5e62e7d0 - stability fix.
+#  - d8ad7cc0885f32104a7cd83c77191aec15fd684f - performance follow up.
+
+diff --git a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+index 8ff04797c8d..30fe382bae3 100644
+--- lib/CodeGen/SelectionDAG/DAGCombiner.cpp
++++ lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+@@ -18462,6 +18462,26 @@ static SDValue narrowExtractedVectorLoad(SDNode *Extract, SelectionDAG &DAG) {
+ 
+   // Allow targets to opt-out.
+   EVT VT = Extract->getValueType(0);
++
++  // We can only create byte sized loads.
++  if (!VT.isByteSized())
++    return SDValue();
++
++  unsigned Index = ExtIdx->getZExtValue();
++  unsigned NumElts = VT.getVectorNumElements();
++
++  // If the index is a multiple of the extract element count, we can offset the
++  // address by the store size multiplied by the subvector index. Otherwise if
++  // the scalar type is byte sized, we can just use the index multiplied by
++  // the element size in bytes as the offset.
++  unsigned Offset;
++  if (Index % NumElts == 0)
++    Offset = (Index / NumElts) * VT.getStoreSize();
++  else if (VT.getScalarType().isByteSized())
++    Offset = Index * VT.getScalarType().getStoreSize();
++  else
++    return SDValue();
++
+   const TargetLowering &TLI = DAG.getTargetLoweringInfo();
+   if (!TLI.shouldReduceLoadWidth(Ld, Ld->getExtensionType(), VT))
+     return SDValue();
+@@ -18469,8 +18489,7 @@ static SDValue narrowExtractedVectorLoad(SDNode *Extract, SelectionDAG &DAG) {
+   // The narrow load will be offset from the base address of the old load if
+   // we are extracting from something besides index 0 (little-endian).
+   SDLoc DL(Extract);
+-  SDValue BaseAddr = Ld->getOperand(1);
+-  unsigned Offset = ExtIdx->getZExtValue() * VT.getScalarType().getStoreSize();
++  SDValue BaseAddr = Ld->getBasePtr();
+ 
+   // TODO: Use "BaseIndexOffset" to make this more effective.
+   SDValue NewAddr = DAG.getMemBasePlusOffset(BaseAddr, Offset, DL);

--- a/llvm_patches/10_0_vXi1calling_avx512_i8_i16.patch
+++ b/llvm_patches/10_0_vXi1calling_avx512_i8_i16.patch
@@ -1,0 +1,163 @@
+# This patch is needed for avx512skx-i8x64 and avx512skx-i16x32 targets.
+
+commit eadea7868f5b7542ee6bdcd9a975697a0c919ffc
+Author: Craig Topper <craig.topper@intel.com>
+Date:   Wed Mar 4 14:57:58 2020 -0800
+
+    [X86] Convert vXi1 vectors to xmm/ymm/zmm types via getRegisterTypeForCallingConv rather than using CCPromoteToType in the td file
+
+    Previously we tried to promote these to xmm/ymm/zmm by promoting
+    in the X86CallingConv.td file. But this breaks when we run out
+    of xmm/ymm/zmm registers and need to fall back to memory. We end
+    up trying to create a non-sensical scalar to vector. This lead
+    to an assertion. The new tests in avx512-calling-conv.ll all
+    trigger this assertion.
+
+    Since we really want to treat these types like we do on avx2,
+    it seems better to promote them before the calling convention
+    code gets involved. Except when the calling convention is one
+    that passes the vXi1 type in a k register.
+
+    The changes in avx512-regcall-Mask.ll are because we indicated
+    that xmm/ymm/zmm types should be passed indirectly for the
+    Win64 ABI before we go to the common lines that promoted the
+    vXi1 types. This caused the promoted types to be picked up by
+    the default calling convention code. Now we promote them earlier
+    so they get passed indirectly as though they were xmm/ymm/zmm.
+
+    Differential Revision: https://reviews.llvm.org/D75154
+
+diff --git a/llvm/lib/Target/X86/X86ISelLowering.cpp b/llvm/lib/Target/X86/X86ISelLowering.cpp
+index d0696c24a11..01948c6c6c1 100644
+--- lib/Target/X86/X86ISelLowering.cpp
++++ lib/Target/X86/X86ISelLowering.cpp
+@@ -2125,51 +2125,83 @@ X86TargetLowering::getPreferredVectorAction(MVT VT) const {
+   return TargetLoweringBase::getPreferredVectorAction(VT);
+ }
+ 
++static std::pair<MVT, unsigned>
++handleMaskRegisterForCallingConv(unsigned NumElts, CallingConv::ID CC,
++                                 const X86Subtarget &Subtarget) {
++  // v2i1/v4i1/v8i1/v16i1 all pass in xmm registers unless the calling
++  // convention is one that uses k registers.
++  if (NumElts == 2)
++    return {MVT::v2i64, 1};
++  if (NumElts == 4)
++    return {MVT::v4i32, 1};
++  if (NumElts == 8 && CC != CallingConv::X86_RegCall &&
++      CC != CallingConv::Intel_OCL_BI)
++    return {MVT::v8i16, 1};
++  if (NumElts == 16 && CC != CallingConv::X86_RegCall &&
++      CC != CallingConv::Intel_OCL_BI)
++    return {MVT::v16i8, 1};
++  // v32i1 passes in ymm unless we have BWI and the calling convention is
++  // regcall.
++  if (NumElts == 32 && (!Subtarget.hasBWI() || CC != CallingConv::X86_RegCall))
++    return {MVT::v32i8, 1};
++  // Split v64i1 vectors if we don't have v64i8 available.
++  if (NumElts == 64 && Subtarget.hasBWI() && CC != CallingConv::X86_RegCall) {
++    if (Subtarget.useAVX512Regs())
++      return {MVT::v64i8, 1};
++    return {MVT::v32i8, 2};
++  }
++
++  // Break wide or odd vXi1 vectors into scalars to match avx2 behavior.
++  if (!isPowerOf2_32(NumElts) || (NumElts == 64 && !Subtarget.hasBWI()) ||
++      NumElts > 64)
++    return {MVT::i8, NumElts};
++
++  return {MVT::INVALID_SIMPLE_VALUE_TYPE, 0};
++}
++
+ MVT X86TargetLowering::getRegisterTypeForCallingConv(LLVMContext &Context,
+                                                      CallingConv::ID CC,
+                                                      EVT VT) const {
+-  // v32i1 vectors should be promoted to v32i8 to match avx2.
+-  if (VT == MVT::v32i1 && Subtarget.hasAVX512() && !Subtarget.hasBWI())
+-    return MVT::v32i8;
+-  // Break wide or odd vXi1 vectors into scalars to match avx2 behavior.
+   if (VT.isVector() && VT.getVectorElementType() == MVT::i1 &&
+-      Subtarget.hasAVX512() &&
+-      (!isPowerOf2_32(VT.getVectorNumElements()) ||
+-       (VT.getVectorNumElements() > 16 && !Subtarget.hasBWI()) ||
+-       (VT.getVectorNumElements() > 64 && Subtarget.hasBWI())))
+-    return MVT::i8;
+-  // Split v64i1 vectors if we don't have v64i8 available.
+-  if (VT == MVT::v64i1 && Subtarget.hasBWI() && !Subtarget.useAVX512Regs() &&
+-      CC != CallingConv::X86_RegCall)
+-    return MVT::v32i1;
++      Subtarget.hasAVX512()) {
++    unsigned NumElts = VT.getVectorNumElements();
++
++    MVT RegisterVT;
++    unsigned NumRegisters;
++    std::tie(RegisterVT, NumRegisters) =
++        handleMaskRegisterForCallingConv(NumElts, CC, Subtarget);
++    if (RegisterVT != MVT::INVALID_SIMPLE_VALUE_TYPE)
++      return RegisterVT;
++  }
++
+   // FIXME: Should we just make these types legal and custom split operations?
+   if ((VT == MVT::v32i16 || VT == MVT::v64i8) && !EnableOldKNLABI &&
+       Subtarget.useAVX512Regs() && !Subtarget.hasBWI())
+     return MVT::v16i32;
++
+   return TargetLowering::getRegisterTypeForCallingConv(Context, CC, VT);
+ }
+ 
+ unsigned X86TargetLowering::getNumRegistersForCallingConv(LLVMContext &Context,
+                                                           CallingConv::ID CC,
+                                                           EVT VT) const {
+-  // v32i1 vectors should be promoted to v32i8 to match avx2.
+-  if (VT == MVT::v32i1 && Subtarget.hasAVX512() && !Subtarget.hasBWI())
+-    return 1;
+-  // Break wide or odd vXi1 vectors into scalars to match avx2 behavior.
+   if (VT.isVector() && VT.getVectorElementType() == MVT::i1 &&
+-      Subtarget.hasAVX512() &&
+-      (!isPowerOf2_32(VT.getVectorNumElements()) ||
+-       (VT.getVectorNumElements() > 16 && !Subtarget.hasBWI()) ||
+-       (VT.getVectorNumElements() > 64 && Subtarget.hasBWI())))
+-    return VT.getVectorNumElements();
+-  // Split v64i1 vectors if we don't have v64i8 available.
+-  if (VT == MVT::v64i1 && Subtarget.hasBWI() && !Subtarget.useAVX512Regs() &&
+-      CC != CallingConv::X86_RegCall)
+-    return 2;
++      Subtarget.hasAVX512()) {
++    unsigned NumElts = VT.getVectorNumElements();
++
++    MVT RegisterVT;
++    unsigned NumRegisters;
++    std::tie(RegisterVT, NumRegisters) =
++        handleMaskRegisterForCallingConv(NumElts, CC, Subtarget);
++    if (RegisterVT != MVT::INVALID_SIMPLE_VALUE_TYPE)
++      return NumRegisters;
++  }
++
+   // FIXME: Should we just make these types legal and custom split operations?
+   if ((VT == MVT::v32i16 || VT == MVT::v64i8) && !EnableOldKNLABI &&
+       Subtarget.useAVX512Regs() && !Subtarget.hasBWI())
+     return 1;
++
+   return TargetLowering::getNumRegistersForCallingConv(Context, CC, VT);
+ }
+ 
+@@ -2180,8 +2212,8 @@ unsigned X86TargetLowering::getVectorTypeBreakdownForCallingConv(
+   if (VT.isVector() && VT.getVectorElementType() == MVT::i1 &&
+       Subtarget.hasAVX512() &&
+       (!isPowerOf2_32(VT.getVectorNumElements()) ||
+-       (VT.getVectorNumElements() > 16 && !Subtarget.hasBWI()) ||
+-       (VT.getVectorNumElements() > 64 && Subtarget.hasBWI()))) {
++       (VT.getVectorNumElements() == 64 && !Subtarget.hasBWI()) ||
++       VT.getVectorNumElements() > 64)) {
+     RegisterVT = MVT::i8;
+     IntermediateVT = MVT::i1;
+     NumIntermediates = VT.getVectorNumElements();
+@@ -2191,7 +2223,7 @@ unsigned X86TargetLowering::getVectorTypeBreakdownForCallingConv(
+   // Split v64i1 vectors if we don't have v64i8 available.
+   if (VT == MVT::v64i1 && Subtarget.hasBWI() && !Subtarget.useAVX512Regs() &&
+       CC != CallingConv::X86_RegCall) {
+-    RegisterVT = MVT::v32i1;
++    RegisterVT = MVT::v32i8;
+     IntermediateVT = MVT::v32i1;
+     NumIntermediates = 2;
+     return 2;


### PR DESCRIPTION
The set of 10.0 patches for avx512skx i8x64 and i16x32 targets (3 stability and 1 performance). The patches are backported from trunk.