### PR TITLE
Cleanup for includes: all LLVM includes are treated as system includes

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -44,9 +44,10 @@
 #include "sym.h"
 #include "type.h"
 #include "util.h"
-#include <llvm/BinaryFormat/Dwarf.h>
+
 #include <map>
 
+#include <llvm/BinaryFormat/Dwarf.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Metadata.h>

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include "ispc.h"
+
 #include <map>
 
 #include <llvm/IR/DIBuilder.h>

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -43,6 +43,7 @@
 #include "sym.h"
 #include "type.h"
 #include "util.h"
+
 #include <set>
 #include <stdio.h>
 #include <string.h>

--- a/src/decl.h
+++ b/src/decl.h
@@ -54,6 +54,7 @@
 #pragma once
 
 #include "ispc.h"
+
 #include <llvm/ADT/SmallVector.h>
 
 struct VariableDeclaration;

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -43,6 +43,7 @@
 #include "sym.h"
 #include "type.h"
 #include "util.h"
+
 #ifndef _MSC_VER
 #include <inttypes.h>
 #endif

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -44,27 +44,26 @@
 #include "sym.h"
 #include "type.h"
 #include "util.h"
+
 #include <stdio.h>
 
+#include <llvm/IR/CFG.h>
 #include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/IRPrintingPasses.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Intrinsics.h>
 #include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Type.h>
-
-#include "llvm/IR/LegacyPassManager.h"
-#include <llvm/IR/CFG.h>
-#include <llvm/IR/IRPrintingPasses.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/PassRegistry.h>
 #include <llvm/Support/FileUtilities.h>
 #include <llvm/Support/FormattedStream.h>
+#include <llvm/Support/ToolOutputFile.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 #include <llvm/Transforms/IPO.h>
-
-#include <llvm/Support/ToolOutputFile.h>
 
 Function::Function(Symbol *s, Stmt *c) {
     sym = s;

--- a/src/func.h
+++ b/src/func.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include "ispc.h"
+
 #include <vector>
 
 class Function {

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -39,6 +39,7 @@
 #include "llvmutil.h"
 #include "module.h"
 #include "util.h"
+
 #include <sstream>
 #include <stdarg.h> /* va_list, va_start, va_arg, va_end */
 #include <stdio.h>
@@ -47,21 +48,21 @@
 #include <windows.h>
 #define strcasecmp stricmp
 #include <intrin.h>
-#else
+#else // !ISPC_HOST_IS_WINDOWS
 #include <sys/types.h>
 #include <unistd.h>
-#endif
+#endif // ISPC_HOST_IS_WINDOWS
+
+#include <llvm/BinaryFormat/Dwarf.h>
 #include <llvm/CodeGen/TargetLowering.h>
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
+#include <llvm/IR/Attributes.h>
 #include <llvm/IR/DIBuilder.h>
+#include <llvm/IR/DataLayout.h>
 #include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
-
-#include <llvm/BinaryFormat/Dwarf.h>
-#include <llvm/IR/Attributes.h>
-#include <llvm/IR/DataLayout.h>
 #include <llvm/Support/CodeGen.h>
 #include <llvm/Support/Host.h>
 #include <llvm/Support/TargetRegistry.h>

--- a/src/ispc_version.h
+++ b/src/ispc_version.h
@@ -40,7 +40,7 @@
 #define ISPC_VERSION_MAJOR 1
 #define ISPC_VERSION_MINOR 14
 #define ISPC_VERSION "1.14.0dev"
-#include "llvm/Config/llvm-config.h"
+#include <llvm/Config/llvm-config.h>
 
 #define ISPC_LLVM_VERSION (LLVM_VERSION_MAJOR * 10000 + LLVM_VERSION_MINOR * 100)
 

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -38,13 +38,15 @@
 #include "llvmutil.h"
 #include "ispc.h"
 #include "type.h"
+
+#include <map>
+#include <set>
+#include <vector>
+
 #include <llvm/Analysis/ValueTracking.h>
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
-#include <map>
-#include <set>
-#include <vector>
 
 llvm::Type *LLVMTypes::VoidType = NULL;
 llvm::PointerType *LLVMTypes::VoidPointerType = NULL;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "target_registry.h"
 #include "type.h"
 #include "util.h"
+
 #include <cstdarg>
 #include <stdio.h>
 #include <stdlib.h>
@@ -48,6 +49,7 @@
 #else
 #include <unistd.h>
 #endif // ISPC_HOST_IS_WINDOWS
+
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/Signals.h>

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -62,7 +62,7 @@
 #include <windows.h>
 #define strcasecmp stricmp
 #endif
-#include "llvm/IR/LegacyPassManager.h"
+
 #include <clang/Basic/TargetInfo.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/TextDiagnosticPrinter.h>
@@ -78,6 +78,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Intrinsics.h>
 #include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Type.h>
 #include <llvm/IR/Verifier.h>

--- a/src/module.h
+++ b/src/module.h
@@ -40,6 +40,7 @@
 
 #include "ast.h"
 #include "ispc.h"
+
 #include <llvm/IR/DebugInfo.h>
 
 namespace llvm {

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -47,54 +47,46 @@
 #include <set>
 #include <stdio.h>
 
-#include "llvm/InitializePasses.h"
-#include <llvm/IR/BasicBlock.h>
-#include <llvm/IR/Constants.h>
-#include <llvm/IR/Function.h>
-#include <llvm/IR/Instructions.h>
-#include <llvm/IR/Intrinsics.h>
-#include <llvm/IR/Module.h>
-#include <llvm/Pass.h>
-
-#include <llvm/Transforms/Instrumentation.h>
-
-#include "llvm/IR/LegacyPassManager.h"
-
-#include <llvm/PassRegistry.h>
-
-#include <llvm/IR/DebugInfo.h>
-#include <llvm/IR/IRPrintingPasses.h>
-#include <llvm/IR/PatternMatch.h>
-#include <llvm/IR/Verifier.h>
-
-#include <llvm/Analysis/ConstantFolding.h>
-
-#include "llvm/Transforms/InstCombine/InstCombine.h"
-#include "llvm/Transforms/Utils.h"
 #include <llvm/ADT/SmallSet.h>
 #include <llvm/ADT/Triple.h>
-#include <llvm/Analysis/TargetLibraryInfo.h>
-#include <llvm/Target/TargetOptions.h>
-#include <llvm/Transforms/IPO.h>
-#include <llvm/Transforms/Scalar.h>
-#include <llvm/Transforms/Utils/BasicBlockUtils.h>
-
-#include <llvm/Analysis/TargetTransformInfo.h>
-#include <llvm/IR/DataLayout.h>
-
-#include "llvm/Analysis/TypeBasedAliasAnalysis.h"
-#include "llvm/Transforms/IPO/FunctionAttrs.h"
-#include "llvm/Transforms/Scalar/GVN.h"
 #include <llvm/Analysis/BasicAliasAnalysis.h>
+#include <llvm/Analysis/ConstantFolding.h>
 #include <llvm/Analysis/Passes.h>
+#include <llvm/Analysis/TargetLibraryInfo.h>
+#include <llvm/Analysis/TargetTransformInfo.h>
+#include <llvm/Analysis/TypeBasedAliasAnalysis.h>
 #include <llvm/BinaryFormat/Dwarf.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DataLayout.h>
+#include <llvm/IR/DebugInfo.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRPrintingPasses.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/IntrinsicInst.h>
+#include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/PatternMatch.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/InitializePasses.h>
+#include <llvm/Pass.h>
+#include <llvm/PassRegistry.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
+#include <llvm/Target/TargetOptions.h>
+#include <llvm/Transforms/IPO.h>
+#include <llvm/Transforms/IPO/FunctionAttrs.h>
+#include <llvm/Transforms/InstCombine/InstCombine.h>
+#include <llvm/Transforms/Instrumentation.h>
+#include <llvm/Transforms/Scalar.h>
+#include <llvm/Transforms/Scalar/GVN.h>
+#include <llvm/Transforms/Utils.h>
+#include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_10_0
-#include "llvm/IR/IntrinsicsX86.h"
+#include <llvm/IR/IntrinsicsX86.h>
 #endif
 
-#include <llvm/IR/IntrinsicInst.h>
 #ifdef ISPC_HOST_IS_LINUX
 #include <alloca.h>
 #elif defined(ISPC_HOST_IS_WINDOWS)

--- a/src/target_registry.cpp
+++ b/src/target_registry.cpp
@@ -35,12 +35,12 @@
     @brief Registry to handle bitcode libraries.
 */
 
+#include "target_registry.h"
+#include "util.h"
+
 #include <numeric>
 #include <string>
 #include <vector>
-
-#include "target_registry.h"
-#include "util.h"
 
 // Returns number of bits required to store this value
 static constexpr uint32_t bits_required(uint32_t x) {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -41,14 +41,15 @@
 #include "module.h"
 #include "sym.h"
 
+#include <map>
+#include <stdio.h>
+
 #include <llvm/BinaryFormat/Dwarf.h>
 #include <llvm/IR/DIBuilder.h>
 #include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Value.h>
 #include <llvm/Support/MathExtras.h>
-#include <map>
-#include <stdio.h>
 
 /** Utility routine used in code that prints out declarations; returns true
     if the given name should be printed, false otherwise.  This allows us

--- a/src/util.h
+++ b/src/util.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include "ispc.h"
+
 #ifdef ISPC_HOST_IS_WINDOWS
 #include <stdarg.h>
 #endif


### PR DESCRIPTION
The changes are assumed to be purely editorial. includes go separate groups:
(1) ISPC includes
(2) C++ library includes
(3) LLVM includes

clang-format was applied to sort these groups.