### PR TITLE
[CI] Use safe defaults for calcite benchmarks diff/regressions policies

### DIFF
--- a/.calcite/calcite.config.js
+++ b/.calcite/calcite.config.js
@@ -1,6 +1,18 @@
 const fs = require('fs');
 const path = require('path');
 
+const defaultDatapointPolicies = {
+    // Median is a safe default to use, see https://doc.calcite.siliceum.com/performance/stability/statistics.html#descriptive-statistics for why we do not pick the mean.
+    aggregationPolicy: 'median',
+    // We want to consider only significant changes, in our case meaning 20% increase of the median.
+    // We chose 20% as a safe default since even when stabilized, a CPU can have such variations due to (for example) the Intel JCC Erratum. (https://www.intel.com/content/dam/support/us/en/documents/processors/mitigations-jump-conditional-code-erratum.pdf)
+    // We can at a later point in time lower this value if benchmarks are stable enough.
+    // See https://doc.calcite.siliceum.com/performance/stability/index.html for a reference of what can impact stability.
+    diffPolicy: 'relativeDifference',
+    regressionPolicy: 'lessIsBetter',
+    regressionArgument: 20
+};
+
 const fromGoogleBenchFile = (filePath, builder, calciteContext) => {
     const data = calciteContext.readJson(filePath);
     
@@ -13,6 +25,7 @@ const fromGoogleBenchFile = (filePath, builder, calciteContext) => {
             'real_time', {
                 values: [bench['real_time']],
                 unit: bench['time_unit'],
+                ...defaultDatapointPolicies
             }
         );
 
@@ -22,6 +35,7 @@ const fromGoogleBenchFile = (filePath, builder, calciteContext) => {
             'cpu_time', {
                 values: [bench['cpu_time']],
                 unit: bench['time_unit'],
+                ...defaultDatapointPolicies
             }
         );
     });


### PR DESCRIPTION
Due to an oversight during refactoring, diff/regression policies for the calcite datapoints were not set.
The calcite CLI default values were not meant to be used (will be fixed in an upcoming update) as it leads to very noisy results.
The slightest difference that passed our statistical tests would be considered as regressions/improvements, even if the change was as small as 1%. This is of course not what one would want for such benchmarks.

Following a general guideline, we now use the the median to compute the importance of the changes, with a threshold set at 20%.
This is a bit high, but takes into account the fact by default benchmarks (perhaps not the case for ISPC, but this is a general guideline) do not take into account for CPU issues such as the JCC erratum.

The threshold could probably be lowered at a later point in time, but for now I'd rather use a high bar to avoid noise.