### PR TITLE
Fix #1771 - wrong code for avx2-i64x4, back-porting LLVM patch. 

### DIFF
--- a/llvm_patches/10_0_fix_for_1771_1.patch
+++ b/llvm_patches/10_0_fix_for_1771_1.patch
@@ -1,0 +1,30 @@
+# This patch is a fix for #1771.
+# It is a port of the following llvm 11.0 commit: https://reviews.llvm.org/D81212.
+# Git hash of the commit: 7c9a89fe
+--- lib/Target/X86/X86ISelLowering.cpp
++++ lib/Target/X86/X86ISelLowering.cpp
+@@ -41439,14 +41439,22 @@
+       getTargetConstantBitsFromNode(N0, NumBitsPerElt, UndefElts, EltBits)) {
+     assert(EltBits.size() == VT.getVectorNumElements() &&
+            "Unexpected shift value type");
+-    for (APInt &Elt : EltBits) {
+-      if (X86ISD::VSHLI == Opcode)
++    // Undef elements need to fold to 0. It's possible SimplifyDemandedBits
++    // created an undef input due to no input bits being demanded, but user
++    // still expects 0 in other bits.
++    for (unsigned i = 0, e = EltBits.size(); i != e; ++i) {
++      APInt &Elt = EltBits[i];
++      if (UndefElts[i])
++        Elt = 0;
++      else if (X86ISD::VSHLI == Opcode)
+         Elt <<= ShiftVal;
+       else if (X86ISD::VSRAI == Opcode)
+         Elt.ashrInPlace(ShiftVal);
+       else
+         Elt.lshrInPlace(ShiftVal);
+     }
++    // Reset undef elements since they were zeroed above.
++    UndefElts = 0;
+     return getConstVector(EltBits, UndefElts, VT.getSimpleVT(), DAG, SDLoc(N));
+   }
+ 

--- a/llvm_patches/10_0_fix_for_1771_2.patch
+++ b/llvm_patches/10_0_fix_for_1771_2.patch
@@ -1,0 +1,35 @@
+# This patch is a fix for #1771.
+# It is a port of the following llvm 11.0 commit: https://reviews.llvm.org/D81292
+# Git hash of the commit: 3408dcbd
+--- lib/Target/X86/X86ISelLowering.cpp
++++ lib/Target/X86/X86ISelLowering.cpp
+@@ -23319,7 +23353,8 @@ static SDValue getTargetVShiftByConstNode(unsigned Opc, const SDLoc &dl, MVT VT,
+       for (unsigned i = 0; i != NumElts; ++i) {
+         SDValue CurrentOp = SrcOp->getOperand(i);
+         if (CurrentOp->isUndef()) {
+-          Elts.push_back(CurrentOp);
++          // Must produce 0s in the correct bits.
++          Elts.push_back(DAG.getConstant(0, dl, ElementType));
+           continue;
+         }
+         auto *ND = cast<ConstantSDNode>(CurrentOp);
+@@ -23331,7 +23366,8 @@ static SDValue getTargetVShiftByConstNode(unsigned Opc, const SDLoc &dl, MVT VT,
+       for (unsigned i = 0; i != NumElts; ++i) {
+         SDValue CurrentOp = SrcOp->getOperand(i);
+         if (CurrentOp->isUndef()) {
+-          Elts.push_back(CurrentOp);
++          // Must produce 0s in the correct bits.
++          Elts.push_back(DAG.getConstant(0, dl, ElementType));
+           continue;
+         }
+         auto *ND = cast<ConstantSDNode>(CurrentOp);
+@@ -23343,7 +23379,8 @@ static SDValue getTargetVShiftByConstNode(unsigned Opc, const SDLoc &dl, MVT VT,
+       for (unsigned i = 0; i != NumElts; ++i) {
+         SDValue CurrentOp = SrcOp->getOperand(i);
+         if (CurrentOp->isUndef()) {
+-          Elts.push_back(CurrentOp);
++          // All shifted in bits must be the same so use 0.
++          Elts.push_back(DAG.getConstant(0, dl, ElementType));
+           continue;
+         }
+         auto *ND = cast<ConstantSDNode>(CurrentOp);

--- a/tests/lit-tests/1771.ispc
+++ b/tests/lit-tests/1771.ispc
@@ -1,0 +1,25 @@
+// RUN: %{ispc} %s --target=avx2-i64x4 --emit-asm -o - | FileCheck %s -check-prefix=CHECKAVX2_I64X4
+// RUN: %{ispc} %s --target=avx2-i32x8 --emit-asm -o - | FileCheck %s -check-prefix=CHECKAVX2_I32X8
+// RUN: %{ispc} %s --target=sse2-i32x4 --emit-asm -o - | FileCheck %s -check-prefix=CHECKSSE2_I32X4
+// RUN: %{ispc} %s --target=sse2-i32x8 --emit-asm -o - | FileCheck %s -check-prefix=CHECKSSE2_I32X8
+// RUN: %{ispc} %s --target=sse4-i16x8 --emit-asm -o - | FileCheck %s -check-prefix=CHECKSSE4_I16X8
+// RUN: %{ispc} %s --target=sse4-i8x16 --emit-asm -o - | FileCheck %s -check-prefix=CHECKSSE4_I8X16
+
+// REQUIRES: LLVM_10_0+
+// REQUIRES: X86_ENABLED
+
+// CHECKAVX2_I32X8: vxorps  %xmm0, %xmm0, %xmm0
+// CHECKAVX2_I64X4: vxorps  %xmm0, %xmm0, %xmm0
+// CHECKSSE2_I32X4: pxor  %xmm0, %xmm0
+// CHECKSSE2_I32X8: xorps   %xmm0, %xmm0
+// CHECKSSE4_I16X8: xorps   %xmm0, %xmm0
+// CHECKSSE4_I8X16: xorps   %xmm0, %xmm0
+
+extern uniform unsigned int var_18;
+extern uniform unsigned int16 arr_202 [17] ;
+extern uniform int8 arr_11 ;
+
+void test() {
+    foreach(i_33 = 0...16)
+        arr_202 [i_33] = arr_11 ? (var_18 << (varying unsigned int64) 17) :  1U;
+}


### PR DESCRIPTION
Closes #1771 .

 
1. For 9.0 and 11.0, this doesn't seem to be an issue.
But 9.0 does create a different xor - https://godbolt.org/z/WeN9zM

Hence test being written for 10.0+ and patch applied only for 10.0

2. Lit test not run for avx512 targets- No constant folding happening anyway. So, assembly is same for 10.0 and 11.0 anyway. And no xor exists : https://godbolt.org/z/gKEGby

3. Craig said he is making a request to backport it to 10.0.1