### PR TITLE
fixes #1821 - Removing LLVMGetName() and switching to LLVM::Twine.

### DIFF
--- a/src/ctx.h
+++ b/src/ctx.h
@@ -302,7 +302,7 @@ class FunctionEmitContext {
     llvm::Value *GetStringPtr(const std::string &str);
 
     /** Create a new basic block with given name */
-    llvm::BasicBlock *CreateBasicBlock(const char *name, llvm::BasicBlock *insertAfter = NULL);
+    llvm::BasicBlock *CreateBasicBlock(const llvm::Twine &name, llvm::BasicBlock *insertAfter = NULL);
 
     /** Given a vector with element type i1, return a vector of type
         LLVMTypes::BoolVectorType.  This method handles the conversion for
@@ -380,33 +380,33 @@ class FunctionEmitContext {
         this also handles applying the given operation to the vector
         elements. */
     llvm::Value *BinaryOperator(llvm::Instruction::BinaryOps inst, llvm::Value *v0, llvm::Value *v1,
-                                const char *name = NULL);
+                                const llvm::Twine &name = "");
 
     /** Emit the "not" operator.  Like BinaryOperator(), this also handles
         a VectorType-based operand. */
-    llvm::Value *NotOperator(llvm::Value *v, const char *name = NULL);
+    llvm::Value *NotOperator(llvm::Value *v, const llvm::Twine &name = "");
 
     /** Emit a comparison instruction.  If the operands are VectorTypes,
         then a value for the corresponding boolean VectorType is
         returned. */
     llvm::Value *CmpInst(llvm::Instruction::OtherOps inst, llvm::CmpInst::Predicate pred, llvm::Value *v0,
-                         llvm::Value *v1, const char *name = NULL);
+                         llvm::Value *v1, const llvm::Twine &name = "");
 
     /** Given a scalar value, return a vector of the same type (or an
         array, for pointer types). */
-    llvm::Value *SmearUniform(llvm::Value *value, const char *name = NULL);
+    llvm::Value *SmearUniform(llvm::Value *value, const llvm::Twine &name = "");
 
-    llvm::Value *BitCastInst(llvm::Value *value, llvm::Type *type, const char *name = NULL);
-    llvm::Value *PtrToIntInst(llvm::Value *value, const char *name = NULL);
-    llvm::Value *PtrToIntInst(llvm::Value *value, llvm::Type *type, const char *name = NULL);
-    llvm::Value *IntToPtrInst(llvm::Value *value, llvm::Type *type, const char *name = NULL);
+    llvm::Value *BitCastInst(llvm::Value *value, llvm::Type *type, const llvm::Twine &name = "");
+    llvm::Value *PtrToIntInst(llvm::Value *value, const llvm::Twine &name = "");
+    llvm::Value *PtrToIntInst(llvm::Value *value, llvm::Type *type, const llvm::Twine &name = "");
+    llvm::Value *IntToPtrInst(llvm::Value *value, llvm::Type *type, const llvm::Twine &name = "");
 
-    llvm::Instruction *TruncInst(llvm::Value *value, llvm::Type *type, const char *name = NULL);
+    llvm::Instruction *TruncInst(llvm::Value *value, llvm::Type *type, const llvm::Twine &name = "");
     llvm::Instruction *CastInst(llvm::Instruction::CastOps op, llvm::Value *value, llvm::Type *type,
-                                const char *name = NULL);
-    llvm::Instruction *FPCastInst(llvm::Value *value, llvm::Type *type, const char *name = NULL);
-    llvm::Instruction *SExtInst(llvm::Value *value, llvm::Type *type, const char *name = NULL);
-    llvm::Instruction *ZExtInst(llvm::Value *value, llvm::Type *type, const char *name = NULL);
+                                const llvm::Twine &name = "");
+    llvm::Instruction *FPCastInst(llvm::Value *value, llvm::Type *type, const llvm::Twine &name = "");
+    llvm::Instruction *SExtInst(llvm::Value *value, llvm::Type *type, const llvm::Twine &name = "");
+    llvm::Instruction *ZExtInst(llvm::Value *value, llvm::Type *type, const llvm::Twine &name = "");
 
     /** Given two integer-typed values (but possibly one vector and the
         other not, and or of possibly-different bit-widths), update their
@@ -426,9 +426,9 @@ class FunctionEmitContext {
         pointers.  The underlying type of the base pointer must be provided
         via the ptrType parameter */
     llvm::Value *GetElementPtrInst(llvm::Value *basePtr, llvm::Value *index, const Type *ptrType,
-                                   const char *name = NULL);
+                                   const llvm::Twine &name = "");
     llvm::Value *GetElementPtrInst(llvm::Value *basePtr, llvm::Value *index0, llvm::Value *index1, const Type *ptrType,
-                                   const char *name = NULL);
+                                   const llvm::Twine &name = "");
 
     /** This method returns a new pointer that represents offsetting the
         given base pointer to point at the given element number of the
@@ -436,26 +436,26 @@ class FunctionEmitContext {
         pointer must be a pointer to a structure type.  The ptrType gives
         the type of the pointer, though it may be NULL if the base pointer
         is uniform. */
-    llvm::Value *AddElementOffset(llvm::Value *basePtr, int elementNum, const Type *ptrType, const char *name = NULL,
-                                  const PointerType **resultPtrType = NULL);
+    llvm::Value *AddElementOffset(llvm::Value *basePtr, int elementNum, const Type *ptrType,
+                                  const llvm::Twine &name = "", const PointerType **resultPtrType = NULL);
 
     /** Bool is stored as i8 and <WIDTH x i8> but represented in IR as i1 and
      * <WIDTH x MASK>. This is a helper function to match bool size at storage
      * interface. */
-    llvm::Value *SwitchBoolSize(llvm::Value *value, llvm::Type *toType, const char *name = NULL);
+    llvm::Value *SwitchBoolSize(llvm::Value *value, llvm::Type *toType, const llvm::Twine &name = "");
     /** Load from the memory location(s) given by lvalue, using the given
         mask.  The lvalue may be varying, in which case this corresponds to
         a gather from the multiple memory locations given by the array of
         pointer values given by the lvalue.  If the lvalue is not varying,
         then both the mask pointer and the type pointer may be NULL. */
-    llvm::Value *LoadInst(llvm::Value *ptr, llvm::Value *mask, const Type *ptrType, const char *name = NULL,
+    llvm::Value *LoadInst(llvm::Value *ptr, llvm::Value *mask, const Type *ptrType, const llvm::Twine &name = "",
                           bool one_elem = false);
 
     /* Load from memory location(s) given.
      * 'type' needs to be provided when storage type is different from IR type. For example,
      * 'unform bool' is 'i1' in IR but stored as 'i8'.
      * Otherwise leave this as NULL. */
-    llvm::Value *LoadInst(llvm::Value *ptr, const Type *type = NULL, const char *name = NULL);
+    llvm::Value *LoadInst(llvm::Value *ptr, const Type *type = NULL, const llvm::Twine &name = "");
 
     /** Emits an alloca instruction to allocate stack storage for the given
         type.  If a non-zero alignment is specified, the object is also
@@ -463,7 +463,8 @@ class FunctionEmitContext {
         instruction is added at the start of the function in the entry
         basic block; if it should be added to the current basic block, then
         the atEntryBlock parameter should be false. */
-    llvm::Value *AllocaInst(llvm::Type *llvmType, const char *name = NULL, int align = 0, bool atEntryBlock = true);
+    llvm::Value *AllocaInst(llvm::Type *llvmType, const llvm::Twine &name = "", int align = 0,
+                            bool atEntryBlock = true);
 
     /** Emits an alloca instruction to allocate stack storage for the given
         type.  If a non-zero alignment is specified, the object is also
@@ -474,7 +475,7 @@ class FunctionEmitContext {
         This implementation is preferred when possible. It is needed when
         storage type is different from IR type. For example,
         'unform bool' is 'i1' in IR but stored as 'i8'. */
-    llvm::Value *AllocaInst(const Type *ptrType, const char *name = NULL, int align = 0, bool atEntryBlock = true);
+    llvm::Value *AllocaInst(const Type *ptrType, const llvm::Twine &name = "", int align = 0, bool atEntryBlock = true);
 
     /** Standard store instruction; for this variant, the lvalue must be a
         single pointer, not a varying lvalue.
@@ -502,39 +503,41 @@ class FunctionEmitContext {
     /** This convenience method maps to an llvm::ExtractElementInst if the
         given value is a llvm::VectorType, and to an llvm::ExtractValueInst
         otherwise. */
-    llvm::Value *ExtractInst(llvm::Value *v, int elt, const char *name = NULL);
+    llvm::Value *ExtractInst(llvm::Value *v, int elt, const llvm::Twine &name = "");
 
     /** This convenience method maps to an llvm::InsertElementInst if the
         given value is a llvm::VectorType, and to an llvm::InsertValueInst
         otherwise. */
-    llvm::Value *InsertInst(llvm::Value *v, llvm::Value *eltVal, int elt, const char *name = NULL);
+    llvm::Value *InsertInst(llvm::Value *v, llvm::Value *eltVal, int elt, const llvm::Twine &name = "");
 
     /** This convenience method maps to an llvm::ShuffleVectorInst. */
-    llvm::Value *ShuffleInst(llvm::Value *v1, llvm::Value *v2, llvm::Value *mask, const char *name = NULL);
+    llvm::Value *ShuffleInst(llvm::Value *v1, llvm::Value *v2, llvm::Value *mask, const llvm::Twine &name = "");
 
     /** This convenience method to generate broadcast pattern. It takes a value
         and a vector type. Type of the value must match element type of the
         vector. */
-    llvm::Value *BroadcastValue(llvm::Value *v, llvm::Type *vecType, const char *name = NULL);
+    llvm::Value *BroadcastValue(llvm::Value *v, llvm::Type *vecType, const llvm::Twine &name = "");
 
-    llvm::PHINode *PhiNode(llvm::Type *type, int count, const char *name = NULL);
-    llvm::Instruction *SelectInst(llvm::Value *test, llvm::Value *val0, llvm::Value *val1, const char *name = NULL);
+    llvm::PHINode *PhiNode(llvm::Type *type, int count, const llvm::Twine &name = "");
+    llvm::Instruction *SelectInst(llvm::Value *test, llvm::Value *val0, llvm::Value *val1,
+                                  const llvm::Twine &name = "");
 
     /** Emits IR to do a function call with the given arguments.  If the
         function type is a varying function pointer type, its full type
         must be provided in funcType.  funcType can be NULL if func is a
         uniform function pointer. */
     llvm::Value *CallInst(llvm::Value *func, const FunctionType *funcType, const std::vector<llvm::Value *> &args,
-                          const char *name = NULL);
+                          const llvm::Twine &name = "");
 
     /** This is a convenience method that issues a call instruction to a
         function that takes just a single argument. */
-    llvm::Value *CallInst(llvm::Value *func, const FunctionType *funcType, llvm::Value *arg, const char *name = NULL);
+    llvm::Value *CallInst(llvm::Value *func, const FunctionType *funcType, llvm::Value *arg,
+                          const llvm::Twine &name = "");
 
     /** This is a convenience method that issues a call instruction to a
         function that takes two arguments. */
     llvm::Value *CallInst(llvm::Value *func, const FunctionType *funcType, llvm::Value *arg0, llvm::Value *arg1,
-                          const char *name = NULL);
+                          const llvm::Twine &name = "");
 
     /** Launch an asynchronous task to run the given function, passing it
         he given argument values. */
@@ -756,9 +759,10 @@ class FunctionEmitContext {
     void maskedStore(llvm::Value *value, llvm::Value *ptr, const Type *ptrType, llvm::Value *mask);
     void storeUniformToSOA(llvm::Value *value, llvm::Value *ptr, llvm::Value *mask, const Type *valueType,
                            const PointerType *ptrType);
-    llvm::Value *loadUniformFromSOA(llvm::Value *ptr, llvm::Value *mask, const PointerType *ptrType, const char *name);
+    llvm::Value *loadUniformFromSOA(llvm::Value *ptr, llvm::Value *mask, const PointerType *ptrType,
+                                    const llvm::Twine &name = "");
 
-    llvm::Value *gather(llvm::Value *ptr, const PointerType *ptrType, llvm::Value *mask, const char *name);
+    llvm::Value *gather(llvm::Value *ptr, const PointerType *ptrType, llvm::Value *mask, const llvm::Twine &name = "");
 
     llvm::Value *addVaryingOffsetsIfNeeded(llvm::Value *ptr, const Type *ptrType);
 };

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1021,11 +1021,11 @@ static llvm::Value *lEmitNegate(Expr *arg, SourcePos pos, FunctionEmitContext *c
     ctx->SetDebugPos(pos);
     if (type->IsFloatType()) {
         llvm::Value *zero = llvm::ConstantFP::getZeroValueForNegation(type->LLVMType(g->ctx));
-        return ctx->BinaryOperator(llvm::Instruction::FSub, zero, argVal, LLVMGetName(argVal, "_negate"));
+        return ctx->BinaryOperator(llvm::Instruction::FSub, zero, argVal, llvm::Twine(argVal->getName()) + "_negate");
     } else {
         llvm::Value *zero = lLLVMConstantValue(type, g->ctx, 0.);
         AssertPos(pos, type->IsIntType());
-        return ctx->BinaryOperator(llvm::Instruction::Sub, zero, argVal, LLVMGetName(argVal, "_negate"));
+        return ctx->BinaryOperator(llvm::Instruction::Sub, zero, argVal, llvm::Twine(argVal->getName()) + "_negate");
     }
 }
 
@@ -1047,11 +1047,11 @@ llvm::Value *UnaryExpr::GetValue(FunctionEmitContext *ctx) const {
         return lEmitNegate(expr, pos, ctx);
     case LogicalNot: {
         llvm::Value *argVal = expr->GetValue(ctx);
-        return ctx->NotOperator(argVal, LLVMGetName(argVal, "_logicalnot"));
+        return ctx->NotOperator(argVal, llvm::Twine(argVal->getName()) + "_logicalnot");
     }
     case BitNot: {
         llvm::Value *argVal = expr->GetValue(ctx);
-        return ctx->NotOperator(argVal, LLVMGetName(argVal, "_bitnot"));
+        return ctx->NotOperator(argVal, llvm::Twine(argVal->getName()) + "_bitnot");
     }
     default:
         FATAL("logic error");
@@ -1518,7 +1518,8 @@ static llvm::Value *lEmitBinaryArith(BinaryExpr::Op op, llvm::Value *value0, llv
             return NULL;
         }
 
-        return ctx->BinaryOperator(inst, value0, value1, LLVMGetName(opName, value0, value1));
+        return ctx->BinaryOperator(inst, value0, value1,
+                                   (((llvm::Twine(opName) + "_") + value0->getName()) + "_") + value1->getName());
     }
 }
 
@@ -1563,7 +1564,7 @@ static llvm::Value *lEmitBinaryCmp(BinaryExpr::Op op, llvm::Value *e0Val, llvm::
     }
 
     llvm::Value *cmp = ctx->CmpInst(isFloatOp ? llvm::Instruction::FCmp : llvm::Instruction::ICmp, pred, e0Val, e1Val,
-                                    LLVMGetName(opName, e0Val, e1Val));
+                                    (((llvm::Twine(opName) + "_") + e0Val->getName()) + "_") + e1Val->getName());
     // This is a little ugly: CmpInst returns i1 values, but we use vectors
     // of i32s for varying bool values; type convert the result here if
     // needed.
@@ -4177,7 +4178,7 @@ static llvm::Value *lConvertToSlicePointer(FunctionEmitContext *ctx, llvm::Value
     // offsets
     llvm::Value *result = llvm::Constant::getNullValue(sliceStructType);
     // And replace the pointer in the struct with the given pointer
-    return ctx->InsertInst(result, ptr, 0, LLVMGetName(ptr, "_slice"));
+    return ctx->InsertInst(result, ptr, 0, llvm::Twine(ptr->getName()) + "_slice");
 }
 
 /** If the given array index is a compile time constant, check to see if it
@@ -4258,8 +4259,8 @@ llvm::Value *IndexExpr::GetLValue(FunctionEmitContext *ctx) const {
         // Convert to a slice pointer if we're indexing into SOA data
         basePtrValue = lConvertPtrToSliceIfNeeded(ctx, basePtrValue, &baseExprType);
 
-        llvm::Value *ptr =
-            ctx->GetElementPtrInst(basePtrValue, indexValue, baseExprType, LLVMGetName(basePtrValue, "_offset"));
+        llvm::Value *ptr = ctx->GetElementPtrInst(basePtrValue, indexValue, baseExprType,
+                                                  llvm::Twine(basePtrValue->getName()) + "_offset");
         return lAddVaryingOffsetsIfNeeded(ctx, ptr, GetLValueType());
     }
 
@@ -4290,8 +4291,8 @@ llvm::Value *IndexExpr::GetLValue(FunctionEmitContext *ctx) const {
     ctx->SetDebugPos(pos);
 
     // And do the actual indexing calculation..
-    llvm::Value *ptr =
-        ctx->GetElementPtrInst(basePtr, LLVMInt32(0), indexValue, basePtrType, LLVMGetName(basePtr, "_offset"));
+    llvm::Value *ptr = ctx->GetElementPtrInst(basePtr, LLVMInt32(0), indexValue, basePtrType,
+                                              llvm::Twine(basePtr->getName()) + "_offset");
     return lAddVaryingOffsetsIfNeeded(ctx, ptr, GetLValueType());
 }
 
@@ -4788,15 +4789,14 @@ llvm::Value *VectorMemberExpr::GetValue(FunctionEmitContext *ctx) const {
         for (size_t i = 0; i < identifier.size(); ++i) {
             char idStr[2] = {identifier[i], '\0'};
             llvm::Value *elementPtr =
-                ctx->AddElementOffset(basePtr, indices[i], basePtrType, LLVMGetName(basePtr, idStr));
+                ctx->AddElementOffset(basePtr, indices[i], basePtrType, llvm::Twine(basePtr->getName()) + idStr);
             llvm::Value *elementValue = ctx->LoadInst(elementPtr, elementMask, elementPtrType);
 
-            const char *resultName = LLVMGetName(resultPtr, idStr);
-            llvm::Value *ptmp = ctx->AddElementOffset(resultPtr, i, NULL, resultName);
+            llvm::Value *ptmp = ctx->AddElementOffset(resultPtr, i, NULL, llvm::Twine(resultPtr->getName()) + idStr);
             ctx->StoreInst(elementValue, ptmp, elementPtrType, expr->GetType()->IsUniformType());
         }
 
-        return ctx->LoadInst(resultPtr, memberType, LLVMGetName(basePtr, "_swizzle"));
+        return ctx->LoadInst(resultPtr, memberType, llvm::Twine(basePtr->getName()) + "_swizzle");
     }
 }
 
@@ -4932,7 +4932,7 @@ llvm::Value *MemberExpr::GetValue(FunctionEmitContext *ctx) const {
 
     ctx->SetDebugPos(pos);
     std::string suffix = std::string("_") + identifier;
-    return ctx->LoadInst(lvalue, mask, lvalueType, LLVMGetName(lvalue, suffix.c_str()));
+    return ctx->LoadInst(lvalue, mask, lvalueType, llvm::Twine(lvalue->getName()) + suffix);
 }
 
 const Type *MemberExpr::GetType() const { return NULL; }
@@ -6502,7 +6502,7 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
                 // does for everyone else...
                 Assert(cast);
                 cast = ctx->SwitchBoolSize(cast, LLVMTypes::BoolVectorType->getElementType(),
-                                           LLVMGetName(cast, "to_i_bool"));
+                                           llvm::Twine(cast->getName()) + "to_i_bool");
             }
         } else {
             // fromType->IsVaryingType())
@@ -8246,7 +8246,7 @@ llvm::Value *NewExpr::GetValue(FunctionEmitContext *ctx) const {
         // pointer of the return type and to run the code for initializers,
         // if present.
         llvm::Type *ptrType = retType->LLVMType(g->ctx);
-        ptrValue = ctx->BitCastInst(ptrValue, ptrType, LLVMGetName(ptrValue, "_cast_ptr"));
+        ptrValue = ctx->BitCastInst(ptrValue, ptrType, llvm::Twine(ptrValue->getName()) + "_cast_ptr");
 
         if (initExpr != NULL)
             InitSymbol(ptrValue, allocType, initExpr, ctx, pos);

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -1605,23 +1605,6 @@ llvm::Value *LLVMShuffleVectors(llvm::Value *v1, llvm::Value *v2, int32_t shuf[]
     return new llvm::ShuffleVectorInst(v1, v2, vec, "shuffle", insertBefore);
 }
 
-const char *LLVMGetName(llvm::Value *v, const char *s) {
-    if (v == NULL)
-        return s;
-    std::string ret = std::string(v->getName());
-    ret += s;
-    return strdup(ret.c_str());
-}
-
-const char *LLVMGetName(const char *op, llvm::Value *v1, llvm::Value *v2) {
-    std::string r = op;
-    r += "_";
-    r += v1->getName().str();
-    r += "_";
-    r += v2->getName().str();
-    return strdup(r.c_str());
-}
-
 #ifdef ISPC_GENX_ENABLED
 bool lIsSVMLoad(llvm::Instruction *inst) {
     Assert(inst);

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -328,11 +328,6 @@ extern llvm::Value *LLVMConcatVectors(llvm::Value *v1, llvm::Value *v2, llvm::In
 extern llvm::Value *LLVMShuffleVectors(llvm::Value *v1, llvm::Value *v2, int32_t shuf[], int shufSize,
                                        llvm::Instruction *insertBefore);
 
-/** Utility routines to concat strings with the names of existing values to
-    create meaningful new names for instruction values.
-*/
-extern const char *LLVMGetName(llvm::Value *v, const char *);
-extern const char *LLVMGetName(const char *op, llvm::Value *v1, llvm::Value *v2);
 #ifdef ISPC_GENX_ENABLED
 enum AddressSpace { Local, Global, External };
 


### PR DESCRIPTION
Planning to switch to llvm::Twine for the entire repo for (const char *) in stages. This is stage 1.