### PR TITLE
Fix print for varying bools.

### DIFF
--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -2660,9 +2660,12 @@ static llvm::Value *lProcessPrintArg(Expr *expr, FunctionEmitContext *ctx, std::
     }
 
     // Just int8 and int16 types to int32s...
+    // Also ensure 'varying bool' is excluded since it's baseType can be one
+    // of these types.
     const Type *baseType = type->GetAsNonConstType()->GetAsUniformType();
-    if (Type::Equal(baseType, AtomicType::UniformInt8) || Type::Equal(baseType, AtomicType::UniformUInt8) ||
-        Type::Equal(baseType, AtomicType::UniformInt16) || Type::Equal(baseType, AtomicType::UniformUInt16)) {
+    if ((Type::Equal(baseType, AtomicType::UniformInt8) || Type::Equal(baseType, AtomicType::UniformUInt8) ||
+         Type::Equal(baseType, AtomicType::UniformInt16) || Type::Equal(baseType, AtomicType::UniformUInt16)) &&
+        !type->IsBoolType()) {
         expr = new TypeCastExpr(type->IsUniformType() ? AtomicType::UniformInt32 : AtomicType::VaryingInt32, expr,
                                 expr->pos);
         type = expr->GetType();
@@ -2676,7 +2679,7 @@ static llvm::Value *lProcessPrintArg(Expr *expr, FunctionEmitContext *ctx, std::
               type->GetString().c_str());
         return NULL;
     } else {
-        if (Type::Equal(baseType, AtomicType::UniformBool)) {
+        if (type->IsBoolType()) {
             // Blast bools to ints, but do it here to preserve encoding for
             // printing 'true' or 'false'
             expr = new TypeCastExpr(type->IsUniformType() ? AtomicType::UniformInt32 : AtomicType::VaryingInt32, expr,

--- a/tests/lit-tests/print_bool.ispc
+++ b/tests/lit-tests/print_bool.ispc
@@ -1,0 +1,10 @@
+// RUN: %{ispc} %s --target=avx2-i32x4 --nowrap -O0 --emit-llvm-text -o - | FileCheck %s
+// REQUIRES: X86_ENABLED
+// CHECK: [[PRTARG_PTR_BITCAST:%[a-zA-Z0-9_.]+]] = bitcast [1 x i8*]*  [[PRTARG_PTR:%[a-zA-Z0-9_.]+]] to i8**
+// CHECK: [[PRTARG_BITCAST:%[a-zA-Z0-9_.]+]] = bitcast <4 x i32>* {{%[a-zA-Z0-9_.]+}} to i8*
+// CHECK: [[SCT_OFF:%[a-zA-Z0-9_.]+]] = getelementptr [1 x i8*], [1 x i8*]* [[PRTARG_PTR]], i32 0, i32 0
+// CHECK: store i8* [[PRTARG_BITCAST]], i8** [[SCT_OFF]]
+// CHECK: __do_print(i8* {{%[a-zA-Z0-9_.]+}}, i8* {{%[a-zA-Z0-9_.]+}}, i32 4, i64 {{%[a-zA-Z0-9_.]+}}, i8** [[PRTARG_PTR_BITCAST]])
+void foo(bool bool_var) {
+    print("\n bool_var = %\n", bool_var);
+}


### PR DESCRIPTION
The _do_print() implementation assumes that bools are 32 bit wide. The existing check was not able to identify 'varying bools' . It was working before the bool storage type change since for target with mask = i32, varying bool was already 32 bit. For something like sse4-i8x16 with mask i8, the logic for printing int8 was handling it - hence why we see varying bool printed as 0,1 instead of true/false on non i32 masked targets.

I haven't added a comment in code since the logic has not been changed.