### PR TITLE
Do not use __vectorcall calling convention on WIN64 by default.

### DIFF
--- a/test_static.cpp
+++ b/test_static.cpp
@@ -76,7 +76,8 @@
 #define ARRAY_SIZE 256
 
 #ifdef ISPC_IS_WINDOWS64
-#define CALLINGCONV __vectorcall
+// __vectorcall calling convention is off by default.
+#define CALLINGCONV //__vectorcall
 #else
 #define CALLINGCONV
 #endif


### PR DESCRIPTION
Fix Win64 tests when using run_tests.py.