### PR TITLE
Benchmarks

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -93,9 +93,9 @@ for:
         cd %ISPC_HOME%
         check_env.py
         mkdir build && cd build
-        cmake .. -Thost=x64 -G %generator% -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%ISPC_HOME%\install -DISPC_PREPARE_PACKAGE=ON -DM4_EXECUTABLE=C:\cygwin64\bin\m4.exe -DISPC_CROSS=ON -DISPC_GNUWIN32_PATH=%CROSS_TOOLS%\gnuwin32 -DISPC_MACOS_SDK_PATH=%CROSS_TOOLS%\%MACOS_SDK% -DWASM_ENABLED=%WASM% -DISPC_INCLUDE_BENCHMARKS=ON
+        cmake .. -Thost=x64 -G %generator% -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=%ISPC_HOME%\install -DISPC_PREPARE_PACKAGE=ON -DM4_EXECUTABLE=C:\cygwin64\bin\m4.exe -DISPC_CROSS=ON -DISPC_GNUWIN32_PATH=%CROSS_TOOLS%\gnuwin32 -DISPC_MACOS_SDK_PATH=%CROSS_TOOLS%\%MACOS_SDK% -DWASM_ENABLED=%WASM% -DISPC_INCLUDE_BENCHMARKS=ON
   build_script:
-    - cmd: msbuild %ISPC_HOME%\build\PACKAGE.vcxproj /p:Platform=x64 /p:Configuration=Release
+    - cmd: msbuild %ISPC_HOME%\build\PACKAGE.vcxproj /p:Platform=x64 /p:Configuration=%configuration%
   test_script:
   # Perf tests require Win64 configuration. "Visual Studio 16" generator is Win64 by default but for older versions
   # we need to specify it manually.
@@ -104,7 +104,7 @@ for:
         cd %ISPC_HOME%
         check_isa.exe
         ispc --support-matrix
-        python perf.py -n 1 -g %generator% && msbuild %ISPC_HOME%\build\tests\check-all.vcxproj /t:Build /p:Platform=x64 /p:Configuration=Release
+        python perf.py -n 1 -g %generator% && msbuild %ISPC_HOME%\build\tests\check-all.vcxproj /t:Build /p:Platform=x64 /p:Configuration=%configuration% && msbuild %ISPC_HOME%\build\RUN_TESTS.vcxproj /t:Build /p:Platform=x64 /p:Configuration=%configuration%
 
 -
   matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -93,7 +93,7 @@ for:
         cd %ISPC_HOME%
         check_env.py
         mkdir build && cd build
-        cmake .. -Thost=x64 -G %generator% -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%ISPC_HOME%\install -DISPC_PREPARE_PACKAGE=ON -DM4_EXECUTABLE=C:\cygwin64\bin\m4.exe -DISPC_CROSS=ON -DISPC_GNUWIN32_PATH=%CROSS_TOOLS%\gnuwin32 -DISPC_MACOS_SDK_PATH=%CROSS_TOOLS%\%MACOS_SDK% -DWASM_ENABLED=%WASM%
+        cmake .. -Thost=x64 -G %generator% -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%ISPC_HOME%\install -DISPC_PREPARE_PACKAGE=ON -DM4_EXECUTABLE=C:\cygwin64\bin\m4.exe -DISPC_CROSS=ON -DISPC_GNUWIN32_PATH=%CROSS_TOOLS%\gnuwin32 -DISPC_MACOS_SDK_PATH=%CROSS_TOOLS%\%MACOS_SDK% -DWASM_ENABLED=%WASM% -DISPC_INCLUDE_BENCHMARKS=ON
   build_script:
     - cmd: msbuild %ISPC_HOME%\build\PACKAGE.vcxproj /p:Platform=x64 /p:Configuration=Release
   test_script:

--- a/benchmarks/01_trivial/01_aossoa.cpp
+++ b/benchmarks/01_trivial/01_aossoa.cpp
@@ -66,8 +66,8 @@ template <typename T> static void check3(T *dst, int count) {
 #define AOS_TO_SOA_STDLIB(N, T_C, T_ISPC)                                                                              \
     static void aos_to_soa##N##_stdlib_##T_ISPC(benchmark::State &state) {                                             \
         int count = state.range(0);                                                                                    \
-        T_C *src = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
-        T_C *dst = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
+        T_C *src = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
+        T_C *dst = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         init(src, dst, count);                                                                                         \
                                                                                                                        \
         for (auto _ : state) {                                                                                         \
@@ -75,16 +75,16 @@ template <typename T> static void check3(T *dst, int count) {
         }                                                                                                              \
                                                                                                                        \
         check##N(dst, count);                                                                                          \
-        free(src);                                                                                                     \
-        free(dst);                                                                                                     \
+        aligned_free_helper(src);                                                                                      \
+        aligned_free_helper(dst);                                                                                      \
     }                                                                                                                  \
     BENCHMARK(aos_to_soa##N##_stdlib_##T_ISPC)->ARGS##N;
 
 #define AOS_TO_SOA_ISPC(N, T_C, T_ISPC)                                                                                \
     static void aos_to_soa##N##_ispc_##T_ISPC(benchmark::State &state) {                                               \
         int count = state.range(0);                                                                                    \
-        T_C *src = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
-        T_C *dst = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
+        T_C *src = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
+        T_C *dst = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         init(src, dst, count);                                                                                         \
                                                                                                                        \
         for (auto _ : state) {                                                                                         \
@@ -92,8 +92,8 @@ template <typename T> static void check3(T *dst, int count) {
         }                                                                                                              \
                                                                                                                        \
         check##N(dst, count);                                                                                          \
-        free(src);                                                                                                     \
-        free(dst);                                                                                                     \
+        aligned_free_helper(src);                                                                                      \
+        aligned_free_helper(dst);                                                                                      \
     }                                                                                                                  \
     BENCHMARK(aos_to_soa##N##_ispc_##T_ISPC)->ARGS##N;
 

--- a/benchmarks/01_trivial/01_aossoa.cpp
+++ b/benchmarks/01_trivial/01_aossoa.cpp
@@ -65,7 +65,7 @@ template <typename T> static void check3(T *dst, int count) {
 
 #define AOS_TO_SOA_STDLIB(N, T_C, T_ISPC)                                                                              \
     static void aos_to_soa##N##_stdlib_##T_ISPC(benchmark::State &state) {                                             \
-        int count = state.range(0);                                                                                    \
+        int count = static_cast<int>(state.range(0));                                                                  \
         T_C *src = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         T_C *dst = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         init(src, dst, count);                                                                                         \
@@ -82,7 +82,7 @@ template <typename T> static void check3(T *dst, int count) {
 
 #define AOS_TO_SOA_ISPC(N, T_C, T_ISPC)                                                                                \
     static void aos_to_soa##N##_ispc_##T_ISPC(benchmark::State &state) {                                               \
-        int count = state.range(0);                                                                                    \
+        int count = static_cast<int>(state.range(0));                                                                  \
         T_C *src = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         T_C *dst = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         init(src, dst, count);                                                                                         \

--- a/benchmarks/01_trivial/01_aossoa.ispc
+++ b/benchmarks/01_trivial/01_aossoa.ispc
@@ -115,7 +115,7 @@ static const varying int vPerm43 = {32,  33,  34,  35,  36,  37,  38,  39,  40, 
         *v3 = shuffle(t3, t1, vPerm43);                                                                                \
     }                                                                                                                  \
                                                                                                                        \
-    export void aos_to_soa4_ispc_##T(uniform T *uniform input, uniform T *uniform output, uniform T n) {               \
+    export void aos_to_soa4_ispc_##T(uniform T *uniform input, uniform T *uniform output, uniform int n) {             \
         uniform int chunk = 4 * programCount;                                                                          \
         uniform int iterations = n / chunk;                                                                            \
                                                                                                                        \
@@ -213,7 +213,7 @@ static const varying int vPerm35 = {0,  1,  2,  3,  4,  5,  6,   7,   8,   9,   
         *v2 = shuffle(t2, src2, vPerm35);                                                                              \
     }                                                                                                                  \
                                                                                                                        \
-    export void aos_to_soa3_ispc_##T(uniform T *uniform input, uniform T *uniform output, uniform T n) {               \
+    export void aos_to_soa3_ispc_##T(uniform T *uniform input, uniform T *uniform output, uniform int n) {             \
         uniform int chunk = 3 * programCount;                                                                          \
         uniform int iterations = n / chunk;                                                                            \
                                                                                                                        \

--- a/benchmarks/01_trivial/02_soaaos.cpp
+++ b/benchmarks/01_trivial/02_soaaos.cpp
@@ -64,8 +64,8 @@ template <typename T> static void check(T *dst, int count) {
 #define SOA_TO_AOS_STDLIB(N, T_C, T_ISPC)                                                                              \
     static void soa_to_aos##N##_stdlib_##T_ISPC(benchmark::State &state) {                                             \
         int count = state.range(0);                                                                                    \
-        T_C *src = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
-        T_C *dst = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
+        T_C *src = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
+        T_C *dst = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         init##N(src, dst, count);                                                                                      \
                                                                                                                        \
         for (auto _ : state) {                                                                                         \
@@ -73,16 +73,16 @@ template <typename T> static void check(T *dst, int count) {
         }                                                                                                              \
                                                                                                                        \
         check(dst, count);                                                                                             \
-        free(src);                                                                                                     \
-        free(dst);                                                                                                     \
+        aligned_free_helper(src);                                                                                      \
+        aligned_free_helper(dst);                                                                                      \
     }                                                                                                                  \
     BENCHMARK(soa_to_aos##N##_stdlib_##T_ISPC)->ARGS##N;
 
 #define SOA_TO_AOS_ISPC(N, T_C, T_ISPC)                                                                                \
     static void soa_to_aos##N##_ispc_##T_ISPC(benchmark::State &state) {                                               \
         int count = state.range(0);                                                                                    \
-        T_C *src = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
-        T_C *dst = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
+        T_C *src = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
+        T_C *dst = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         init(src, dst, count);                                                                                         \
                                                                                                                        \
         for (auto _ : state) {                                                                                         \
@@ -90,8 +90,8 @@ template <typename T> static void check(T *dst, int count) {
         }                                                                                                              \
                                                                                                                        \
         check##N(dst, count);                                                                                          \
-        free(src);                                                                                                     \
-        free(dst);                                                                                                     \
+        aligned_free_helper(src);                                                                                      \
+        aligned_free_helper(dst);                                                                                      \
     }                                                                                                                  \
     BENCHMARK(soa_to_aos##N##_ispc_##T_ISPC)->ARGS##N;
 

--- a/benchmarks/01_trivial/02_soaaos.cpp
+++ b/benchmarks/01_trivial/02_soaaos.cpp
@@ -63,7 +63,7 @@ template <typename T> static void check(T *dst, int count) {
 
 #define SOA_TO_AOS_STDLIB(N, T_C, T_ISPC)                                                                              \
     static void soa_to_aos##N##_stdlib_##T_ISPC(benchmark::State &state) {                                             \
-        int count = state.range(0);                                                                                    \
+        int count = static_cast<int>(state.range(0));                                                                  \
         T_C *src = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         T_C *dst = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         init##N(src, dst, count);                                                                                      \
@@ -80,7 +80,7 @@ template <typename T> static void check(T *dst, int count) {
 
 #define SOA_TO_AOS_ISPC(N, T_C, T_ISPC)                                                                                \
     static void soa_to_aos##N##_ispc_##T_ISPC(benchmark::State &state) {                                               \
-        int count = state.range(0);                                                                                    \
+        int count = static_cast<int>(state.range(0));                                                                  \
         T_C *src = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         T_C *dst = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         init(src, dst, count);                                                                                         \

--- a/benchmarks/01_trivial/03_popcnt.cpp
+++ b/benchmarks/01_trivial/03_popcnt.cpp
@@ -55,8 +55,8 @@ template <typename T> static void check_even(T *src, T *dst, int count) {
 #define POPCNT(T_C, T_ISPC, V, ALL)                                                                                    \
     static void popcnt_stdlib_##V##_##T_ISPC##_##ALL(benchmark::State &state) {                                        \
         int count = state.range(0);                                                                                    \
-        T_C *src = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
-        T_C *dst = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
+        T_C *src = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
+        T_C *dst = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         init(src, dst, count);                                                                                         \
                                                                                                                        \
         for (auto _ : state) {                                                                                         \
@@ -64,8 +64,8 @@ template <typename T> static void check_even(T *src, T *dst, int count) {
         }                                                                                                              \
                                                                                                                        \
         check_##ALL(src, dst, count);                                                                                  \
-        free(src);                                                                                                     \
-        free(dst);                                                                                                     \
+        aligned_free_helper(src);                                                                                      \
+        aligned_free_helper(dst);                                                                                      \
         state.SetComplexityN(state.range(0));                                                                          \
     }                                                                                                                  \
     BENCHMARK(popcnt_stdlib_##V##_##T_ISPC##_##ALL)->ARGS;

--- a/benchmarks/01_trivial/03_popcnt.cpp
+++ b/benchmarks/01_trivial/03_popcnt.cpp
@@ -54,7 +54,7 @@ template <typename T> static void check_even(T *src, T *dst, int count) {
 
 #define POPCNT(T_C, T_ISPC, V, ALL)                                                                                    \
     static void popcnt_stdlib_##V##_##T_ISPC##_##ALL(benchmark::State &state) {                                        \
-        int count = state.range(0);                                                                                    \
+        int count = static_cast<int>(state.range(0));                                                                  \
         T_C *src = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         T_C *dst = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         init(src, dst, count);                                                                                         \

--- a/benchmarks/01_trivial/04_fastdiv.cpp
+++ b/benchmarks/01_trivial/04_fastdiv.cpp
@@ -44,7 +44,7 @@ template <typename T> static void check(T *src, T *dst, int divisor, int count) 
 
 #define FASTDIV(T_C, T_ISPC, DIV_VAL)                                                                                  \
     static void fastdiv_##T_ISPC##_##DIV_VAL(benchmark::State &state) {                                                \
-        int count = state.range(0);                                                                                    \
+        int count = static_cast<int>(state.range(0));                                                                  \
         T_C *dst = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         T_C *src = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         init_src(src, count);                                                                                          \

--- a/benchmarks/01_trivial/04_fastdiv.cpp
+++ b/benchmarks/01_trivial/04_fastdiv.cpp
@@ -45,8 +45,8 @@ template <typename T> static void check(T *src, T *dst, int divisor, int count) 
 #define FASTDIV(T_C, T_ISPC, DIV_VAL)                                                                                  \
     static void fastdiv_##T_ISPC##_##DIV_VAL(benchmark::State &state) {                                                \
         int count = state.range(0);                                                                                    \
-        T_C *dst = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
-        T_C *src = static_cast<T_C *>(aligned_alloc(ALIGNMENT, sizeof(T_C) * count));                                  \
+        T_C *dst = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
+        T_C *src = static_cast<T_C *>(aligned_alloc_helper(sizeof(T_C) * count));                                      \
         init_src(src, count);                                                                                          \
         init_dst(dst, count);                                                                                          \
                                                                                                                        \
@@ -55,8 +55,8 @@ template <typename T> static void check(T *src, T *dst, int divisor, int count) 
         }                                                                                                              \
                                                                                                                        \
         check(src, dst, DIV_VAL, count);                                                                               \
-        free(src);                                                                                                     \
-        free(dst);                                                                                                     \
+        aligned_free_helper(src);                                                                                      \
+        aligned_free_helper(dst);                                                                                      \
         state.SetComplexityN(state.range(0));                                                                          \
     }                                                                                                                  \
     BENCHMARK(fastdiv_##T_ISPC##_##DIV_VAL)->ARGS;

--- a/benchmarks/02_medium/test01.cpp
+++ b/benchmarks/02_medium/test01.cpp
@@ -4,16 +4,16 @@
 
 #include "test01_ispc.h"
 
-const float eps = 0.00001;
+const float eps = 0.00001f;
 #define ARGS Arg(100)->Arg(1000)->Arg(10000)
 
 using namespace ispc;
 
 static void init(struct FVector *dst, struct FVector *src0, struct FVector *src1, int count) {
     for (int i = 0; i < count; i++) {
-        src0[i].V[0] = i;
-        src0[i].V[1] = i + 1;
-        src0[i].V[2] = i + 2;
+        src0[i].V[0] = (float)i;
+        src0[i].V[1] = (float)(i + 1);
+        src0[i].V[2] = (float)(i + 2);
         src1[i].V[0] = 2;
         src1[i].V[1] = 4;
         src1[i].V[2] = 8;
@@ -35,7 +35,7 @@ static void check(struct FVector *dst, struct FVector *src0, struct FVector *src
 }
 
 static void test01_1(benchmark::State &state) {
-    int count = state.range(0);
+    int count = static_cast<int>(state.range(0));
     FVector *src0 = new FVector[count];
     FVector *src1 = new FVector[count];
     FVector *dst = new FVector[count];
@@ -53,7 +53,7 @@ static void test01_1(benchmark::State &state) {
 BENCHMARK(test01_1)->ARGS;
 
 static void test01_2(benchmark::State &state) {
-    int count = state.range(0);
+    int count = static_cast<int>(state.range(0));
     FVector *src0 = new FVector[count];
     FVector *src1 = new FVector[count];
     FVector *dst = new FVector[count];
@@ -71,7 +71,7 @@ static void test01_2(benchmark::State &state) {
 BENCHMARK(test01_2)->ARGS;
 
 static void test01_3(benchmark::State &state) {
-    int count = state.range(0);
+    int count = static_cast<int>(state.range(0));
     FVector *src0 = new FVector[count];
     FVector *src1 = new FVector[count];
     FVector *dst = new FVector[count];

--- a/benchmarks/common.h
+++ b/benchmarks/common.h
@@ -1,5 +1,12 @@
+#include <cassert>
 #include <iostream>
 #include <string>
+
+#if defined(_WIN32) || defined(_WIN64)
+#include <malloc.h>
+#else
+#include <cstdlib>
+#endif
 
 // Set maximum alignment for existing ISPC targets.
 #define ALIGNMENT 64
@@ -8,3 +15,22 @@ class Docs {
   public:
     Docs(std::string message) { std::cout << message << "\n"; }
 };
+
+// Helper function to enabled allocated allocations.
+// Despite aligned_alloc() is part of C++, MSVS doesn't support it.
+void *aligned_alloc_helper(size_t size, size_t alignment = ALIGNMENT) {
+    assert(size % alignment == 0 && "Size is not multiple of alignment");
+#if defined(_WIN32) || defined(_WIN64)
+    return _aligned_malloc(size, alignment);
+#else
+    return aligned_alloc(alignment, size);
+#endif
+}
+
+void aligned_free_helper(void *ptr) {
+#if defined(_WIN32) || defined(_WIN64)
+    _aligned_free(ptr);
+#else
+    free(ptr);
+#endif
+}


### PR DESCRIPTION
* fix build warnings when building benchmarks on Windows
* enable benchmarks build in Appveyor (on WIndows).