### PR TITLE
Benchmarks fixes and enable benchmark testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,11 @@ before_install:
 
 script:
   - mkdir build_$LLVM_VERSION && cd build_$LLVM_VERSION
-  - cmake -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR $WASM_FLAGS ../
+  - cmake -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR -DISPC_INCLUDE_BENCHMARKS=ON $WASM_FLAGS ../
     # Build ispc and check_isa utility. Run lit tests.
   - make ispc check_isa check-all -j4
+    # Build benchmarks and test them.
+  - make ispc_benchmarks && make test
     # Add ispc to the PATH
   - export PATH=$ISPC_HOME/build_$LLVM_VERSION/bin:$PATH && cd $ISPC_HOME
   - check_isa

--- a/benchmarks/01_trivial/01_aossoa.cpp
+++ b/benchmarks/01_trivial/01_aossoa.cpp
@@ -1,4 +1,5 @@
 #include <benchmark/benchmark.h>
+#include <cstdint>
 #include <stdio.h>
 
 #include "../common.h"
@@ -98,22 +99,22 @@ template <typename T> static void check3(T *dst, int count) {
 
 AOS_TO_SOA_STDLIB(4, int, int32);
 AOS_TO_SOA_STDLIB(4, float, float);
-AOS_TO_SOA_STDLIB(4, long long, int64);
+AOS_TO_SOA_STDLIB(4, int64_t, int64);
 AOS_TO_SOA_STDLIB(4, double, double);
 
 AOS_TO_SOA_ISPC(4, int, int32);
 AOS_TO_SOA_ISPC(4, float, float);
-AOS_TO_SOA_ISPC(4, long long, int64);
+AOS_TO_SOA_ISPC(4, int64_t, int64);
 AOS_TO_SOA_ISPC(4, double, double);
 
 AOS_TO_SOA_STDLIB(3, int, int32);
 AOS_TO_SOA_STDLIB(3, float, float);
-AOS_TO_SOA_STDLIB(3, long long, int64);
+AOS_TO_SOA_STDLIB(3, int64_t, int64);
 AOS_TO_SOA_STDLIB(3, double, double);
 
 AOS_TO_SOA_ISPC(3, int, int32);
 AOS_TO_SOA_ISPC(3, float, float);
-AOS_TO_SOA_ISPC(3, long long, int64);
+AOS_TO_SOA_ISPC(3, int64_t, int64);
 AOS_TO_SOA_ISPC(3, double, double);
 
 BENCHMARK_MAIN();

--- a/benchmarks/01_trivial/01_aossoa.cpp
+++ b/benchmarks/01_trivial/01_aossoa.cpp
@@ -66,8 +66,8 @@ template <typename T> static void check3(T *dst, int count) {
 #define AOS_TO_SOA_STDLIB(N, T_C, T_ISPC)                                                                              \
     static void aos_to_soa##N##_stdlib_##T_ISPC(benchmark::State &state) {                                             \
         int count = state.range(0);                                                                                    \
-        T_C *src = new T_C[count];                                                                                     \
-        T_C *dst = new T_C[count];                                                                                     \
+        T_C *src = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
+        T_C *dst = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
         init(src, dst, count);                                                                                         \
                                                                                                                        \
         for (auto _ : state) {                                                                                         \
@@ -75,16 +75,16 @@ template <typename T> static void check3(T *dst, int count) {
         }                                                                                                              \
                                                                                                                        \
         check##N(dst, count);                                                                                          \
-        delete[] src;                                                                                                  \
-        delete[] dst;                                                                                                  \
+        free(src);                                                                                                     \
+        free(dst);                                                                                                     \
     }                                                                                                                  \
     BENCHMARK(aos_to_soa##N##_stdlib_##T_ISPC)->ARGS##N;
 
 #define AOS_TO_SOA_ISPC(N, T_C, T_ISPC)                                                                                \
     static void aos_to_soa##N##_ispc_##T_ISPC(benchmark::State &state) {                                               \
         int count = state.range(0);                                                                                    \
-        T_C *src = new T_C[count];                                                                                     \
-        T_C *dst = new T_C[count];                                                                                     \
+        T_C *src = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
+        T_C *dst = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
         init(src, dst, count);                                                                                         \
                                                                                                                        \
         for (auto _ : state) {                                                                                         \
@@ -92,8 +92,8 @@ template <typename T> static void check3(T *dst, int count) {
         }                                                                                                              \
                                                                                                                        \
         check##N(dst, count);                                                                                          \
-        delete[] src;                                                                                                  \
-        delete[] dst;                                                                                                  \
+        free(src);                                                                                                     \
+        free(dst);                                                                                                     \
     }                                                                                                                  \
     BENCHMARK(aos_to_soa##N##_ispc_##T_ISPC)->ARGS##N;
 

--- a/benchmarks/01_trivial/01_aossoa.ispc
+++ b/benchmarks/01_trivial/01_aossoa.ispc
@@ -8,7 +8,7 @@ export uniform int width() { return programCount; }
 // input parameter "n" is number of elements input array. Must be multiple of 4*programCount;
 
 #define AOS_TO_SOA4_STDLIB(T)                                                                                          \
-    export void aos_to_soa4_stdlib_##T(uniform T *uniform input, uniform T *uniform output, uniform T n) {             \
+    export void aos_to_soa4_stdlib_##T(uniform T *uniform input, uniform T *uniform output, uniform int n) {           \
         uniform int chunk = 4 * programCount;                                                                          \
         uniform int iterations = n / chunk;                                                                            \
                                                                                                                        \
@@ -33,7 +33,7 @@ AOS_TO_SOA4_STDLIB(double)
 // input parameter "n" is number of elements input array. Must be multiple of 3*programCount;
 
 #define AOS_TO_SOA3_STDLIB(T)                                                                                          \
-    export void aos_to_soa3_stdlib_##T(uniform T *uniform input, uniform T *uniform output, uniform T n) {             \
+    export void aos_to_soa3_stdlib_##T(uniform T *uniform input, uniform T *uniform output, uniform int n) {           \
         uniform int chunk = 3 * programCount;                                                                          \
         uniform int iterations = n / chunk;                                                                            \
                                                                                                                        \

--- a/benchmarks/01_trivial/02_soaaos.cpp
+++ b/benchmarks/01_trivial/02_soaaos.cpp
@@ -1,4 +1,5 @@
 #include <benchmark/benchmark.h>
+#include <cstdint>
 #include <stdio.h>
 
 #include "../common.h"
@@ -96,22 +97,22 @@ template <typename T> static void check(T *dst, int count) {
 
 SOA_TO_AOS_STDLIB(4, int, int32);
 SOA_TO_AOS_STDLIB(4, float, float);
-SOA_TO_AOS_STDLIB(4, long long, int64);
+SOA_TO_AOS_STDLIB(4, int64_t, int64);
 SOA_TO_AOS_STDLIB(4, double, double);
 
 // SOA_TO_AOS_ISPC(4, int, int32);
 // SOA_TO_AOS_ISPC(4, float, float);
-// SOA_TO_AOS_ISPC(4, long long, int64);
+// SOA_TO_AOS_ISPC(4, int64_t, int64);
 // SOA_TO_AOS_ISPC(4, double, double);
 
 SOA_TO_AOS_STDLIB(3, int, int32);
 SOA_TO_AOS_STDLIB(3, float, float);
-SOA_TO_AOS_STDLIB(3, long long, int64);
+SOA_TO_AOS_STDLIB(3, int64_t, int64);
 SOA_TO_AOS_STDLIB(3, double, double);
 
 // SOA_TO_AOS_ISPC(3, int, int32);
 // SOA_TO_AOS_ISPC(3, float, float);
-// SOA_TO_AOS_ISPC(3, long long, int64);
+// SOA_TO_AOS_ISPC(3, int64_t, int64);
 // SOA_TO_AOS_ISPC(3, double, double);
 
 BENCHMARK_MAIN();

--- a/benchmarks/01_trivial/02_soaaos.cpp
+++ b/benchmarks/01_trivial/02_soaaos.cpp
@@ -64,8 +64,8 @@ template <typename T> static void check(T *dst, int count) {
 #define SOA_TO_AOS_STDLIB(N, T_C, T_ISPC)                                                                              \
     static void soa_to_aos##N##_stdlib_##T_ISPC(benchmark::State &state) {                                             \
         int count = state.range(0);                                                                                    \
-        T_C *src = new T_C[count];                                                                                     \
-        T_C *dst = new T_C[count];                                                                                     \
+        T_C *src = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
+        T_C *dst = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
         init##N(src, dst, count);                                                                                      \
                                                                                                                        \
         for (auto _ : state) {                                                                                         \
@@ -73,16 +73,16 @@ template <typename T> static void check(T *dst, int count) {
         }                                                                                                              \
                                                                                                                        \
         check(dst, count);                                                                                             \
-        delete[] src;                                                                                                  \
-        delete[] dst;                                                                                                  \
+        free(src);                                                                                                     \
+        free(dst);                                                                                                     \
     }                                                                                                                  \
     BENCHMARK(soa_to_aos##N##_stdlib_##T_ISPC)->ARGS##N;
 
 #define SOA_TO_AOS_ISPC(N, T_C, T_ISPC)                                                                                \
     static void soa_to_aos##N##_ispc_##T_ISPC(benchmark::State &state) {                                               \
         int count = state.range(0);                                                                                    \
-        T_C *src = new T_C[count];                                                                                     \
-        T_C *dst = new T_C[count];                                                                                     \
+        T_C *src = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
+        T_C *dst = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
         init(src, dst, count);                                                                                         \
                                                                                                                        \
         for (auto _ : state) {                                                                                         \
@@ -90,8 +90,8 @@ template <typename T> static void check(T *dst, int count) {
         }                                                                                                              \
                                                                                                                        \
         check##N(dst, count);                                                                                          \
-        delete[] src;                                                                                                  \
-        delete[] dst;                                                                                                  \
+        free(src);                                                                                                     \
+        free(dst);                                                                                                     \
     }                                                                                                                  \
     BENCHMARK(soa_to_aos##N##_ispc_##T_ISPC)->ARGS##N;
 

--- a/benchmarks/01_trivial/02_soaaos.ispc
+++ b/benchmarks/01_trivial/02_soaaos.ispc
@@ -8,7 +8,7 @@ export uniform int width() { return programCount; }
 // input parameter "n" is number of elements input array. Must be multiple of 4*programCount;
 
 #define SOA_TO_AOS4_STDLIB(T)                                                                                          \
-    export void soa_to_aos4_stdlib_##T(uniform T *uniform input, uniform T *uniform output, uniform T n) {             \
+    export void soa_to_aos4_stdlib_##T(uniform T *uniform input, uniform T *uniform output, uniform int n) {           \
         uniform int chunk = 4 * programCount;                                                                          \
         uniform int iterations = n / chunk;                                                                            \
                                                                                                                        \
@@ -33,7 +33,7 @@ SOA_TO_AOS4_STDLIB(double)
 // input parameter "n" is number of elements input array. Must be multiple of 3*programCount;
 
 #define SOA_TO_AOS3_STDLIB(T)                                                                                          \
-    export void soa_to_aos3_stdlib_##T(uniform T *uniform input, uniform T *uniform output, uniform T n) {             \
+    export void soa_to_aos3_stdlib_##T(uniform T *uniform input, uniform T *uniform output, uniform int n) {           \
         uniform int chunk = 3 * programCount;                                                                          \
         uniform int iterations = n / chunk;                                                                            \
                                                                                                                        \

--- a/benchmarks/common.h
+++ b/benchmarks/common.h
@@ -1,6 +1,9 @@
 #include <iostream>
 #include <string>
 
+// Set maximum alignment for existing ISPC targets.
+#define ALIGNMENT 64
+
 class Docs {
   public:
     Docs(std::string message) { std::cout << message << "\n"; }


### PR DESCRIPTION
- Benchmarks fixes: aligned memory allocation, typos, corrects type to run on all platforms.
- Enabling benchmark build and running sanity check in Travis. This adds less than a minute for individual run and about 3 minutes for total compute time consumed.