### PR TITLE
Github Actions fixes

### DIFF
--- a/.github/workflows/linux-nightly-llvm10.yml
+++ b/.github/workflows/linux-nightly-llvm10.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - '**test_nightly**'
+  workflow_dispatch:
 
 env:
   LLVM_VERSION: "10.0"

--- a/.github/workflows/linux-nightly-llvm10.yml
+++ b/.github/workflows/linux-nightly-llvm10.yml
@@ -31,7 +31,7 @@ jobs:
         sudo apt-get install bison flex libc6-dev-i386 g++-multilib lib32stdc++6 ncurses-dev
         wget -q $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
         tar xf $LLVM_TAR
-        echo "PATH=${GITHUB_WORKSPACE}/bin-$LLVM_VERSION/bin:$PATH" >> $GITHUB_ENV
+        echo "${GITHUB_WORKSPACE}/bin-$LLVM_VERSION/bin" >> $GITHUB_PATH
 
     - name: Check environment
       run: |
@@ -41,6 +41,7 @@ jobs:
 
     - name: Build package
       run: |
+        echo PATH=$PATH
         mkdir build && cd build
         cmake .. -DISPC_PREPARE_PACKAGE=ON -DISPC_INCLUDE_BENCHMARKS=ON
         make -j4 package
@@ -84,9 +85,9 @@ jobs:
         find /usr -name cdefs.h
         wget --user-agent='Mozilla/4.0' https://software.intel.com/content/dam/develop/external/us/en/documents/$SDE_TAR_NAME.tar.bz2
         tar xf $SDE_TAR_NAME.tar.bz2
-        echo "ADD_PATH=$GITHUB_WORKSPACE/$SDE_TAR_NAME:$ADD_PATH" >> $GITHUB_ENV
+        echo "SDE_HOME=$GITHUB_WORKSPACE/$SDE_TAR_NAME" >> $GITHUB_ENV
         tar xf ispc-trunk-linux.tar.gz
-        echo "ADD_PATH=$GITHUB_WORKSPACE/ispc-trunk-linux/bin:$ADD_PATH" >> $GITHUB_ENV
+        echo "$GITHUB_WORKSPACE/ispc-trunk-linux/bin" >> $GITHUB_PATH
         echo "LLVM_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
         echo "ISPC_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
 
@@ -95,9 +96,7 @@ jobs:
         cat /proc/cpuinfo
     - name: Running tests
       run: |
-        # Setting PATH in prev step not surived moving to this step
-        # use ADD_PATH to pass it through steps in this job.
-        export PATH=$ADD_PATH:$PATH
+        echo PATH=$PATH
         ./alloy.py -r --only="stability current -O0 -O1 -O2" --only-targets="${{ matrix.target }}" --time --update-errors=FP
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@v2

--- a/.github/workflows/linux-nightly-llvm10.yml
+++ b/.github/workflows/linux-nightly-llvm10.yml
@@ -14,7 +14,7 @@ env:
   LLVM_VERSION: "10.0"
   LLVM_REPO: https://github.com/dbabokin/llvm-project
   LLVM_TAR: llvm-10.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
-  SDE_TAR_NAME: sde-external-8.56.0-2020-07-05-lin
+  SDE_TAR_NAME: sde-external-8.59.0-2020-10-05-lin
 
 jobs:
   linux-build:
@@ -29,7 +29,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install bison flex libc6-dev-i386 g++-multilib lib32stdc++6 ncurses-dev
-        wget -q $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
+        wget $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
         tar xf $LLVM_TAR
         echo "${GITHUB_WORKSPACE}/bin-$LLVM_VERSION/bin" >> $GITHUB_PATH
 
@@ -83,7 +83,7 @@ jobs:
       run: |
         sudo apt-get update && sudo apt-get install libc6-dev-i386 g++-multilib lib32stdc++6
         find /usr -name cdefs.h
-        wget --user-agent='Mozilla/4.0' https://software.intel.com/content/dam/develop/external/us/en/documents/$SDE_TAR_NAME.tar.bz2
+        wget --user-agent='Mozilla/4.0' https://software.intel.com/content/dam/develop/external/us/en/documents/downloads/$SDE_TAR_NAME.tar.bz2
         tar xf $SDE_TAR_NAME.tar.bz2
         echo "SDE_HOME=$GITHUB_WORKSPACE/$SDE_TAR_NAME" >> $GITHUB_ENV
         tar xf ispc-trunk-linux.tar.gz

--- a/.github/workflows/linux-nightly-llvm11.yml
+++ b/.github/workflows/linux-nightly-llvm11.yml
@@ -5,7 +5,7 @@ name: Nightly Linux tests / LLVM 11.0
 # Run daily - test sse2-avx512 targets @ -O0/-O1/-O2
 on:
   schedule:
-    - cron:  '0 7 * * *'
+    - cron:  '0 8 * * *'
   push:
     branches:
       - '**test_nightly**'

--- a/.github/workflows/linux-nightly-llvm11.yml
+++ b/.github/workflows/linux-nightly-llvm11.yml
@@ -66,7 +66,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install bison flex libc6-dev-i386 g++-multilib lib32stdc++6 ncurses-dev
         tar xf llvm-11.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
-        echo "PATH=${GITHUB_WORKSPACE}/bin-11.0/bin:$PATH" >> $GITHUB_ENV
+        echo "${GITHUB_WORKSPACE}/bin-11.0/bin" >> $GITHUB_PATH
 
     - name: Check environment
       run: |
@@ -76,6 +76,7 @@ jobs:
 
     - name: Build package
       run: |
+        echo PATH=$PATH
         mkdir build && cd build
         cmake .. -DISPC_PREPARE_PACKAGE=ON -DISPC_INCLUDE_BENCHMARKS=ON
         make -j4 package
@@ -119,9 +120,9 @@ jobs:
         find /usr -name cdefs.h
         wget -q https://software.intel.com/content/dam/develop/external/us/en/documents/$SDE_TAR_NAME.tar.bz2
         tar xf $SDE_TAR_NAME.tar.bz2
-        echo "ADD_PATH=$GITHUB_WORKSPACE/$SDE_TAR_NAME:$ADD_PATH" >> $GITHUB_ENV
+        echo "SDE_HOME=$GITHUB_WORKSPACE/$SDE_TAR_NAME" >> $GITHUB_ENV
         tar xf ispc-trunk-linux.tar.gz
-        echo "ADD_PATH=$GITHUB_WORKSPACE/ispc-trunk-linux/bin:$ADD_PATH" >> $GITHUB_ENV
+        echo "$GITHUB_WORKSPACE/ispc-trunk-linux/bin" >> $GITHUB_PATH
         echo "LLVM_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
         echo "ISPC_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
 
@@ -130,9 +131,7 @@ jobs:
         cat /proc/cpuinfo
     - name: Running tests
       run: |
-        # Setting PATH in prev step not surived moving to this step
-        # use ADD_PATH to pass it through steps in this job.
-        export PATH=$ADD_PATH:$PATH
+        echo PATH=$PATH
         ./alloy.py -r --only="stability current -O0 -O1 -O2" --only-targets="${{ matrix.target }}" --time --update-errors=FP
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@v2

--- a/.github/workflows/linux-nightly-llvm11.yml
+++ b/.github/workflows/linux-nightly-llvm11.yml
@@ -14,7 +14,7 @@ env:
   LLVM_VERSION: "11.0"
   LLVM_REPO: https://github.com/dbabokin/llvm-project
   LLVM_TAR: llvm-11.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
-  SDE_TAR_NAME: sde-external-8.56.0-2020-07-05-lin
+  SDE_TAR_NAME: sde-external-8.59.0-2020-10-05-lin
 
 jobs:
   linux-build:
@@ -29,7 +29,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install bison flex libc6-dev-i386 g++-multilib lib32stdc++6 ncurses-dev
-        wget -q $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
+        wget $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
         tar xf $LLVM_TAR
         echo "${GITHUB_WORKSPACE}/bin-$LLVM_VERSION/bin" >> $GITHUB_PATH
 
@@ -83,7 +83,7 @@ jobs:
       run: |
         sudo apt-get update && sudo apt-get install libc6-dev-i386 g++-multilib lib32stdc++6
         find /usr -name cdefs.h
-        wget --user-agent='Mozilla/4.0' https://software.intel.com/content/dam/develop/external/us/en/documents/$SDE_TAR_NAME.tar.bz2
+        wget --user-agent='Mozilla/4.0' https://software.intel.com/content/dam/develop/external/us/en/documents/downloads/$SDE_TAR_NAME.tar.bz2
         tar xf $SDE_TAR_NAME.tar.bz2
         echo "SDE_HOME=$GITHUB_WORKSPACE/$SDE_TAR_NAME" >> $GITHUB_ENV
         tar xf ispc-trunk-linux.tar.gz

--- a/.github/workflows/linux-nightly-llvm11.yml
+++ b/.github/workflows/linux-nightly-llvm11.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - '**test_nightly**'
+  workflow_dispatch:
 
 env:
   LLVM_VERSION: "11.0"

--- a/.github/workflows/linux-nightly-llvm11.yml
+++ b/.github/workflows/linux-nightly-llvm11.yml
@@ -11,62 +11,27 @@ on:
       - '**test_nightly**'
 
 env:
+  LLVM_VERSION: "11.0"
+  LLVM_REPO: https://github.com/dbabokin/llvm-project
+  LLVM_TAR: llvm-11.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
   SDE_TAR_NAME: sde-external-8.56.0-2020-07-05-lin
 
 jobs:
-  # Building LLVM in docker, as using native Ubuntu 16.04 github-hosted image contains newer-than-expected libs and
-  # makes the resulting build not usable on other Ubuntu 16.04 images.
-  linux-build-llvm:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: Check environment
-      run: |
-        cat /proc/cpuinfo
-
-    - name: Build LLVM
-      run: |
-        cd docker/ubuntu/llvm_build
-        docker build --tag ispc/ubuntu16.04 --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=11.0 .
-
-    - name: Pack LLVM
-      run: |
-        cd docker/ubuntu/llvm_build
-        docker run ispc/ubuntu16.04
-        export CONTAINER=`docker ps --all |head -2 |tail -1 |awk '//{print $1}'`
-        sudo docker cp $CONTAINER:/usr/local/src/llvm/bin-11.0 .
-        tar cJvf llvm-11.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz bin-11.0
-
-    - name: Upload package
-      uses: actions/upload-artifact@v2
-      with:
-        name: llvm_11.0_linux
-        path: docker/ubuntu/llvm_build/llvm-11.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
-
   linux-build:
     runs-on: ubuntu-latest
-    needs: linux-build-llvm
 
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: true
-
-    - name: Download package
-      uses: actions/download-artifact@v2
-      with:
-        name: llvm_11.0_linux
 
     - name: Install dependencies
       run: |
         sudo apt-get update
         sudo apt-get install bison flex libc6-dev-i386 g++-multilib lib32stdc++6 ncurses-dev
-        tar xf llvm-11.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
-        echo "${GITHUB_WORKSPACE}/bin-11.0/bin" >> $GITHUB_PATH
+        wget -q $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
+        tar xf $LLVM_TAR
+        echo "${GITHUB_WORKSPACE}/bin-$LLVM_VERSION/bin" >> $GITHUB_PATH
 
     - name: Check environment
       run: |
@@ -92,7 +57,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: ispc_llvm_11.0_linux
+        name: ispc_llvm11_linux
         path: build/ispc-trunk-linux.tar.gz
 
   test:
@@ -113,12 +78,12 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: ispc_llvm_11.0_linux
+        name: ispc_llvm11_linux
     - name: Install dependencies and unpack artifacts
       run: |
         sudo apt-get update && sudo apt-get install libc6-dev-i386 g++-multilib lib32stdc++6
         find /usr -name cdefs.h
-        wget -q https://software.intel.com/content/dam/develop/external/us/en/documents/$SDE_TAR_NAME.tar.bz2
+        wget --user-agent='Mozilla/4.0' https://software.intel.com/content/dam/develop/external/us/en/documents/$SDE_TAR_NAME.tar.bz2
         tar xf $SDE_TAR_NAME.tar.bz2
         echo "SDE_HOME=$GITHUB_WORKSPACE/$SDE_TAR_NAME" >> $GITHUB_ENV
         tar xf ispc-trunk-linux.tar.gz

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - '**test_nightly**'
+  workflow_dispatch:
 
 env:
   SDE_TAR_NAME: sde-external-8.59.0-2020-10-05-lin

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -11,7 +11,7 @@ on:
       - '**test_nightly**'
 
 env:
-  SDE_TAR_NAME: sde-external-8.56.0-2020-07-05-lin
+  SDE_TAR_NAME: sde-external-8.59.0-2020-10-05-lin
 
 jobs:
   # Building LLVM in docker, as using native Ubuntu 16.04 github-hosted image contains newer-than-expected libs and
@@ -118,7 +118,7 @@ jobs:
       run: |
         sudo apt-get update && sudo apt-get install libc6-dev-i386 g++-multilib lib32stdc++6
         find /usr -name cdefs.h
-        wget -q https://software.intel.com/content/dam/develop/external/us/en/documents/$SDE_TAR_NAME.tar.bz2
+        wget --user-agent='Mozilla/4.0' https://software.intel.com/content/dam/develop/external/us/en/documents/downloads/$SDE_TAR_NAME.tar.bz2
         tar xf $SDE_TAR_NAME.tar.bz2
         echo "SDE_HOME=$GITHUB_WORKSPACE/$SDE_TAR_NAME" >> $GITHUB_ENV
         tar xf ispc-trunk-linux.tar.gz

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -66,7 +66,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install bison flex libc6-dev-i386 g++-multilib lib32stdc++6 ncurses-dev
         tar xf llvm-trunk-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
-        echo "PATH=${GITHUB_WORKSPACE}/bin-trunk/bin:$PATH" >> $GITHUB_ENV
+        echo "${GITHUB_WORKSPACE}/bin-trunk/bin" >> $GITHUB_PATH
 
     - name: Check environment
       run: |
@@ -76,6 +76,7 @@ jobs:
 
     - name: Build package
       run: |
+        echo PATH=$PATH
         mkdir build && cd build
         cmake .. -DISPC_PREPARE_PACKAGE=ON -DISPC_INCLUDE_BENCHMARKS=ON
         make -j4 package
@@ -119,9 +120,9 @@ jobs:
         find /usr -name cdefs.h
         wget -q https://software.intel.com/content/dam/develop/external/us/en/documents/$SDE_TAR_NAME.tar.bz2
         tar xf $SDE_TAR_NAME.tar.bz2
-        echo "ADD_PATH=$GITHUB_WORKSPACE/$SDE_TAR_NAME:$ADD_PATH" >> $GITHUB_ENV
+        echo "SDE_HOME=$GITHUB_WORKSPACE/$SDE_TAR_NAME" >> $GITHUB_ENV
         tar xf ispc-trunk-linux.tar.gz
-        echo "ADD_PATH=$GITHUB_WORKSPACE/ispc-trunk-linux/bin:$ADD_PATH" >> $GITHUB_ENV
+        echo "$GITHUB_WORKSPACE/ispc-trunk-linux/bin" >> $GITHUB_PATH
         echo "LLVM_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
         echo "ISPC_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
 
@@ -130,9 +131,7 @@ jobs:
         cat /proc/cpuinfo
     - name: Running tests
       run: |
-        # Setting PATH in prev step not surived moving to this step
-        # use ADD_PATH to pass it through steps in this job.
-        export PATH=$ADD_PATH:$PATH
+        echo PATH=$PATH
         ./alloy.py -r --only="stability current -O0 -O1 -O2" --only-targets="${{ matrix.target }}" --time --update-errors=FP
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@v2

--- a/.github/workflows/rebuild-llvm10.yml
+++ b/.github/workflows/rebuild-llvm10.yml
@@ -108,13 +108,13 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-10.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.zip bin-10.0
+        7z.exe a -t7z llvm-10.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.7z bin-10.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm10_win
-        path: llvm/llvm-10.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.zip
+        path: llvm/llvm-10.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.7z
 
   win-build-release:
     runs-on: windows-latest
@@ -149,13 +149,13 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-10.0.1-win.vs2019-Release-x86.arm.wasm.zip bin-10.0
+        7z.exe a -t7z llvm-10.0.1-win.vs2019-Release-x86.arm.wasm.7z bin-10.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm10rel_win
-        path: llvm/llvm-10.0.1-win.vs2019-Release-x86.arm.wasm.zip
+        path: llvm/llvm-10.0.1-win.vs2019-Release-x86.arm.wasm.7z
 
   mac-build:
     runs-on: macos-10.15

--- a/.github/workflows/rebuild-llvm10.yml
+++ b/.github/workflows/rebuild-llvm10.yml
@@ -9,6 +9,7 @@ on:
       - "llvm_patches/*10_0*"
       - "alloy.py"
       - ".github/workflows/rebuild-llvm10.yml"
+  workflow_dispatch:
 
 jobs:
   # Building LLVM in docker, as using native Ubuntu 16.04 github-hosted image contains newer-than-expected libs and

--- a/.github/workflows/rebuild-llvm10.yml
+++ b/.github/workflows/rebuild-llvm10.yml
@@ -95,14 +95,12 @@ jobs:
       shell: cmd
       run: |
         mkdir llvm
-        echo ::set-env name=LLVM_HOME::%GITHUB_WORKSPACE%\llvm
-        echo ::set-env name=ISPC_HOME::%GITHUB_WORKSPACE%
+        echo LLVM_HOME=%GITHUB_WORKSPACE%\llvm>> %GITHUB_ENV%
+        echo ISPC_HOME=%GITHUB_WORKSPACE%>> %GITHUB_ENV%
 
     - name: Build LLVM
       shell: cmd
       run: |
-        echo %LLVM_HOME%
-        echo %ISPC_HOME%
         python ./alloy.py -b --version=10.0 --verbose
         cd alloy_results* && type alloy_build.log
 
@@ -138,14 +136,12 @@ jobs:
       shell: cmd
       run: |
         mkdir llvm
-        echo ::set-env name=LLVM_HOME::%GITHUB_WORKSPACE%\llvm
-        echo ::set-env name=ISPC_HOME::%GITHUB_WORKSPACE%
+        echo LLVM_HOME=%GITHUB_WORKSPACE%\llvm>> %GITHUB_ENV%
+        echo ISPC_HOME=%GITHUB_WORKSPACE%>> %GITHUB_ENV%
 
     - name: Build LLVM
       shell: cmd
       run: |
-        echo %LLVM_HOME%
-        echo %ISPC_HOME%
         python ./alloy.py -b --version=10.0 --verbose --llvm-disable-assertions
         cd alloy_results* && type alloy_build.log
 
@@ -180,8 +176,8 @@ jobs:
         sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
         xcrun --show-sdk-path
         mkdir llvm
-        echo "::set-env name=LLVM_HOME::${GITHUB_WORKSPACE}/llvm"
-        echo "::set-env name=ISPC_HOME::${GITHUB_WORKSPACE}"
+        echo "LLVM_HOME=${GITHUB_WORKSPACE}/llvm" >> $GITHUB_ENV
+        echo "ISPC_HOME=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
 
     - name: Check environment
       run: |
@@ -223,8 +219,8 @@ jobs:
         sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
         xcrun --show-sdk-path
         mkdir llvm
-        echo "::set-env name=LLVM_HOME::${GITHUB_WORKSPACE}/llvm"
-        echo "::set-env name=ISPC_HOME::${GITHUB_WORKSPACE}"
+        echo "LLVM_HOME=${GITHUB_WORKSPACE}/llvm" >> $GITHUB_ENV
+        echo "ISPC_HOME=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
 
     - name: Check environment
       run: |

--- a/.github/workflows/rebuild-llvm11.yml
+++ b/.github/workflows/rebuild-llvm11.yml
@@ -108,13 +108,13 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-11.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.zip bin-11.0
+        7z.exe a -t7z llvm-11.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z bin-11.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11_win
-        path: llvm/llvm-11.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.zip
+        path: llvm/llvm-11.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z
 
   win-build-release:
     runs-on: windows-latest
@@ -149,13 +149,13 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-11.0.0-win.vs2019-Release-x86.arm.wasm.zip bin-11.0
+        7z.exe a -t7z llvm-11.0.0-win.vs2019-Release-x86.arm.wasm.7z bin-11.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11rel_win
-        path: llvm/llvm-11.0.0-win.vs2019-Release-x86.arm.wasm.zip
+        path: llvm/llvm-11.0.0-win.vs2019-Release-x86.arm.wasm.7z
 
   mac-build:
     runs-on: macos-10.15

--- a/.github/workflows/rebuild-llvm11.yml
+++ b/.github/workflows/rebuild-llvm11.yml
@@ -95,14 +95,12 @@ jobs:
       shell: cmd
       run: |
         mkdir llvm
-        echo ::set-env name=LLVM_HOME::%GITHUB_WORKSPACE%\llvm
-        echo ::set-env name=ISPC_HOME::%GITHUB_WORKSPACE%
+        echo LLVM_HOME=%GITHUB_WORKSPACE%\llvm>> %GITHUB_ENV%
+        echo ISPC_HOME=%GITHUB_WORKSPACE%>> %GITHUB_ENV%
 
     - name: Build LLVM
       shell: cmd
       run: |
-        echo %LLVM_HOME%
-        echo %ISPC_HOME%
         python ./alloy.py -b --version=11.0 --verbose
         cd alloy_results* && type alloy_build.log
 
@@ -138,14 +136,12 @@ jobs:
       shell: cmd
       run: |
         mkdir llvm
-        echo ::set-env name=LLVM_HOME::%GITHUB_WORKSPACE%\llvm
-        echo ::set-env name=ISPC_HOME::%GITHUB_WORKSPACE%
+        echo LLVM_HOME=%GITHUB_WORKSPACE%\llvm>> %GITHUB_ENV%
+        echo ISPC_HOME=%GITHUB_WORKSPACE%>> %GITHUB_ENV%
 
     - name: Build LLVM
       shell: cmd
       run: |
-        echo %LLVM_HOME%
-        echo %ISPC_HOME%
         python ./alloy.py -b --version=11.0 --verbose --llvm-disable-assertions
         cd alloy_results* && type alloy_build.log
 
@@ -180,8 +176,8 @@ jobs:
         sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
         xcrun --show-sdk-path
         mkdir llvm
-        echo "::set-env name=LLVM_HOME::${GITHUB_WORKSPACE}/llvm"
-        echo "::set-env name=ISPC_HOME::${GITHUB_WORKSPACE}"
+        echo "LLVM_HOME=${GITHUB_WORKSPACE}/llvm" >> $GITHUB_ENV
+        echo "ISPC_HOME=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
 
     - name: Check environment
       run: |
@@ -223,8 +219,8 @@ jobs:
         sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
         xcrun --show-sdk-path
         mkdir llvm
-        echo "::set-env name=LLVM_HOME::${GITHUB_WORKSPACE}/llvm"
-        echo "::set-env name=ISPC_HOME::${GITHUB_WORKSPACE}"
+        echo "LLVM_HOME=${GITHUB_WORKSPACE}/llvm" >> $GITHUB_ENV
+        echo "ISPC_HOME=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
 
     - name: Check environment
       run: |

--- a/.github/workflows/rebuild-llvm11.yml
+++ b/.github/workflows/rebuild-llvm11.yml
@@ -9,6 +9,7 @@ on:
       - "llvm_patches/*11_0*"
       - "alloy.py"
       - ".github/workflows/rebuild-llvm11.yml"
+  workflow_dispatch:
 
 jobs:
   # Building LLVM in docker, as using native Ubuntu 16.04 github-hosted image contains newer-than-expected libs and


### PR DESCRIPTION
- Correct use of GITHUB_ENV and GITHUB_PATH in nightly testing and LLVM rebuild pipelines
- Use pre-build LLVM for testing with LLVM 11.0
- Update SDE to 8.59.0
- Start LLVM 11.0 nightly one hour later
- Use 7z extension for LLVM Windows archives
- Enable manual triggering for workflows