### PR TITLE
Update calcite cli to 0.7.2 (no more out of date dependencies)

### DIFF
--- a/.calcite/package-lock.json
+++ b/.calcite/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "@siliceum/calcite-cli": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@siliceum/calcite-cli/-/calcite-cli-0.7.0.tgz",
-      "integrity": "sha512-lWLTORgKbcLznaJwTG9XUpnvsU0iMwSFifKqdB7fFrWC5EEl1bpxK5CYcQkEjK1QGKbDpXpeBlTU7sNz9vNsyQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@siliceum/calcite-cli/-/calcite-cli-0.7.2.tgz",
+      "integrity": "sha512-gKmphKPFKtiYuAsQt7lSC35bNbMXDxvyD6SVeBONTF6aZrh247TBJYKiA4iry3w3CWKpngZN1Y1qW4mi4rbB7A==",
       "requires": {
         "@types/mime-types": "^2.1.0",
         "@types/node": "^13.13.2",
         "axios": "^0.19.2",
-        "class-transformer": "^0.2.3",
+        "class-transformer": "^0.3.1",
         "class-validator": "^0.12.2",
         "commander": "^5.0.0",
         "log4js": "^6.3.0",
@@ -26,9 +26,9 @@
       "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM="
     },
     "@types/node": {
-      "version": "13.13.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.29.tgz",
-      "integrity": "sha512-WPGpyEDx4/F4Rx1p1Zar8m+JsMxpSY/wNFPlyNXWV+UzJwkYt3LQg2be/qJgpsLdVJsfxTR5ipY6rv2579jStQ=="
+      "version": "13.13.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.33.tgz",
+      "integrity": "sha512-1B3GM1yuYsFyEvBb+ljBqWBOylsWDYioZ5wpu8AhXdIhq20neXS7eaSC8GkwHE0yQYGiOIV43lMsgRYTgKZefQ=="
     },
     "@types/validator": {
       "version": "13.0.0",
@@ -44,9 +44,9 @@
       }
     },
     "class-transformer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.2.3.tgz",
-      "integrity": "sha512-qsP+0xoavpOlJHuYsQJsN58HXSl8Jvveo+T37rEvCEeRfMWoytAyR0Ua/YsFgpM6AZYZ/og2PJwArwzJl1aXtQ=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
+      "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA=="
     },
     "class-validator": {
       "version": "0.12.2",
@@ -101,9 +101,9 @@
       }
     },
     "google-libphonenumber": {
-      "version": "3.2.14",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.14.tgz",
-      "integrity": "sha512-4r7mQRbk7EUYV1gyfP1SInYuQsjuDtRXCGLSotxeYDJaj/aF1xFO5PV/GSQeIxXWhIw050DujROICvWpZ1XYRw=="
+      "version": "3.2.15",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.15.tgz",
+      "integrity": "sha512-tbCIuzMoH34RdrbFRw5kijAZn/p6JMQvsgtr1glg2ugbwqrMPlOL8pHNK8cyGo9B6SXpcMm4hdyDqwomR+HPRg=="
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -131,9 +131,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -189,9 +189,9 @@
           "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA=="
         },
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
           }

--- a/.calcite/package.json
+++ b/.calcite/package.json
@@ -5,6 +5,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@siliceum/calcite-cli": "^0.7.0"
+    "@siliceum/calcite-cli": "^0.7.2"
   }
 }

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -120,7 +120,7 @@ jobs:
           BENCH_OUTPUT_FILES: ${{github.workspace}}
           CALCITE_TOKEN: ${{ secrets.CALCITE_TOKEN }}
       - name: Trigger calcite workflow
-        if: github.event_name == 'pull_request' && success()
+        if: github.event_name == 'pull_request_target' && success()
         working-directory: .calcite
         run: npx calcite trigger $(git cat-file -p HEAD | awk 'NR > 1 {if(/^parent/){print $2;}{exit}}') -tt pullrequest
         env:


### PR DESCRIPTION
As asked, this updates calcite-cli to be using the latest version of `class-transformer` since 0.2.3 had a CVE.