### PR TITLE
builtins/cpu: Give __num_cores C-linkage when building WASM

### DIFF
--- a/builtins/builtins-c-cpu.cpp
+++ b/builtins/builtins-c-cpu.cpp
@@ -180,7 +180,7 @@ extern "C" void __do_print(const char *format, const char *types, WidthT width, 
 }
 
 #ifdef WASM
-int __num_cores() { return 1; }
+extern "C" int __num_cores() { return 1; }
 #else // WASM
 
 extern "C" int __num_cores() {


### PR DESCRIPTION
The `__num_cores` intrinsic is not found when compiling with stdlib for WASM:

    stdlib.ispc:1765:12: Error: Undeclared symbol "__num_cores". Did you mean "num_cores"?

This function was moved from a c to cpp file in 2f6d077e ("New print implementation with support of genx.") but `extern "C"` wasn't added to every function declaration, leading to a mangled symbol name that cannot be found by its demangled C name.