### PR TITLE
Fix Appveyor

### DIFF
--- a/.appveyor-clean-cache.txt
+++ b/.appveyor-clean-cache.txt
@@ -43,3 +43,4 @@ by updates of docker files.
 03/18/2020: Updated LLVM 10.0 docker
 04/02/2020: Updated Windows dockers with LLVM built for x64
 04/29/2020: Updated LLVM 9.0/10.0 with backport fix from trunk for #1767.
+06/21/2020: Do not cache LLVM

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -99,14 +99,13 @@ for:
   # Perf tests require Win64 configuration. "Visual Studio 16" generator is Win64 by default but for older versions
   # we need to specify it manually.
     - cmd: |-
-        msbuild c:\projects\ispc\build\tests\check-all.vcxproj /t:Build /p:Platform=x64 /p:Configuration=Release
         set PATH=%ISPC_HOME%\build\bin\%configuration%;%PATH%
         cd %ISPC_HOME%
         check_isa.exe
         ispc --support-matrix
         if %vsversion%==2017 ( set generator="Visual Studio 15 Win64")
         if %vsversion%==2019 ( set generator="Visual Studio 16")
-        python perf.py -n 1 -g %generator%
+        python perf.py -n 1 -g %generator% && msbuild %ISPC_HOME%\build\tests\check-all.vcxproj /t:Build /p:Platform=x64 /p:Configuration=Release
 
 -
   matrix:
@@ -150,8 +149,8 @@ for:
   test_script:
     # Run only lit testing here since we have full testing in Travis
     - sh: |-
-        make check-all
         bin/ispc --support-matrix
+        make check-all
 
 cache:
   - '%CHOCO_DIR%\bin -> .appveyor.yml'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -91,7 +91,9 @@ for:
         set PATH=%LLVM_HOME%\bin-%LLVM_VERSION%\bin;%PATH%
   before_build:
     - cmd: |-
-        cd %ISPC_HOME% && mkdir build && cd build
+        cd %ISPC_HOME%
+        check_env.py
+        mkdir build && cd build
         cmake .. -Thost=x64 -G %generator% -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%ISPC_HOME%\install -DISPC_PREPARE_PACKAGE=ON -DM4_EXECUTABLE=C:\cygwin64\bin\m4.exe -DISPC_CROSS=ON -DISPC_GNUWIN32_PATH=%CROSS_TOOLS%\gnuwin32 -DISPC_MACOS_SDK_PATH=%CROSS_TOOLS%\%MACOS_SDK% -DWASM_ENABLED=%WASM%
   build_script:
     - cmd: msbuild %ISPC_HOME%\build\PACKAGE.vcxproj /p:Platform=x64 /p:Configuration=Release

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,12 +37,16 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1604
       LLVM_VERSION: latest
+      LLVM_TAR: llvm-10.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: latest
+      LLVM_TAR: llvm-10.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.zip
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: 9.0
+      LLVM_TAR: llvm-9.0.1-win.vs2017-Release+Asserts-x86.arm.wasm.zip
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       LLVM_VERSION: 8.0
+      LLVM_TAR: llvm-8.0.1-win.vs2017-Release+Asserts-x86.arm.wasm.zip
 
 for:
 -
@@ -67,7 +71,7 @@ for:
         cinst winflexbison3
         set FLEX_PATH=%CHOCO_DIR%\lib\winflexbison3\tools
         if exist "%FLEX_PATH%\win_flex.exe" ( cd %FLEX_PATH% && ren win_flex.exe flex.exe )
-        if exist "%LLVM_HOME%\bin\" (if exist "%CROSS_TOOLS%\gnuwin32\" set NONEEDDOCKER=rem)
+        if exist "%CROSS_TOOLS%\gnuwin32\" set NONEEDDOCKER=rem
         if "%LLVM_VERSION%" == "latest" set LLVM_VERSION=%LLVM_LATEST%
         set LLVM_SHORT_VER=%LLVM_VERSION:.=%
         cd %ISPC_HOME%
@@ -78,9 +82,13 @@ for:
         %NONEEDDOCKER% docker run -d %DOCKER_NAME%
         %NONEEDDOCKER% docker ps --all  --format "{{.ID}}" --filter ancestor=%DOCKER_NAME% | head -1 > container_id.txt
         %NONEEDDOCKER% set /p CONTAINER=<container_id.txt
-        %NONEEDDOCKER% docker cp %CONTAINER%:%LLVM_HOME%\bin-%LLVM_VERSION% %LLVM_HOME%
         %NONEEDDOCKER% docker cp %CONTAINER%:%CROSS_TOOLS% %CROSS_TOOLS%
         set PATH=%LLVM_HOME%\bin;C:\Python37\;C:\Python37\Scripts;%CHOCO_DIR%\lib\winflexbison3\tools;%PATH%
+        mkdir %LLVM_HOME% && cd %LLVM_HOME%
+        cinst wget
+        wget https://github.com/dbabokin/llvm-project/releases/download/llvm-%LLVM_VERSION%-ispc-dev/%LLVM_TAR%
+        7z.exe x -t7z %LLVM_TAR%
+        set PATH=%LLVM_HOME%\bin-%LLVM_VERSION%\bin;%PATH%
   before_build:
     - cmd: |-
         cd %ISPC_HOME% && mkdir build && cd build
@@ -107,7 +115,7 @@ for:
   init:
     - sh: |-
         export ISPC_HOME=$APPVEYOR_BUILD_FOLDER
-        export LLVM_HOME=/usr/local/src/llvm
+        export LLVM_HOME=$APPVEYOR_BUILD_FOLDER/llvm
         export CROSS_TOOLS=/usr/local/src/cross
         export MACOS_SDK=MacOSX10.13.sdk
         export WASM=OFF
@@ -122,13 +130,15 @@ for:
         if [ "$WASM" == "ON" ]; then source scripts/install_emscripten.sh && emcc --version; fi
         LLVM_SHORT_VER=${LLVM_VERSION/\.}
         export DOCKER_NAME=$DOCKER_PATH:ubuntu_llvm$LLVM_SHORT_VER
-        if [ ! -d "$LLVM_HOME/bin-$LLVM_VERSION/bin" ]; then
+        if [ ! -d "$CROSS_TOOLS" ]; then
           docker pull "$DOCKER_NAME"
           docker run "$DOCKER_NAME"
           export CONTAINER=`docker ps --all |head -2 |tail -1 |awk '//{print $1}'`
-          sudo docker cp $CONTAINER:$LLVM_HOME $LLVM_HOME
           sudo docker cp $CONTAINER:$CROSS_TOOLS $CROSS_TOOLS
         fi
+        mkdir $LLVM_HOME && cd $LLVM_HOME
+        wget https://github.com/dbabokin/llvm-project/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
+        tar xvf $LLVM_TAR
         export PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
   before_build:
     - sh: |-
@@ -146,7 +156,6 @@ for:
 cache:
   - '%CHOCO_DIR%\bin -> .appveyor.yml'
   - '%CHOCO_DIR%\lib -> .appveyor.yml'
-  - '%LLVM_HOME% -> .appveyor-clean-cache.txt'
   - '%CROSS_TOOLS%\gnuwin32 -> .appveyor-clean-cache.txt'
   - '%CROSS_TOOLS%\%MACOS_SDK% -> .appveyor-clean-cache.txt'
 


### PR DESCRIPTION
- Appveyor to use LLVM builds from Github Releases
- Fail Appveyor if run if "make check-all" is failing.
- Check env before building (for debugging purposes).

What's not in this PR, but needs to be done as well:
- Remove dependency on Docker file (cross tools, macOS SDK)