### PR TITLE
Calcite config: do not take aggregates into account

### DIFF
--- a/.calcite/calcite.config.js
+++ b/.calcite/calcite.config.js
@@ -17,8 +17,9 @@ const fromGoogleBenchFile = (filePath, builder, calciteContext) => {
     const data = calciteContext.readJson(filePath);
     
     const testSuiteName = path.basename(data.context.executable);
-    
-    data.benchmarks.forEach((bench) => {
+
+    const benchsNoAggregate = data.benchmarks.filter(bench => bench.run_type === 'iteration');
+    benchsNoAggregate.forEach((bench) => {
         builder.addOrUpdateDataPoint(
             testSuiteName ,
             bench.run_name,


### PR DESCRIPTION
When I converted to the latest calcite CLI I forgot to filter out aggregates in the google bench reports.
This PR ensures that we only send actual data to calcite.

Note that it didn't have much impact except when viewing the details as we are using outlier aware algorithms on the platform.