### PR TITLE
fix #1772 - adding ispc namespace for global

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -296,6 +296,7 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::F
         /* If debugging is enabled, tell the debug information emission
            code about this new function */
         diFile = funcStartPos.GetDIFile();
+        diSpace = funcStartPos.GetDINamespace();
         llvm::DIScope *scope = m->diCompileUnit;
         llvm::DIType *diSubprogramType = NULL;
 
@@ -330,7 +331,7 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::F
         if (isStatic)
             SPFlags |= llvm::DISubprogram::SPFlagLocalToUnit;
 
-        diSubprogram = m->diBuilder->createFunction(diFile /* scope */, funSym->name, mangledName, diFile, firstLine,
+        diSubprogram = m->diBuilder->createFunction(diSpace /* scope */, funSym->name, mangledName, diFile, firstLine,
                                                     diSubprogramType_n, firstLine, flags, SPFlags);
         llvmFunction->setSubprogram(diSubprogram);
 
@@ -339,6 +340,7 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::F
     } else {
         diSubprogram = NULL;
         diFile = NULL;
+        diSpace = NULL;
     }
 }
 

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -654,6 +654,9 @@ class FunctionEmitContext {
         function was defined (used for debugging info). */
     llvm::DIFile *diFile;
 
+    /** DINamespace object corresponding to 'ispc' namespace in 'diFile'. */
+    llvm::DINamespace *diSpace;
+
     /** DISubprogram corresponding to this function (used for debugging
         info). */
     llvm::DISubprogram *diSubprogram;

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1591,6 +1591,12 @@ SourcePos::GetDIFile() const {
     return ret;
 }
 
+llvm::DINamespace *SourcePos::GetDINamespace() const {
+    llvm::DIScope *discope = GetDIFile();
+    llvm::DINamespace *ret = m->diBuilder->createNameSpace(discope, "ispc", true);
+    return ret;
+}
+
 void SourcePos::Print() const {
     printf(" @ [%s:%d.%d - %d.%d] ", name, first_line, first_column, last_line, last_column);
 }

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -89,6 +89,7 @@ class TargetMachine;
 class Type;
 class Value;
 class DIFile;
+class DINamespace;
 class DIType;
 
 class DIScope;
@@ -134,6 +135,9 @@ struct SourcePos {
 
     /** Returns a LLVM DIFile object that represents the SourcePos's file */
     llvm::DIFile *GetDIFile() const;
+
+    /** Returns a LLVM DINamespace object that represents 'ispc' namespace. */
+    llvm::DINamespace *GetDINamespace() const;
 
     bool operator==(const SourcePos &p2) const;
 };

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -437,11 +437,12 @@ void Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *
 
     if (diBuilder) {
         llvm::DIFile *file = pos.GetDIFile();
+        llvm::DINamespace *diSpace = pos.GetDINamespace();
         // llvm::MDFile *file = pos.GetDIFile();
         llvm::GlobalVariable *sym_GV_storagePtr = llvm::dyn_cast<llvm::GlobalVariable>(sym->storagePtr);
         Assert(sym_GV_storagePtr);
         llvm::DIGlobalVariableExpression *var = diBuilder->createGlobalVariableExpression(
-            file, name, name, file, pos.first_line, sym->type->GetDIType(file), (sym->storageClass == SC_STATIC));
+            diSpace, name, name, file, pos.first_line, sym->type->GetDIType(diSpace), (sym->storageClass == SC_STATIC));
         sym_GV_storagePtr->addDebugInfo(var);
         /*#if ISPC_LLVM_VERSION <= ISPC_LLVM_3_6
                 Assert(var.Verify());

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -755,9 +755,10 @@ llvm::DIType *EnumType::GetDIType(llvm::DIScope *scope) const {
 
     llvm::DINodeArray elementArray = m->diBuilder->getOrCreateArray(enumeratorDescriptors);
     llvm::DIFile *diFile = pos.GetDIFile();
+    llvm::DINamespace *diSpace = pos.GetDINamespace();
     llvm::DIType *underlyingType = AtomicType::UniformInt32->GetDIType(scope);
     llvm::DIType *diType =
-        m->diBuilder->createEnumerationType(diFile, name, diFile, pos.first_line, 32 /* size in bits */,
+        m->diBuilder->createEnumerationType(diSpace, GetString(), diFile, pos.first_line, 32 /* size in bits */,
                                             32 /* align in bits */, elementArray, underlyingType, name);
     switch (variability.type) {
     case Variability::Uniform:
@@ -1848,7 +1849,8 @@ llvm::DIType *StructType::GetDIType(llvm::DIScope *scope) const {
 
     llvm::DINodeArray elements = m->diBuilder->getOrCreateArray(elementLLVMTypes);
     llvm::DIFile *diFile = pos.GetDIFile();
-    return m->diBuilder->createStructType(diFile, name, diFile,
+    llvm::DINamespace *diSpace = pos.GetDINamespace();
+    return m->diBuilder->createStructType(diSpace, GetString(), diFile,
                                           pos.first_line,          // Line number
                                           layout->getSizeInBits(), // Size in bits
 #if ISPC_LLVM_VERSION <= ISPC_LLVM_9_0
@@ -2026,8 +2028,9 @@ llvm::Type *UndefinedStructType::LLVMType(llvm::LLVMContext *ctx) const {
 
 llvm::DIType *UndefinedStructType::GetDIType(llvm::DIScope *scope) const {
     llvm::DIFile *diFile = pos.GetDIFile();
+    llvm::DINamespace *diSpace = pos.GetDINamespace();
     llvm::DINodeArray elements;
-    return m->diBuilder->createStructType(diFile, name, diFile,
+    return m->diBuilder->createStructType(diSpace, GetString(), diFile,
                                           pos.first_line,         // Line number
                                           0,                      // Size
                                           0,                      // Align


### PR DESCRIPTION
fixes #1772 

Adding namespace for ispc module and adding variability to name in some cases prevents symbol colliding with CodeView.