### PR TITLE
CI adjustments and editorial changes

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -215,3 +215,47 @@ jobs:
         git diff
         # Exit with error code if there are fails.
         [ -z "`git diff`" ]
+
+  # Debug run is experimental with the purpose to see if it's capable to catch anything.
+  # So it's running in "full" mode only for now.
+  # Single target, as it should be representative enough.
+  linux-test-debug-llvm11:
+    needs: [define-flow, linux-build-ispc-llvm11]
+    if: ${{ needs.define-flow.outputs.flow_type == 'full' }}
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: ispc_llvm11_linux
+
+    - name: Install dependencies and unpack artifacts
+      run: |
+        .github/workflows/scripts/install-test-deps.sh
+
+    - name: Check environment
+      run: |
+        cat /proc/cpuinfo
+
+    - name: Running tests
+      run: |
+        echo PATH=$PATH
+        ./alloy.py -r --only="stability current debug -O0 -O2" --only-targets="avx2-i32x8" --time --update-errors=FP
+
+    - name: Upload fail_db.txt
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: fail_db.debug.txt
+        path: fail_db.txt
+
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff
+        # Exit with error code if there are fails.
+        [ -z "`git diff`" ]

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -15,18 +15,21 @@ env:
   SDE_TAR_NAME: sde-external-8.59.0-2020-10-05-lin
   LLVM_REPO: https://github.com/dbabokin/llvm-project
   TARGETS_SMOKE: '["avx2-i32x8"]'
+  OPTSETS_SMOKE: "-O2"
   TARGETS_FULL:  '["sse2-i32x4", "sse2-i32x8",
                    "sse4-i8x16", "sse4-i16x8", "sse4-i32x4", "sse4-i32x8",
                    "avx1-i32x4", "avx1-i32x8", "avx1-i32x16", "avx1-i64x4",
                    "avx2-i8x32", "avx2-i16x16", "avx2-i32x4", "avx2-i32x8", "avx2-i32x16", "avx2-i64x4",
                    "avx512knl-i32x16",
                    "avx512skx-i32x8", "avx512skx-i32x16", "avx512skx-i8x64", "avx512skx-i16x32"]'
+  OPTSETS_FULL: "-O0 -O1 -O2"
 
 jobs:
   define-flow:
     runs-on: ubuntu-latest
     outputs:
       tests_matrix_targets: ${{ steps.set-flow.outputs.matrix }}
+      tests_optsets: ${{ steps.set-flow.outputs.optsets }}
       flow_type: ${{ steps.set-flow.outputs.type }}
     env:
       # for debug purposes
@@ -51,6 +54,9 @@ jobs:
         # set tests matrix depends on flow
         $RUN_SMOKE && echo "::set-output name=matrix::${TARGETS_SMOKE}" || true
         $RUN_FULL &&  echo "::set-output name=matrix::${TARGETS_FULL}" || true
+        # set tests optsets
+        $RUN_SMOKE && echo "::set-output name=optsets::${OPTSETS_SMOKE}" || true
+        $RUN_FULL &&  echo "::set-output name=optsets::${OPTSETS_FULL}" || true
 
   linux-build-ispc-llvm10:
     needs: [define-flow]
@@ -152,7 +158,7 @@ jobs:
     - name: Running tests
       run: |
         echo PATH=$PATH
-        ./alloy.py -r --only="stability current -O0 -O1 -O2" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+        ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
 
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@v2
@@ -194,7 +200,7 @@ jobs:
     - name: Running tests
       run: |
         echo PATH=$PATH
-        ./alloy.py -r --only="stability current -O0 -O1 -O2" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+        ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
 
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -60,7 +60,7 @@ jobs:
 
   linux-build-ispc-llvm10:
     needs: [define-flow]
-    if: ${{ needs.define-flow.outputs.flow_type == 'full' }}
+    #if: ${{ needs.define-flow.outputs.flow_type == 'full' }}
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "10.0"

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, Intel Corporation
+#  Copyright (c) 2018-2020, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -44,7 +44,7 @@ if(CMAKE_BUILD_TYPE)
 
     string(FIND "${CONFIGURATION_TYPES}" "${CMAKE_BUILD_TYPE}" MATCHED_CONFIG)
     if (${MATCHED_CONFIG} EQUAL -1)
-         message(FATAL_ERROR "CMAKE_BUILD_TYPE (${CMAKE_BUILD_TYPE}) allows only the following values: ${CONFIGURATION_TYPES}")
+        message(FATAL_ERROR "CMAKE_BUILD_TYPE (${CMAKE_BUILD_TYPE}) allows only the following values: ${CONFIGURATION_TYPES}")
     endif()
 else(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")

--- a/examples/portable/genx/cmake/AddPerfExample.cmake
+++ b/examples/portable/genx/cmake/AddPerfExample.cmake
@@ -123,10 +123,10 @@ function(add_perf_example)
             set_target_properties(${CM_HOST_BINARY} PROPERTIES FOLDER "GEN_Examples")
         else()
             add_custom_command(
-               OUTPUT ${parsed_CM_OBJ_NAME}
-               COMMAND ${CMC_EXECUTABLE} -march=SKL -fcmocl "-DCM_PTRSIZE=64" -emit-spirv -o ${parsed_CM_OBJ_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${parsed_CM_SRC_NAME}.cpp
-               VERBATIM
-               DEPENDS ${CMC_EXECUTABLE}
+                OUTPUT ${parsed_CM_OBJ_NAME}
+                COMMAND ${CMC_EXECUTABLE} -march=SKL -fcmocl "-DCM_PTRSIZE=64" -emit-spirv -o ${parsed_CM_OBJ_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${parsed_CM_SRC_NAME}.cpp
+                VERBATIM
+                DEPENDS ${CMC_EXECUTABLE}
             )
             target_compile_definitions(${CM_HOST_BINARY} PRIVATE ISPCRT CMKERNEL)
             target_include_directories(${CM_HOST_BINARY} PRIVATE ${COMMON_PATH})

--- a/ispcrt/CMakeLists.txt
+++ b/ispcrt/CMakeLists.txt
@@ -24,7 +24,7 @@ include(GNUInstallDirs)
 ## Establish project ##########################################################
 
 # TODO: use ISPC version here
-project(ispcrt VERSION 1.13.0 LANGUAGES C CXX)
+project(ispcrt VERSION 1.16.0 LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 

--- a/src/ispc_version.h
+++ b/src/ispc_version.h
@@ -38,7 +38,7 @@
 #pragma once
 
 #define ISPC_VERSION_MAJOR 1
-#define ISPC_VERSION_MINOR 15
+#define ISPC_VERSION_MINOR 16
 #define ISPC_VERSION "1.16.0dev"
 #include <llvm/Config/llvm-config.h>
 


### PR DESCRIPTION
* reduce amount (and time) of `smoke` testing
* Introduce testing with `-g` in `full` mode
* enabled LLVM10 testing for `smoke`
* Fix ISPCRT version to match ISPC version
* Editorial changes