### PR TITLE
Fix fails reporting in ISPC CI

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -160,19 +160,17 @@ jobs:
         echo PATH=$PATH
         ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
 
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@v2
       if: failure()
       with:
         name: fail_db.llvm10.${{matrix.target}}.txt
         path: fail_db.txt
-
-    - name: Check
-      run: |
-        # Print fails to the log.
-        git diff
-        # Exit with error code if there are fails.
-        [ -z "`git diff`" ]
 
   linux-test-llvm11:
     needs: [define-flow, linux-build-ispc-llvm11]
@@ -202,19 +200,17 @@ jobs:
         echo PATH=$PATH
         ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
 
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@v2
       if: failure()
       with:
         name: fail_db.llvm11.${{matrix.target}}.txt
         path: fail_db.txt
-
-    - name: Check
-      run: |
-        # Print fails to the log.
-        git diff
-        # Exit with error code if there are fails.
-        [ -z "`git diff`" ]
 
   # Debug run is experimental with the purpose to see if it's capable to catch anything.
   # So it's running in "full" mode only for now.
@@ -246,19 +242,17 @@ jobs:
         echo PATH=$PATH
         ./alloy.py -r --only="stability current debug -O0 -O2" --only-targets="avx2-i32x8" --time --update-errors=FP
 
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@v2
       if: failure()
       with:
         name: fail_db.llvm11.debug.txt
         path: fail_db.txt
-
-    - name: Check
-      run: |
-        # Print fails to the log.
-        git diff
-        # Exit with error code if there are fails.
-        [ -z "`git diff`" ]
 
   win-build-ispc-llvm10:
     needs: [define-flow]
@@ -377,6 +371,11 @@ jobs:
         .github/workflows/scripts/load-vs-env.ps1 "${{ matrix.arch }}"
         python .\alloy.py -r --only="stability ${{ matrix.arch }} current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
 
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@v2
       if: failure()
@@ -384,10 +383,6 @@ jobs:
         name: fail_db.llvm10.${{matrix.arch}}.${{matrix.target}}.txt
         path: fail_db.txt
 
-    - name: Check
-      run: |
-        # Print fails to the log.
-        git diff
 
   win-test-llvm11:
     needs: [define-flow, win-build-ispc-llvm11]
@@ -423,6 +418,10 @@ jobs:
         .github/workflows/scripts/load-vs-env.ps1 "${{ matrix.arch }}"
         python .\alloy.py -r --only="stability ${{ matrix.arch }} current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
 
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
 
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@v2
@@ -431,7 +430,3 @@ jobs:
         name: fail_db.llvm11.${{matrix.arch}}.${{matrix.target}}.txt
         path: fail_db.txt
 
-    - name: Check
-      run: |
-        # Print fails to the log.
-        git diff


### PR DESCRIPTION
`alloy.py` return non-zero error code only if there were problems during testing (i.e. the process failed to complete, etc). Failing tests are not triggering non-zero error code. So `if: failure()` would not trigger in case of fails.

`git diff --exit-code` produces non-zero exit code if there are differences, so the job will be indicated as failing and fail log will be uploaded.