### PR TITLE
CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,8 @@ jobs:
       os: linux
       arch: arm64
       dist: bionic
+      env:
+        - LLVM_VERSION=10.0 OS=Ubuntu18.04
       before_install:
         - sudo apt-get update
         - dpkg --print-architecture
@@ -168,6 +170,8 @@ jobs:
     - stage: test
       os: osx
       osx_image: xcode11.4
+      env:
+        - LLVM_VERSION=10.0 OS=macOS10.15
       before_install:
         - wget https://github.com/dbabokin/llvm-project/releases/download/llvm-10.0.0-ispc-dev/llvm-10.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
         - tar xvf llvm-10.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ env:
     - LLVM_HOME=/usr/local/src/llvm
     - ISPC_HOME=$TRAVIS_BUILD_DIR
 
+# Matrix expansion is not supported in builds stages, see: https://github.com/travis-ci/travis-ci/issues/8295
+# Using tags as workaround to reduce amount of copy-pasting.
 my_tag: &my_tag
       stage: test
       before_install:
@@ -92,6 +94,7 @@ stages:
 
 jobs:
   include:
+    # Check source formatting
     - stage: check format
       os: linux
       dist: focal
@@ -103,16 +106,76 @@ jobs:
       before_install:
       script:
         - ./check_format.sh clang-format-10
+    # LLVM 10.0 + Ubuntu 16.04: build, lit tests, examples (build + run), benchmarks (build + trial run), tests
     - <<: *my_tag
       env:
         - LLVM_VERSION=10.0 OS=Ubuntu16.04 DOCKER_TAG=llvm100
+    # LLVM 9.0 + Ubuntu 16.04: build, lit tests, examples (build + run), benchmarks (build + trial run)
     - <<: *my_tag
       env:
         - LLVM_VERSION=9.0 OS=Ubuntu16.04 DOCKER_TAG=llvm90
+    # LLVM 8.0 + Ubuntu 16.04: build, lit tests, examples (build + run), benchmarks (build + trial run)
     - <<: *my_tag
       env:
         - LLVM_VERSION=8.0 OS=Ubuntu16.04 DOCKER_TAG=llvm80
     # WASM enabled build
+    # LLVM 10.0 + Ubuntu 16.04: build, lit tests, examples (build), benchmarks (build + trial run)
     - <<: *my_tag
       env:
         - LLVM_VERSION=10.0 OS=Ubuntu16.04 DOCKER_TAG=llvm100 WASM_FLAGS="-DWASM_ENABLED=ON"
+    # ARM build
+    # LLVM 10.0 + Ubuntu 18.04:
+    #   - ARM only (default): build, lit tests, examples (build)
+    #   - ARM + x86: build, lit tests, examples (build), tests (aarch64)
+    - stage: test
+      os: linux
+      arch: arm64
+      dist: bionic
+      before_install:
+        - sudo apt-get update
+        - dpkg --print-architecture
+        - dpkg --print-foreign-architectures
+        - sudo apt-get install flex libc6-dev libc6-dev-armhf-cross libc6-dev-i386-cross libc6-dev-i386-amd64-cross
+        - find /usr -name cdefs.h
+        - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
+            sudo apt-get install libuv1 rhash libstdc++6;
+            wget https://anaconda.org/conda-forge/cmake/3.17.0/download/linux-aarch64/cmake-3.17.0-h28c56e5_0.tar.bz2;
+            mkdir $HOME/cmake;
+            tar -xjvf cmake-3.17.0-h28c56e5_0.tar.bz2 -C $HOME/cmake;
+            export PATH=$HOME/cmake/bin:$PATH;
+          fi
+        - wget https://github.com/dbabokin/llvm-project/releases/download/llvm-10.0.0-ispc-dev/llvm-10.0.0-ubuntu16.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        - tar xvf llvm-10.0.0-ubuntu16.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        - export PATH=`pwd`/bin-10.0/bin:$PATH
+      script:
+        - mkdir build-arm && cd build-arm
+        - cmake ..
+        - make -j4
+        - make check-all
+        - bin/ispc --support-matrix
+        - cd ..
+        - mkdir build-all && cd build-all
+        - cmake .. -DX86_ENABLED=ON
+        - make -j4
+        - make check-all
+        - bin/ispc --support-matrix
+        - cp bin/ispc ..
+        - cd ..
+        - export ISPC_HOME=`pwd`
+        - ./run_tests.py --arch=aarch64 --target=neon-i32x4
+    # macOS build
+    # LLVM 10.0 + macOS 10.15 Catalina: build, lit tests, examples (build)
+    - stage: test
+      os: osx
+      osx_image: xcode11.4
+      before_install:
+        - wget https://github.com/dbabokin/llvm-project/releases/download/llvm-10.0.0-ispc-dev/llvm-10.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
+        - tar xvf llvm-10.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
+        - export PATH=`pwd`/bin-10.0/bin:$PATH
+        - brew update && brew install bison
+        - export PATH=/usr/local/opt/bison/bin:$PATH
+      script:
+        - mkdir build && cd build
+        - cmake ..
+        - make -j4
+        - make check-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,43 +53,38 @@ env:
     - DOCKER_REPO_PATH=ispc/ubuntu_16.04
     - LLVM_HOME=/usr/local/src/llvm
     - ISPC_HOME=$TRAVIS_BUILD_DIR
-  matrix:
-    - LLVM_VERSION=10.0 OS=Ubuntu16.04 DOCKER_TAG=llvm100
-    - LLVM_VERSION=9.0 OS=Ubuntu16.04 DOCKER_TAG=llvm90
-    - LLVM_VERSION=8.0 OS=Ubuntu16.04 DOCKER_TAG=llvm80
-      # WASM enabled build
-    - LLVM_VERSION=10.0 OS=Ubuntu16.04 DOCKER_TAG=llvm100 WASM_FLAGS="-DWASM_ENABLED=ON"
 
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y libc6-dev-i386 g++-multilib lib32stdc++6
-  - if [ -n "$WASM_FLAGS" ]; then source scripts/install_emscripten.sh && emcc --version; fi
-  - if [ -n "$WASM_FLAGS" ]; then source scripts/install_v8.sh && v8 -e "console.log(\"V8 WORKS\")"; fi
-  - wget https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.17.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.17.0-Linux-x86_64.sh
-  - export PATH=/opt/cmake/bin:$PATH
-  - cmake --version
-  - docker pull "$DOCKER_REPO_PATH:$DOCKER_TAG"
-  - docker run "$DOCKER_REPO_PATH:$DOCKER_TAG"
-  - export CONTAINER=`docker ps --all |head -2 |tail -1 |awk '//{print $1}'`
-  - sudo docker cp $CONTAINER:$LLVM_HOME /usr/local/src
-  - export PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
-
-script:
-  - mkdir build_$LLVM_VERSION && cd build_$LLVM_VERSION
-  - cmake -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR -DISPC_INCLUDE_BENCHMARKS=ON $WASM_FLAGS ../
-    # Build ispc and check_isa utility. Run lit tests.
-  - make ispc check_isa check-all -j4
-    # Build benchmarks and test them.
-  - make ispc_benchmarks && make test
-    # Add ispc to the PATH
-  - export PATH=$ISPC_HOME/build_$LLVM_VERSION/bin:$PATH && cd $ISPC_HOME
-  - check_isa
-  - ispc --support-matrix
-  - ./check_env.py
-    # Run examples
-  - if [ -z "$WASM_FLAGS" ]; then ./perf.py -n 1; fi
-    # Run tests for latest LLVM version
-  - if [ "$LLVM_VERSION" == "10.0" -a -z "$WASM_FLAGS" ]; then ./run_tests.py; ./run_tests.py -a x86; fi
+my_tag: &my_tag
+      stage: test
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get install -y libc6-dev-i386 g++-multilib lib32stdc++6
+        - if [ -n "$WASM_FLAGS" ]; then source scripts/install_emscripten.sh && emcc --version; fi
+        - if [ -n "$WASM_FLAGS" ]; then source scripts/install_v8.sh && v8 -e "console.log(\"V8 WORKS\")"; fi
+        - wget https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.17.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.17.0-Linux-x86_64.sh
+        - export PATH=/opt/cmake/bin:$PATH
+        - cmake --version
+        - docker pull "$DOCKER_REPO_PATH:$DOCKER_TAG"
+        - docker run "$DOCKER_REPO_PATH:$DOCKER_TAG"
+        - export CONTAINER=`docker ps --all |head -2 |tail -1 |awk '//{print $1}'`
+        - sudo docker cp $CONTAINER:$LLVM_HOME /usr/local/src
+        - export PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+      script:
+        - mkdir build_$LLVM_VERSION && cd build_$LLVM_VERSION
+        - cmake -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR -DISPC_INCLUDE_BENCHMARKS=ON $WASM_FLAGS ../
+          # Build ispc and check_isa utility. Run lit tests.
+        - make ispc check_isa check-all -j4
+          # Build benchmarks and test them.
+        - make ispc_benchmarks && make test
+          # Add ispc to the PATH
+        - export PATH=$ISPC_HOME/build_$LLVM_VERSION/bin:$PATH && cd $ISPC_HOME
+        - check_isa
+        - ispc --support-matrix
+        - ./check_env.py
+          # Run examples
+        - if [ -z "$WASM_FLAGS" ]; then ./perf.py -n 1; fi
+          # Run tests for latest LLVM version
+        - if [ "$LLVM_VERSION" == "10.0" -a -z "$WASM_FLAGS" ]; then ./run_tests.py; ./run_tests.py -a x86; fi
 
 stages:
   - check format
@@ -108,3 +103,16 @@ jobs:
       before_install:
       script:
         - ./check_format.sh clang-format-10
+    - <<: *my_tag
+      env:
+        - LLVM_VERSION=10.0 OS=Ubuntu16.04 DOCKER_TAG=llvm100
+    - <<: *my_tag
+      env:
+        - LLVM_VERSION=9.0 OS=Ubuntu16.04 DOCKER_TAG=llvm90
+    - <<: *my_tag
+      env:
+        - LLVM_VERSION=8.0 OS=Ubuntu16.04 DOCKER_TAG=llvm80
+    # WASM enabled build
+    - <<: *my_tag
+      env:
+        - LLVM_VERSION=10.0 OS=Ubuntu16.04 DOCKER_TAG=llvm100 WASM_FLAGS="-DWASM_ENABLED=ON"

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -42,14 +42,14 @@ WORKDIR /usr/local/src/ispc
 
 # Build Clang with all required patches.
 # Pass required LLVM_VERSION with --build-arg LLVM_VERSION=<version>.
-# By default 8.0 is used.
+# By default 10.0 is used.
 # Note self-build options, it's required to build clang and ispc with the same compiler,
 # i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
 # or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
 # "rm" are just to keep docker image small.
-ARG LLVM_VERSION=8.0
+ARG LLVM_VERSION=10.0
 RUN ./alloy.py -b --version=$LLVM_VERSION --selfbuild --git && \
-    rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-$LLVM_VERSION_temp $LLVM_HOME/build-$LLVM_VERSION_temp
+    rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-"$LLVM_VERSION"_temp $LLVM_HOME/build-"$LLVM_VERSION"_temp
 
 ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
 

--- a/tests/clock.ispc
+++ b/tests/clock.ispc
@@ -1,10 +1,14 @@
+// issue #1783 for ARM support.
+// rule: skip on arch=arm
+// rule: skip on arch=aarch64
 
 export uniform int width() { return programCount; }
 
+float x;
 
 export void f_f(uniform float RET[], uniform float aFOO[]) {
   unsigned uniform int64 a = clock();
-  float x = pow(sqrt(aFOO[programIndex]), 5.5);
+  x = pow(sqrt(aFOO[programIndex]), 5.5);
   unsigned uniform int64 b = clock();
   RET[programIndex] = (b - a) > 0 ? 1 : 0;
 }


### PR DESCRIPTION
* Travis restructured to allow adding more jobs not fitting in matrix
* Add ARM and macOS build jobs.
* Disable tests/clock on ARM (issue #1783)
* Switch docker/ubuntu to 10.0 as default
* Fix bug in Dockerfile, which led to not removing *_temp folders (5Gb total size)

Note, ARM and macOS currently using ``dybaboki/llvm-project`` repo for downloads. I'll switch it to ``ispc/llvm-project`` in future changes.