### PR TITLE
Fix behavior of lit tests on Windows

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,9 +46,9 @@ list(APPEND LIT_ARGS "-Dispc_test_exec_root=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${
 # LLVM version used to build ISPC
 list(APPEND LIT_ARGS "-Dispc_llvm_version_number=${LLVM_VERSION_NUMBER}")
 # ISPC enabled targets
-list(APPEND LIT_ARGS "-Dx86_enabled=$<IF:$<BOOL:${X86_ENABLED}>,'ON','OFF'>")
-list(APPEND LIT_ARGS "-Darm_enabled=$<IF:$<BOOL:${ARM_ENABLED}>,'ON','OFF'>")
-list(APPEND LIT_ARGS "-Dwasm_enabled=$<IF:$<BOOL:${WASM_ENABLED}>,'ON','OFF'>")
+list(APPEND LIT_ARGS "-Dx86_enabled=$<IF:$<BOOL:${X86_ENABLED}>,ON,OFF>")
+list(APPEND LIT_ARGS "-Darm_enabled=$<IF:$<BOOL:${ARM_ENABLED}>,ON,OFF>")
+list(APPEND LIT_ARGS "-Dwasm_enabled=$<IF:$<BOOL:${WASM_ENABLED}>,ON,OFF>")
 add_custom_target(check-all DEPENDS ispc
     COMMAND ${LIT_COMMAND} ${LIT_ARGS}
     COMMENT "Running lit tests"

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -38,21 +38,27 @@ x86_enabled = lit_config.params.get('x86_enabled')
 if x86_enabled == "ON":
     print("X86_ENABLED: YES")
     config.available_features.add("X86_ENABLED")
-else:
+elif x86_enabled == "OFF":
     print("X86_ENABLED: NO")
+else:
+    sys.exit("Cannot parse x86_enabled: " + x86_enabled)
 
 # ARM backend
 arm_enabled = lit_config.params.get('arm_enabled')
 if arm_enabled == "ON":
     print("ARM_ENABLED: YES")
     config.available_features.add("ARM_ENABLED")
-else:
+elif arm_enabled == "OFF":
     print("ARM_ENABLED: NO")
+else:
+    sys.exit("Cannot parse arm_enabled: " + arm_enabled)
 
 # WebAssembly backend
 wasm_enabled = lit_config.params.get('wasm_enabled')
 if wasm_enabled == "ON":
     print("WASM_ENABLED: YES")
     config.available_features.add("WASM_ENABLED")
-else:
+elif wasm_enabled == "OFF":
     print("WASM_ENABLED: NO")
+else:
+    sys.exit("Cannot parse wasm_enabled: " + wasm_enabled)


### PR DESCRIPTION
Using single quote (i.e ' ) around strings is treated differently on Unix and Windows. So passing ON and OFF without quotes. Also asserting for if the parameter is not recognized as either ON or OFF.