### PR TITLE
Switch to LLVM 12 (part2)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-#  Copyright (c) 2018-2020, Intel Corporation
+#  Copyright (c) 2018-2021, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -32,7 +32,7 @@
 configuration: Release
 
 environment:
-  LLVM_LATEST: 11.1
+  LLVM_LATEST: 12.0
   DOCKER_PATH: "ispc/test_repo"
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1604
@@ -40,7 +40,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: latest
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      LLVM_VERSION: 10.0
+      LLVM_VERSION: 11.1
 
 for:
 -
@@ -58,7 +58,8 @@ for:
         if "%LLVM_VERSION%"=="latest" (set WASM=ON)
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( (set generator="Visual Studio 15 Win64") & (set vsversion=2017))
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vsversion=2019))
-        set LLVM_TAR=llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z
+        set LLVM_TAR=llvm-12.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z
+        if "%LLVM_VERSION%"=="11.1" (set LLVM_TAR=llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z)
         if "%LLVM_VERSION%"=="10.0" (set LLVM_TAR=llvm-10.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.zip)
   install:
     - ps: choco install --no-progress winflexbison3 wget 7zip
@@ -108,7 +109,7 @@ for:
         export LLVM_HOME=$APPVEYOR_BUILD_FOLDER/llvm
         export CROSS_TOOLS=/usr/local/src/cross
         export WASM=OFF
-        export LLVM_TAR=llvm-11.1.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        export LLVM_TAR=llvm-12.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
   install:
     - sh: |-
         sudo apt-get update

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -58,46 +58,9 @@ jobs:
         $RUN_SMOKE && echo "::set-output name=optsets::${OPTSETS_SMOKE}" || true
         $RUN_FULL &&  echo "::set-output name=optsets::${OPTSETS_FULL}" || true
 
-  linux-build-ispc-llvm10:
-    needs: [define-flow]
-    #if: ${{ needs.define-flow.outputs.flow_type == 'full' }}
-    runs-on: ubuntu-latest
-    env:
-      LLVM_VERSION: "10.0"
-      LLVM_TAR: llvm-10.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: Install dependencies
-      run: |
-        .github/workflows/scripts/install-build-deps.sh
-
-    - name: Check environment
-      run: |
-        ./check_env.py
-        which -a clang
-        cat /proc/cpuinfo
-
-    - name: Build package
-      run: |
-        .github/workflows/scripts/build-ispc.sh
-
-    - name: Sanity testing (make check-all, make test)
-      run: |
-        .github/workflows/scripts/check-ispc.sh
-
-    - name: Upload package
-      uses: actions/upload-artifact@v2
-      with:
-        name: ispc_llvm10_linux
-        path: build/ispc-trunk-linux.tar.gz
-
-
   linux-build-ispc-llvm11:
     needs: [define-flow]
+    #if: ${{ needs.define-flow.outputs.flow_type == 'full' }}
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "11.1"
@@ -132,45 +95,42 @@ jobs:
         name: ispc_llvm11_linux
         path: build/ispc-trunk-linux.tar.gz
 
-  linux-test-llvm10:
-    needs: [define-flow, linux-build-ispc-llvm10]
+
+  linux-build-ispc-llvm12:
+    needs: [define-flow]
     runs-on: ubuntu-latest
-    continue-on-error: false
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
+    env:
+      LLVM_VERSION: "12.0"
+      LLVM_TAR: llvm-12.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+
     steps:
     - uses: actions/checkout@v2
-    - name: Download package
-      uses: actions/download-artifact@v2
       with:
-        name: ispc_llvm10_linux
+        submodules: true
 
-    - name: Install dependencies and unpack artifacts
+    - name: Install dependencies
       run: |
-        .github/workflows/scripts/install-test-deps.sh
+        .github/workflows/scripts/install-build-deps.sh
 
     - name: Check environment
       run: |
+        ./check_env.py
+        which -a clang
         cat /proc/cpuinfo
 
-    - name: Running tests
+    - name: Build package
       run: |
-        echo PATH=$PATH
-        ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+        .github/workflows/scripts/build-ispc.sh
 
-    - name: Check
+    - name: Sanity testing (make check-all, make test)
       run: |
-        # Print fails to the log.
-        git diff --exit-code
+        .github/workflows/scripts/check-ispc.sh
 
-    - name: Upload fail_db.txt
+    - name: Upload package
       uses: actions/upload-artifact@v2
-      if: failure()
       with:
-        name: fail_db.llvm10.${{matrix.target}}.txt
-        path: fail_db.txt
+        name: ispc_llvm12_linux
+        path: build/ispc-trunk-linux.tar.gz
 
   linux-test-llvm11:
     needs: [define-flow, linux-build-ispc-llvm11]
@@ -212,11 +172,51 @@ jobs:
         name: fail_db.llvm11.${{matrix.target}}.txt
         path: fail_db.txt
 
+  linux-test-llvm12:
+    needs: [define-flow, linux-build-ispc-llvm12]
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: ispc_llvm12_linux
+
+    - name: Install dependencies and unpack artifacts
+      run: |
+        .github/workflows/scripts/install-test-deps.sh
+
+    - name: Check environment
+      run: |
+        cat /proc/cpuinfo
+
+    - name: Running tests
+      run: |
+        echo PATH=$PATH
+        ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
+    - name: Upload fail_db.txt
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: fail_db.llvm12.${{matrix.target}}.txt
+        path: fail_db.txt
+
   # Debug run is experimental with the purpose to see if it's capable to catch anything.
   # So it's running in "full" mode only for now.
   # Single target, as it should be representative enough.
-  linux-test-debug-llvm11:
-    needs: [define-flow, linux-build-ispc-llvm11]
+  linux-test-debug-llvm12:
+    needs: [define-flow, linux-build-ispc-llvm12]
     if: ${{ needs.define-flow.outputs.flow_type == 'full' }}
     runs-on: ubuntu-latest
     continue-on-error: false
@@ -227,7 +227,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: ispc_llvm11_linux
+        name: ispc_llvm12_linux
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -251,49 +251,8 @@ jobs:
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: fail_db.llvm11.debug.txt
+        name: fail_db.llvm12.debug.txt
         path: fail_db.txt
-
-  win-build-ispc-llvm10:
-    needs: [define-flow]
-    runs-on: windows-latest
-    env:
-      LLVM_VERSION: "10.0"
-      LLVM_TAR: llvm-10.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.zip
-      LLVM_HOME: "C:\\projects\\llvm"
-      CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
-      BUILD_TYPE: "Release"
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
-
-    - name: Install dependencies
-      run: |
-        .github/workflows/scripts/install-build-deps.ps1
-
-    - name: Check environment
-      shell: cmd
-      run: |
-        wmic cpu get caption, deviceid, name, numberofcores, maxclockspeed, status
-
-    - name: Build package
-      run: |
-        .github/workflows/scripts/build-ispc.ps1
-
-    - name: Sanity testing (make check-all, make test)
-      run: |
-        .github/workflows/scripts/check-ispc.ps1
-
-    - name: Upload package
-      uses: actions/upload-artifact@v2
-      with:
-        name: ispc_llvm10_win
-        path: build/ispc-trunk-windows.msi
 
   win-build-ispc-llvm11:
     needs: [define-flow]
@@ -336,59 +295,53 @@ jobs:
         name: ispc_llvm11_win
         path: build/ispc-trunk-windows.msi
 
-
-  win-test-llvm10:
-    needs: [define-flow, win-build-ispc-llvm10]
+  win-build-ispc-llvm12:
+    needs: [define-flow]
     runs-on: windows-latest
     env:
+      LLVM_VERSION: "12.0"
+      LLVM_TAR: llvm-12.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z
       LLVM_HOME: "C:\\projects\\llvm"
-    continue-on-error: false
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [x86, x86-64]
-        target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
+      CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
+      BUILD_TYPE: "Release"
 
     steps:
     - uses: actions/checkout@v2
-    - name: Download package
-      uses: actions/download-artifact@v2
       with:
-        name: ispc_llvm10_win
+        submodules: true
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Install dependencies
       run: |
-        .github/workflows/scripts/install-test-deps.ps1
+        .github/workflows/scripts/install-build-deps.ps1
 
     - name: Check environment
       shell: cmd
       run: |
         wmic cpu get caption, deviceid, name, numberofcores, maxclockspeed, status
 
-    - name: Running tests
+    - name: Build package
       run: |
-        $env:ISPC_HOME = "$pwd"
-        .github/workflows/scripts/load-vs-env.ps1 "${{ matrix.arch }}"
-        python .\alloy.py -r --only="stability ${{ matrix.arch }} current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+        .github/workflows/scripts/build-ispc.ps1
 
-    - name: Check
+    - name: Sanity testing (make check-all, make test)
       run: |
-        # Print fails to the log.
-        git diff --exit-code
+        .github/workflows/scripts/check-ispc.ps1
 
-    - name: Upload fail_db.txt
+    - name: Upload package
       uses: actions/upload-artifact@v2
-      if: failure()
       with:
-        name: fail_db.llvm10.${{matrix.arch}}.${{matrix.target}}.txt
-        path: fail_db.txt
+        name: ispc_llvm12_win
+        path: build/ispc-trunk-windows.msi
 
 
   win-test-llvm11:
     needs: [define-flow, win-build-ispc-llvm11]
+    runs-on: windows-latest
     env:
       LLVM_HOME: "C:\\projects\\llvm"
-    runs-on: windows-latest
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -428,5 +381,52 @@ jobs:
       if: failure()
       with:
         name: fail_db.llvm11.${{matrix.arch}}.${{matrix.target}}.txt
+        path: fail_db.txt
+
+
+  win-test-llvm12:
+    needs: [define-flow, win-build-ispc-llvm12]
+    env:
+      LLVM_HOME: "C:\\projects\\llvm"
+    runs-on: windows-latest
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86, x86-64]
+        target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: ispc_llvm12_win
+
+    - name: Install dependencies
+      run: |
+        .github/workflows/scripts/install-test-deps.ps1
+
+    - name: Check environment
+      shell: cmd
+      run: |
+        wmic cpu get caption, deviceid, name, numberofcores, maxclockspeed, status
+
+    - name: Running tests
+      run: |
+        $env:ISPC_HOME = "$pwd"
+        .github/workflows/scripts/load-vs-env.ps1 "${{ matrix.arch }}"
+        python .\alloy.py -r --only="stability ${{ matrix.arch }} current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
+    - name: Upload fail_db.txt
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: fail_db.llvm12.${{matrix.arch}}.${{matrix.target}}.txt
         path: fail_db.txt
 

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -1,4 +1,4 @@
-name: Linux benchmarks / LLVM 11.1
+name: Linux benchmarks / LLVM 12.0
 
 on:
   pull_request_target:
@@ -10,9 +10,9 @@ on:
   workflow_dispatch:
 
 env:
-  LLVM_VERSION: "11.1"
+  LLVM_VERSION: "12.0"
   LLVM_REPO: https://github.com/ispc/llvm-project
-  LLVM_TAR: llvm-11.1.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+  LLVM_TAR: llvm-12.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
 
 jobs:
   linux-build:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ sudo: required
 jobs:
   include:
     # ARM build
-    # LLVM 11.0 + Ubuntu 18.04:
+    # LLVM 12.0 + Ubuntu 18.04:
     #   - ARM only (default): build, lit tests, examples (build)
     #   - ARM + x86: build, lit tests, examples (build), tests (aarch64)
     - stage: test
@@ -50,8 +50,8 @@ jobs:
       arch: arm64
       dist: bionic
       env:
-        - LLVM_VERSION=11.1 OS=Ubuntu18.04aarch64
-        - LLVM_TAR=llvm-11.1.0-ubuntu16.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_VERSION=12.0 OS=Ubuntu18.04aarch64
+        - LLVM_TAR=llvm-12.0.0-ubuntu16.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
         - LLVM_REPO=https://github.com/ispc/llvm-project
         - ISPC_HOME=$TRAVIS_BUILD_DIR
       before_install:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,7 +420,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 # Compile options
 if (MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE /W3 /wd4146 /wd4800 /wd4996 /wd4355 /wd4624 /wd4244 /wd4141 /wd4291 /wd4018 /wd4267)
+    target_compile_options(${PROJECT_NAME} PRIVATE /W3 /wd4018 /wd4065 /wd4141 /wd4146 /wd4244 /wd4267 /wd4291 /wd4355 /wd4624 /wd4800 /wd4996)
     # Security options
     target_compile_options(${PROJECT_NAME} PRIVATE /GS)
     set_source_files_properties(${FLEX_OUTPUT} PROPERTIES COMPILE_FLAGS "/wd4005 /wd4003")

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -60,7 +60,6 @@
 #ifdef ISPC_HOST_IS_WINDOWS
 #include <io.h>
 #include <windows.h>
-#define strcasecmp stricmp
 #endif
 
 #include <clang/Basic/TargetInfo.h>
@@ -112,6 +111,11 @@
 #else
 #error "Unexpected platform"
 #endif
+#endif
+
+#ifdef ISPC_HOST_IS_WINDOWS
+// Note that this define must be after clang includes, as they undefining this symbol.
+#define strcasecmp stricmp
 #endif
 
 using namespace ispc;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -57,10 +57,6 @@
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#ifdef ISPC_HOST_IS_WINDOWS
-#include <io.h>
-#include <windows.h>
-#endif
 
 #include <clang/Basic/TargetInfo.h>
 #include <clang/Frontend/CompilerInstance.h>
@@ -114,6 +110,11 @@
 #endif
 
 #ifdef ISPC_HOST_IS_WINDOWS
+#include <io.h>
+// windows.h defines CALLBACK as __stdcall
+// clang/Analysis/CFG.h contains typename with name CALLBACK, which is got screwed up.
+// So we include it after clang includes.
+#include <windows.h>
 // Note that this define must be after clang includes, as they undefining this symbol.
 #define strcasecmp stricmp
 #endif


### PR DESCRIPTION
Bump pre-built LLVM versions for testing:
- Travis: `11.1` => `12.0`
- Appveyor: `10.0` & `11.1` => `11.1` & `12.0`
- Github Actions smoke& nightly: `10.0` & `11.1` => `11.1` & `12.0`
- Benchmarks: `11.1` => `12.0`