### PR TITLE
Bunch of small fixes

### DIFF
--- a/cmake/GenerateBuiltins.cmake
+++ b/cmake/GenerateBuiltins.cmake
@@ -194,9 +194,7 @@ function(builtin_to_cpp bit os_name arch supported_archs supported_oses resultFi
             set(SKIP ON)
         endif()
     endif()
-    if (${os_name} STREQUAL "freebsd" AND ${target_arch} STREQUAL "x86_64")
-        set(target_arch "amd64")
-    endif()
+    # FreeBSD seems to prefer using amd64 over x86_64 naming, but it's nothing more than an alias.
 
     # Determine triple
     if (${os_name} STREQUAL "windows")

--- a/docker/v1.10.0/centos7/Dockerfile
+++ b/docker/v1.10.0/centos7/Dockerfile
@@ -1,0 +1,56 @@
+FROM centos:7
+MAINTAINER Dmitry Babokin <dmitry.y.babokin@intel.com>
+
+# !!! Make sure that your docker config provides enough memory to the container,
+# otherwise LLVM build may fail, as it will use all the cores available to container.
+
+# Packages required to build ISPC and Clang.
+RUN yum install -y vim wget yum-utils gcc gcc-c++ git subversion python3 m4 bison flex patch make ncurses-devel zlib-devel glibc-devel.x86_64 glibc-devel.i686 xz && \
+    yum clean -y all
+
+# These packages are required if you need to link IPSC with -static.
+RUN yum install -y ncurses-static libstdc++-static zlib-static && \
+    yum clean -y all
+
+# Download and install required version of cmake (3.12) for ISPC build
+RUN wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.12.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.12.0-Linux-x86_64.sh
+
+# If you are behind a proxy, you need to configure git.
+#RUN git config --global --add http.proxy http://proxy.yourcompany.com:888
+
+WORKDIR /usr/local/src
+
+RUN git clone https://github.com/ispc/ispc.git && cd ispc && git checkout v1.10.0 && sed s/xvzf/xvf/ alloy.py -i && sed s/pthread\ dl/pthread/ CMakeLists.txt -i && sed s/${PROJECT_NAME}\ z/${PROJECT_NAME}\ -Wl,-Bstatic\ z/ CMakeLists.txt -i
+RUN wget https://releases.llvm.org/5.0.2/llvm-5.0.2.src.tar.xz
+RUN wget https://releases.llvm.org/5.0.2/cfe-5.0.2.src.tar.xz
+
+# This is home for Clang builds
+RUN mkdir /usr/local/src/llvm
+
+ENV ISPC_HOME=/usr/local/src/ispc
+ENV LLVM_HOME=/usr/local/src/llvm
+
+# If you are going to run test for future platforms, go to
+# http://www.intel.com/software/sde and download the latest version,
+# extract it, add to path and set SDE_HOME.
+
+WORKDIR /usr/local/src/ispc
+
+# Build Clang with all required patches.
+# Pass required LLVM_VERSION with --build-arg LLVM_VERSION=<version>.
+# By default 5.0 is used.
+# Note self-build options, it's required to build clang and ispc with the same compiler,
+# i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
+# or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
+# "rm" are just to keep docker image small.
+ARG LLVM_VERSION=5.0
+RUN ./alloy.py -b --version=$LLVM_VERSION --selfbuild --tarball="/usr/local/src/llvm-5.0.2.src.tar.xz /usr/local/src/cfe-5.0.2.src.tar.xz" && \
+    rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-$LLVM_VERSION_temp $LLVM_HOME/build-$LLVM_VERSION_temp
+
+ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+
+# Build ISPC
+RUN mkdir build
+WORKDIR /usr/local/src/ispc/build
+RUN cmake .. -DCMAKE_EXE_LINKER_FLAGS="-z noexecstack -z relro -z now -Wl,--gc-sections -static-libgcc -static-libstdc++" && make -j8

--- a/docker/v1.11.0/centos7/Dockerfile
+++ b/docker/v1.11.0/centos7/Dockerfile
@@ -1,0 +1,58 @@
+FROM centos:7
+MAINTAINER Dmitry Babokin <dmitry.y.babokin@intel.com>
+
+# !!! Make sure that your docker config provides enough memory to the container,
+# otherwise LLVM build may fail, as it will use all the cores available to container.
+
+# Packages required to build ISPC and Clang.
+RUN yum -y update; yum -y install centos-release-scl epel-release; yum clean all
+RUN yum install -y vim wget yum-utils gcc gcc-c++ git subversion python3 m4 bison flex patch make ncurses-devel zlib-devel glibc-devel.x86_64 glibc-devel.i686 xz devtoolset-7 && \
+    yum clean -y all
+
+# These packages are required if you need to link IPSC with -static.
+RUN yum install -y ncurses-static libstdc++-static zlib-static && \
+    yum clean -y all
+
+# Download and install required version of cmake (3.12) for ISPC build
+RUN wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.12.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.12.0-Linux-x86_64.sh
+
+# If you are behind a proxy, you need to configure git.
+#RUN git config --global --add http.proxy http://proxy.yourcompany.com:888
+
+WORKDIR /usr/local/src
+
+RUN git clone https://github.com/ispc/ispc.git && cd ispc && git checkout v1.11.0 && sed s/xvzf/xvf/ alloy.py -i && sed s/pthread\ dl/pthread/ CMakeLists.txt -i && sed s/${PROJECT_NAME}\ z/${PROJECT_NAME}\ -Wl,-Bstatic\ z/ CMakeLists.txt -i
+RUN wget https://releases.llvm.org/8.0.0/llvm-8.0.0.src.tar.xz
+RUN wget https://releases.llvm.org/8.0.0/cfe-8.0.0.src.tar.xz
+
+# This is home for Clang builds
+RUN mkdir /usr/local/src/llvm
+
+ENV ISPC_HOME=/usr/local/src/ispc
+ENV LLVM_HOME=/usr/local/src/llvm
+
+# If you are going to run test for future platforms, go to
+# http://www.intel.com/software/sde and download the latest version,
+# extract it, add to path and set SDE_HOME.
+
+WORKDIR /usr/local/src/ispc
+
+# Build Clang with all required patches.
+# Pass required LLVM_VERSION with --build-arg LLVM_VERSION=<version>.
+# By default 8.0 is used.
+# Note self-build options, it's required to build clang and ispc with the same compiler,
+# i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
+# or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
+# "rm" are just to keep docker image small.
+ARG LLVM_VERSION=8.0
+RUN source /opt/rh/devtoolset-7/enable && \
+    ./alloy.py -b --version=$LLVM_VERSION --selfbuild --tarball="/usr/local/src/llvm-8.0.0.src.tar.xz /usr/local/src/cfe-8.0.0.src.tar.xz" && \
+    rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-$LLVM_VERSION_temp $LLVM_HOME/build-$LLVM_VERSION_temp
+
+ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+
+# Build ISPC
+RUN mkdir build
+WORKDIR /usr/local/src/ispc/build
+RUN cmake .. -DCMAKE_EXE_LINKER_FLAGS="-z noexecstack -z relro -z now -Wl,--gc-sections -static-libgcc -static-libstdc++" && make -j8

--- a/docker/v1.12.0/centos7/Dockerfile
+++ b/docker/v1.12.0/centos7/Dockerfile
@@ -1,0 +1,58 @@
+FROM centos:7
+MAINTAINER Dmitry Babokin <dmitry.y.babokin@intel.com>
+
+# !!! Make sure that your docker config provides enough memory to the container,
+# otherwise LLVM build may fail, as it will use all the cores available to container.
+
+# Packages required to build ISPC and Clang.
+RUN yum -y update; yum -y install centos-release-scl epel-release; yum clean all
+RUN yum install -y vim wget yum-utils gcc gcc-c++ git subversion python3 m4 bison flex patch make ncurses-devel zlib-devel glibc-devel.x86_64 glibc-devel.i686 xz devtoolset-7 && \
+    yum clean -y all
+
+# These packages are required if you need to link IPSC with -static.
+RUN yum install -y ncurses-static libstdc++-static zlib-static && \
+    yum clean -y all
+
+# Download and install required version of cmake (3.12) for ISPC build
+RUN wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.12.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.12.0-Linux-x86_64.sh
+
+# If you are behind a proxy, you need to configure git.
+#RUN git config --global --add http.proxy http://proxy.yourcompany.com:888
+
+WORKDIR /usr/local/src
+
+RUN git clone https://github.com/ispc/ispc.git && cd ispc && git checkout v1.12.0 && sed s/xvzf/xvf/ alloy.py -i && sed s/pthread\ dl/pthread/ CMakeLists.txt -i && sed s/${PROJECT_NAME}\ z/${PROJECT_NAME}\ -Wl,-Bstatic\ z/ CMakeLists.txt -i
+RUN wget https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/llvm-8.0.1.src.tar.xz
+RUN wget https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/cfe-8.0.1.src.tar.xz
+
+# This is home for Clang builds
+RUN mkdir /usr/local/src/llvm
+
+ENV ISPC_HOME=/usr/local/src/ispc
+ENV LLVM_HOME=/usr/local/src/llvm
+
+# If you are going to run test for future platforms, go to
+# http://www.intel.com/software/sde and download the latest version,
+# extract it, add to path and set SDE_HOME.
+
+WORKDIR /usr/local/src/ispc
+
+# Build Clang with all required patches.
+# Pass required LLVM_VERSION with --build-arg LLVM_VERSION=<version>.
+# By default 8.0 is used.
+# Note self-build options, it's required to build clang and ispc with the same compiler,
+# i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
+# or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
+# "rm" are just to keep docker image small.
+ARG LLVM_VERSION=8.0
+RUN source /opt/rh/devtoolset-7/enable && \
+    ./alloy.py -b --version=$LLVM_VERSION --selfbuild --tarball="/usr/local/src/llvm-8.0.1.src.tar.xz /usr/local/src/cfe-8.0.1.src.tar.xz" && \
+    rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-$LLVM_VERSION_temp $LLVM_HOME/build-$LLVM_VERSION_temp
+
+ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+
+# Build ISPC
+RUN mkdir build
+WORKDIR /usr/local/src/ispc/build
+RUN cmake .. -DCMAKE_EXE_LINKER_FLAGS="-z noexecstack -z relro -z now -Wl,--gc-sections -static-libgcc -static-libstdc++" && make -j8

--- a/docker/v1.9.1/centos7/Dockerfile
+++ b/docker/v1.9.1/centos7/Dockerfile
@@ -1,0 +1,54 @@
+FROM centos:7
+MAINTAINER Dmitry Babokin <dmitry.y.babokin@intel.com>
+
+# !!! Make sure that your docker config provides enough memory to the container,
+# otherwise LLVM build may fail, as it will use all the cores available to container.
+
+# Packages required to build ISPC and Clang.
+RUN yum install -y vim wget yum-utils gcc gcc-c++ git subversion python3 m4 bison flex patch make ncurses-devel zlib-devel glibc-devel.x86_64 glibc-devel.i686 xz && \
+    yum clean -y all
+
+# These packages are required if you need to link IPSC with -static.
+RUN yum install -y ncurses-static libstdc++-static zlib-static && \
+    yum clean -y all
+
+# Download and install required version of cmake (3.12) for ISPC build
+RUN wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.12.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.12.0-Linux-x86_64.sh
+
+# If you are behind a proxy, you need to configure git.
+#RUN git config --global --add http.proxy http://proxy.yourcompany.com:888
+
+WORKDIR /usr/local/src
+
+RUN git clone https://github.com/ispc/ispc.git && cd ispc && git checkout v1.9.1 && sed s/xvzf/xvf/ alloy.py -i && sed s/-ldl// Makefile -i && sed s/-lcurses\ -lz/-ldl\ -Wl,-Bstatic\ -lcurses\ -lz/ Makefile -i
+RUN wget https://releases.llvm.org/3.8.1/llvm-3.8.1.src.tar.xz
+RUN wget https://releases.llvm.org/3.8.1/cfe-3.8.1.src.tar.xz
+
+# This is home for Clang builds
+RUN mkdir /usr/local/src/llvm
+
+ENV ISPC_HOME=/usr/local/src/ispc
+ENV LLVM_HOME=/usr/local/src/llvm
+
+# If you are going to run test for future platforms, go to
+# http://www.intel.com/software/sde and download the latest version,
+# extract it, add to path and set SDE_HOME.
+
+WORKDIR /usr/local/src/ispc
+
+# Build Clang with all required patches.
+# Pass required LLVM_VERSION with --build-arg LLVM_VERSION=<version>.
+# By default 3.8 is used.
+# Note self-build options, it's required to build clang and ispc with the same compiler,
+# i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
+# or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
+# "rm" are just to keep docker image small.
+ARG LLVM_VERSION=3.8
+RUN ./alloy.py -b --version=$LLVM_VERSION --selfbuild --tarball="/usr/local/src/llvm-3.8.1.src.tar.xz /usr/local/src/cfe-3.8.1.src.tar.xz" && \
+    rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-$LLVM_VERSION_temp $LLVM_HOME/build-$LLVM_VERSION_temp
+
+ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+
+# Build ISPC
+RUN make ispc -j8 LDFLAGS="-static-libgcc -static-libstdc++"

--- a/docker/v1.9.2/centos7/Dockerfile
+++ b/docker/v1.9.2/centos7/Dockerfile
@@ -1,0 +1,54 @@
+FROM centos:7
+MAINTAINER Dmitry Babokin <dmitry.y.babokin@intel.com>
+
+# !!! Make sure that your docker config provides enough memory to the container,
+# otherwise LLVM build may fail, as it will use all the cores available to container.
+
+# Packages required to build ISPC and Clang.
+RUN yum install -y vim wget yum-utils gcc gcc-c++ git subversion python3 m4 bison flex patch make ncurses-devel zlib-devel glibc-devel.x86_64 glibc-devel.i686 xz && \
+    yum clean -y all
+
+# These packages are required if you need to link IPSC with -static.
+RUN yum install -y ncurses-static libstdc++-static zlib-static && \
+    yum clean -y all
+
+# Download and install required version of cmake (3.12) for ISPC build
+RUN wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.12.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.12.0-Linux-x86_64.sh
+
+# If you are behind a proxy, you need to configure git.
+#RUN git config --global --add http.proxy http://proxy.yourcompany.com:888
+
+WORKDIR /usr/local/src
+
+RUN git clone https://github.com/ispc/ispc.git && cd ispc && git checkout v1.9.2 && sed s/xvzf/xvf/ alloy.py -i && sed s/-ldl// Makefile -i && sed s/-lcurses\ -lz/-ldl\ -Wl,-Bstatic\ -lcurses\ -lz/ Makefile -i
+RUN wget https://releases.llvm.org/5.0.0/llvm-5.0.0.src.tar.xz
+RUN wget https://releases.llvm.org/5.0.0/cfe-5.0.0.src.tar.xz
+
+# This is home for Clang builds
+RUN mkdir /usr/local/src/llvm
+
+ENV ISPC_HOME=/usr/local/src/ispc
+ENV LLVM_HOME=/usr/local/src/llvm
+
+# If you are going to run test for future platforms, go to
+# http://www.intel.com/software/sde and download the latest version,
+# extract it, add to path and set SDE_HOME.
+
+WORKDIR /usr/local/src/ispc
+
+# Build Clang with all required patches.
+# Pass required LLVM_VERSION with --build-arg LLVM_VERSION=<version>.
+# By default 5.0 is used.
+# Note self-build options, it's required to build clang and ispc with the same compiler,
+# i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
+# or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
+# "rm" are just to keep docker image small.
+ARG LLVM_VERSION=5.0
+RUN ./alloy.py -b --version=$LLVM_VERSION --selfbuild --tarball="/usr/local/src/llvm-5.0.0.src.tar.xz /usr/local/src/cfe-5.0.0.src.tar.xz" && \
+    rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-$LLVM_VERSION_temp $LLVM_HOME/build-$LLVM_VERSION_temp
+
+ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+
+# Build ISPC
+RUN make ispc -j8 LDFLAGS="-static-libgcc -static-libstdc++"

--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -761,24 +761,6 @@ void AddBitcodeToModule(const BitcodeLib *lib, llvm::Module *module, SymbolTable
         llvm::Triple mTriple(m->module->getTargetTriple());
         llvm::Triple bcTriple(bcModule->getTargetTriple());
         Debug(SourcePos(), "module triple: %s\nbitcode triple: %s\n", mTriple.str().c_str(), bcTriple.str().c_str());
-#if defined(ISPC_ARM_ENABLED) && !defined(__arm__)
-        // FIXME: More ugly and dangerous stuff.  We really haven't set up
-        // proper build and runtime infrastructure for ispc to do
-        // cross-compilation, yet it's at minimum useful to be able to emit
-        // ARM code from x86 for ispc development.  One side-effect is that
-        // when the build process turns builtins/builtins.c to LLVM bitcode
-        // for us to link in at runtime, that bitcode has been compiled for
-        // an IA target, which in turn causes the checks in the following
-        // code to (appropraitely) fail.
-        //
-        // In order to be able to have some ability to generate ARM code on
-        // IA, we'll just skip those tests in that case and allow the
-        // setTargetTriple() and setDataLayout() calls below to shove in
-        // the values for an ARM target.  This maybe won't cause problems
-        // in the generated code, since bulitins.c doesn't do anything too
-        // complex w.r.t. struct layouts, etc.
-        if (g->target->getISA() != Target::NEON)
-#endif // !__arm__
 
         // Disable this code for cross compilation
 #if 0
@@ -803,7 +785,8 @@ void AddBitcodeToModule(const BitcodeLib *lib, llvm::Module *module, SymbolTable
                 }
             }
 #endif
-            bcModule->setTargetTriple(mTriple.str());
+
+        bcModule->setTargetTriple(mTriple.str());
         bcModule->setDataLayout(module->getDataLayout());
 
         // A hack to move over declaration, which have no definition.

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1312,7 +1312,7 @@ const char *Target::ISAToTargetString(ISA isa) {
     return "";
 }
 
-const char *Target::GetISATargetString() const { return ISAToString(m_isa); }
+const char *Target::GetISATargetString() const { return ISAToTargetString(m_isa); }
 
 static bool lGenericTypeLayoutIndeterminate(llvm::Type *type) {
     if (type->isFloatingPointTy() || type->isX86_MMXTy() || type->isVoidTy() || type->isIntegerTy() ||

--- a/src/target_enums.cpp
+++ b/src/target_enums.cpp
@@ -51,6 +51,8 @@ Arch ParseArch(std::string arch) {
         return Arch::arm;
     } else if (arch == "aarch64") {
         return Arch::aarch64;
+    } else if (arch == "wasm32") {
+        return Arch::wasm32;
     }
     return Arch::error;
 }


### PR DESCRIPTION
* Adding Dockerfiles for reproducing 1.9.1-1.12.0 releases.
* GetISATargetString() is fixed. It doesn't have uses, so it's not really affecting anything.
* Parse ``--arch=wasm32``, which we forgot to add earlier.
* Removing outdated comment about cross-compilation support, which also affects setting triple for ARM targets.
* Enable stricter arguments checking in bitcode2cpp.py.
* Do not use amd64 as arch on FreeBSD, as internally it's just and alias for x86_64 and only create confusion.