### PR TITLE
More changes for C++17 enabling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ find_package(BISON 3.0 REQUIRED)
     )
     endif()
 
-find_package(FLEX 2.5 REQUIRED)
+find_package(FLEX 2.6 REQUIRED)
     if (FLEX_FOUND)
         set(FLEX_INPUT  src/lex.ll)
         set(FLEX_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lex.cpp)

--- a/alloy.py
+++ b/alloy.py
@@ -560,11 +560,11 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
         stability.num_jobs = speed_number
         stability.verbose = False
         stability.time = time
-        # 900 is more than default value in run_tests.py (600).
+        # 1200 is more than default value in run_tests.py (600).
         # There's a single test, which requires longer time on AVX2 capable server (Github Action):
         # tests/idiv.ispc running for avx512-i8x64 for x86 under SDE.
         # For any other tests it should be more than enough.
-        stability.test_time = 900
+        stability.test_time = 1200
         stability.csv = ""
         stability.non_interactive = True
         stability.update = update

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -1,0 +1,73 @@
+FROM centos:7
+MAINTAINER Dmitry Babokin <dmitry.y.babokin@intel.com>
+
+ARG REPO=ispc/ispc
+ARG SHA=master
+ARG LLVM_VERSION=11.0
+
+# !!! Make sure that your docker config provides enough memory to the container,
+# otherwise LLVM build may fail, as it will use all the cores available to container.
+
+# Packages required to build ISPC and Clang.
+RUN yum -y update; yum -y install centos-release-scl epel-release; yum clean all
+RUN yum install -y vim wget yum-utils gcc gcc-c++ git subversion python3 m4 bison flex patch make ncurses-devel glibc-devel.x86_64 glibc-devel.i686 xz devtoolset-7 && \
+    yum install -y libtool autopoint gettext-devel texinfo help2man && \
+    yum clean -y all
+
+# These packages are required if you need to link IPSC with -static.
+RUN yum install -y ncurses-static libstdc++-static && \
+    yum clean -y all
+
+# Download and install required version of cmake (3.14) for ISPC build
+RUN wget https://cmake.org/files/v3.14/cmake-3.14.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.14.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.14.0-Linux-x86_64.sh
+
+# If you are behind a proxy, you need to configure git.
+#RUN git config --global --add http.proxy http://proxy.yourcompany.com:888
+
+WORKDIR /usr/local/src
+
+# Fork ispc on github and clone *your* fork.
+RUN git clone https://github.com/$REPO.git ispc
+RUN cd ispc && git checkout $SHA && cd ..
+
+# This is home for Clang builds
+RUN mkdir /usr/local/src/llvm
+
+ENV ISPC_HOME=/usr/local/src/ispc
+ENV LLVM_HOME=/usr/local/src/llvm
+
+# If you are going to run test for future platforms, go to
+# http://www.intel.com/software/sde and download the latest version,
+# extract it, add to path and set SDE_HOME.
+
+WORKDIR /usr/local/src/ispc
+
+# Build Clang with all required patches.
+# Pass required LLVM_VERSION with --build-arg LLVM_VERSION=<version>.
+# By default 11.0 is used.
+# Note self-build options, it's required to build clang and ispc with the same compiler,
+# i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
+# or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
+# "rm" are just to keep docker image small.
+RUN source /opt/rh/devtoolset-7/enable && \
+    ./alloy.py -b --version=$LLVM_VERSION --selfbuild --llvm-disable-assertions && \
+    rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-"$LLVM_VERSION"_temp $LLVM_HOME/build-"$LLVM_VERSION"_temp
+
+ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+
+# Install newer zlib
+WORKDIR /usr/local/src
+RUN git clone https://github.com/madler/zlib.git && cd zlib && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release && make -j8 && make install
+
+# Install news flex (2.6.4)
+WORKDIR /usr/local/src
+RUN git clone https://github.com/westes/flex.git && cd flex && git checkout v2.6.4 && ./autogen.sh && ./configure && make -j8 && make install
+
+# MacOSX10.14.sdk to enable cross compilation to macOS.
+COPY MacOSX10.14.sdk /usr/local/
+
+# Build ISPC
+RUN mkdir build
+WORKDIR /usr/local/src/ispc/build
+RUN cmake .. -DISPC_PREPARE_PACKAGE=ON -DISPC_CROSS=ON -DISPC_MACOS_SDK_PATH=/usr/local/MacOSX10.14.sdk && make -j8 package


### PR DESCRIPTION
- CMakefile to require flex 2.6 and later (otherwise C++17 compiler would compilain on `register` keyword). See #1904 for more details.
- Centos7 based Dockerfile, which includes flex 2.6.4.
- Support LLVM debug build on Windows (in alloy.py).
- Extend timeout for individual tests when running under alloy.py to 1200 sec, as CI still fails from time to time.