### PR TITLE
Introducing ispc namespace

### DIFF
--- a/bitcode2cpp.py
+++ b/bitcode2cpp.py
@@ -83,7 +83,9 @@ width = 16
 
 name = "builtins_bitcode_" + target_os_old + "_" + target_arch + name;
 
-sys.stdout.write("#include \"bitcode_lib.h\"\n\n");
+sys.stdout.write("#include \"bitcode_lib.h\"\n\n")
+
+sys.stdout.write("using namespace ispc;\n\n")
 
 sys.stdout.write("extern const unsigned char " + name + "[] = {\n")
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2020, Intel Corporation
+  Copyright (c) 2011-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -45,6 +45,9 @@
 #include "util.h"
 
 #include <llvm/Support/TimeProfiler.h>
+
+using namespace ispc;
+
 ///////////////////////////////////////////////////////////////////////////
 // ASTNode
 
@@ -67,7 +70,7 @@ void AST::GenerateIR() {
 
 ///////////////////////////////////////////////////////////////////////////
 
-ASTNode *WalkAST(ASTNode *node, ASTPreCallBackFunc preFunc, ASTPostCallBackFunc postFunc, void *data) {
+ASTNode *ispc::WalkAST(ASTNode *node, ASTPreCallBackFunc preFunc, ASTPostCallBackFunc postFunc, void *data) {
     if (node == NULL)
         return node;
 
@@ -236,19 +239,19 @@ ASTNode *WalkAST(ASTNode *node, ASTPreCallBackFunc preFunc, ASTPostCallBackFunc 
 
 static ASTNode *lOptimizeNode(ASTNode *node, void *) { return node->Optimize(); }
 
-ASTNode *Optimize(ASTNode *root) { return WalkAST(root, NULL, lOptimizeNode, NULL); }
+ASTNode *ispc::Optimize(ASTNode *root) { return WalkAST(root, NULL, lOptimizeNode, NULL); }
 
-Expr *Optimize(Expr *expr) { return (Expr *)Optimize((ASTNode *)expr); }
+Expr *ispc::Optimize(Expr *expr) { return (Expr *)Optimize((ASTNode *)expr); }
 
-Stmt *Optimize(Stmt *stmt) { return (Stmt *)Optimize((ASTNode *)stmt); }
+Stmt *ispc::Optimize(Stmt *stmt) { return (Stmt *)Optimize((ASTNode *)stmt); }
 
 static ASTNode *lTypeCheckNode(ASTNode *node, void *) { return node->TypeCheck(); }
 
-ASTNode *TypeCheck(ASTNode *root) { return WalkAST(root, NULL, lTypeCheckNode, NULL); }
+ASTNode *ispc::TypeCheck(ASTNode *root) { return WalkAST(root, NULL, lTypeCheckNode, NULL); }
 
-Expr *TypeCheck(Expr *expr) { return (Expr *)TypeCheck((ASTNode *)expr); }
+Expr *ispc::TypeCheck(Expr *expr) { return (Expr *)TypeCheck((ASTNode *)expr); }
 
-Stmt *TypeCheck(Stmt *stmt) { return (Stmt *)TypeCheck((ASTNode *)stmt); }
+Stmt *ispc::TypeCheck(Stmt *stmt) { return (Stmt *)TypeCheck((ASTNode *)stmt); }
 
 struct CostData {
     CostData() { cost = foreachDepth = 0; }
@@ -273,7 +276,7 @@ static ASTNode *lCostCallbackPost(ASTNode *node, void *d) {
     return node;
 }
 
-int EstimateCost(ASTNode *root) {
+int ispc::EstimateCost(ASTNode *root) {
     CostData data;
     WalkAST(root, lCostCallbackPre, lCostCallbackPost, &data);
     return data.cost;
@@ -419,7 +422,7 @@ static bool lCheckAllOffSafety(ASTNode *node, void *data) {
     return true;
 }
 
-bool SafeToRunWithMaskAllOff(ASTNode *root) {
+bool ispc::SafeToRunWithMaskAllOff(ASTNode *root) {
     bool safe = true;
     WalkAST(root, lCheckAllOffSafety, NULL, &safe);
     return safe;

--- a/src/ast.h
+++ b/src/ast.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2019, Intel Corporation
+  Copyright (c) 2011-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,8 @@
 
 #include "ispc.h"
 #include <vector>
+
+namespace ispc {
 
 /** @brief Abstract base class for nodes in the abstract syntax tree (AST).
 
@@ -200,3 +202,5 @@ extern int EstimateCost(ASTNode *root);
 /** Returns true if it would be safe to run the given code with an "all
     off" mask. */
 extern bool SafeToRunWithMaskAllOff(ASTNode *root);
+
+} // namespace ispc

--- a/src/bitcode_lib.cpp
+++ b/src/bitcode_lib.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019, Intel Corporation
+  Copyright (c) 2019-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -38,6 +38,8 @@
 
 #include "bitcode_lib.h"
 #include "target_registry.h"
+
+using namespace ispc;
 
 // Dispatch constructor
 BitcodeLib::BitcodeLib(const unsigned char lib[], int size, TargetOS os)

--- a/src/bitcode_lib.h
+++ b/src/bitcode_lib.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019, Intel Corporation
+  Copyright (c) 2019-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,8 @@
 
 #include "target_enums.h"
 
+namespace ispc {
+
 class BitcodeLib {
   public:
     enum class BitcodeLibType { Dispatch, Builtins_c, ISPC_target };
@@ -72,3 +74,5 @@ class BitcodeLib {
     const Arch getArch() const;
     const ISPCTarget getISPCTarget() const;
 };
+
+} // namespace ispc

--- a/src/builtins-info.h
+++ b/src/builtins-info.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019, Intel Corporation
+  Copyright (c) 2019-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -65,6 +65,8 @@
 #include <llvm/GenXIntrinsics/GenXIntrinsics.h>
 #endif
 
+using namespace ispc;
+
 extern int yyparse();
 struct yy_buffer_state;
 extern yy_buffer_state *yy_scan_string(const char *);
@@ -241,7 +243,7 @@ static bool lCreateISPCSymbol(llvm::Function *func, SymbolTable *symbolTable) {
     return true;
 }
 
-Symbol *CreateISPCSymbolForLLVMIntrinsic(llvm::Function *func, SymbolTable *symbolTable) {
+Symbol *ispc::CreateISPCSymbolForLLVMIntrinsic(llvm::Function *func, SymbolTable *symbolTable) {
     Symbol *existingSym = symbolTable->LookupIntrinsics(func);
     if (existingSym != NULL) {
         return existingSym;
@@ -930,7 +932,7 @@ static void lSetAlwaysInlineFunctions(llvm::Module *module) {
     @param module      Module to link the bitcode into
     @param symbolTable Symbol table to add definitions to
  */
-void AddBitcodeToModule(const BitcodeLib *lib, llvm::Module *module, SymbolTable *symbolTable) {
+void ispc::AddBitcodeToModule(const BitcodeLib *lib, llvm::Module *module, SymbolTable *symbolTable) {
     llvm::StringRef sb = llvm::StringRef((const char *)lib->getLib(), lib->getSize());
     llvm::MemoryBufferRef bcBuf = llvm::MemoryBuffer::getMemBuffer(sb)->getMemBufferRef();
 
@@ -1119,7 +1121,8 @@ static void emitLLVMUsed(llvm::Module &module, std::vector<llvm::Constant *> &li
     GV->setSection("llvm.metadata");
 }
 
-void DefineStdlib(SymbolTable *symbolTable, llvm::LLVMContext *ctx, llvm::Module *module, bool includeStdlibISPC) {
+void ispc::DefineStdlib(SymbolTable *symbolTable, llvm::LLVMContext *ctx, llvm::Module *module,
+                        bool includeStdlibISPC) {
     // debug_symbols are symbols that supposed to be preserved in debug information.
     // They will be referenced in llvm.used intrinsic to prevent they removal from
     // the object file.

--- a/src/builtins.h
+++ b/src/builtins.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,8 @@
 
 #include "ispc.h"
 
+namespace ispc {
+
 /** Adds declarations and definitions of ispc standard library functions
     and types to the given module.
 
@@ -62,3 +64,5 @@ void AddBitcodeToModule(const BitcodeLib *lib, llvm::Module *module, SymbolTable
     @return                Symbol created for the LLVM::Function
  */
 Symbol *CreateISPCSymbolForLLVMIntrinsic(llvm::Function *func, SymbolTable *symbolTable);
+
+} // namespace ispc

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -56,6 +56,9 @@
 #ifdef ISPC_GENX_ENABLED
 #include <llvm/GenXIntrinsics/GenXIntrinsics.h>
 #endif
+
+namespace ispc {
+
 /** This is a small utility structure that records information related to one
     level of nested control flow.  It's mostly used in correctly restoring
     the mask and other state as we exit control flow nesting levels.
@@ -3818,3 +3821,4 @@ bool FunctionEmitContext::emitGenXHardwareMask() {
 #endif
     return emitGenXHardwareMask;
 }
+} // namespace ispc

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -45,6 +45,8 @@
 #include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/InstrTypes.h>
 #include <llvm/IR/Instructions.h>
+
+namespace ispc {
 
 struct CFInfo;
 
@@ -774,3 +776,4 @@ class FunctionEmitContext {
 
     llvm::Value *addVaryingOffsetsIfNeeded(llvm::Value *ptr, const Type *ptrType);
 };
+} // namespace ispc

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2020, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -47,6 +47,8 @@
 #include <set>
 #include <stdio.h>
 #include <string.h>
+
+using namespace ispc;
 
 static void lPrintTypeQualifiers(int typeQualifiers) {
     if (typeQualifiers & TYPEQUAL_INLINE)
@@ -668,10 +670,10 @@ void Declaration::Print(int indent) const {
 
 ///////////////////////////////////////////////////////////////////////////
 
-void GetStructTypesNamesPositions(const std::vector<StructDeclaration *> &sd,
-                                  llvm::SmallVector<const Type *, 8> *elementTypes,
-                                  llvm::SmallVector<std::string, 8> *elementNames,
-                                  llvm::SmallVector<SourcePos, 8> *elementPositions) {
+void ispc::GetStructTypesNamesPositions(const std::vector<StructDeclaration *> &sd,
+                                        llvm::SmallVector<const Type *, 8> *elementTypes,
+                                        llvm::SmallVector<std::string, 8> *elementNames,
+                                        llvm::SmallVector<SourcePos, 8> *elementPositions) {
     std::set<std::string> seenNames;
     for (unsigned int i = 0; i < sd.size(); ++i) {
         const Type *type = sd[i]->type;

--- a/src/decl.h
+++ b/src/decl.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -56,6 +56,8 @@
 #include "ispc.h"
 
 #include <llvm/ADT/SmallVector.h>
+
+namespace ispc {
 
 struct VariableDeclaration;
 
@@ -214,3 +216,4 @@ extern void GetStructTypesNamesPositions(const std::vector<StructDeclaration *> 
                                          llvm::SmallVector<const Type *, 8> *elementTypes,
                                          llvm::SmallVector<std::string, 8> *elementNames,
                                          llvm::SmallVector<SourcePos, 8> *elementPositions);
+} // namespace ispc

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -68,6 +68,8 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Type.h>
 
+using namespace ispc;
+
 /////////////////////////////////////////////////////////////////////////////////////
 // Expr
 
@@ -544,11 +546,11 @@ typecast_ok:
     return true;
 }
 
-bool CanConvertTypes(const Type *fromType, const Type *toType, const char *errorMsgBase, SourcePos pos) {
+bool ispc::CanConvertTypes(const Type *fromType, const Type *toType, const char *errorMsgBase, SourcePos pos) {
     return lDoTypeConv(fromType, toType, NULL, errorMsgBase == NULL, errorMsgBase, pos);
 }
 
-Expr *TypeConvertExpr(Expr *expr, const Type *toType, const char *errorMsgBase) {
+Expr *ispc::TypeConvertExpr(Expr *expr, const Type *toType, const char *errorMsgBase) {
     if (expr == NULL)
         return NULL;
 
@@ -565,7 +567,7 @@ Expr *TypeConvertExpr(Expr *expr, const Type *toType, const char *errorMsgBase) 
         return NULL;
 }
 
-bool PossiblyResolveFunctionOverloads(Expr *expr, const Type *type) {
+bool ispc::PossiblyResolveFunctionOverloads(Expr *expr, const Type *type) {
     FunctionSymbolExpr *fse = NULL;
     const FunctionType *funcType = NULL;
     if (CastType<PointerType>(type) != NULL && (funcType = CastType<FunctionType>(type->GetBaseType())) &&
@@ -594,7 +596,7 @@ bool PossiblyResolveFunctionOverloads(Expr *expr, const Type *type) {
     @param ctx       FunctionEmitContext to use for generating instructions
     @param pos       Source file position of the variable being initialized
 */
-void InitSymbol(llvm::Value *ptr, const Type *symType, Expr *initExpr, FunctionEmitContext *ctx, SourcePos pos) {
+void ispc::InitSymbol(llvm::Value *ptr, const Type *symType, Expr *initExpr, FunctionEmitContext *ctx, SourcePos pos) {
     if (initExpr == NULL)
         // leave it uninitialized
         return;
@@ -1624,7 +1626,7 @@ bool lCreateBinaryOperatorCall(const BinaryExpr::Op bop, Expr *a0, Expr *a1, Exp
     return abort;
 }
 
-Expr *MakeBinaryExpr(BinaryExpr::Op o, Expr *a, Expr *b, SourcePos p) {
+Expr *ispc::MakeBinaryExpr(BinaryExpr::Op o, Expr *a, Expr *b, SourcePos p) {
     Expr *op = NULL;
     bool abort = lCreateBinaryOperatorCall(o, a, b, op, p);
     if (op != NULL) {

--- a/src/expr.h
+++ b/src/expr.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2020, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,8 @@
 #include "ast.h"
 #include "ispc.h"
 #include "type.h"
+
+namespace ispc {
 
 /** @brief Expr is the abstract base class that defines the interface that
     all expression types must implement.
@@ -832,3 +834,4 @@ Expr *MakeBinaryExpr(BinaryExpr::Op o, Expr *a, Expr *b, SourcePos p);
 void InitSymbol(llvm::Value *lvalue, const Type *symType, Expr *initExpr, FunctionEmitContext *ctx, SourcePos pos);
 
 bool PossiblyResolveFunctionOverloads(Expr *expr, const Type *type);
+} // namespace ispc

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2020, Intel Corporation
+  Copyright (c) 2011-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -68,6 +68,8 @@
 #ifdef ISPC_GENX_ENABLED
 #include <llvm/GenXIntrinsics/GenXMetadata.h>
 #endif
+
+using namespace ispc;
 
 Function::Function(Symbol *s, Stmt *c) {
     sym = s;

--- a/src/func.h
+++ b/src/func.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2019, Intel Corporation
+  Copyright (c) 2011-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,8 @@
 
 #include <vector>
 
+namespace ispc {
+
 class Function {
   public:
     Function(Symbol *sym, Stmt *code);
@@ -64,3 +66,4 @@ class Function {
     Symbol *taskIndexSym1, *taskCountSym1;
     Symbol *taskIndexSym2, *taskCountSym2;
 };
+} // namespace ispc

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -70,8 +70,10 @@
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 
-Globals *g;
-Module *m;
+using namespace ispc;
+
+Globals *ispc::g;
+Module *ispc::m;
 
 ///////////////////////////////////////////////////////////////////////////
 // Target
@@ -1807,7 +1809,7 @@ bool SourcePos::operator==(const SourcePos &p2) const {
             last_line == p2.last_line && last_column == p2.last_column);
 }
 
-SourcePos Union(const SourcePos &p1, const SourcePos &p2) {
+SourcePos ispc::Union(const SourcePos &p1, const SourcePos &p2) {
     if (strcmp(p1.name, p2.name) != 0)
         return p1;
 

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -97,6 +97,8 @@ class DIType;
 class DIScope;
 } // namespace llvm
 
+namespace ispc {
+
 class ArrayType;
 class AST;
 class ASTNode;
@@ -758,3 +760,4 @@ enum {
 
 extern Globals *g;
 extern Module *m;
+} // namespace ispc

--- a/src/ispc_version.h
+++ b/src/ispc_version.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2015-2020, Intel Corporation
+  Copyright (c) 2015-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/src/lex.ll
+++ b/src/lex.ll
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -38,9 +38,11 @@
 #include "util.h"
 #include "module.h"
 #include "type.h"
-#include "parse.hh"
 #include <stdlib.h>
 #include <stdint.h>
+
+using namespace ispc;
+#include "parse.hh"
 
 static uint64_t lParseBinary(const char *ptr, SourcePos pos, char **endPtr);
 static int lParseInteger(bool dotdotdot);

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2020, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -51,6 +51,8 @@
 #ifdef ISPC_GENX_ENABLED
 #include <llvm/GenXIntrinsics/GenXIntrinsics.h>
 #endif
+
+namespace ispc {
 
 llvm::Type *LLVMTypes::VoidType = NULL;
 llvm::PointerType *LLVMTypes::VoidPointerType = NULL;
@@ -1695,3 +1697,4 @@ AddressSpace GetAddressSpace(llvm::Value *v) {
     return AddressSpace::Local;
 }
 #endif
+} // namespace ispc

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2020, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -56,6 +56,8 @@ class InsertElementInst;
 #else
 #define LLVMVECTOR llvm::VectorType
 #endif
+
+namespace ispc {
 
 /** This structure holds pointers to a variety of LLVM types; code
     elsewhere can use them from here, ratherthan needing to make more
@@ -333,3 +335,4 @@ enum AddressSpace { Local, Global, External };
 
 extern AddressSpace GetAddressSpace(llvm::Value *v);
 #endif
+} // namespace ispc

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2020, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -56,6 +56,8 @@
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/ToolOutputFile.h>
+
+using namespace ispc;
 
 #ifdef ISPC_HOST_IS_WINDOWS
 #define strcasecmp stricmp

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -114,6 +114,8 @@
 #endif
 #endif
 
+using namespace ispc;
+
 /*! list of files encountered by the parser. this allows emitting of
     the module file's dependencies via the -MMM option */
 std::set<std::string> registeredDependencies;
@@ -231,11 +233,11 @@ extern void yy_switch_to_buffer(YY_BUFFER_STATE);
 extern YY_BUFFER_STATE yy_scan_string(const char *);
 extern YY_BUFFER_STATE yy_create_buffer(FILE *, int);
 extern void yy_delete_buffer(YY_BUFFER_STATE);
+extern void ParserInit();
 
 int Module::CompileFile() {
     llvm::TimeTraceScope CompileFileTimeScope(
         "CompileFile", llvm::StringRef(filename + ("_" + std::string(g->target->GetISAString()))));
-    extern void ParserInit();
     ParserInit();
 
     // FIXME: it'd be nice to do this in the Module constructor, but this
@@ -2114,7 +2116,7 @@ bool Module::writeHeader(const char *fn) {
     return true;
 }
 
-struct DispatchHeaderInfo {
+struct ispc::DispatchHeaderInfo {
     bool EmitUnifs;
     bool EmitFuncs;
     bool EmitFrontMatter;

--- a/src/module.h
+++ b/src/module.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2020, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -52,6 +52,8 @@
 namespace llvm {
 class raw_string_ostream;
 }
+
+namespace ispc {
 
 struct DispatchHeaderInfo;
 
@@ -219,3 +221,4 @@ inline Module::OutputFlags &operator&=(Module::OutputFlags &lhs, const __underly
 inline Module::OutputFlags operator|(const Module::OutputFlags lhs, const Module::OutputFlags rhs) {
     return (Module::OutputFlags)((__underlying_type(Module::OutputFlags))lhs | rhs);
 }
+} // namespace ispc

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -115,9 +115,12 @@
 #include <llvm/GenXIntrinsics/GenXSPIRVWriterAdaptor.h>
 // Used for GenX gather coalescing
 #include <llvm/Transforms/Utils/Local.h>
+
 // Constant in number of bytes.
 enum { BYTE = 1, WORD = 2, DWORD = 4, QWORD = 8, OWORD = 16, GRF = 32 };
 #endif
+
+using namespace ispc;
 
 static llvm::Pass *CreateIntrinsicsOptPass();
 static llvm::Pass *CreateInstructionSimplifyPass();
@@ -463,7 +466,7 @@ void DebugPassManager::add(llvm::Pass *P, int stage = -1) {
 }
 ///////////////////////////////////////////////////////////////////////////
 
-void Optimize(llvm::Module *module, int optLevel) {
+void ispc::Optimize(llvm::Module *module, int optLevel) {
 #ifndef ISPC_NO_DUMPS
     if (g->debugPrint) {
         printf("*** Code going into optimization ***\n");

--- a/src/opt.h
+++ b/src/opt.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -39,9 +39,12 @@
 
 #include "ispc.h"
 
+namespace ispc {
+
 /** Optimize the functions in the given module, applying the specified
     level of optimization.  optLevel zero corresponds to essentially no
     optimization--just enough to generate correct code, while level one
     corresponds to full optimization.
 */
 void Optimize(llvm::Module *module, int optLevel);
+} // namespace ispc

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2013, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -96,6 +96,8 @@ struct PragmaAttributes {
 
 #include <stdio.h>
 #include <llvm/IR/Constants.h>
+
+using namespace ispc;
 
 #define UNIMPLEMENTED \
         Error(yylloc, "Unimplemented parser functionality %s:%d", \

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2020, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -59,6 +59,8 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Type.h>
 #include <llvm/Support/raw_ostream.h>
+
+using namespace ispc;
 
 ///////////////////////////////////////////////////////////////////////////
 // Stmt

--- a/src/stmt.h
+++ b/src/stmt.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,8 @@
 
 #include "ast.h"
 #include "ispc.h"
+
+namespace ispc {
 
 /** @brief Interface class for statements in the ispc language.
 
@@ -584,3 +586,4 @@ class DeleteStmt : public Stmt {
 };
 
 extern Stmt *CreateForeachActiveStmt(Symbol *iterSym, Stmt *stmts, SourcePos pos);
+} // namespace ispc

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -42,6 +42,8 @@
 #include <array>
 #include <iterator>
 #include <stdio.h>
+
+using namespace ispc;
 
 ///////////////////////////////////////////////////////////////////////////
 // Symbol

--- a/src/sym.h
+++ b/src/sym.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -42,6 +42,8 @@
 #include "decl.h"
 #include "ispc.h"
 #include <map>
+
+namespace ispc {
 
 class StructType;
 class ConstExpr;
@@ -324,3 +326,4 @@ void SymbolTable::GetMatchingVariables(Predicate pred, std::vector<Symbol *> *ma
         }
     }
 }
+} // namespace ispc

--- a/src/target_enums.cpp
+++ b/src/target_enums.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2020, Intel Corporation
+  Copyright (c) 2019-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,8 @@
 #include "util.h"
 
 #include <cstring>
+
+namespace ispc {
 
 Arch ParseArch(std::string arch) {
     if (arch == "x86") {
@@ -408,3 +410,4 @@ TargetOS GetHostOS() {
     return TargetOS::error;
 #endif
 }
+} // namespace ispc

--- a/src/target_enums.h
+++ b/src/target_enums.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2020, Intel Corporation
+  Copyright (c) 2019-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,8 @@
 
 #include <string>
 #include <vector>
+
+namespace ispc {
 
 enum class CallingConv { uninitialized, defaultcall, x86_vectorcall };
 
@@ -95,3 +97,4 @@ bool ISPCTargetIsX86(ISPCTarget target);
 bool ISPCTargetIsNeon(ISPCTarget target);
 bool ISPCTargetIsWasm(ISPCTarget target);
 bool ISPCTargetIsGen(ISPCTarget target);
+} // namespace ispc

--- a/src/target_registry.cpp
+++ b/src/target_registry.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2020, Intel Corporation
+  Copyright (c) 2019-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,8 @@
 #include <numeric>
 #include <string>
 #include <vector>
+
+using namespace ispc;
 
 // Returns number of bits required to store this value
 static constexpr uint32_t bits_required(uint32_t x) {

--- a/src/target_registry.h
+++ b/src/target_registry.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019, Intel Corporation
+  Copyright (c) 2019-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -43,6 +43,7 @@
 #include <map>
 #include <vector>
 
+namespace ispc {
 // Some background information useful for understanding how this works.
 // - static variables with global or class scope and without constructor are
 //   initialized at load time.
@@ -107,3 +108,4 @@ class TargetLibRegistry {
 
     bool isSupported(ISPCTarget target, TargetOS os, Arch arch) const;
 };
+} // namespace ispc

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2020, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -50,6 +50,8 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Value.h>
 #include <llvm/Support/MathExtras.h>
+
+using namespace ispc;
 
 /** Utility routine used in code that prints out declarations; returns true
     if the given name should be printed, false otherwise.  This allows us

--- a/src/type.h
+++ b/src/type.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2020, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -43,6 +43,8 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Type.h>
+
+namespace ispc {
 
 class ConstExpr;
 class StructType;
@@ -1011,3 +1013,5 @@ template <> inline const FunctionType *CastType(const Type *type) {
 }
 
 inline bool IsReferenceType(const Type *t) { return CastType<ReferenceType>(t) != NULL; }
+
+} // namespace ispc

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2020, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -67,13 +67,15 @@
 
 #include <llvm/IR/DataLayout.h>
 
+using namespace ispc;
+
 /** Returns the width of the terminal where the compiler is running.
     Finding this out may fail in a variety of reasonable situations (piping
     compiler output to 'less', redirecting output to a file, running the
     compiler under a debuffer; in this case, just return a reasonable
     default.
  */
-int TerminalWidth() {
+int ispc::TerminalWidth() {
     if (g->disableLineWrap)
         return 1 << 30;
 
@@ -207,7 +209,7 @@ static int lFindIndent(int numColons, const char *buf) {
 /** Print the given string to the given FILE, assuming the given output
     column width.  Break words as needed to avoid words spilling past the
     last column.  */
-void PrintWithWordBreaks(const char *buf, int indent, int columnWidth, FILE *out) {
+void ispc::PrintWithWordBreaks(const char *buf, int indent, int columnWidth, FILE *out) {
 #ifdef ISPC_HOST_IS_WINDOWS
     fputs(buf, out);
     fputs("\n", out);
@@ -348,7 +350,7 @@ static void lPrint(const char *type, bool isError, SourcePos p, const char *fmt,
     free(formattedBuf);
 }
 
-void Error(SourcePos p, const char *fmt, ...) {
+void ispc::Error(SourcePos p, const char *fmt, ...) {
     if (m != NULL) {
         ++m->errorCount;
         if ((g->errorLimit != -1) && (g->errorLimit <= m->errorCount - 1))
@@ -363,7 +365,7 @@ void Error(SourcePos p, const char *fmt, ...) {
     va_end(args);
 }
 
-void Debug(SourcePos p, const char *fmt, ...) {
+void ispc::Debug(SourcePos p, const char *fmt, ...) {
 #ifndef ISPC_NO_DUMPS
     if (!g->debugPrint || g->quiet)
         return;
@@ -375,7 +377,7 @@ void Debug(SourcePos p, const char *fmt, ...) {
 #endif
 }
 
-void Warning(SourcePos p, const char *fmt, ...) {
+void ispc::Warning(SourcePos p, const char *fmt, ...) {
 
     std::map<std::pair<int, std::string>, bool>::iterator turnOffWarnings_it =
         g->turnOffWarnings.find(std::pair<int, std::string>(p.last_line, std::string(p.name)));
@@ -394,7 +396,7 @@ void Warning(SourcePos p, const char *fmt, ...) {
     va_end(args);
 }
 
-void PerformanceWarning(SourcePos p, const char *fmt, ...) {
+void ispc::PerformanceWarning(SourcePos p, const char *fmt, ...) {
     std::string stdlibFile = "stdlib.ispc";
     std::string sourcePosName = p.name;
     if (!g->emitPerfWarnings ||
@@ -431,19 +433,19 @@ static void lPrintBugText() {
                     "like to fix!\n***\n");
 }
 
-[[noreturn]] void FatalError(const char *file, int line, const char *message) {
+[[noreturn]] void ispc::FatalError(const char *file, int line, const char *message) {
     fprintf(stderr, "%s(%d): FATAL ERROR: %s\n", file, line, message);
     lPrintBugText();
     abort();
 }
 
-void DoAssert(const char *file, int line, const char *expr) {
+void ispc::DoAssert(const char *file, int line, const char *expr) {
     fprintf(stderr, "%s:%u: Assertion failed: \"%s\".\n", file, line, expr);
     lPrintBugText();
     abort();
 }
 
-void DoAssertPos(SourcePos pos, const char *file, int line, const char *expr) {
+void ispc::DoAssertPos(SourcePos pos, const char *file, int line, const char *expr) {
     Error(pos, "Assertion failed (%s:%u): \"%s\".", file, line, expr);
     lPrintBugText();
     abort();
@@ -452,7 +454,7 @@ void DoAssertPos(SourcePos pos, const char *file, int line, const char *expr) {
 ///////////////////////////////////////////////////////////////////////////
 
 // http://en.wikipedia.org/wiki/Levenshtein_distance
-int StringEditDistance(const std::string &str1, const std::string &str2, int maxDist) {
+int ispc::StringEditDistance(const std::string &str1, const std::string &str2, int maxDist) {
     // Small hack: don't return 0 if the strings are the same; if we've
     // gotten here, there's been a parsing error, and suggesting the same
     // string isn't going to actually help things.
@@ -487,7 +489,7 @@ int StringEditDistance(const std::string &str1, const std::string &str2, int max
     return previous[n2];
 }
 
-std::vector<std::string> MatchStrings(const std::string &str, const std::vector<std::string> &options) {
+std::vector<std::string> ispc::MatchStrings(const std::string &str, const std::vector<std::string> &options) {
     if (str.size() == 0 || (str.size() == 1 && !isalpha(str[0])))
         // don't even try...
         return std::vector<std::string>();
@@ -513,8 +515,8 @@ std::vector<std::string> MatchStrings(const std::string &str, const std::vector<
     return std::vector<std::string>();
 }
 
-void GetDirectoryAndFileName(const std::string &currentDirectory, const std::string &relativeName,
-                             std::string *directory, std::string *filename) {
+void ispc::GetDirectoryAndFileName(const std::string &currentDirectory, const std::string &relativeName,
+                                   std::string *directory, std::string *filename) {
 #ifdef ISPC_HOST_IS_WINDOWS
     char path[MAX_PATH];
     const char *combPath = PathCombine(path, currentDirectory.c_str(), relativeName.c_str());
@@ -618,7 +620,7 @@ bool VerifyDataLayoutCompatibility(const std::string &module_dl, const std::stri
     return true;
 }
 
-bool IsStdin(const char *filepath) {
+bool ispc::IsStdin(const char *filepath) {
     Assert(filepath != nullptr);
     if (!strcmp(filepath, "-")) {
         return true;

--- a/src/util.h
+++ b/src/util.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2019, Intel Corporation
+  Copyright (c) 2010-2021, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -44,6 +44,20 @@
 #include <stdarg.h>
 #endif
 
+#ifdef __GNUG__
+#define PRINTF_FUNC __attribute__((format(printf, 2, 3)))
+#else
+#define PRINTF_FUNC
+#endif // __GNUG__
+
+// for cross-platform compatibility
+#ifdef ISPC_HOST_IS_WINDOWS
+int vasprintf(char **sptr, const char *fmt, va_list argv);
+int asprintf(char **sptr, const char *fmt, ...);
+#endif
+
+namespace ispc {
+
 struct SourcePos;
 
 /** Rounds up the given value to the next power of two, if it isn't a power
@@ -57,18 +71,6 @@ inline uint32_t RoundUpPow2(uint32_t v) {
     v |= v >> 16;
     return v + 1;
 }
-
-#ifdef __GNUG__
-#define PRINTF_FUNC __attribute__((format(printf, 2, 3)))
-#else
-#define PRINTF_FUNC
-#endif // __GNUG__
-
-// for cross-platform compatibility
-#ifdef ISPC_HOST_IS_WINDOWS
-int vasprintf(char **sptr, const char *fmt, va_list argv);
-int asprintf(char **sptr, const char *fmt, ...);
-#endif
 
 /** Prints a debugging message.  These messages are only printed if
     g->debugPrint is \c true.  In addition to a program source code
@@ -199,3 +201,4 @@ int TerminalWidth();
 /** Returns true is the filepath represents stdin, otherwise false.
  */
 bool IsStdin(const char *);
+} // namespace ispc

--- a/stdlib2cpp.py
+++ b/stdlib2cpp.py
@@ -4,6 +4,7 @@ import sys
 
 t=str(sys.argv[1])
 
+sys.stdout.write("namespace ispc {\n")
 sys.stdout.write("extern const char stdlib_" + t + "_code[] = {\n")
 
 width = 16
@@ -14,5 +15,6 @@ for i in range(0, len(data), 1):
     if i%width == (width-1):
         sys.stdout.write("\n")
 
-sys.stdout.write("0x00 };\n\n")
+sys.stdout.write("0x00 };\n")
+sys.stdout.write("} // namespace ispc\n")
                                     


### PR DESCRIPTION
Introducing `ispc` namespace is the right thing to do and is also required for upgrading to LLVM 12 on Windows, because of more includes now transitively included in clang and a MSVC bug. Including `clang/AST/Expr.h` and `clang/AST/Stmt.h` introduces strange conflicts with our declarations in `expr.h` and `stmt.h` and yield a bunch of compile errors, which are specific to MSVC. Clang handles the code just fine.

Practically speaking, now all `.h` files are wrapped by `namespace ispc {}` and all `.cpp` files have `using namespace ispc;` statement in the beginning. In addition to that definition of freestanding functions (not member functions) need to explicitly be qualified with `ispc::`, if they are not defined inside `namespace ispc {...}`.

Here's an example, which demonstrates the use of namespace:

foo.h
```c++
#include <stdio.h>

namespace ispc {
  class abc {
    public:
      // Member function
      void foo();
  };

  // Freestanding function declared in ispc namespace
  void walk_abc(abc* p);
}
```

foo.cpp
```c++
#include "foo.h"

using namespace ispc;

int main() {
  abc A;
  A.foo();

  // No need to use "ispc::" as "using namespace ispc" is above
  walk_abc(&A);

  return 0;
}

// Member function definition - no need to have "ispc::" qualifier.
void abc::foo() {
  printf("foo\n");
}

// Static function definition - no need to have "ispc::" qualifier,
// as the name doesn't escape from compilation unit.
static void boo() {
  printf("boo\n");
}

// Freestanding function definition - need to use "ispc::" qualified name.
void ispc::walk_abc(abc* p) {
  printf("walk abc\n");
  p->foo();
  boo();
}
```