### PR TITLE
CI & scripts & Dockerfile fixes

### DIFF
--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -40,20 +40,21 @@ jobs:
         docker run ispc/ubuntu16.04
         export CONTAINER=`docker ps --all |head -2 |tail -1 |awk '//{print $1}'`
         sudo docker cp $CONTAINER:/usr/local/src/llvm/bin-trunk .
-        tar cJvf llvm-trunk-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz bin-trunk
+        # Note using gzip here, instead of xz - trading of space for speed, as it's just for passing to another stage.
+        tar czvf llvm-trunk-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.gz bin-trunk
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm_trunk_linux
-        path: docker/ubuntu/llvm_build/llvm-trunk-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/llvm_build/llvm-trunk-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.gz
 
   linux-build-ispc-llvm-trunk:
     needs: [linux-build-llvm-trunk]
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "trunk"
-      LLVM_TAR: llvm-trunk-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-trunk-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.gz
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rebuild-llvm11.yml
+++ b/.github/workflows/rebuild-llvm11.yml
@@ -37,13 +37,13 @@ jobs:
         docker run ispc/ubuntu16.04
         export CONTAINER=`docker ps --all |head -2 |tail -1 |awk '//{print $1}'`
         sudo docker cp $CONTAINER:/usr/local/src/llvm/bin-11.0 .
-        tar cJvf llvm-11.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz bin-11.0
+        tar cJvf llvm-11.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz bin-11.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11_linux
-        path: docker/ubuntu/llvm_build/llvm-11.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/llvm_build/llvm-11.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
 
   linux-build-release:
     runs-on: ubuntu-latest
@@ -68,13 +68,13 @@ jobs:
         docker run ispc/ubuntu16.04
         export CONTAINER=`docker ps --all |head -2 |tail -1 |awk '//{print $1}'`
         sudo docker cp $CONTAINER:/usr/local/src/llvm/bin-11.0 .
-        tar cJvf llvm-11.0.0-ubuntu16.04-Release-x86.arm.wasm.tar.xz bin-11.0
+        tar cJvf llvm-11.0.1-ubuntu16.04-Release-x86.arm.wasm.tar.xz bin-11.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11rel_linux
-        path: docker/ubuntu/llvm_build/llvm-11.0.0-ubuntu16.04-Release-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/llvm_build/llvm-11.0.1-ubuntu16.04-Release-x86.arm.wasm.tar.xz
 
   win-build:
     runs-on: windows-latest
@@ -109,13 +109,13 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-11.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z bin-11.0
+        7z.exe a -t7z llvm-11.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.7z bin-11.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11_win
-        path: llvm/llvm-11.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z
+        path: llvm/llvm-11.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.7z
 
   win-build-release:
     runs-on: windows-latest
@@ -150,13 +150,13 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-11.0.0-win.vs2019-Release-x86.arm.wasm.7z bin-11.0
+        7z.exe a -t7z llvm-11.0.1-win.vs2019-Release-x86.arm.wasm.7z bin-11.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11rel_win
-        path: llvm/llvm-11.0.0-win.vs2019-Release-x86.arm.wasm.7z
+        path: llvm/llvm-11.0.1-win.vs2019-Release-x86.arm.wasm.7z
 
   mac-build:
     runs-on: macos-10.15
@@ -193,13 +193,13 @@ jobs:
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-11.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz bin-11.0
+        tar cJvf llvm-11.0.1-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz bin-11.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11_macos
-        path: llvm/llvm-11.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
+        path: llvm/llvm-11.0.1-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
 
   mac-build-release:
     runs-on: macos-10.15
@@ -236,11 +236,11 @@ jobs:
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-11.0.0-macos10.15-Release-x86.arm.wasm.tar.xz bin-11.0
+        tar cJvf llvm-11.0.1-macos10.15-Release-x86.arm.wasm.tar.xz bin-11.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11rel_macos
-        path: llvm/llvm-11.0.0-macos10.15-Release-x86.arm.wasm.tar.xz
+        path: llvm/llvm-11.0.1-macos10.15-Release-x86.arm.wasm.tar.xz
 

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -19,7 +19,7 @@ RUN yum install -y ncurses-static libstdc++-static && \
     yum clean -y all
 
 # Download and install required version of cmake (3.14) for ISPC build
-RUN wget https://cmake.org/files/v3.14/cmake-3.14.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.14.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://cmake.org/files/v3.14/cmake-3.14.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.14.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
     ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.14.0-Linux-x86_64.sh
 
 # If you are behind a proxy, you need to configure git.

--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -14,7 +14,7 @@ RUN dnf install -y ncurses-static libstdc++-static zlib-static glibc-static && \
     dnf clean -y all
 
 # Download and install required version of cmake (3.13) for ISPC build
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.13.5/cmake-3.13.5-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.13.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/Kitware/CMake/releases/download/v3.13.5/cmake-3.13.5-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.13.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
     ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.13.5-Linux-x86_64.sh
 
 # If you are behind a proxy, you need to configure git and svn.

--- a/docker/ubuntu/full_ispc_build/Dockerfile
+++ b/docker/ubuntu/full_ispc_build/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get -y update && apt-get install -y wget build-essential vim gcc g++ git
     rm -rf /var/lib/apt/lists/*
 
 # Download and install required version of cmake (3.13) for ISPC build
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.13.5/cmake-3.13.5-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.13.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/Kitware/CMake/releases/download/v3.13.5/cmake-3.13.5-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.13.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
     ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.13.5-Linux-x86_64.sh
 
 # If you are behind a proxy, you need to configure git and svn.

--- a/docker/ubuntu/gen/Dockerfile
+++ b/docker/ubuntu/gen/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get -y update && apt-get install -y repo clang-8 build-essential libnuma
     rm -rf /var/lib/apt/lists/*
 
 # Download and install required version of cmake (3.14) for ISPC build
-RUN wget https://cmake.org/files/v3.14/cmake-3.14.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.14.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://cmake.org/files/v3.14/cmake-3.14.0-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.14.0-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
     ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && ln -s /opt/cmake/bin/cmake /usr/bin/cmake && \
     ln -s /opt/cmake/bin/ctest /usr/local/bin/ctest && ln -s /opt/cmake/bin/ctest /usr/bin/ctest && rm cmake-3.14.0-Linux-x86_64.sh
 
@@ -35,19 +35,19 @@ RUN ./alloy.py -b --version=$LLVM_VERSION --selfbuild && \
 WORKDIR /home/packages
 
 # Compute runtime
-RUN wget https://github.com/intel/compute-runtime/releases/download/20.50.18716/intel-gmmlib_20.3.2_amd64.deb
-RUN wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.5819/intel-igc-core_1.0.5819_amd64.deb
-RUN wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.5819/intel-igc-opencl_1.0.5819_amd64.deb
-RUN wget https://github.com/intel/compute-runtime/releases/download/20.50.18716/intel-opencl_20.50.18716_amd64.deb
-RUN wget https://github.com/intel/compute-runtime/releases/download/20.50.18716/intel-ocloc_20.50.18716_amd64.deb
-RUN wget https://github.com/intel/compute-runtime/releases/download/20.50.18716/intel-level-zero-gpu_1.0.18716_amd64.deb
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/intel/compute-runtime/releases/download/20.50.18716/intel-gmmlib_20.3.2_amd64.deb
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.5819/intel-igc-core_1.0.5819_amd64.deb
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.5819/intel-igc-opencl_1.0.5819_amd64.deb
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/intel/compute-runtime/releases/download/20.50.18716/intel-opencl_20.50.18716_amd64.deb
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/intel/compute-runtime/releases/download/20.50.18716/intel-ocloc_20.50.18716_amd64.deb
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/intel/compute-runtime/releases/download/20.50.18716/intel-level-zero-gpu_1.0.18716_amd64.deb
 
-RUN wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.$IGC_VER/intel-igc-opencl-devel_1.0.${IGC_VER}_amd64.deb
-RUN wget https://raw.githubusercontent.com/intel/intel-graphics-compiler/igc-1.0.$IGC_VER/inc/common/igfxfmid.h -O igfxfmid.h
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.$IGC_VER/intel-igc-opencl-devel_1.0.${IGC_VER}_amd64.deb
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://raw.githubusercontent.com/intel/intel-graphics-compiler/igc-1.0.$IGC_VER/inc/common/igfxfmid.h -O igfxfmid.h
 
 # L0 loaader
-RUN wget https://github.com/oneapi-src/level-zero/releases/download/v$L0L_VER/level-zero-devel_$L0L_VER+u18.04_amd64.deb
-RUN wget https://github.com/oneapi-src/level-zero/releases/download/v$L0L_VER/level-zero_$L0L_VER+u18.04_amd64.deb
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/oneapi-src/level-zero/releases/download/v$L0L_VER/level-zero-devel_$L0L_VER+u18.04_amd64.deb
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/oneapi-src/level-zero/releases/download/v$L0L_VER/level-zero_$L0L_VER+u18.04_amd64.deb
 
 # Install packages and clean up
 RUN dpkg -i *.deb

--- a/docker/ubuntu/llvm_build/Dockerfile
+++ b/docker/ubuntu/llvm_build/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get -y update && apt-get install -y wget build-essential gcc g++ git pyt
 #RUN git config --global --add http.proxy http://proxy.yourcompany.com:888
 
 # Download and install required version of cmake (3.13) for ISPC build
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.13.5/cmake-3.13.5-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.13.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/Kitware/CMake/releases/download/v3.13.5/cmake-3.13.5-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.13.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
     ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.13.5-Linux-x86_64.sh
 
 WORKDIR /usr/local/src


### PR DESCRIPTION
* make alloy.py return proper exit code when failing to build LLVM
* Make LLVM 11 rebuild pipeline to producer correctly named artifacts (11.0.0 -> 11.0.1)
* Use more robust wget parameters in Dockerfiles
* When running LLVM trunk nightly pipeline use gzip instead of xz, so reducing overall time.