### PR TITLE
Fix #1806 - treat bool as unsigned, not as signed.

### DIFF
--- a/src/type.cpp
+++ b/src/type.cpp
@@ -174,7 +174,7 @@ bool AtomicType::IsIntType() const {
 }
 
 bool AtomicType::IsUnsignedType() const {
-    return (basicType == TYPE_UINT8 || basicType == TYPE_UINT16 || basicType == TYPE_UINT32 ||
+    return (basicType == TYPE_BOOL || basicType == TYPE_UINT8 || basicType == TYPE_UINT16 || basicType == TYPE_UINT32 ||
             basicType == TYPE_UINT64);
 }
 

--- a/tests/lit-tests/1806.ispc
+++ b/tests/lit-tests/1806.ispc
@@ -1,0 +1,9 @@
+// RUN: %{ispc} %s --target=host --emit-llvm-text -o - | FileCheck %s
+// CHECK: ret i32 0
+extern uniform int test() {
+    for (uniform bool i = 0; i < (uniform bool)1; i += 1)
+    {
+        return 0;
+    }
+    return 1;
+}


### PR DESCRIPTION
This affects how true (1) is treated. In case of unsigned it's 1. In case of signed, it's treated as -1.

There's another problem with boolean </> comparison - we do compare without promoting to i32, which is inconsistent with C/C++. If it causes a problem again, we should change it.