### PR TITLE
Fix sporadic GH Actions test hangs on Windows

### DIFF
--- a/alloy.py
+++ b/alloy.py
@@ -942,6 +942,7 @@ def Main():
         os.rename(f_date, date_name)
         print_debug("Logs are in " + date_name + "\n", False, "")
     except Exception as e:
+        # Do not return non-zero exit code here, as it's not a critical error and testing might be considered successful.
         print_debug("Exception: " + str(e), False, stability_log)
 
     if current_OS == "Windows":

--- a/alloy.py
+++ b/alloy.py
@@ -944,6 +944,10 @@ def Main():
     except Exception as e:
         print_debug("Exception: " + str(e), False, stability_log)
 
+    if current_OS == "Windows":
+        # Windows hangs from time to time on exit, so returning without cleanup.
+        sys.stdout.flush()
+        os._exit(return_status)
     exit(return_status)
 
 ###Main###

--- a/alloy.py
+++ b/alloy.py
@@ -502,7 +502,8 @@ def execute_stability(stability, R, print_version):
         else:
             str_time = "\n"
         print_debug(temp[4][1:-3] + stability1.ispc_flags + str_fails + str_new_fails + str_new_passes + str_time, False, stability_log)
-    except:
+    except Exception as e:
+        print_debug("Exception: " + str(e), False, stability_log)
         exc_type, exc_value, exc_traceback = sys.exc_info()
         traceback.print_tb(exc_traceback, file=sys.stderr)
         print_debug("ERROR: Exception in execute_stability: %s\n" % (sys.exc_info()[1]), False, stability_log)
@@ -817,7 +818,8 @@ def send_mail(body_header, msg):
         fp = open(os.environ["ISPC_HOME"] + os.sep + "notify_log.log", 'rb')
         f_lines = fp.readlines()
         fp.close()
-    except:
+    except Exception as e:
+        print_debug("Exception: " + str(e), False, stability_log)
         body_header += "\nUnable to open notify_log.log: " + str(sys.exc_info()) + "\n"
         print_debug("Unable to open notify_log.log: " + str(sys.exc_info()) + "\n", False, stability_log)
         return_status = 1
@@ -927,14 +929,22 @@ def Main():
         elapsed_time = time.time() - start_time
         if options.time:
             print_debug("Elapsed time: " + time.strftime('%Hh%Mm%Ssec.', time.gmtime(elapsed_time)) + "\n", False, "")
-    finally:
+    except Exception as e:
+        print_debug("Exception: " + str(e), False, stability_log)
+        return_status = 1
+
+    # Finish execution: time reporting and copy log
+    try:
         os.chdir(current_path)
         date_name = "alloy_results_" + datetime.datetime.now().strftime('%Y_%m_%d_%H_%M_%S')
         if os.path.exists(date_name):
             alloy_error("It's forbidden to run alloy two times in a second, logs are in ./logs", 1)
         os.rename(f_date, date_name)
         print_debug("Logs are in " + date_name + "\n", False, "")
-        exit(return_status)
+    except Exception as e:
+        print_debug("Exception: " + str(e), False, stability_log)
+
+    exit(return_status)
 
 ###Main###
 from optparse import OptionParser

--- a/common.py
+++ b/common.py
@@ -476,7 +476,7 @@ class ExecutionStateGatherer(object):
 
     def dump(self, fname, obj):
         import pickle
-        with open(fname, 'w') as fp:
+        with open(fname, 'wb') as fp:
             pickle.dump(obj, fp)  
 
     def undump(self, fname):


### PR DESCRIPTION
For some reason `alloy.py` doesn't return properly on Windows. It reaches `sys.exit(n)` and hangs. This means that trying to clean up (release file handlers, flush streams, etc) it gets locked. In GH Actions we have 1-2 hangs (out of 84 jobs) per nightly run almost daily.

The fix is to use `os._exit(n)` instead, which exits the script, but doesn't release all resources.

The PR also contains several improvements in exception handling in `alloy.py` and a fix for a problem with `pickle`, which was previously hidden my exception handlers. 