### PR TITLE
Ubuntu images to use python3.6 explicitly to run alloy.py

### DIFF
--- a/docker/ubuntu/full_ispc_build/Dockerfile
+++ b/docker/ubuntu/full_ispc_build/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /usr/local/src/ispc
 # i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
 # or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
 # "rm" are just to keep docker image small.
-RUN ./alloy.py -b --version=$LLVM_VERSION --selfbuild $EXTRA_BUILD_ARG && \
+RUN python3.6 ./alloy.py -b --version=$LLVM_VERSION --selfbuild $EXTRA_BUILD_ARG && \
     rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-"$LLVM_VERSION"_temp $LLVM_HOME/build-"$LLVM_VERSION"_temp
 
 ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH

--- a/docker/ubuntu/llvm_build/Dockerfile
+++ b/docker/ubuntu/llvm_build/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR /usr/local/src/ispc
 # i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
 # or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
 # "rm" are just to keep docker image small.
-RUN ./alloy.py -b --version=$LLVM_VERSION --selfbuild --verbose $EXTRA_BUILD_ARG && \
+RUN python3.6 ./alloy.py -b --version=$LLVM_VERSION --selfbuild --verbose $EXTRA_BUILD_ARG && \
     rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-"$LLVM_VERSION"_temp $LLVM_HOME/build-"$LLVM_VERSION"_temp
 
 ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH

--- a/docker/ubuntu/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/xpu_ispc_build/Dockerfile
@@ -34,7 +34,7 @@ ENV ISPC_HOME=/home/src/ispc
 
 # LLVM
 ENV LLVM_HOME=/home/tools/llvm/$LLVM_VERSION
-RUN ./alloy.py -b --version=$LLVM_VERSION --selfbuild && \
+RUN python3.6 ./alloy.py -b --version=$LLVM_VERSION --selfbuild && \
     rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-"$LLVM_VERSION"_temp $LLVM_HOME/build-"$LLVM_VERSION"_temp
 
 WORKDIR /home/packages


### PR DESCRIPTION
Fix Ubuntu dockers.
`software-properties-common` package brings `python3.5`, which has alias `python3`. So `alloy.py` runs with `3.5`, which is not sufficient and causes the fail.