### PR TITLE
Add a collection of tests for ISPC response file handling

### DIFF
--- a/tests/lit-tests/1638.args
+++ b/tests/lit-tests/1638.args
@@ -1,0 +1,1 @@
+--target=avx2 -I "C:\path to include\ with spaces/"

--- a/tests/lit-tests/nested_response_files.args
+++ b/tests/lit-tests/nested_response_files.args
@@ -1,0 +1,1 @@
+--target=sse2-i32x8,avx2,avx512knl-i32x16 @missing_response_file.args

--- a/tests/lit-tests/response_files.ispc
+++ b/tests/lit-tests/response_files.ispc
@@ -1,0 +1,11 @@
+//; RUN: %{ispc} @%S/1638.args  %s > %t
+//; RUN: not %{ispc} %s @%S/missing_response_file.args -o %t.o --nowrap --target=avx2-i32x8 2>&1 | FileCheck %s
+//; RUN: not %{ispc} %s @%S/nested_response_files.args -o %t.o --nowrap 2>&1 | FileCheck %s
+
+
+//; CHECK: Error: Multiple input files specified on command line:
+//; CHECK: missing_response_file.args
+
+void test(uniform float &Val) { Val = Val * -(Val * Val); }
+
+


### PR DESCRIPTION
I couldn't find any test that verified the fix to https://github.com/ispc/ispc/issues/1638 so I went ahead and added one. This behavior is important to the project I am working on.

At the same time I noticed that ISPC didn't have any tests verifying missing or nested response files so I added those as well.