### PR TITLE
Fixing llvm-trunk build warnings + lit test failures.

### DIFF
--- a/builtins/target-avx512skx-i32x8.ll
+++ b/builtins/target-avx512skx-i32x8.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2016-2019, Intel Corporation
+;;  Copyright (c) 2016-2020, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -31,14 +31,7 @@
 
 define(`WIDTH',`8')
 
-
-ifelse(LLVM_VERSION, LLVM_8_0,
-    `include(`target-avx512-common-8.ll')',
-       LLVM_VERSION, LLVM_9_0,
-    `include(`target-avx512-common-8.ll')',
-         LLVM_VERSION, LLVM_10_0,
-    `include(`target-avx512-common-8.ll')'
-  )
+include(`target-avx512-common-8.ll')
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rcp, rsqrt
@@ -82,12 +75,6 @@ define <8 x float> @__rsqrt_fast_varying_float(<8 x float> %v) nounwind readonly
 }
 ')
 
-ifelse(LLVM_VERSION, LLVM_8_0,
-    rcp_rsqrt_varying_float_skx_8(),
-         LLVM_VERSION, LLVM_9_0,
-    rcp_rsqrt_varying_float_skx_8(),
-         LLVM_VERSION, LLVM_10_0,
-    rcp_rsqrt_varying_float_skx_8()
-  )
+rcp_rsqrt_varying_float_skx_8()
 
 ;;saturation_arithmetic_novec()

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2020, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -224,6 +224,9 @@ extern llvm::Constant *LLVMMaskAllOff;
     are equal.  Like lValuesAreEqual(), this is a conservative test and may
     return false for arrays where the values are actually all equal.  */
 extern bool LLVMVectorValuesAllEqual(llvm::Value *v, llvm::Value **splat = NULL);
+
+/** Tests to see if OR is actually an ADD.  */
+extern bool IsOrEquivalentToAdd(llvm::Value *op);
 
 /** Given vector of integer-typed values, this function returns true if it
     can determine that the elements of the vector have a step of 'stride'

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -1286,7 +1286,7 @@ static llvm::Value *lGetBasePtrAndOffsets(llvm::Value *ptrs, llvm::Value **offse
         if (broadcastDetected) {
             llvm::Value *op = shuffle->getOperand(0);
             llvm::BinaryOperator *bop_var = llvm::dyn_cast<llvm::BinaryOperator>(op);
-            if (bop_var != NULL && bop_var->getOpcode() == llvm::Instruction::Add) {
+            if (bop_var != NULL && ((bop_var->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop_var))) {
                 // We expect here ConstantVector as
                 // <i64 4, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef>
                 llvm::ConstantVector *cv = llvm::dyn_cast<llvm::ConstantVector>(bop_var->getOperand(1));
@@ -1306,7 +1306,7 @@ static llvm::Value *lGetBasePtrAndOffsets(llvm::Value *ptrs, llvm::Value **offse
     }
 
     llvm::BinaryOperator *bop = llvm::dyn_cast<llvm::BinaryOperator>(ptrs);
-    if (bop != NULL && bop->getOpcode() == llvm::Instruction::Add) {
+    if (bop != NULL && ((bop->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop))) {
         // If we have a common pointer plus something, then we're also
         // good.
         if ((base = lGetBasePtrAndOffsets(bop->getOperand(0), offsets, insertBefore)) != NULL) {
@@ -1346,7 +1346,7 @@ static llvm::Value *lGetBasePtrAndOffsets(llvm::Value *ptrs, llvm::Value **offse
                 // it as having an offset of zero
                 elementBase = ce;
                 delta[i] = g->target->is32Bit() ? LLVMInt32(0) : LLVMInt64(0);
-            } else if (ce->getOpcode() == llvm::Instruction::Add) {
+            } else if ((ce->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(ce)) {
                 // Try both orderings of the operands to see if we can get
                 // a pointer+offset out of them.
                 elementBase = lGetConstantAddExprBaseOffset(ce->getOperand(0), ce->getOperand(1), &delta[i]);
@@ -1435,7 +1435,7 @@ static void lExtractConstantOffset(llvm::Value *vec, llvm::Value **constOffset, 
         llvm::Value *op1 = bop->getOperand(1);
         llvm::Value *c0, *v0, *c1, *v1;
 
-        if (bop->getOpcode() == llvm::Instruction::Add) {
+        if (bop != NULL && ((bop->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop))) {
             lExtractConstantOffset(op0, &c0, &v0, insertBefore);
             lExtractConstantOffset(op1, &c1, &v1, insertBefore);
 
@@ -1610,7 +1610,7 @@ static llvm::Value *lExtractOffsetVector248Scale(llvm::Value **vec) {
         return LLVMInt32(1);
 
     llvm::Value *op0 = bop->getOperand(0), *op1 = bop->getOperand(1);
-    if (bop->getOpcode() == llvm::Instruction::Add) {
+    if (bop != NULL && ((bop->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop))) {
         if (llvm::isa<llvm::ConstantAggregateZero>(op0)) {
             *vec = op1;
             return lExtractOffsetVector248Scale(vec);
@@ -1817,7 +1817,7 @@ static bool lOffsets32BitSafe(llvm::Value **variableOffsetPtr, llvm::Value **con
 static bool lIs32BitSafeHelper(llvm::Value *v) {
     // handle Adds, SExts, Constant Vectors
     if (llvm::BinaryOperator *bop = llvm::dyn_cast<llvm::BinaryOperator>(v)) {
-        if (bop->getOpcode() == llvm::Instruction::Add) {
+        if (bop != NULL && ((bop->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop))) {
             return lIs32BitSafeHelper(bop->getOperand(0)) && lIs32BitSafeHelper(bop->getOperand(1));
         }
         return false;


### PR DESCRIPTION
1. Removing version check in avx512skx-i32x8 builtin file.
2. An OR in IR could be equivalent to an ADD.
   Checking for these add-equivalent ORs in our opt passes.