### PR TITLE
AVX512 code gen tuning

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -808,6 +808,13 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasRsqrtd = this->m_hasRcpd = false;
         this->m_hasVecPrefetch = false;
         CPUfromISA = CPU_SKX;
+        if (g->opt.disableZMM) {
+            this->m_funcAttributes.push_back(std::make_pair("prefer-vector-width", "256"));
+            this->m_funcAttributes.push_back(std::make_pair("min-legal-vector-width", "256"));
+        } else {
+            this->m_funcAttributes.push_back(std::make_pair("prefer-vector-width", "512"));
+            this->m_funcAttributes.push_back(std::make_pair("min-legal-vector-width", "512"));
+        }
         break;
     case ISPCTarget::generic_1:
         this->m_isa = Target::GENERIC;
@@ -1428,6 +1435,7 @@ Opt::Opt() {
     disableGatherScatterFlattening = false;
     disableUniformMemoryOptimizations = false;
     disableCoalescing = false;
+    disableZMM = false;
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -339,8 +339,8 @@ class AllCPUs {
         names[CPU_SKX].push_back("skx");
 
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_8_0 // LLVM 8.0+
-        names[CPU_ICL].push_back("icl");
         names[CPU_ICL].push_back("icelake-client");
+        names[CPU_ICL].push_back("icl");
 #endif
 
 #ifdef ISPC_ARM_ENABLED

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -485,6 +485,10 @@ struct Opt {
     /** Disables optimizations that coalesce incoherent scalar memory
         access from gathers into wider vector operations, when possible. */
     bool disableCoalescing;
+
+    /** Disable using zmm registers for avx512 target in favour of ymm.
+        Affects only >= 512 bit wide targets and only if avx512vl is available */
+    bool disableZMM;
 };
 
 /** @brief This structure collects together a number of global variables.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,6 +150,10 @@ static void lPrintVersion() {
     printf("        disable-assertions\t\tRemove assertion statements from final code.\n");
     printf("        disable-fma\t\t\tDisable 'fused multiply-add' instructions (on targets that support them)\n");
     printf("        disable-loop-unroll\t\tDisable loop unrolling.\n");
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_8_0
+    printf("        disable-zmm\t\tDisable using zmm registers for avx512 targets in favour of ymm. This also affects "
+           "ABI.\n");
+#endif
     printf("        fast-masked-vload\t\tFaster masked vector loads on SSE (may go past end of array)\n");
     printf("        fast-math\t\t\tPerform non-IEEE-compliant optimizations of numeric expressions\n");
     printf("        force-aligned-memory\t\tAlways issue \"aligned\" vector load and store instructions\n");
@@ -691,6 +695,10 @@ int main(int Argc, char *Argv[]) {
                 g->opt.unrollLoops = false;
             else if (!strcmp(opt, "disable-fma"))
                 g->opt.disableFMA = true;
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_8_0
+            else if (!strcmp(opt, "disable-zmm"))
+                g->opt.disableZMM = true;
+#endif
             else if (!strcmp(opt, "force-aligned-memory"))
                 g->opt.forceAlignedMemory = true;
 

--- a/stdlib.ispc
+++ b/stdlib.ispc
@@ -1,6 +1,6 @@
 // -*- mode: c++ -*-
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2020, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/tests/lit-tests/avx512skx-registers.ispc
+++ b/tests/lit-tests/avx512skx-registers.ispc
@@ -1,0 +1,38 @@
+// This test checks that avx512skx-i32x16:
+// - uses only zmm registers by default (for 512 bit vectors)
+// - uses only ymm registers when --opt=disable-zmm is passed.
+//
+// This code is especially problematic, as shuffle generates a sequence of gep
+// instructions, which are later combined to shuffle by code gen.
+
+// RUN: %{ispc} %s --emit-asm --target=avx512skx-i32x16 -o - 2>&1 | FileCheck %s -check-prefix=ZMM
+// RUN: %{ispc} %s --emit-asm --target=avx512skx-i32x16 --opt=disable-zmm -o - 2>&1 | FileCheck %s -check-prefix=YMM
+
+// REQUIRES: LLVM_8_0+
+
+// ZMM-NOT: ymm
+// YMM-NOT: zmm
+
+struct FM {
+    float M[16];
+};
+
+unmasked inline uniform FM bar(const uniform FM &m) {
+    uniform FM r;
+
+    uniform float *uniform mp = (uniform float *uniform) & m;
+    uniform float *uniform rp = (uniform float *uniform) & r;
+
+    static const varying int perm = {0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15};
+
+    const varying float s = mp[programIndex];
+    rp[programIndex] = shuffle(s, perm);
+
+    return r;
+}
+
+export void foo(uniform FM out[], const uniform FM src[], const uniform int n) {
+    for (uniform unsigned int i = 0; i < n; i++) {
+        out[i] = bar(src[i]);
+    }
+}

--- a/tests/lit-tests/cpus_x86.ispc
+++ b/tests/lit-tests/cpus_x86.ispc
@@ -1,0 +1,27 @@
+// The test checks that cpu definitions (including all synonyms) are successfully consumed by compiler.
+
+//; RUN: %{ispc} %s -o %t.cpp --emit-c++ --nostdlib --target=generic-4 --cpu=generic
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=x86-64
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=atom
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=bonnell
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=core2
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=penryn
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=slm
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=silvermont
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=corei7
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=nehalem
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=btver2
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=ps4
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=corei7-avx
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=sandybridge
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=core-avx-i
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=ivybridge
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=core-avx2
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=haswell
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=broadwell
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=knl
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=skx
+
+uniform int i;
+
+void foo() {}

--- a/tests/lit-tests/cpus_x86_llvm_80plus.ispc
+++ b/tests/lit-tests/cpus_x86_llvm_80plus.ispc
@@ -1,0 +1,10 @@
+// The test checks that cpu definitions (including all synonyms) are successfully consumed by compiler.
+
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=icelake-client
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=icl
+
+// REQUIRES: LLVM_8_0+
+
+uniform int i;
+
+void foo() {}


### PR DESCRIPTION
* introduce ``--opt=disbale-zmm`` switch to allow using only ymm registers even for avx512skx-i32x16 target.
* fix ``icl`` cpu definition.