### PR TITLE
Add testing with LLVM 11.0 and other fixes.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,13 +32,15 @@
 configuration: Release
 
 environment:
-  LLVM_LATEST: 10.0
+  LLVM_LATEST: 11.0
   DOCKER_PATH: "ispc/test_repo"
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1604
       LLVM_VERSION: latest
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: latest
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      LLVM_VERSION: 10.0
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: 9.0
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -61,7 +63,8 @@ for:
         if "%LLVM_VERSION%"=="latest" (set WASM=ON)
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( (set generator="Visual Studio 15 Win64") & (set vsversion=2017))
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vsversion=2019))
-        set LLVM_TAR=llvm-10.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.zip
+        set LLVM_TAR=llvm-11.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z
+        if "%LLVM_VERSION%"=="10.0" (set LLVM_TAR=llvm-10.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.zip)
         if "%LLVM_VERSION%"=="9.0" (set LLVM_TAR=llvm-9.0.1-win.vs2017-Release+Asserts-x86.arm.wasm.zip)
         if "%LLVM_VERSION%"=="8.0" (set LLVM_TAR=llvm-8.0.1-win.vs2017-Release+Asserts-x86.arm.wasm.zip)
   install:
@@ -113,7 +116,7 @@ for:
         export CROSS_TOOLS=/usr/local/src/cross
         export MACOS_SDK=MacOSX10.13.sdk
         export WASM=OFF
-        export LLVM_TAR=llvm-10.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        export LLVM_TAR=llvm-11.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
   install:
     - sh: |-
         sudo apt-get update

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,8 +43,6 @@ environment:
       LLVM_VERSION: 10.0
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: 9.0
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      LLVM_VERSION: 8.0
 
 for:
 -
@@ -66,7 +64,6 @@ for:
         set LLVM_TAR=llvm-11.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z
         if "%LLVM_VERSION%"=="10.0" (set LLVM_TAR=llvm-10.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.zip)
         if "%LLVM_VERSION%"=="9.0" (set LLVM_TAR=llvm-9.0.1-win.vs2017-Release+Asserts-x86.arm.wasm.zip)
-        if "%LLVM_VERSION%"=="8.0" (set LLVM_TAR=llvm-8.0.1-win.vs2017-Release+Asserts-x86.arm.wasm.zip)
   install:
     - ps: choco install --no-progress winflexbison3 wget 7zip
     - cmd: |-

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,13 +113,6 @@ jobs:
         - LLVM_TAR=llvm-9.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
         - LLVM_REPO=https://github.com/dbabokin/llvm-project
         - ISPC_HOME=$TRAVIS_BUILD_DIR
-    # LLVM 8.0 + Ubuntu 16.04: build, lit tests, examples (build + run), benchmarks (build + trial run)
-    - <<: *my_tag
-      env:
-        - LLVM_VERSION=8.0 OS=Ubuntu16.04
-        - LLVM_TAR=llvm-8.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
-        - LLVM_REPO=https://github.com/dbabokin/llvm-project
-        - ISPC_HOME=$TRAVIS_BUILD_DIR
     # WASM enabled build
     # LLVM 11.0 + Ubuntu 16.04: build, lit tests, examples (build), benchmarks (build + trial run)
     - <<: *my_tag

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ my_tag: &my_tag
           # Run examples
         - if [ -z "$WASM_FLAGS" ]; then ./perf.py -n 1; fi
           # Run tests for latest LLVM version
-        - if [ "$LLVM_VERSION" == "10.0" -a -z "$WASM_FLAGS" ]; then ./run_tests.py; ./run_tests.py -a x86; fi
+        - if [ "$LLVM_VERSION" == "11.0" -a -z "$WASM_FLAGS" ]; then ./run_tests.py; ./run_tests.py -a x86; fi
 
 stages:
   - check format
@@ -92,7 +92,14 @@ jobs:
       before_install:
       script:
         - ./check_format.sh clang-format-10
-    # LLVM 10.0 + Ubuntu 16.04: build, lit tests, examples (build + run), benchmarks (build + trial run), tests
+    # LLVM 11.0 + Ubuntu 16.04: build, lit tests, examples (build + run), benchmarks (build + trial run), tests
+    - <<: *my_tag
+      env:
+        - LLVM_VERSION=11.0 OS=Ubuntu16.04
+        - LLVM_TAR=llvm-11.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_REPO=https://github.com/dbabokin/llvm-project
+        - ISPC_HOME=$TRAVIS_BUILD_DIR
+    # LLVM 10.0 + Ubuntu 16.04: build, lit tests, examples (build + run), benchmarks (build + trial run)
     - <<: *my_tag
       env:
         - LLVM_VERSION=10.0 OS=Ubuntu16.04
@@ -114,15 +121,15 @@ jobs:
         - LLVM_REPO=https://github.com/dbabokin/llvm-project
         - ISPC_HOME=$TRAVIS_BUILD_DIR
     # WASM enabled build
-    # LLVM 10.0 + Ubuntu 16.04: build, lit tests, examples (build), benchmarks (build + trial run)
+    # LLVM 11.0 + Ubuntu 16.04: build, lit tests, examples (build), benchmarks (build + trial run)
     - <<: *my_tag
       env:
-        - LLVM_VERSION=10.0 OS=Ubuntu16.04 WASM_FLAGS="-DWASM_ENABLED=ON"
-        - LLVM_TAR=llvm-10.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_VERSION=11.0 OS=Ubuntu16.04 WASM_FLAGS="-DWASM_ENABLED=ON"
+        - LLVM_TAR=llvm-11.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
         - LLVM_REPO=https://github.com/dbabokin/llvm-project
         - ISPC_HOME=$TRAVIS_BUILD_DIR
     # ARM build
-    # LLVM 10.0 + Ubuntu 18.04:
+    # LLVM 11.0 + Ubuntu 18.04:
     #   - ARM only (default): build, lit tests, examples (build)
     #   - ARM + x86: build, lit tests, examples (build), tests (aarch64)
     - stage: test
@@ -130,8 +137,8 @@ jobs:
       arch: arm64
       dist: bionic
       env:
-        - LLVM_VERSION=10.0 OS=Ubuntu18.04aarch64
-        - LLVM_TAR=llvm-10.0.1-ubuntu16.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_VERSION=11.0 OS=Ubuntu18.04aarch64
+        - LLVM_TAR=llvm-11.0.0-ubuntu16.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
         - LLVM_REPO=https://github.com/dbabokin/llvm-project
         - ISPC_HOME=$TRAVIS_BUILD_DIR
       before_install:
@@ -167,13 +174,13 @@ jobs:
         - export ISPC_HOME=`pwd`
         - ./run_tests.py --arch=aarch64 --target=neon-i32x4
     # macOS build
-    # LLVM 10.0 + macOS 10.15 Catalina: build, lit tests, examples (build)
+    # LLVM 11.0 + macOS 10.15 Catalina: build, lit tests, examples (build)
     - stage: test
       os: osx
       osx_image: xcode11.4
       env:
-        - LLVM_VERSION=10.0 OS=macOS10.15
-        - LLVM_TAR=llvm-10.0.1-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_VERSION=11.0 OS=macOS10.15
+        - LLVM_TAR=llvm-11.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
         - LLVM_REPO=https://github.com/dbabokin/llvm-project
         - ISPC_HOME=$TRAVIS_BUILD_DIR
       before_install:

--- a/alloy.py
+++ b/alloy.py
@@ -477,35 +477,42 @@ def build_ispc(version_LLVM, make):
     os.chdir(current_path)
 
 def execute_stability(stability, R, print_version):
-    stability1 = copy.deepcopy(stability)
+    global return_status
+    try:
+        stability1 = copy.deepcopy(stability)
 
-    b_temp = run_tests.run_tests(stability1, [], print_version)
-    temp = b_temp[0]
-    time = b_temp[1]
-    for j in range(0,4):
-        R[j][0] = R[j][0] + temp[j] # new_runfails, new_compfails, new_passes_runfails, new_passes_compfails
-        for i in range(0,len(temp[j])):
-            R[j][1].append(temp[4])
-    number_of_fails = temp[5]
-    number_of_new_fails = len(temp[0]) + len(temp[1])
-    number_of_passes = len(temp[2]) + len(temp[3])
-    if number_of_fails == 0:
-        str_fails = ". No fails"
-    else:
-        str_fails = ". Fails: " + str(number_of_fails)
-    if number_of_new_fails == 0:
-        str_new_fails = ", No new fails"
-    else:
-        str_new_fails = ", New fails: " + str(number_of_new_fails)
-    if number_of_passes == 0:
-        str_new_passes = "."
-    else:
-        str_new_passes = ", " + str(number_of_passes) + " new passes."
-    if stability.time:
-        str_time = " " + time + "\n"
-    else:
-        str_time = "\n"
-    print_debug(temp[4][1:-3] + stability1.ispc_flags + str_fails + str_new_fails + str_new_passes + str_time, False, stability_log)
+        b_temp = run_tests.run_tests(stability1, [], print_version)
+        temp = b_temp[0]
+        time = b_temp[1]
+        for j in range(0,4):
+            R[j][0] = R[j][0] + temp[j] # new_runfails, new_compfails, new_passes_runfails, new_passes_compfails
+            for i in range(0,len(temp[j])):
+                R[j][1].append(temp[4])
+        number_of_fails = temp[5]
+        number_of_new_fails = len(temp[0]) + len(temp[1])
+        number_of_passes = len(temp[2]) + len(temp[3])
+        if number_of_fails == 0:
+            str_fails = ". No fails"
+        else:
+            str_fails = ". Fails: " + str(number_of_fails)
+        if number_of_new_fails == 0:
+            str_new_fails = ", No new fails"
+        else:
+            str_new_fails = ", New fails: " + str(number_of_new_fails)
+        if number_of_passes == 0:
+            str_new_passes = "."
+        else:
+            str_new_passes = ", " + str(number_of_passes) + " new passes."
+        if stability.time:
+            str_time = " " + time + "\n"
+        else:
+            str_time = "\n"
+        print_debug(temp[4][1:-3] + stability1.ispc_flags + str_fails + str_new_fails + str_new_passes + str_time, False, stability_log)
+    except:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        traceback.print_tb(exc_traceback, file=sys.stderr)
+        print_debug("ERROR: Exception in execute_stability: %s\n" % (sys.exc_info()[1]), False, stability_log)
+        return_status = 1
 
 
 '''
@@ -545,7 +552,6 @@ def concatenate_test_results(R1, R2):
     return R
 
 def validation_run(only, only_targets, reference_branch, number, notify, update, speed_number, make, perf_llvm, time):
-    global return_status
     os.chdir(os.environ["ISPC_HOME"])
     if current_OS != "Windows":
         os.environ["PATH"] = os.environ["ISPC_HOME"] + ":" + os.environ["PATH"]
@@ -696,13 +702,7 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
                             stability.ispc_flags = ispc_flags_tmp
                             if (i3 != 0):
                                 stability.ispc_flags += " -g"
-                            try:
-                                execute_stability(stability, R_tmp, print_version)
-                            except:
-                                exc_type, exc_value, exc_traceback = sys.exc_info()
-                                traceback.print_tb(exc_traceback, file=sys.stderr)
-                                print_debug("ERROR: Exception in execute_stability: %s\n" % (sys.exc_info()[1]), False, stability_log)
-                                return_status = 1
+                            execute_stability(stability, R_tmp, print_version)
                             print_version = 0
             for j in range(0,len(sde_targets)):
                 stability.target = sde_targets[j][1]

--- a/docs/template-perf.txt
+++ b/docs/template-perf.txt
@@ -20,7 +20,7 @@
     <div id="header">
       <h1 id="logo">Intel® Implicit SPMD Program Compiler</h1>
       <div id="slogan">An open-source compiler for high-performance SIMD programming on
-      the CPU</div>
+      the CPU and GPU</div>
     </div>
     <div id="nav">
       <div id="nbar">

--- a/docs/template.txt
+++ b/docs/template.txt
@@ -20,7 +20,7 @@
     <div id="header">
       <h1 id="logo">Intel® Implicit SPMD Program Compiler</h1>
       <div id="slogan">An open-source compiler for high-performance SIMD programming on
-      the CPU</div>
+      the CPU and GPU</div>
     </div>
     <div id="nav">
       <div id="nbar">

--- a/run_tests.py
+++ b/run_tests.py
@@ -84,7 +84,7 @@ class Host(object):
                     ispc_exe = counter + os.sep + "ispc" + ispc_ext
         # checks the required ispc compiler otherwise prints an error message
         if ispc_exe == "":
-            error("ISPC compiler not found.\nAdded path to ispc compiler to your PATH variable or ISPC_HOME variable\n", 1)
+            error("ISPC compiler not found.\nAdd path to ispc compiler to your PATH or ISPC_HOME env variable\n", 1)
         # use relative path
         self.ispc_exe = os.path.relpath(ispc_exe, os.getcwd())
 

--- a/scripts/install_emscripten.sh
+++ b/scripts/install_emscripten.sh
@@ -2,6 +2,7 @@ WD=`pwd`
 git clone https://github.com/emscripten-core/emsdk.git && \
 cd emsdk
 git pull && \
+git checkout 2.0.4 && \
 ./emsdk install sdk-1.39.11-64bit && \
 ./emsdk activate sdk-1.39.11-64bit  && \
 source ./emsdk_env.sh


### PR DESCRIPTION
- Adding testing with LLVM 11.0 to Appveyor and Travis.
- Removing testing with LLVM 8.0 from Appveyor and Travis.
- Changing emcc testing for Linux to use fixed version instead of trunk (as we do on Windows).
- Fix alloy.py to fail uniformly with native testing and SDE.
- Fix site template to say that ISPC compiler for CPU *and GPU*.