### PR TITLE
Added Type Scoping

### DIFF
--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -169,7 +169,7 @@ Symbol *SymbolTable::LookupFunction(const char *name, const FunctionType *type) 
 }
 
 bool SymbolTable::AddType(const char *name, const Type *type, SourcePos pos) {
-    const Type *t = LookupType(name);
+    const Type *t = LookupLocalType(name);
     if (t != NULL && CastType<UndefinedStructType>(t) == NULL) {
         // If we have a previous declaration of anything other than an
         // UndefinedStructType with this struct name, issue an error.  If
@@ -193,6 +193,17 @@ const Type *SymbolTable::LookupType(const char *name) const {
             return type_it->second;
     }
     return nullptr;
+}
+
+const Type *SymbolTable::LookupLocalType(const char *name) const {
+
+    Assert(types.size() > 0);
+
+    auto result = types.back().find(name);
+    if (result == types.back().end())
+        return nullptr;
+    else
+        return result->second;
 }
 
 bool SymbolTable::ContainsType(const Type *type) const {

--- a/src/sym.h
+++ b/src/sym.h
@@ -212,6 +212,14 @@ class SymbolTable {
     */
     const Type *LookupType(const char *name) const;
 
+    /** Looks for a type of the given name in the most local
+        scope in the symbol table. This is useful for determining
+        whether a type definition can assume a certain name.
+
+        @return A pointer to the type that was found or null.
+     */
+    const Type *LookupLocalType(const char *name) const;
+
     /** Look for a type given a pointer.
 
         @return True if found, False otherwise.

--- a/src/sym.h
+++ b/src/sym.h
@@ -270,7 +270,7 @@ class SymbolTable {
     /** Type definitions can't currently be scoped.
      */
     typedef std::map<std::string, const Type *> TypeMapType;
-    TypeMapType types;
+    std::vector<TypeMapType> types;
 };
 
 template <typename Predicate>

--- a/tests/lit-tests/scoped-typedef.ispc
+++ b/tests/lit-tests/scoped-typedef.ispc
@@ -1,0 +1,6 @@
+//; RUN: not %{ispc} %s 2>&1 | FileCheck %s -check-prefix=CHECK
+//; CHECK: scoped-typedef.ispc:6:19
+
+void a() { typedef int64 BigInt; }
+
+void b() { BigInt a; }

--- a/tests_errors/scoped-typedef.ispc
+++ b/tests_errors/scoped-typedef.ispc
@@ -1,5 +1,0 @@
-// syntax error, unexpected identifier.
-
-void a() { typedef int64 BigInt; }
-
-void b() { BigInt a; }

--- a/tests_errors/scoped-typedef.ispc
+++ b/tests_errors/scoped-typedef.ispc
@@ -1,0 +1,5 @@
+// syntax error, unexpected identifier.
+
+void a() { typedef int64 BigInt; }
+
+void b() { BigInt a; }


### PR DESCRIPTION
Fixes #1929

Changes were minor but `ClosestTypeMatch` and `RandomType` remaining untested/unused even though they are part of the patch.