### PR TITLE
[WASM] Add v8 install script to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y libc6-dev-i386 g++-multilib lib32stdc++6
   - if [ -n "$WASM_FLAGS" ]; then source scripts/install_emscripten.sh && emcc --version; fi
+  - if [ -n "$WASM_FLAGS" ]; then source scripts/install_v8.sh && d8 --version; fi
   - wget https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.17.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.17.0-Linux-x86_64.sh
   - export PATH=/opt/cmake/bin:$PATH
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y libc6-dev-i386 g++-multilib lib32stdc++6
   - if [ -n "$WASM_FLAGS" ]; then source scripts/install_emscripten.sh && emcc --version; fi
-  - if [ -n "$WASM_FLAGS" ]; then source scripts/install_v8.sh && d8 --version; fi
+  - if [ -n "$WASM_FLAGS" ]; then source scripts/install_v8.sh && v8-debug --version; fi
   - wget https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.17.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.17.0-Linux-x86_64.sh
   - export PATH=/opt/cmake/bin:$PATH
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y libc6-dev-i386 g++-multilib lib32stdc++6
   - if [ -n "$WASM_FLAGS" ]; then source scripts/install_emscripten.sh && emcc --version; fi
-  - if [ -n "$WASM_FLAGS" ]; then source scripts/install_v8.sh && v8-debug --version; fi
+  - if [ -n "$WASM_FLAGS" ]; then source scripts/install_v8.sh && v8-debug -e "console.log(\"V8 TEST\")"; fi
   - wget https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.17.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.17.0-Linux-x86_64.sh
   - export PATH=/opt/cmake/bin:$PATH
   - cmake --version

--- a/scripts/install_v8.sh
+++ b/scripts/install_v8.sh
@@ -2,6 +2,5 @@ WD=`pwd`
 sudo apt install nodejs && \
 npm install jsvu -g && \
 export PATH="${HOME}/.jsvu:${PATH}" && \
-jsvu --os=linux64 --engines=v8-debug && \
-alias d8=v8-debug
+jsvu --os=linux64 --engines=v8-debug
 cd $WD

--- a/scripts/install_v8.sh
+++ b/scripts/install_v8.sh
@@ -1,5 +1,5 @@
 WD=`pwd`
-sudo apt install nodejs && \
+sudo apt-get install nodejs && \
 npm install jsvu -g && \
 export PATH="${HOME}/.jsvu:${PATH}" && \
 jsvu --os=linux64 --engines=v8-debug

--- a/scripts/install_v8.sh
+++ b/scripts/install_v8.sh
@@ -5,8 +5,8 @@ fetch v8 &&  \
 cd v8 &&  \
 gclient sync &&  \
 ./build/install-build-deps.sh &&  \
-./tools/dev/v8gen.py x64.optdebug &&  \
-ninja -C out.gn/x64.optdebug &&  \
-export PATH=$WD/v8/out.gn/x64.optdebug:"$PATH"
+./tools/dev/v8gen.py x64.release &&  \
+ninja -j12 -C out.gn/x64.release &&  \
+export PATH=$WD/v8/out.gn/x64.release:"$PATH"
 
 cd $WD

--- a/scripts/install_v8.sh
+++ b/scripts/install_v8.sh
@@ -1,0 +1,12 @@
+WD=`pwd`
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+export PATH=$WD/depot_tools:"$PATH"
+fetch v8 &&  \
+cd v8 &&  \
+gclient sync &&  \
+./build/install-build-deps.sh &&  \
+./tools/dev/v8gen.py x64.optdebug &&  \
+ninja -C out.gn/x64.optdebug &&  \
+export PATH=$WD/v8/out.gn/x64.optdebug:"$PATH"
+
+cd $WD

--- a/scripts/install_v8.sh
+++ b/scripts/install_v8.sh
@@ -1,12 +1,7 @@
 WD=`pwd`
-git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-export PATH=$WD/depot_tools:"$PATH"
-fetch v8 &&  \
-cd v8 &&  \
-gclient sync &&  \
-./build/install-build-deps.sh &&  \
-./tools/dev/v8gen.py x64.release &&  \
-ninja -j12 -C out.gn/x64.release &&  \
-export PATH=$WD/v8/out.gn/x64.release:"$PATH"
-
+sudo apt install nodejs && \
+npm install jsvu -g && \
+export PATH="${HOME}/.jsvu:${PATH}" && \
+jsvu --os=linux64 --engines=v8-debug && \
+alias d8=v8-debug
 cd $WD

--- a/src/cbackend.cpp
+++ b/src/cbackend.cpp
@@ -4860,7 +4860,7 @@ llvm::Value *SmearCleanupPass::getShuffleSmearValue(llvm::Instruction *inst) con
 
     if (!(mask &&
           (mask->isNullValue() ||
-#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_11_0
            (shuffleInst->getShuffleMaskForBitcode()->getSplatValue() != 0))
 #else
            (shuffleInst->getMask()->getSplatValue() != 0))
@@ -4888,7 +4888,7 @@ llvm::Value *SmearCleanupPass::getShuffleSmearValue(llvm::Instruction *inst) con
         if (extractFunc == NULL) {
             // Declare the __extract_element function if needed; it takes a vector and
             // a scalar parameter and returns a scalar of the vector parameter type.
-#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_11_0
             llvm::VectorType *vtype = llvm::dyn_cast<llvm::VectorType>(shuffleInst->getOperand(0)->getType());
             llvm::FunctionCallee ef = module->getOrInsertFunction("__extract_element", vtype->getElementType(),
                                                                   shuffleInst->getOperand(0)->getType(),

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -2079,9 +2079,11 @@ llvm::Value *FunctionEmitContext::LoadInst(llvm::Value *ptr, const Type *type, c
 
     if (name == NULL)
         name = LLVMGetName(ptr, "_load");
-
+#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+    llvm::LoadInst *inst = new llvm::LoadInst(pt->getPointerElementType(), ptr, name, bblock);
+#else
     llvm::LoadInst *inst = new llvm::LoadInst(ptr, name, bblock);
-
+#endif
     if (g->opt.forceAlignedMemory && llvm::dyn_cast<llvm::VectorType>(pt->getElementType())) {
 #if ISPC_LLVM_VERSION <= ISPC_LLVM_9_0
         inst->setAlignment(g->target->getNativeVectorAlignment());
@@ -2220,8 +2222,14 @@ llvm::Value *FunctionEmitContext::LoadInst(llvm::Value *ptr, llvm::Value *mask, 
 #if ISPC_LLVM_VERSION <= ISPC_LLVM_9_0
             llvm::Instruction *inst = new llvm::LoadInst(ptr, name, false /* not volatile */, align, bblock);
 #else // LLVM 10.0+
+#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+            llvm::PointerType *ptr_type = llvm::dyn_cast<llvm::PointerType>(ptr->getType());
+            llvm::Instruction *inst = new llvm::LoadInst(ptr_type->getPointerElementType(), ptr, name,
+                                                         false /* not volatile */, llvm::MaybeAlign(align), bblock);
+#else
             llvm::Instruction *inst =
                 new llvm::LoadInst(ptr, name, false /* not volatile */, llvm::MaybeAlign(align), bblock);
+#endif
 #endif
             AddDebugPos(inst);
             llvm::Value *loadVal = inst;
@@ -2897,7 +2905,11 @@ llvm::Value *FunctionEmitContext::BroadcastValue(llvm::Value *v, llvm::Type *vec
     }
 
     llvm::VectorType *ty = llvm::dyn_cast<llvm::VectorType>(vecType);
+#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+    Assert(ty && ty->getElementType() == v->getType());
+#else
     Assert(ty && ty->getVectorElementType() == v->getType());
+#endif
 
     if (name == NULL) {
         char buf[32];
@@ -2922,9 +2934,15 @@ llvm::Value *FunctionEmitContext::BroadcastValue(llvm::Value *v, llvm::Type *vec
     llvm::Constant *zeroVec = llvm::ConstantVector::getSplat(
         vecType->getVectorNumElements(), llvm::Constant::getNullValue(llvm::Type::getInt32Ty(*g->ctx)));
 #else // LLVM 11.0+
+#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+    llvm::Constant *zeroVec =
+        llvm::ConstantVector::getSplat({static_cast<unsigned int>(ty->getNumElements()), false},
+                                       llvm::Constant::getNullValue(llvm::Type::getInt32Ty(*g->ctx)));
+#else
     llvm::Constant *zeroVec =
         llvm::ConstantVector::getSplat({static_cast<unsigned int>(vecType->getVectorNumElements()), false},
                                        llvm::Constant::getNullValue(llvm::Type::getInt32Ty(*g->ctx)));
+#endif
 #endif
     llvm::Value *ret = ShuffleInst(insert, undef2, zeroVec, name);
 
@@ -2991,7 +3009,13 @@ llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType
     if (llvm::isa<llvm::VectorType>(func->getType()) == false) {
         // Regular 'uniform' function call--just one function or function
         // pointer, so just emit the IR directly.
+#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+        llvm::PointerType *func_ptr_type = llvm::dyn_cast<llvm::PointerType>(func->getType());
+        llvm::FunctionType *func_type = llvm::dyn_cast<llvm::FunctionType>(func_ptr_type->getPointerElementType());
+        llvm::Instruction *ci = llvm::CallInst::Create(func_type, func, argVals, name ? name : "", bblock);
+#else
         llvm::Instruction *ci = llvm::CallInst::Create(func, argVals, name ? name : "", bblock);
+#endif
 
         // Copy noalias attribute to call instruction, to enable better
         // alias analysis.

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -682,7 +682,12 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
     //              <i64 4, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef>
     //   %gep_offset = shufflevector <8 x i64> %0, <8 x i64> undef, <8 x i32> zeroinitializer
     else if (llvm::ShuffleVectorInst *shuf = llvm::dyn_cast<llvm::ShuffleVectorInst>(inst)) {
+#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+        llvm::Value *indices = shuf->getShuffleMaskForBitcode();
+#else
         llvm::Value *indices = shuf->getOperand(2);
+#endif
+
         if (llvm::isa<llvm::ConstantAggregateZero>(indices)) {
             llvm::Value *op = shuf->getOperand(0);
             llvm::InsertElementInst *ie = llvm::dyn_cast<llvm::InsertElementInst>(op);
@@ -1048,7 +1053,12 @@ static bool lVectorValuesAllEqual(llvm::Value *v, int vectorLength, std::vector<
 
     llvm::ShuffleVectorInst *shuffle = llvm::dyn_cast<llvm::ShuffleVectorInst>(v);
     if (shuffle != NULL) {
+#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+        llvm::Value *indices = shuffle->getShuffleMaskForBitcode();
+#else
         llvm::Value *indices = shuffle->getOperand(2);
+#endif
+
         if (lVectorValuesAllEqual(indices, vectorLength, seenPhis))
             // The easy case--just a smear of the same element across the
             // whole vector.
@@ -1478,7 +1488,11 @@ static llvm::Value *lExtractFirstVectorElement(llvm::Value *v, std::map<llvm::PH
     // "lExtractFirstVectorElement" function.
     if (llvm::isa<llvm::ShuffleVectorInst>(v)) {
         llvm::ShuffleVectorInst *shuf = llvm::dyn_cast<llvm::ShuffleVectorInst>(v);
+#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+        llvm::Value *indices = shuf->getShuffleMaskForBitcode();
+#else
         llvm::Value *indices = shuf->getOperand(2);
+#endif
         if (llvm::isa<llvm::ConstantAggregateZero>(indices)) {
             return lExtractFirstVectorElement(shuf->getOperand(0), phiMap);
         }

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -682,7 +682,7 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
     //              <i64 4, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef>
     //   %gep_offset = shufflevector <8 x i64> %0, <8 x i64> undef, <8 x i32> zeroinitializer
     else if (llvm::ShuffleVectorInst *shuf = llvm::dyn_cast<llvm::ShuffleVectorInst>(inst)) {
-#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_11_0
         llvm::Value *indices = shuf->getShuffleMaskForBitcode();
 #else
         llvm::Value *indices = shuf->getOperand(2);
@@ -1053,7 +1053,7 @@ static bool lVectorValuesAllEqual(llvm::Value *v, int vectorLength, std::vector<
 
     llvm::ShuffleVectorInst *shuffle = llvm::dyn_cast<llvm::ShuffleVectorInst>(v);
     if (shuffle != NULL) {
-#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_11_0
         llvm::Value *indices = shuffle->getShuffleMaskForBitcode();
 #else
         llvm::Value *indices = shuffle->getOperand(2);
@@ -1488,7 +1488,7 @@ static llvm::Value *lExtractFirstVectorElement(llvm::Value *v, std::map<llvm::PH
     // "lExtractFirstVectorElement" function.
     if (llvm::isa<llvm::ShuffleVectorInst>(v)) {
         llvm::ShuffleVectorInst *shuf = llvm::dyn_cast<llvm::ShuffleVectorInst>(v);
-#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_11_0
         llvm::Value *indices = shuf->getShuffleMaskForBitcode();
 #else
         llvm::Value *indices = shuf->getOperand(2);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2192,7 +2192,13 @@ static void lCreateDispatchFunction(llvm::Module *module, llvm::Function *setISA
     llvm::CallInst::Create(setISAFunc, "", bblock);
 
     // Now we can load the system's ISA enumerant
+#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+    llvm::PointerType *ptr_type = llvm::dyn_cast<llvm::PointerType>(systemBestISAPtr->getType());
+    llvm::Value *systemISA =
+        new llvm::LoadInst(ptr_type->getPointerElementType(), systemBestISAPtr, "system_isa", bblock);
+#else
     llvm::Value *systemISA = new llvm::LoadInst(systemBestISAPtr, "system_isa", bblock);
+#endif
 
     // Now emit code that works backwards though the available variants of
     // the function.  We'll call out to the first one we find that will run

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2192,7 +2192,7 @@ static void lCreateDispatchFunction(llvm::Module *module, llvm::Function *setISA
     llvm::CallInst::Create(setISAFunc, "", bblock);
 
     // Now we can load the system's ISA enumerant
-#if ISPC_LLVM_VERSION == ISPC_LLVM_11_0
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_11_0
     llvm::PointerType *ptr_type = llvm::dyn_cast<llvm::PointerType>(systemBestISAPtr->getType());
     llvm::Value *systemISA =
         new llvm::LoadInst(ptr_type->getPointerElementType(), systemBestISAPtr, "system_isa", bblock);


### PR DESCRIPTION
* Add v8 install script to CI
* Fix LLVM 11.0(trunk) build

Unfortunately LLVM trunk had some changes that prevent building ISPC so I had to fix some of the issues. The fixes are ad-hoc and it'd be better to wrap changed API in a separate function that handles all the differences.
If the initial version doesn't break the CI I'll push WASM testing to this or a new PR