### PR TITLE
Fix choco timeouts in Github Actions.

### DIFF
--- a/.github/workflows/scripts/install-build-deps.ps1
+++ b/.github/workflows/scripts/install-build-deps.ps1
@@ -1,4 +1,9 @@
-choco install --no-progress winflexbison3 wget 7zip cygwin cyg-get
+# Choco-Install is GH Actions wrappers around choco, which does retries
+Choco-Install -PackageName winflexbison3
+Choco-Install -PackageName wget
+Choco-Install -PackageName 7zip
+Choco-Install -PackageName cygwin
+Choco-Install -PackageName cyg-get
 
 # Install M4 exec and put it into PATH
 cyg-get m4

--- a/.github/workflows/scripts/install-test-deps.ps1
+++ b/.github/workflows/scripts/install-test-deps.ps1
@@ -1,4 +1,5 @@
-choco install --no-progress wget
+# Choco-Install is GH Actions wrappers around choco, which does retries
+Choco-Install -PackageName wget
 
 # Install ISPC package
 $msiexecArgs = @(


### PR DESCRIPTION
Choco doesn't have retry mechanism (see https://github.com/chocolatey/choco/issues/385 for more details), so if it fails, we have a failed pipeline. We had quite a few such pipelines recently.

The rescue comes from Github Actions wrapper `Choco-Install`, which does retries (see https://github.com/actions/virtual-environments/pull/721 for more details).