### PR TITLE
Updates for Gen target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,19 @@ else()
     endif()
 endif()
 
+# Get ispc version
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/src/ispc_version.h" ispc_ver)
+string(REGEX MATCH "ISPC_VERSION \"([0-9]*)\.([0-9]*)\.([0-9]*)([a-z]*)" _ ${ispc_ver})
+set(ISPC_VERSION_MAJOR ${CMAKE_MATCH_1})
+set(ISPC_VERSION_MINOR ${CMAKE_MATCH_2})
+set(ISPC_VERSION_PATCH ${CMAKE_MATCH_3})
+set(ISPC_VERSION_SUFFIX ${CMAKE_MATCH_4})
+if (${ISPC_VERSION_SUFFIX} MATCHES ".*dev")
+    set (REPO_TAG "main")
+else()
+    set (REPO_TAG "v${ISPC_VERSION_MAJOR}.${ISPC_VERSION_MINOR}.${ISPC_VERSION_PATCH}${ISPC_VERSION_SUFFIX}")
+endif()
+
 if (APPLE)
     # Use standard macOS SDK location if this is not specified.
     if (NOT ISPC_MACOS_SDK_PATH)
@@ -601,19 +614,6 @@ if (ISPC_PREPARE_PACKAGE)
     install (FILES "${PROJECT_SOURCE_DIR}/LICENSE.txt" DESTINATION .)
     install (FILES "${PROJECT_SOURCE_DIR}/third-party-programs.txt" DESTINATION .)
     install (FILES "${PROJECT_SOURCE_DIR}/docs/ReleaseNotes.txt" DESTINATION .)
-
-    # Get ispc version
-    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/src/ispc_version.h" ispc_ver)
-    string(REGEX MATCH "ISPC_VERSION \"([0-9]*)\.([0-9]*)\.([0-9]*)([a-z]*)" _ ${ispc_ver})
-    set(ISPC_VERSION_MAJOR ${CMAKE_MATCH_1})
-    set(ISPC_VERSION_MINOR ${CMAKE_MATCH_2})
-    set(ISPC_VERSION_PATCH ${CMAKE_MATCH_3})
-    set(ISPC_VERSION_SUFFIX ${CMAKE_MATCH_4})
-    if (${ISPC_VERSION_SUFFIX} MATCHES ".*dev")
-        set (REPO_TAG "main")
-    else()
-        set (REPO_TAG "v${ISPC_VERSION_MAJOR}.${ISPC_VERSION_MINOR}.${ISPC_VERSION_PATCH}${ISPC_VERSION_SUFFIX}")
-    endif()
 
     # Clone corresponding version of documentation
     include(ExternalProject)

--- a/examples/xpu/common/L0_helpers.h
+++ b/examples/xpu/common/L0_helpers.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2020, Intel Corporation
+  Copyright (c) 2020-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -178,7 +178,7 @@ void L0Create_EventPool(ze_device_handle_t hDevice, ze_context_handle_t hContext
     // Create event pool and enable time measurements
     ze_event_pool_desc_t eventPoolDesc = {};
     eventPoolDesc.count = size;
-    eventPoolDesc.flags = (ze_event_pool_flag_t)(ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP);
+    eventPoolDesc.flags = (ze_event_pool_flag_t)(ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP | ZE_EVENT_POOL_FLAG_HOST_VISIBLE);
     L0_SAFE_CALL(zeEventPoolCreate(hContext, &eventPoolDesc, 1, &hDevice, &hPool));
 }
 

--- a/examples/xpu/common/L0_helpers.h
+++ b/examples/xpu/common/L0_helpers.h
@@ -147,7 +147,7 @@ void L0InitContext(ze_driver_handle_t &hDriver, ze_device_handle_t &hDevice, ze_
     moduleDesc.format = use_zebin ? ZE_MODULE_FORMAT_NATIVE : ZE_MODULE_FORMAT_IL_SPIRV;
     moduleDesc.inputSize = codeSize;
     moduleDesc.pInputModule = codeBin;
-    moduleDesc.pBuildFlags = "-vc-codegen -no-optimize";
+    moduleDesc.pBuildFlags = "-vc-codegen -no-optimize -Xfinalizer '-presched'";
     L0_SAFE_CALL(zeModuleCreate(hContext, hDevice, &moduleDesc, &hModule, nullptr));
 }
 

--- a/examples/xpu/mandelbrot/mandelbrot.cpp
+++ b/examples/xpu/mandelbrot/mandelbrot.cpp
@@ -132,6 +132,7 @@ static int run(unsigned int width, unsigned int height, unsigned int test_iterat
             reset_and_start_timer();
             queue.copyToDevice(p_dev);
             queue.barrier();
+            queue.submit();
             queue.sync();
             auto res = queue.launch(kernel, p_dev, width / p.tile_size, height / p.tile_size);
             queue.barrier();

--- a/fail_db.txt
+++ b/fail_db.txt
@@ -10,14 +10,12 @@
 ./tests/pdivus-vi32.ispc runfail  genx64        genx-x8 TGLLP   Linux LLVM 11.1 clang++11.1  spv *
 ./tests/soa-6.ispc runfail  genx64        genx-x8 TGLLP   Linux LLVM 11.1 clang++11.1  spv *
 ./tests/soa-7.ispc runfail  genx64        genx-x8 TGLLP   Linux LLVM 11.1 clang++11.1  spv *
-./tests/print_bool_simd.ispc runfail  genx64        genx-x8 unspec   Linux LLVM 11.1 clang++11.1  spv *
 ./tests/soa-6.ispc runfail  genx64        genx-x8 unspec   Linux LLVM 11.1 clang++11.1  spv *
 ./tests/soa-7.ispc runfail  genx64        genx-x8 unspec   Linux LLVM 11.1 clang++11.1  spv *
 ./tests/masked-struct-scatter-varying.ispc runfail  genx64       genx-x16 TGLLP   Linux LLVM 11.1 clang++11.1  spv *
 ./tests/pdivus-i32.ispc runfail  genx64       genx-x16 TGLLP   Linux LLVM 11.1 clang++11.1  spv *
 ./tests/pdivus-vi32.ispc runfail  genx64       genx-x16 TGLLP   Linux LLVM 11.1 clang++11.1  spv *
 ./tests/masked-struct-scatter-varying.ispc runfail  genx64       genx-x16 unspec   Linux LLVM 11.1 clang++11.1  spv *
-./tests/print_bool_simd.ispc runfail  genx64       genx-x16 unspec   Linux LLVM 11.1 clang++11.1  spv *
 .\tests\1546.ispc runfail  genx64        genx-x8 unspec Windows LLVM 11.1         cl  spv *
 .\tests\acos.ispc runfail  genx64        genx-x8 unspec Windows LLVM 11.1         cl  spv *
 .\tests\array-gather-multi-unif.ispc runfail  genx64        genx-x8 unspec Windows LLVM 11.1         cl  spv *

--- a/ispcrt/CMakeLists.txt
+++ b/ispcrt/CMakeLists.txt
@@ -21,8 +21,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 ## Establish project ##########################################################
 
-# TODO: use ISPC version here
-project(ispcrt VERSION 1.16.0 LANGUAGES CXX)
+# set (REPO_TAG "v${ISPC_VERSION_MAJOR}.${ISPC_VERSION_MINOR}.${ISPC_VERSION_PATCH}${ISPC_VERSION_SUFFIX}")
+project(ispcrt VERSION ${ISPC_VERSION_MAJOR}.${ISPC_VERSION_MINOR}.${ISPC_VERSION_PATCH} LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/ispcrt/detail/TaskQueue.h
+++ b/ispcrt/detail/TaskQueue.h
@@ -21,6 +21,7 @@ struct TaskQueue : public RefCounted {
 
     virtual base::Future *launch(Kernel &k, base::MemoryView *params, size_t dim0, size_t dim1, size_t dim2) = 0;
 
+    virtual void submit() = 0;
     virtual void sync() = 0;
 
     virtual void* taskQueueNativeHandle() const = 0;

--- a/ispcrt/detail/cpu/CPUDevice.cpp
+++ b/ispcrt/detail/cpu/CPUDevice.cpp
@@ -168,6 +168,10 @@ struct TaskQueue : public ispcrt::base::TaskQueue {
         return future;
     }
 
+    void submit() override {
+        // no-op
+    }
+
     void sync() override {
         // no-op
     }

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -156,9 +156,7 @@ struct EventPool {
         // Create pool
         ze_event_pool_desc_t eventPoolDesc = {};
         eventPoolDesc.count = POOL_SIZE;
-        // TODO: shouldn't it be host-visible?
-        // ZE_EVENT_POOL_FLAG_HOST_VISIBLE
-        eventPoolDesc.flags = (ze_event_pool_flag_t)(ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP);
+        eventPoolDesc.flags = (ze_event_pool_flag_t)(ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP | ZE_EVENT_POOL_FLAG_HOST_VISIBLE);
         L0_SAFE_CALL(zeEventPoolCreate(m_context, &eventPoolDesc, 1, &m_device, &m_pool));
         if (!m_pool) {
             std::stringstream ss;

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -305,7 +305,7 @@ struct Module : public ispcrt::base::Module {
         // + or = sign. '+' means that the content of the variable should
         // be added to the default igc options, while '=' will replace
         // the options with the content of the env var.
-        std::string igcOptions = "-vc-codegen -no-optimize";
+        std::string igcOptions = "-vc-codegen -no-optimize -Xfinalizer '-presched'";
         constexpr auto MAX_ISPCRT_IGC_OPTIONS = 2000UL;
 #if defined(_WIN32) || defined(_WIN64)
         char* userIgcOptionsEnv = nullptr;

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -290,6 +290,12 @@ ISPCRTFuture ispcrtLaunch3D(ISPCRTTaskQueue q, ISPCRTKernel k, ISPCRTMemoryView 
 }
 ISPCRT_CATCH_END(nullptr)
 
+void ispcrtSubmit(ISPCRTTaskQueue q) ISPCRT_CATCH_BEGIN {
+    auto &queue = referenceFromHandle<ispcrt::base::TaskQueue>(q);
+    queue.submit();
+}
+ISPCRT_CATCH_END()
+
 void ispcrtSync(ISPCRTTaskQueue q) ISPCRT_CATCH_BEGIN {
     auto &queue = referenceFromHandle<ispcrt::base::TaskQueue>(q);
     queue.sync();

--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -120,6 +120,7 @@ ISPCRTFuture ispcrtLaunch2D(ISPCRTTaskQueue, ISPCRTKernel, ISPCRTMemoryView para
 ISPCRTFuture ispcrtLaunch3D(ISPCRTTaskQueue, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0, size_t dim1,
                             size_t dim2);
 
+void ispcrtSubmit(ISPCRTTaskQueue);
 void ispcrtSync(ISPCRTTaskQueue);
 
 // Futures and task timing ////////////////////////////////////////////////////

--- a/ispcrt/ispcrt.hpp
+++ b/ispcrt/ispcrt.hpp
@@ -368,6 +368,10 @@ class TaskQueue : public GenericObject<ISPCRTTaskQueue> {
     template <typename T, AllocType AT>
     Future launch(const Kernel &k, const Array<T,AT> &p, size_t dim0, size_t dim1, size_t dim2) const;
 
+    // start executing, but don't wait for the completion
+    void submit() const;
+
+    // wait for the command list to be executed (start the execution if needed as well)
     void sync() const;
 
     void* nativeTaskQueueHandle() const;
@@ -413,6 +417,8 @@ template <typename T, AllocType AT>
 inline Future TaskQueue::launch(const Kernel &k, const Array<T,AT> &p, size_t dim0, size_t dim1, size_t dim2) const {
     return ispcrtLaunch3D(handle(), k.handle(), p.handle(), dim0, dim1, dim2);
 }
+
+inline void TaskQueue::submit() const { ispcrtSubmit(handle()); }
 
 inline void TaskQueue::sync() const { ispcrtSync(handle()); }
 

--- a/ispcrt/tests/level_zero_mock/ze_mock.cpp
+++ b/ispcrt/tests/level_zero_mock/ze_mock.cpp
@@ -9,6 +9,27 @@ namespace ispcrt {
 namespace testing {
 namespace mock {
 
+// Counters
+
+std::unordered_map<std::string, int> CallCounters::counters;
+
+void CallCounters::inc(const std::string& fun) {
+    counters[fun]++;
+}
+
+int  CallCounters::get(const std::string& fun) {
+    return counters[fun];
+}
+void CallCounters::resetAll() {
+    counters.clear();
+}
+
+void CallCounters::resetOne(const std::string& fun) {
+    counters[fun] = 0;
+}
+
+// Config
+
 std::unordered_map<std::string, ze_result_t> Config::resultsMap;
 std::vector<CmdListElem> Config::cmdList;
 bool Config::cmdListOpened = true;

--- a/ispcrt/tests/level_zero_mock/ze_mock.h
+++ b/ispcrt/tests/level_zero_mock/ze_mock.h
@@ -38,6 +38,15 @@ struct DeviceProperties {
     DeviceProperties(uint32_t vendorId, uint32_t deviceId) : vendorId(vendorId), deviceId(deviceId) {}
 };
 
+struct CallCounters {
+    static void inc(const std::string& fun);
+    static int  get(const std::string& fun);
+    static void resetAll();
+    static void resetOne(const std::string& fun);
+  private:
+    static std::unordered_map<std::string, int> counters;
+};
+
 class Config {
   public:
     static void setRetValue(const std::string &fun, ze_result_t result);

--- a/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
+++ b/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
@@ -13,6 +13,7 @@ namespace driver {
 
 #define MOCK_RET return Config::getRetValue(__FUNCTION__)
 #define MOCK_SHOULD_SUCCEED (Config::getRetValue(__FUNCTION__) == ZE_RESULT_SUCCESS)
+#define MOCK_CNT_CALL CallCounters::inc(__FUNCTION__)
 
 static unsigned MockHandleHandle = 1;
 
@@ -49,6 +50,7 @@ bool ValidDevice(ze_device_handle_t hDevice) {
 ze_result_t zeInit(ze_init_flags_t flags) { MOCK_RET; }
 
 ze_result_t zeDriverGet(uint32_t *pCount, ze_driver_handle_t *phDrivers) {
+    MOCK_CNT_CALL;
     if (*pCount == 0) {
         *pCount = 1;
     }
@@ -57,6 +59,7 @@ ze_result_t zeDriverGet(uint32_t *pCount, ze_driver_handle_t *phDrivers) {
 }
 
 ze_result_t zeDeviceGet(ze_driver_handle_t hDriver, uint32_t *pCount, ze_device_handle_t *phDevices) {
+    MOCK_CNT_CALL;
     *pCount = Config::getDeviceCount();
     if (phDevices) {
         for (int i = 0; i < *pCount; i++) {
@@ -67,6 +70,7 @@ ze_result_t zeDeviceGet(ze_driver_handle_t hDriver, uint32_t *pCount, ze_device_
 }
 
 ze_result_t zeDeviceGetProperties(ze_device_handle_t hDevice, ze_device_properties_t *pDeviceProperties) {
+    MOCK_CNT_CALL;
     if (!ValidDevice(hDevice) || pDeviceProperties == nullptr)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
 
@@ -82,11 +86,13 @@ ze_result_t zeDeviceGetProperties(ze_device_handle_t hDevice, ze_device_properti
 }
 
 ze_result_t zeContextCreate(ze_driver_handle_t hDriver, const ze_context_desc_t *desc, ze_context_handle_t *phContext) {
+    MOCK_CNT_CALL;
     *phContext = ContextHandle.get();
     MOCK_RET;
 }
 
 ze_result_t zeContextDestroy(ze_context_handle_t hContext) {
+    MOCK_CNT_CALL;
     if (hContext != ContextHandle.get())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     MOCK_RET;
@@ -94,6 +100,7 @@ ze_result_t zeContextDestroy(ze_context_handle_t hContext) {
 
 ze_result_t zeCommandQueueCreate(ze_context_handle_t hContext, ze_device_handle_t hDevice,
                                  const ze_command_queue_desc_t *desc, ze_command_queue_handle_t *phCommandQueue) {
+    MOCK_CNT_CALL;
     if (!ExpectedDevice(hDevice) || hContext != ContextHandle.get() || desc == nullptr ||
         phCommandQueue == nullptr)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
@@ -102,6 +109,7 @@ ze_result_t zeCommandQueueCreate(ze_context_handle_t hContext, ze_device_handle_
 }
 
 ze_result_t zeCommandQueueDestroy(ze_command_queue_handle_t hCommandQueue) {
+    MOCK_CNT_CALL;
     if (hCommandQueue != CmdQueueHandle.get())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     MOCK_RET;
@@ -109,12 +117,14 @@ ze_result_t zeCommandQueueDestroy(ze_command_queue_handle_t hCommandQueue) {
 
 ze_result_t zeCommandQueueExecuteCommandLists(ze_command_queue_handle_t hCommandQueue, uint32_t numCommandLists,
                                               ze_command_list_handle_t *phCommandLists, ze_fence_handle_t hFence) {
+    MOCK_CNT_CALL;
     if (hCommandQueue != CmdQueueHandle.get() || !Config::isCmdListClosed())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     MOCK_RET;
 }
 
 ze_result_t zeCommandQueueSynchronize(ze_command_queue_handle_t hCommandQueue, uint64_t timeout) {
+    MOCK_CNT_CALL;
     if (hCommandQueue != CmdQueueHandle.get() || !Config::isCmdListClosed())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     MOCK_RET;
@@ -122,6 +132,7 @@ ze_result_t zeCommandQueueSynchronize(ze_command_queue_handle_t hCommandQueue, u
 
 ze_result_t zeCommandListCreate(ze_context_handle_t hContext, ze_device_handle_t hDevice,
                                 const ze_command_list_desc_t *desc, ze_command_list_handle_t *phCommandList) {
+    MOCK_CNT_CALL;
     if (!ExpectedDevice(hDevice) || hContext != ContextHandle.get() || desc == nullptr || phCommandList == nullptr)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     *phCommandList = CmdListHandle.get();
@@ -129,12 +140,14 @@ ze_result_t zeCommandListCreate(ze_context_handle_t hContext, ze_device_handle_t
 }
 
 ze_result_t zeCommandListDestroy(ze_command_list_handle_t hCommandList) {
+    MOCK_CNT_CALL;
     if (hCommandList != CmdListHandle.get())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     MOCK_RET;
 }
 
 ze_result_t zeCommandListClose(ze_command_list_handle_t hCommandList) {
+    MOCK_CNT_CALL;
     if (hCommandList != CmdListHandle.get())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     Config::closeCmdList();
@@ -142,6 +155,7 @@ ze_result_t zeCommandListClose(ze_command_list_handle_t hCommandList) {
 }
 
 ze_result_t zeCommandListReset(ze_command_list_handle_t hCommandList) {
+    MOCK_CNT_CALL;
     if (hCommandList != CmdListHandle.get())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     Config::resetCmdList();
@@ -150,6 +164,7 @@ ze_result_t zeCommandListReset(ze_command_list_handle_t hCommandList) {
 
 ze_result_t zeCommandListAppendBarrier(ze_command_list_handle_t hCommandList, ze_event_handle_t hSignalEvent,
                                        uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents) {
+    MOCK_CNT_CALL;
     if (hCommandList != CmdListHandle.get() || Config::isCmdListClosed())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     if (MOCK_SHOULD_SUCCEED)
@@ -160,6 +175,7 @@ ze_result_t zeCommandListAppendBarrier(ze_command_list_handle_t hCommandList, ze
 ze_result_t zeCommandListAppendMemoryCopy(ze_command_list_handle_t hCommandList, void *dstptr, const void *srcptr,
                                           size_t size, ze_event_handle_t hSignalEvent, uint32_t numWaitEvents,
                                           ze_event_handle_t *phWaitEvents) {
+    MOCK_CNT_CALL;
     if (hCommandList != CmdListHandle.get() || Config::isCmdListClosed())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     if (MOCK_SHOULD_SUCCEED)
@@ -169,6 +185,7 @@ ze_result_t zeCommandListAppendMemoryCopy(ze_command_list_handle_t hCommandList,
 
 ze_result_t zeEventPoolCreate(ze_context_handle_t hContext, const ze_event_pool_desc_t *desc, uint32_t numDevices,
                               ze_device_handle_t *phDevices, ze_event_pool_handle_t *phEventPool) {
+    MOCK_CNT_CALL;
     if (hContext != ContextHandle.get() || numDevices == 0 || !phDevices || !phEventPool)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     *phEventPool = EventPoolHandle.get();
@@ -176,24 +193,33 @@ ze_result_t zeEventPoolCreate(ze_context_handle_t hContext, const ze_event_pool_
 }
 
 ze_result_t zeEventPoolDestroy(ze_event_pool_handle_t hEventPool) {
+    MOCK_CNT_CALL;
     if (hEventPool != EventPoolHandle.get())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     MOCK_RET;
 }
 
 ze_result_t zeEventCreate(ze_event_pool_handle_t hEventPool, const ze_event_desc_t *desc, ze_event_handle_t *phEvent) {
+    MOCK_CNT_CALL;
     if (hEventPool != EventPoolHandle.get() || !desc || !phEvent)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     *phEvent = LaunchEventHandle.get();
     MOCK_RET;
 }
 
-ze_result_t zeEventDestroy(ze_event_handle_t hEvent) { MOCK_RET; }
+ze_result_t zeEventDestroy(ze_event_handle_t hEvent) {
+    MOCK_CNT_CALL;
+    MOCK_RET;
+}
 
-ze_result_t zeEventQueryKernelTimestamp(ze_event_handle_t hEvent, ze_kernel_timestamp_result_t *dstptr) { MOCK_RET; }
+ze_result_t zeEventQueryKernelTimestamp(ze_event_handle_t hEvent, ze_kernel_timestamp_result_t *dstptr) {
+    MOCK_CNT_CALL;
+    MOCK_RET;
+}
 
 ze_result_t zeMemAllocDevice(ze_context_handle_t hContext, const ze_device_mem_alloc_desc_t *device_desc, size_t size,
                              size_t alignment, ze_device_handle_t hDevice, void **pptr) {
+    MOCK_CNT_CALL;
     if (hContext != ContextHandle.get())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     if (MOCK_SHOULD_SUCCEED)
@@ -202,6 +228,7 @@ ze_result_t zeMemAllocDevice(ze_context_handle_t hContext, const ze_device_mem_a
 }
 
 ze_result_t zeMemFree(ze_context_handle_t hContext, void *ptr) {
+    MOCK_CNT_CALL;
     if (hContext != ContextHandle.get() || !ptr)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     delete[](uint8_t *) ptr;
@@ -210,6 +237,7 @@ ze_result_t zeMemFree(ze_context_handle_t hContext, void *ptr) {
 
 ze_result_t zeModuleCreate(ze_context_handle_t hContext, ze_device_handle_t hDevice, const ze_module_desc_t *desc,
                            ze_module_handle_t *phModule, ze_module_build_log_handle_t *phBuildLog) {
+    MOCK_CNT_CALL;
     if (hContext != ContextHandle.get() || !ExpectedDevice(hDevice))
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
 
@@ -219,6 +247,7 @@ ze_result_t zeModuleCreate(ze_context_handle_t hContext, ze_device_handle_t hDev
 }
 
 ze_result_t zeModuleDestroy(ze_module_handle_t hModule) {
+    MOCK_CNT_CALL;
     if (hModule != ModuleHandle.get())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
 
@@ -226,6 +255,7 @@ ze_result_t zeModuleDestroy(ze_module_handle_t hModule) {
 }
 
 ze_result_t zeKernelCreate(ze_module_handle_t hModule, const ze_kernel_desc_t *desc, ze_kernel_handle_t *phKernel) {
+    MOCK_CNT_CALL;
     if (hModule != ModuleHandle.get())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
 
@@ -235,6 +265,7 @@ ze_result_t zeKernelCreate(ze_module_handle_t hModule, const ze_kernel_desc_t *d
 }
 
 ze_result_t zeKernelDestroy(ze_kernel_handle_t hKernel) {
+    MOCK_CNT_CALL;
     if (hKernel != KernelHandle.get())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
 
@@ -243,16 +274,19 @@ ze_result_t zeKernelDestroy(ze_kernel_handle_t hKernel) {
 
 ze_result_t zeKernelSetArgumentValue(ze_kernel_handle_t hKernel, uint32_t argIndex, size_t argSize,
                                      const void *pArgValue) {
+    MOCK_CNT_CALL;
     MOCK_RET;
 }
 
 ze_result_t zeKernelSetIndirectAccess(ze_kernel_handle_t hKernel, ze_kernel_indirect_access_flags_t) {
+    MOCK_CNT_CALL;
     MOCK_RET;
 }
 
 ze_result_t zeCommandListAppendLaunchKernel(ze_command_list_handle_t hCommandList, ze_kernel_handle_t hKernel,
                                             const ze_group_count_t *pLaunchFuncArgs, ze_event_handle_t hSignalEvent,
                                             uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents) {
+    MOCK_CNT_CALL;
     if (hCommandList != CmdListHandle.get() || hKernel != KernelHandle.get() || !pLaunchFuncArgs)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     if (MOCK_SHOULD_SUCCEED)

--- a/run_tests.py
+++ b/run_tests.py
@@ -187,6 +187,10 @@ def run_command(cmd, timeout=600, cwd="."):
 # (whether test and reference outputs are same)
 # NOTE: output contains both test and reference lines
 def check_print_output(output):
+    # if message about spill size is appeared, remove it from output
+    spill_line_idx = output.find("Spill")
+    if spill_line_idx != -1:
+        output = output[0:spill_line_idx]
     lines = output.splitlines()
     if len(lines) == 0 or len(lines) % 2:
         return False

--- a/run_tests.py
+++ b/run_tests.py
@@ -201,6 +201,11 @@ def prerun_debug_check_genx():
 def postrun_debug_check_genx(test_name, exe_wd):
     objdumpProc = subprocess.run('/usr/bin/objdump -h *_dwarf.elf', shell=True, cwd=exe_wd, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     readelfProc = subprocess.run('/usr/bin/readelf --debug-dump *_dwarf.elf', shell=True, cwd=exe_wd, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    # Cleanup files used to check debug information
+    # since this directory may be reused by other tests.
+    subprocess.run('rm -rf *_dwarf.elf', shell=True)
+
     if objdumpProc.returncode != 0:
         print("[DEBUG CHECK] " + test_name + " - objdump failed - return code: " + str(objdumpProc.returncode))
         return False
@@ -217,7 +222,6 @@ def postrun_debug_check_genx(test_name, exe_wd):
             if line.find('Warning:') != -1 or line.find('Error:') != -1:
                 print(line)
         return False
-    subprocess.run('rm -rf *_dwarf.elf', shell=True)
     return True
 
 

--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -301,7 +301,7 @@ static void lUpdateIntrinsicsAttributes(llvm::Module *module) {
     for (auto F = module->begin(), E = module->end(); F != E; ++F) {
         llvm::Function *Fn = &*F;
 
-        if (llvm::GenXIntrinsic::isGenXIntrinsic(Fn)) {
+        if (Fn && llvm::GenXIntrinsic::isGenXIntrinsic(Fn)) {
             Fn->setAttributes(
                 llvm::GenXIntrinsic::getAttributes(Fn->getContext(), llvm::GenXIntrinsic::getGenXIntrinsicID(Fn)));
         }

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -751,6 +751,9 @@ enum {
 
     CHECK_MASK_AT_FUNCTION_START_COST = 16,
     PREDICATE_SAFE_IF_STATEMENT_COST = 6,
+    // For gen target we want to avoid branches as much as possible
+    // so we use increased cost here
+    PREDICATE_SAFE_SHORT_CIRC_GENX_STATEMENT_COST = 10,
 };
 
 extern Globals *g;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1232,7 +1232,7 @@ bool Module::writeZEBin(llvm::Module *module, const char *outFileName) {
         return false;
     }
 
-    std::string options{"-vc-codegen -no-optimize"};
+    std::string options{"-vc-codegen -no-optimize -Xfinalizer '-presched'"};
     // Add debug option to VC backend of "-g" is set to ISPC
     if (g->generateDebuggingSymbols) {
         options.append(" -g");

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -2948,7 +2948,7 @@ static llvm::CallInst *lGenXLoadInst(llvm::Value *ptr, llvm::Type *retType, llvm
 
     llvm::Value *svm_ld_ptrtoint = new llvm::PtrToIntInst(ptr, LLVMTypes::Int64Type, "svm_ld_ptrtoint", inst);
 
-    auto Fn = llvm::GenXIntrinsic::getGenXDeclaration(m->module, llvm::GenXIntrinsic::genx_svm_block_ld,
+    auto Fn = llvm::GenXIntrinsic::getGenXDeclaration(m->module, llvm::GenXIntrinsic::genx_svm_block_ld_unaligned,
                                                       {retType, svm_ld_ptrtoint->getType()});
 
     return llvm::CallInst::Create(Fn, svm_ld_ptrtoint, inst->getName());
@@ -6768,7 +6768,7 @@ restart:
                     goto restart;
                 }
             }
-        } else if (llvm::GenXIntrinsic::getGenXIntrinsicID(inst) == llvm::GenXIntrinsic::genx_svm_block_ld) {
+        } else if (llvm::GenXIntrinsic::getGenXIntrinsicID(inst) == llvm::GenXIntrinsic::genx_svm_block_ld_unaligned) {
             llvm::Instruction *load_inst = processSVMVectorLoad(inst);
             if (load_inst != NULL) {
                 applyReplace(load_inst, inst);

--- a/test_static_l0.cpp
+++ b/test_static_l0.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2020, Intel Corporation
+  Copyright (c) 2019-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -185,7 +185,7 @@ static void L0InitContext(ze_device_handle_t &hDevice, ze_module_handle_t &hModu
     is.read((char *)codeBin, codeSize);
     is.close();
 
-    std::string igcOptions = "-vc-codegen -no-optimize";
+    std::string igcOptions = "-vc-codegen -no-optimize -Xfinalizer '-presched'";
     const char *userIgcOptionsEnv = getenv("ISPCRT_IGC_OPTIONS");
     if (userIgcOptionsEnv) {
         std::string userIgcOptions(userIgcOptionsEnv);

--- a/tests/lit-tests/full_mask.ispc
+++ b/tests/lit-tests/full_mask.ispc
@@ -1,0 +1,63 @@
+// RUN: %{ispc} %s -DISPC_EXPORT --emit-llvm-text -O0 --nowrap -o %t.ll
+// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_ISPC_EXPORT %s
+
+// RUN: %{ispc} %s -DISPC_UNMASKED --emit-llvm-text -O0 --nowrap -o %t.ll
+// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_ISPC_UNMASKED %s
+
+// RUN: %{ispc} %s -DISPC_NOQUALIF --emit-llvm-text -O0 --nowrap -o %t.ll
+// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_ISPC_NOQUALIF %s
+
+// RUN: %{ispc} %s -DISPC_TASK --emit-llvm-text -O0 --nowrap -o %t.ll
+// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_ISPC_TASK %s
+
+struct Parameters {
+    float *vout;
+    int param;
+};
+
+#ifdef ISPC_EXPORT
+// CHECK_ISPC_EXPORT: define void @simple_export___
+// CHECK_ISPC_EXPORT: %full_mask_memory = alloca
+// CHECK_ISPC_EXPORT: define void @simple_export(
+// CHECK_ISPC_EXPORT-NOT: %full_mask_memory = alloca
+export void simple_export(void *uniform _p) {
+    Parameters *uniform p = (Parameters * uniform) _p;
+    if (programIndex > p->param)
+        p->vout[programIndex] = programCount * programIndex;
+}
+#endif
+#ifdef ISPC_UNMASKED
+// CHECK_ISPC_UNMASKED: define void @simple_unmasked
+// CHECK_ISPC_UNMASKED-NOT: %full_mask_memory = alloca
+unmasked void simple_unmasked(void *uniform _p) {
+    Parameters *uniform p = (Parameters * uniform) _p;
+    if (programIndex > p->param)
+        p->vout[programIndex] = programCount * programIndex;
+}
+#endif
+#ifdef ISPC_NOQUALIF
+// CHECK_ISPC_NOQUALIF: define void @simple
+// CHECK_ISPC_NOQUALIF: %full_mask_memory = alloca
+void simple(void *uniform _p) {
+    Parameters *uniform p = (Parameters * uniform) _p;
+    if (programIndex > p->param)
+        p->vout[programIndex] = programCount * programIndex;
+}
+#endif
+#ifdef ISPC_TASK
+
+// CHECK_ISPC_TASK: define void @simple_task
+// CHECK_ISPC_TASK-NOT: %full_mask_memory = alloca
+// CHECK_ISPC_TASK: define void @simple_entry_point__
+// CHECK_ISPC_TASK: %full_mask_memory = alloca
+// CHECK_ISPC_TASK: define void @simple_entry_point(
+// CHECK_ISPC_TASK-NOT: %full_mask_memory = alloca
+task void simple_task(void *uniform _p) {
+    Parameters *uniform p = (Parameters * uniform) _p;
+    if (programIndex > p->param)
+        p->vout[programIndex] = programCount * programIndex;
+}
+export void simple_entry_point(void *uniform parameters, uniform int dim0, uniform int dim1, uniform int dim2) {
+    launch[dim0, dim1, dim2] simple_task(parameters);
+}
+#endif

--- a/tests/lit-tests/genx_addr_space.ispc
+++ b/tests/lit-tests/genx_addr_space.ispc
@@ -14,18 +14,18 @@ struct vec3f {
     float z;
 };
 
-// CHECK_GENX_X16: call <16 x float> @llvm.genx.svm.block.ld.v16f32.i64
+// CHECK_GENX_X16: call <16 x float> @llvm.genx.svm.block.ld.unaligned.v16f32.i64
 // CHECK_GENX_X16: call void @llvm.genx.svm.block.st.i64.v16f32
-// CHECK_GENX_X8: call <8 x float> @llvm.genx.svm.block.ld.v8f32.i64
+// CHECK_GENX_X8: call <8 x float> @llvm.genx.svm.block.ld.unaligned.v8f32.i64
 // CHECK_GENX_X8: call void @llvm.genx.svm.block.st.i64.v8f32
 export void checkAddrSpace1(void *uniform _in, uniform float * uniform _out) {
   const varying vec3f *uniform in_test = (const varying vec3f *uniform) _in;
   _out[programIndex] = in_test->x;
 }
 
-// CHECK_GENX_X16: call <16 x float> @llvm.genx.svm.block.ld.v16f32.i64
+// CHECK_GENX_X16: call <16 x float> @llvm.genx.svm.block.ld.unaligned.v16f32.i64
 // CHECK_GENX_X16: call void @llvm.genx.svm.block.st.i64.v16f32
-// CHECK_GENX_X8: call <8 x float> @llvm.genx.svm.block.ld.v8f32.i64
+// CHECK_GENX_X8: call <8 x float> @llvm.genx.svm.block.ld.unaligned.v8f32.i64
 // CHECK_GENX_X8: call void @llvm.genx.svm.block.st.i64.v8f32
 export void checkAddrSpace2(void *uniform _out, uniform float * uniform _in) {
   varying vec3f *uniform out_test = (varying vec3f *uniform) _out;

--- a/tests/lit-tests/genx_short_circuit.ispc
+++ b/tests/lit-tests/genx_short_circuit.ispc
@@ -1,0 +1,83 @@
+// RUN: %{ispc} %s --target=genx-x16 --arch=genx64 --emit-llvm-text --nowrap -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s
+
+// REQUIRES: GENX_ENABLED
+struct vec3f {
+    float x;
+    float y;
+    float z;
+};
+struct Volume {
+    float num;
+    vec3f dimensions;
+};
+float square1(void *uniform  _self, const vec3f &localCoordinates) {
+    Volume* uniform self = (Volume* uniform)_self;
+    const uniform vec3f test = self->dimensions;
+    if (localCoordinates.x < 0.f ||
+      localCoordinates.x > test.x - 1.f ||
+      localCoordinates.y < 0.f ||
+      localCoordinates.y > test.y - 1.f ||
+      localCoordinates.z < 0.f ||
+      localCoordinates.z > test.z - 1.f) {
+  // CHECK: or <16 x i1>
+  // CHECK: or <16 x i1>
+  // CHECK: or <16 x i1>
+  // CHECK: or <16 x i1>
+  // CHECK: or <16 x i1>
+  // CHECK-NOT: logical_op_done
+    return 0;
+  }
+  return self->num*localCoordinates.x;
+}
+
+float square2(void *uniform  _self, const vec3f &localCoordinates, uniform float x, uniform float y, uniform float z) {
+  Volume* uniform self = (Volume* uniform)_self;
+  if (localCoordinates.x < 0.f ||
+    localCoordinates.x > x - 1.f ||
+    localCoordinates.y < 0.f ||
+    localCoordinates.y > y - 1.f ||
+    localCoordinates.z < 0.f ||
+    localCoordinates.z > z - 1.f) {
+  // CHECK: or <16 x i1>
+  // CHECK: or <16 x i1>
+  // CHECK: or <16 x i1>
+  // CHECK: or <16 x i1>
+  // CHECK: or <16 x i1>
+  // CHECK-NOT: logical_op_done
+    return 0;
+  }
+  return self->num*localCoordinates.x;
+}
+
+float square3(void *uniform  _self, const vec3f &localCoordinates) {
+    Volume* uniform self = (Volume* uniform)_self;
+    if (localCoordinates.x < 0.f ||
+      localCoordinates.x > self->dimensions.x - 1.f ||
+      localCoordinates.y < 0.f ||
+      localCoordinates.y > self->dimensions.y - 1.f ||
+      localCoordinates.z < 0.f ||
+      localCoordinates.z > self->dimensions.z - 1.f) {
+// CHECK: logical_op_done
+// CHECK: logical_op_done
+// CHECK: logical_op_done
+    return 0;
+  }
+
+  return self->num*localCoordinates.x;
+}
+
+task void test1(void* uniform _self, int* uniform out){
+  vec3f coord = {out[0], out[1], out[2]};
+  out[programIndex]=square1(_self, coord);
+}
+
+task void test2(void* uniform _self, int* uniform out){
+  vec3f coord = {out[0], out[1], out[2]};
+  out[programIndex]=square2(_self, coord, out[0], out[1], out[2]);
+}
+
+task void test3(void* uniform _self, int* uniform out){
+  vec3f coord = {out[0], out[1], out[2]};
+  out[programIndex]=square3(_self, coord);
+}

--- a/tests/print_bool_simd.ispc
+++ b/tests/print_bool_simd.ispc
@@ -43,8 +43,12 @@ export void print_result() {
               ",false,false,true,false,false,true,false,false"
               ",true,false,false,true,false,false,true,false"
               ",false,true,false,false,true,false,false,true");
+#ifndef ISPC_TARGET_GENX
+        print("]; in simd cf: [_________,_________,true,false");
+#else
+        print("]; in simd cf: [((false)),((true)),true,false");
+#endif
 
-    print("]; in simd cf: [_________,_________,true,false");
     if (programCount > 4)
         print(",true,true,false,true");
     if (programCount > 8)
@@ -57,8 +61,11 @@ export void print_result() {
               ",true,true,false,true,true,false,true,true"
               ",false,true,true,false,true,true,false,true"
               ",true,false,true,true,false,true,true,false");
-
+#ifndef ISPC_TARGET_GENX
     print("], [_________,_________,false,true");
+#else
+    print("], [((true)),((false)),false,true");
+#endif
     if (programCount > 4)
         print(",false,false,true,false");
     if (programCount > 8)


### PR DESCRIPTION
- Performance fix for short-circuit logic on Gen.
- `TaskQueue::submit()` method was add to ISPCRT.
- SVM block loads to use unaligned version - conservative fix for stability.
- `-presched` passed to finalizer to enabled register allocation before scheduling, it's good for performance.
- Do not generate full function mask if the function doesn't have a mask parameter (in this case it's always equivalent to internal mask).