### PR TITLE
Changes for LLVM13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,6 +427,9 @@ if (MSVC)
     set_source_files_properties(${BISON_OUTPUT} PROPERTIES COMPILE_FLAGS "/wd4005 /wd4065")
 else()
     target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wno-sign-compare -Wno-unused-function -Werror ${LLVM_CPP_FLAGS})
+    if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "13.0.0")
+        set_source_files_properties(${BISON_CPP_OUTPUT} PROPERTIES COMPILE_FLAGS "-Wno-unused-but-set-variable")
+    endif()
     # Security options
     target_compile_options(${PROJECT_NAME} PRIVATE -fstack-protector-strong
                            -fdata-sections -ffunction-sections -fno-delete-null-pointer-checks

--- a/src/bitcode_lib.cpp
+++ b/src/bitcode_lib.cpp
@@ -60,22 +60,18 @@ BitcodeLib::BitcodeLib(const unsigned char lib[], int size, ISPCTarget target, T
 
 // TODO: this is debug version: either remove or make it use friendly.
 void BitcodeLib::print() const {
-    const char *type = nullptr;
     std::string os = OSToString(m_os);
     switch (m_type) {
     case BitcodeLibType::Dispatch: {
-        type = "Dispatch";
         printf("Type: dispatch.    size: %zu, OS: %s\n", m_size, os.c_str());
         break;
     }
     case BitcodeLibType::Builtins_c: {
-        type = "Builtins-c";
         std::string arch = ArchToString(m_arch);
         printf("Type: builtins-c.  size: %zu, OS: %s, arch: %s\n", m_size, os.c_str(), arch.c_str());
         break;
     }
     case BitcodeLibType::ISPC_target: {
-        type = "ISPC-target";
         std::string target = ISPCTargetToString(m_target);
         std::string arch = ArchToString(m_arch);
         printf("Type: ispc-target. size: %zu, OS: %s, target: %s, arch(runtime) %s\n", m_size, os.c_str(),

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -5039,7 +5039,7 @@ llvm::Value *MemberExpr::GetLValue(FunctionEmitContext *ctx) const {
     if (elementNumber == -1)
         return NULL;
 
-    const Type *exprLValueType = dereferenceExpr ? expr->GetType() : expr->GetLValueType();
+    const Type *exprLValueType = dereferenceExpr ? exprType : expr->GetLValueType();
     ctx->SetDebugPos(pos);
     llvm::Value *ptr = ctx->AddElementOffset(basePtr, elementNumber, exprLValueType, basePtr->getName().str().c_str());
     if (ptr == NULL) {
@@ -7276,8 +7276,7 @@ llvm::Value *ReferenceExpr::GetValue(FunctionEmitContext *ctx) const {
     // value is NULL if the expression is a temporary; in this case, we'll
     // allocate storage for it so that we can return the pointer to that...
     const Type *type;
-    llvm::Type *llvmType;
-    if ((type = expr->GetType()) == NULL || (llvmType = type->LLVMType(g->ctx)) == NULL) {
+    if ((type = expr->GetType()) == NULL || type->LLVMType(g->ctx) == NULL) {
         AssertPos(pos, m->errorCount > 0);
         return NULL;
     }
@@ -7585,8 +7584,7 @@ Expr *AddressOfExpr::Optimize() { return this; }
 int AddressOfExpr::EstimateCost() const { return 0; }
 
 std::pair<llvm::Constant *, bool> AddressOfExpr::GetConstant(const Type *type) const {
-    const Type *exprType;
-    if (expr == NULL || (exprType = expr->GetType()) == NULL) {
+    if (expr == NULL || expr->GetType() == NULL) {
         AssertPos(pos, m->errorCount > 0);
         return std::pair<llvm::Constant *, bool>(NULL, false);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,7 @@
 
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/Debug.h>
+#include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Signals.h>
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Support/TargetSelect.h>
@@ -471,7 +472,7 @@ static void setCallingConv(VectorCallStatus vectorCall, Arch arch) {
 static void writeCompileTimeFile(const char *outFileName) {
     llvm::SmallString<128> jsonFileName(outFileName);
     jsonFileName.append(".json");
-    llvm::sys::fs::OpenFlags flags = llvm::sys::fs::F_Text;
+    llvm::sys::fs::OpenFlags flags = llvm::sys::fs::OF_Text;
     std::error_code error;
     std::unique_ptr<llvm::ToolOutputFile> of(new llvm::ToolOutputFile(jsonFileName.c_str(), error, flags));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -536,6 +536,8 @@ static void lParseInclude(const char *path) {
     } while (pos_end != std::string::npos);
 }
 
+extern int yydebug;
+
 int main(int Argc, char *Argv[]) {
     std::vector<char *> argv;
     lGetAllArgs(Argc, Argv, argv);
@@ -867,7 +869,6 @@ int main(int Argc, char *Argv[]) {
         else if (!strcmp(argv[i], "--quiet"))
             g->quiet = true;
         else if (!strcmp(argv[i], "--yydebug")) {
-            extern int yydebug;
             yydebug = 1;
         } else if (!strcmp(argv[i], "-MMM")) {
             if (++i != argc) {

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -2267,9 +2267,8 @@ void ForeachUniqueStmt::EmitCode(FunctionEmitContext *ctx) const {
     // And we'll store its value into locally-allocated storage, for ease
     // of indexing over it with non-compile-time-constant indices.
     const Type *exprType;
-    llvm::VectorType *llvmExprType;
     if (exprValue == NULL || (exprType = expr->GetType()) == NULL ||
-        (llvmExprType = llvm::dyn_cast<llvm::VectorType>(exprValue->getType())) == NULL) {
+        llvm::dyn_cast<llvm::VectorType>(exprValue->getType()) == NULL) {
         Assert(m->errorCount > 0);
         return;
     }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -2513,9 +2513,6 @@ llvm::FunctionType *FunctionType::LLVMFunctionType(llvm::LLVMContext *ctx, bool 
         return NULL;
     }
 
-    bool isStorageType = false;
-    if (CastType<AtomicType>(returnType) == NULL)
-        isStorageType = true;
     const Type *retType = returnType;
 
     llvm::Type *llvmReturnType = retType->LLVMType(g->ctx);


### PR DESCRIPTION
- Accommodate to clang13 switch `-Wunused-but-set-variable`
- Explicitly include `FileSystem.h` and use not deprecated version of `F_Text`, i.e. `OF_Text`