### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/rebuild-llvm10.yml
+++ b/.github/workflows/rebuild-llvm10.yml
@@ -9,42 +9,38 @@ on:
       - "llvm_patches/**"
 
 jobs:
+  # Building LLVM in docker, as using native Ubuntu 16.04 github-hosted image contains newer-than-expected libs and
+  # makes the resulting build not usable on other Ubuntu 16.04 images.
   linux-build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: true
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install libc6-dev-i386 ncurses-dev
-        mkdir llvm
-        echo "::set-env name=LLVM_HOME::${GITHUB_WORKSPACE}/llvm"
-        echo "::set-env name=ISPC_HOME::${GITHUB_WORKSPACE}"
-
     - name: Check environment
       run: |
-        ./check_env.py
-        which -a clang
         cat /proc/cpuinfo
 
     - name: Build LLVM
       run: |
-        ./alloy.py -b --version=10.0 --selfbuild
+        cd docker/ubuntu/llvm_build
+        docker build --tag ispc/ubuntu16.04 --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA .
 
     - name: Pack LLVM
       run: |
-        cd llvm
+        cd docker/ubuntu/llvm_build
+        docker run ispc/ubuntu16.04
+        export CONTAINER=`docker ps --all |head -2 |tail -1 |awk '//{print $1}'`
+        sudo docker cp $CONTAINER:/usr/local/src/llvm/bin-10.0 .
         tar cJvf llvm-10.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz bin-10.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm10_linux
-        path: llvm/llvm-10.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/llvm_build/llvm-10.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
 
   mac-build:
     runs-on: macos-10.15

--- a/.github/workflows/rebuild-llvm10.yml
+++ b/.github/workflows/rebuild-llvm10.yml
@@ -5,10 +5,8 @@ on:
     branches:
       - master
     path:
-      - "llvm_patches/*10_0*"
-  pull_request:
-    path:
-      - "llvm_patches/*10_0*"
+      # "llvm_patches/*10_0*" pattern is known not to work, i.e. triggers on any commit.
+      - "llvm_patches/**"
 
 jobs:
   linux-build:
@@ -81,6 +79,6 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: llvm10_windows
+        name: llvm10_macos
         path: llvm/llvm-10.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
 

--- a/.github/workflows/rebuild-llvm10.yml
+++ b/.github/workflows/rebuild-llvm10.yml
@@ -56,7 +56,14 @@ jobs:
 
     - name: Install dependencies
       run: |
-        #brew update && brew install bison
+        ls -ald /Applications/Xcode*
+        xcrun --show-sdk-path
+        # There are several Xcode versions installed.
+        # /Applications/Xcode.app is a symlink pointing to the one that needs to be used.
+        # But the one, which is currently "selected" doesn't use symlink.
+        # We need canonical location to make resulting clang build working on other machines.
+        sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
+        xcrun --show-sdk-path
         mkdir llvm
         echo "::set-env name=LLVM_HOME::${GITHUB_WORKSPACE}/llvm"
         echo "::set-env name=ISPC_HOME::${GITHUB_WORKSPACE}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,19 +39,8 @@ services:
     - docker
 dist: xenial
 
-# Some magic is here. Docker is used to load pre-built LLVM as part of custom built image.
-# Custom built LLVM is required because
-#   (1) we need a patched version of LLVM for some of LLVM versions for performance and
-#       stability reasons,
-#   (2) it must be a dump-enabled LLVM build (release version without assertions and without
-#       stripping off dump() function), this affects LLVM 5.0 and later versions,
-#   (3) same compiler needs to be used for building LLVM and ISPC, otherwise there might be
-#       ABI incompatibilities causing link errors and runtime segfaults,
-#   (4) to have flexibility of testing with a range of LLVM versions that we need.
-env:
-  global:
-    - LLVM_REPO=https://github.com/dbabokin/llvm-project
-    - ISPC_HOME=$TRAVIS_BUILD_DIR
+# Note, global env variables are not used, even though they would make sense, because they appear first in
+# web view and hide matrix env variables.
 
 # Matrix expansion is not supported in builds stages, see: https://github.com/travis-ci/travis-ci/issues/8295
 # Using tags as workaround to reduce amount of copy-pasting.
@@ -106,24 +95,32 @@ jobs:
     # LLVM 10.0 + Ubuntu 16.04: build, lit tests, examples (build + run), benchmarks (build + trial run), tests
     - <<: *my_tag
       env:
-        - LLVM_VERSION=10.0 OS=Ubuntu16.04 DOCKER_TAG=llvm100
+        - LLVM_VERSION=10.0 OS=Ubuntu16.04
         - LLVM_TAR=llvm-10.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_REPO=https://github.com/dbabokin/llvm-project
+        - ISPC_HOME=$TRAVIS_BUILD_DIR
     # LLVM 9.0 + Ubuntu 16.04: build, lit tests, examples (build + run), benchmarks (build + trial run)
     - <<: *my_tag
       env:
-        - LLVM_VERSION=9.0 OS=Ubuntu16.04 DOCKER_TAG=llvm90
+        - LLVM_VERSION=9.0 OS=Ubuntu16.04
         - LLVM_TAR=llvm-9.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_REPO=https://github.com/dbabokin/llvm-project
+        - ISPC_HOME=$TRAVIS_BUILD_DIR
     # LLVM 8.0 + Ubuntu 16.04: build, lit tests, examples (build + run), benchmarks (build + trial run)
     - <<: *my_tag
       env:
-        - LLVM_VERSION=8.0 OS=Ubuntu16.04 DOCKER_TAG=llvm80
+        - LLVM_VERSION=8.0 OS=Ubuntu16.04
         - LLVM_TAR=llvm-8.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_REPO=https://github.com/dbabokin/llvm-project
+        - ISPC_HOME=$TRAVIS_BUILD_DIR
     # WASM enabled build
     # LLVM 10.0 + Ubuntu 16.04: build, lit tests, examples (build), benchmarks (build + trial run)
     - <<: *my_tag
       env:
-        - LLVM_VERSION=10.0 OS=Ubuntu16.04 DOCKER_TAG=llvm100 WASM_FLAGS="-DWASM_ENABLED=ON"
+        - LLVM_VERSION=10.0 OS=Ubuntu16.04 WASM_FLAGS="-DWASM_ENABLED=ON"
         - LLVM_TAR=llvm-10.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_REPO=https://github.com/dbabokin/llvm-project
+        - ISPC_HOME=$TRAVIS_BUILD_DIR
     # ARM build
     # LLVM 10.0 + Ubuntu 18.04:
     #   - ARM only (default): build, lit tests, examples (build)
@@ -133,8 +130,10 @@ jobs:
       arch: arm64
       dist: bionic
       env:
-        - LLVM_VERSION=10.0 OS=Ubuntu18.04
+        - LLVM_VERSION=10.0 OS=Ubuntu18.04aarch64
         - LLVM_TAR=llvm-10.0.0-ubuntu16.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_REPO=https://github.com/dbabokin/llvm-project
+        - ISPC_HOME=$TRAVIS_BUILD_DIR
       before_install:
         - sudo apt-get update
         - dpkg --print-architecture
@@ -175,6 +174,8 @@ jobs:
       env:
         - LLVM_VERSION=10.0 OS=macOS10.15
         - LLVM_TAR=llvm-10.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_REPO=https://github.com/dbabokin/llvm-project
+        - ISPC_HOME=$TRAVIS_BUILD_DIR
       before_install:
         - wget $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
         - tar xvf $LLVM_TAR

--- a/docker/ubuntu/full_ispc_build/Dockerfile
+++ b/docker/ubuntu/full_ispc_build/Dockerfile
@@ -1,0 +1,66 @@
+FROM ubuntu:16.04
+MAINTAINER Dmitry Babokin <dmitry.y.babokin@intel.com>
+
+ARG REPO=ispc/ispc
+ARG SHA=master
+ARG LLVM_VERSION=10.0
+
+# !!! Make sure that your docker config provides enough memory to the container,
+# otherwise LLVM build may fail, as it will use all the cores available to container.
+
+# If you are behind a proxy, let apt-get know about it
+#ENV http_proxy=http://proxy.yourcompany.com:888
+
+# Packages required to build ISPC and Clang.
+RUN apt-get -y update && apt-get install -y wget build-essential vim gcc g++ git subversion python3 m4 bison flex zlib1g-dev ncurses-dev libtinfo-dev libc6-dev-i386 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and install required version of cmake (3.13) for ISPC build
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.13.5/cmake-3.13.5-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.13.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.13.5-Linux-x86_64.sh
+
+# If you are behind a proxy, you need to configure git and svn.
+#RUN git config --global --add http.proxy http://proxy.yourcompany.com:888
+
+WORKDIR /usr/local/src
+
+# Fork ispc on github and clone *your* fork.
+RUN git clone https://github.com/$REPO.git ispc
+RUN cd ispc && git checkout $SHA && cd ..
+
+# This is home for Clang builds
+RUN mkdir /usr/local/src/llvm
+
+ENV ISPC_HOME=/usr/local/src/ispc
+ENV LLVM_HOME=/usr/local/src/llvm
+
+# If you are going to run test for future platforms, go to
+# http://www.intel.com/software/sde and download the latest version,
+# extract it, add to path and set SDE_HOME.
+
+WORKDIR /usr/local/src/ispc
+
+# Build Clang with all required patches.
+# Pass required LLVM_VERSION with --build-arg LLVM_VERSION=<version>.
+# By default 10.0 is used.
+# Note self-build options, it's required to build clang and ispc with the same compiler,
+# i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
+# or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
+# "rm" are just to keep docker image small.
+RUN ./alloy.py -b --version=$LLVM_VERSION --selfbuild --git && \
+    rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-"$LLVM_VERSION"_temp $LLVM_HOME/build-"$LLVM_VERSION"_temp
+
+ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+
+# Configure ISPC build
+RUN mkdir build_$LLVM_VERSION
+WORKDIR build_$LLVM_VERSION
+RUN cmake ../ -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/usr/local/src/ispc/bin-$LLVM_VERSION
+
+# Build ISPC
+RUN make ispc -j8 && make install
+WORKDIR ../
+RUN rm -rf build_$LLVM_VERSION
+
+#export path for ispc
+ENV PATH=/usr/local/src/ispc/bin-$LLVM_VERSION/bin:$PATH

--- a/docker/ubuntu/llvm_build/Dockerfile
+++ b/docker/ubuntu/llvm_build/Dockerfile
@@ -1,32 +1,30 @@
 FROM ubuntu:16.04
 MAINTAINER Dmitry Babokin <dmitry.y.babokin@intel.com>
 
+ARG REPO=ispc/ispc
+ARG SHA=master
+ARG LLVM_VERSION=10.0
+
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
 
 # If you are behind a proxy, let apt-get know about it
 #ENV http_proxy=http://proxy.yourcompany.com:888
 
-# Packages required to build ISPC and Clang.
-RUN apt-get -y update && apt-get install -y wget build-essential vim gcc g++ git subversion python3 m4 bison flex zlib1g-dev ncurses-dev libtinfo-dev libc6-dev-i386 && \
-    rm -rf /var/lib/apt/lists/*
+RUN uname -a
 
-# Download and install required version of cmake (3.13) for ISPC build
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.13.5/cmake-3.13.5-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.13.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
-    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.13.5-Linux-x86_64.sh
+# Packages required to build ISPC and Clang.
+RUN apt-get -y update && apt-get install -y build-essential gcc g++ git python3 ncurses-dev libtinfo-dev cmake && \
+    rm -rf /var/lib/apt/lists/*
 
 # If you are behind a proxy, you need to configure git and svn.
 #RUN git config --global --add http.proxy http://proxy.yourcompany.com:888
 
-# Initialize svn configs
-#RUN svn --version --quiet
-#RUN echo "http-proxy-host=proxy.yourcompany.com" >> ~/.subversion/servers
-#RUN echo "http-proxy-port=888" >> ~/.subversion/servers
-
 WORKDIR /usr/local/src
 
 # Fork ispc on github and clone *your* fork.
-RUN git clone https://github.com/ispc/ispc.git
+RUN git clone https://github.com/$REPO.git ispc
+RUN cd ispc && git checkout $SHA && cd ..
 
 # This is home for Clang builds
 RUN mkdir /usr/local/src/llvm
@@ -47,21 +45,7 @@ WORKDIR /usr/local/src/ispc
 # i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
 # or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
 # "rm" are just to keep docker image small.
-ARG LLVM_VERSION=10.0
-RUN ./alloy.py -b --version=$LLVM_VERSION --selfbuild --git && \
+RUN ./alloy.py -b --version=$LLVM_VERSION --selfbuild --verbose --git && \
     rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-"$LLVM_VERSION"_temp $LLVM_HOME/build-"$LLVM_VERSION"_temp
 
 ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
-
-# Configure ISPC build
-RUN mkdir build_$LLVM_VERSION
-WORKDIR build_$LLVM_VERSION
-RUN cmake ../ -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/usr/local/src/ispc/bin-$LLVM_VERSION
-
-# Build ISPC
-RUN make ispc -j8 && make install
-WORKDIR ../
-RUN rm -rf build_$LLVM_VERSION
-
-#export path for ispc
-ENV PATH=/usr/local/src/ispc/bin-$LLVM_VERSION/bin:$PATH


### PR DESCRIPTION
* Removing global env vars in Travis to make web view more informative
* Fix macOS build in Github Actions: use correct path to Xcode t make build portable and fix typo in artifact naming
* Add ``--verbose`` switch to alloy to see build progress on slow machines / Github Actions
* Add a separate Dockerfile for LLVM build (Ubuntu 16.04)
* Add more ARGs to Ubuntu Dockerfile to manage the build.
* Use Docker in Github Action for LLVM 10.0 build, as native Ubuntu 16.04 contains too new libs, which make resulting build not usable on other machines.