### PR TITLE
fixes #1755.

### DIFF
--- a/src/type.cpp
+++ b/src/type.cpp
@@ -248,31 +248,7 @@ const AtomicType *AtomicType::GetAsUniformType() const {
         return this;
 
     if (asUniformType == NULL) {
-        BasicType bType = basicType;
-        // Varying bool needs to be handled differently since LLVMTypes::BoolVectorType
-        // is not always composed of i1.
-        if (basicType == TYPE_BOOL && variability == Variability::Varying) {
-            switch (g->target->getMaskBitCount()) {
-            case 1:
-                bType = TYPE_BOOL;
-                break;
-            case 8:
-                bType = TYPE_INT8;
-                break;
-            case 16:
-                bType = TYPE_INT16;
-                break;
-            case 32:
-                bType = TYPE_INT32;
-                break;
-            case 64:
-                bType = TYPE_INT64;
-                break;
-            default:
-                FATAL("Unhandled mask width");
-            }
-        }
-        asUniformType = new AtomicType(bType, Variability::Uniform, isConst);
+        asUniformType = new AtomicType(basicType, Variability::Uniform, isConst);
         if (variability == Variability::Varying)
             asUniformType->asVaryingType = this;
     }

--- a/tests/lit-tests/1755.ispc
+++ b/tests/lit-tests/1755.ispc
@@ -1,0 +1,17 @@
+// RUN: %{ispc} --target=sse4-i32x4 %s > %t 2>&1
+// RUN: %{ispc} --target=sse4-i16x8 %s > %t 2>&1
+// RUN: %{ispc} --target=sse4-i8x16 %s > %t 2>&1
+// RUN: %{ispc} --target=avx1-i32x8 %s > %t 2>&1
+// RUN: %{ispc} --target=avx2-i64x4 %s > %t 2>&1
+// RUN: %{ispc} --target=avx512skx-i32x16 %s > %t 2>&1
+// REQUIRES: X86_ENABLED
+void a(uniform bool aFOO)
+{
+#if TARGET_WIDTH == 4
+    bool t = {aFOO, false, false, false};
+#elif TARGET_WIDTH == 8
+    bool t = {aFOO, false, false, false, false, false, false, false};
+#elif TARGET_WIDTH == 16
+    bool t = {aFOO, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};
+#endif
+}


### PR DESCRIPTION
The hack to return uniform type for bool varying was needed earlier since returning i1 causes a crash when trying to store it. But it's not a problem anymore since now we are storing both uniform and varying as i8 irrespective of mask type.