### PR TITLE
Rearranging ifdefs

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -2219,14 +2219,14 @@ llvm::Value *FunctionEmitContext::LoadInst(llvm::Value *ptr, llvm::Value *mask, 
                 align = 1;
 #if ISPC_LLVM_VERSION <= ISPC_LLVM_9_0
             llvm::Instruction *inst = new llvm::LoadInst(ptr, name, false /* not volatile */, align, bblock);
-#elif ISPC_LLVM_VERSION >= ISPC_LLVM_11_0
+#elif ISPC_LLVM_VERSION == ISPC_LLVM_10_0
+            llvm::Instruction *inst =
+                new llvm::LoadInst(ptr, name, false /* not volatile */, llvm::MaybeAlign(align).valueOrOne(), bblock);
+#else // LLVM 11.0+
             llvm::PointerType *ptr_type = llvm::dyn_cast<llvm::PointerType>(ptr->getType());
             llvm::Instruction *inst =
                 new llvm::LoadInst(ptr_type->getPointerElementType(), ptr, name, false /* not volatile */,
                                    llvm::MaybeAlign(align).valueOrOne(), bblock);
-#else
-            llvm::Instruction *inst =
-                new llvm::LoadInst(ptr, name, false /* not volatile */, llvm::MaybeAlign(align).valueOrOne(), bblock);
 #endif
             AddDebugPos(inst);
             llvm::Value *loadVal = inst;


### PR DESCRIPTION
Rearranging ifdefs to makethe code easier to read and more maintainable:
- LLVM versions are going from lesser to greater.
- Do not break function calls by multiple ifdefs.
- Number of "(" should match ")" to make possible jumping between them in the editor.