### PR TITLE
[WASM] Enable tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y libc6-dev-i386 g++-multilib lib32stdc++6
   - if [ -n "$WASM_FLAGS" ]; then source scripts/install_emscripten.sh && emcc --version; fi
-  - if [ -n "$WASM_FLAGS" ]; then source scripts/install_v8.sh && v8-debug -e "console.log(\"V8 TEST\")"; fi
+  - if [ -n "$WASM_FLAGS" ]; then source scripts/install_v8.sh && v8 -e "console.log(\"V8 TEST\")"; fi
   - wget https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.17.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.17.0-Linux-x86_64.sh
   - export PATH=/opt/cmake/bin:$PATH
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y libc6-dev-i386 g++-multilib lib32stdc++6
   - if [ -n "$WASM_FLAGS" ]; then source scripts/install_emscripten.sh && emcc --version; fi
-  - if [ -n "$WASM_FLAGS" ]; then source scripts/install_v8.sh && v8 -e "console.log(\"V8 TEST\")"; fi
+  - if [ -n "$WASM_FLAGS" ]; then source scripts/install_v8.sh && v8 -e "console.log(\"V8 WORKS\")"; fi
   - wget https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.17.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.17.0-Linux-x86_64.sh
   - export PATH=/opt/cmake/bin:$PATH
   - cmake --version

--- a/scripts/install_emscripten.sh
+++ b/scripts/install_emscripten.sh
@@ -2,7 +2,7 @@ WD=`pwd`
 git clone https://github.com/emscripten-core/emsdk.git && \
 cd emsdk
 git pull && \
-./emsdk install latest && \
-./emsdk activate latest && \
+./emsdk install sdk-1.39.11-64bit && \
+./emsdk activate sdk-1.39.11-64bit  && \
 source ./emsdk_env.sh
 cd $WD

--- a/scripts/install_v8.sh
+++ b/scripts/install_v8.sh
@@ -1,6 +1,8 @@
 WD=`pwd`
-sudo apt-get install nodejs && \
-npm install jsvu -g && \
+#sudo apt-get install nodejs && \
+#npm install jsvu -g && \
 export PATH="${HOME}/.jsvu:${PATH}" && \
-jsvu --os=linux64 --engines=v8-debug
+jsvu --os=linux64 v8-debug@8.4.200 && \
+cp scripts/v8-redirect.sh ${HOME}/.jsvu/v8 && \
+chmod +x ${HOME}/.jsvu/v8
 cd $WD

--- a/scripts/install_v8.sh
+++ b/scripts/install_v8.sh
@@ -1,6 +1,6 @@
 WD=`pwd`
-#sudo apt-get install nodejs && \
-#npm install jsvu -g && \
+sudo apt-get install nodejs && \
+npm install jsvu -g && \
 export PATH="${HOME}/.jsvu:${PATH}" && \
 jsvu --os=linux64 v8-debug@8.4.200 && \
 cp scripts/v8-redirect.sh ${HOME}/.jsvu/v8 && \

--- a/scripts/v8-redirect.sh
+++ b/scripts/v8-redirect.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+"${HOME}/.jsvu/engines/v8-debug-8.4.200/v8-debug-8.4.200" --snapshot_blob="${HOME}/.jsvu/engines/v8-debug-8.4.200/snapshot_blob.bin" "$@"


### PR DESCRIPTION
V8 is switching to new simd binary opcodes (https://github.com/v8/v8/commit/41fbbd12a35d4f7bb89859c91da4b7b88e9d2d74) due to this PR (https://github.com/WebAssembly/simd/pull/209) so versions of emscripten and v8 have to be aligned to the recent compatible for now. Later the versions would have to be bumped manually.

expected failures:
* tests/clock.ispc - the kernel is too fast for low precision timer available for web 

To run:
```console
python3 run_tests.py --arch=wasm32 --target=wasm-i32x4
```