### PR TITLE
check_format.sh update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,5 +98,13 @@ stages:
 jobs:
   include:
     - stage: check format
+      os: linux
+      dist: focal
+      addons:
+        apt:
+          packages:
+            - clang-format
+      env: LLVM_VERSION=10.0 OS=Ubuntu20.04
+      before_install:
       script:
-        - cd $ISPC_HOME && ./check_format.sh
+        - ./check_format.sh clang-format-10

--- a/check_format.sh
+++ b/check_format.sh
@@ -34,16 +34,17 @@ EXIT_CODE=0
 echo "\
 ############################################################################
 Checking formatting of modified files. It is expected that the files were
-formatted with clang-format 8.0.0. It is also expected that clang-format
-version 8.0.0 is used for the check. Otherwise the result can ne unexpected.
+formatted with clang-format 10.0.0. It is also expected that clang-format
+version 10.0.0 is used for the check. Otherwise the result can ne unexpected.
 ############################################################################"
 
 CLANG_FORMAT="clang-format"
-REQUIRED_VERSION="8.0.0"
-VERSION_STRING="$CLANG_FORMAT version $REQUIRED_VERSION .*"
-CURRENT_VERSION="$(clang-format --version)"
+[[ ! -z $1 ]] && CLANG_FORMAT=$1
+REQUIRED_VERSION="10.0.0"
+VERSION_STRING="clang-format version $REQUIRED_VERSION.*"
+CURRENT_VERSION="$($CLANG_FORMAT --version)"
 if ! [[ $CURRENT_VERSION =~ $VERSION_STRING ]] ; then
-    echo WARNING: $CLANG_FORMAT version $REQUIRED_VERSION is required but $CURRENT_VERSION is used.
+    echo WARNING: clang-format version $REQUIRED_VERSION is required but $CURRENT_VERSION is used.
     echo The results can be unexpected.
 fi
 


### PR DESCRIPTION
* update check_format.sh to use clang-format 10.0.0.
* change the script to accept alternative name of clang-format as a first parameter.
* change the script to be more robust in recognition of clang-format version (accept clang-format-10 from Ubuntu packages).
* change the TravisCI job for checking format to use Ubuntu 20.04 image with clang-format package. This reduces time for this stage from 8min50 sec to 1min0sec.