### PR TITLE
Fix download links for Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,16 +37,12 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1604
       LLVM_VERSION: latest
-      LLVM_TAR: llvm-10.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: latest
-      LLVM_TAR: llvm-10.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.zip
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: 9.0
-      LLVM_TAR: llvm-9.0.1-win.vs2017-Release+Asserts-x86.arm.wasm.zip
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       LLVM_VERSION: 8.0
-      LLVM_TAR: llvm-8.0.1-win.vs2017-Release+Asserts-x86.arm.wasm.zip
 
 for:
 -
@@ -66,6 +62,9 @@ for:
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( (set generator="Visual Studio 15 Win64") & (set vsversion=2017))
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vsversion=2019))
         call "C:\Program Files (x86)\Microsoft Visual Studio\%vsversion%\Community\VC\Auxiliary\Build\vcvars64.bat"
+        set LLVM_TAR=llvm-10.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.zip
+        if "%LLVM_VERSION%"=="9.0" (set LLVM_TAR=llvm-9.0.1-win.vs2017-Release+Asserts-x86.arm.wasm.zip)
+        if "%LLVM_VERSION%"=="8.0" (set LLVM_TAR=llvm-8.0.1-win.vs2017-Release+Asserts-x86.arm.wasm.zip)
   install:
     - cmd: |-
         cinst winflexbison3
@@ -120,6 +119,7 @@ for:
         export CROSS_TOOLS=/usr/local/src/cross
         export MACOS_SDK=MacOSX10.13.sdk
         export WASM=OFF
+        export LLVM_TAR=llvm-10.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
   install:
     - sh: |-
         sudo apt-get update


### PR DESCRIPTION
The problem was that "Environment" for job description in Appveyor has changed, while permanent download link requires fully specifying it. The fix reverts Environment change.