### PR TITLE
Fixed alignment issues when using gcc

### DIFF
--- a/builtins/util.m4
+++ b/builtins/util.m4
@@ -5034,6 +5034,34 @@ define void @__keep_funcs_live(i8 * %ptr, <WIDTH x i8> %v8, <WIDTH x i16> %v16,
   %mld = call <WIDTH x double> @__masked_load_double(i8 * %ptr, <WIDTH x MASK> %mask)
   call void @__usedouble(<WIDTH x double> %mld)
 
+  ;; private loads
+  %prml8  = call <WIDTH x i8>  @__masked_load_private_i8(i8 * %ptr, <WIDTH x MASK> %mask)
+  call void @__use8(<WIDTH x i8> %prml8)
+  %prml16 = call <WIDTH x i16> @__masked_load_private_i16(i8 * %ptr, <WIDTH x MASK> %mask)
+  call void @__use16(<WIDTH x i16> %prml16)
+  %prml32 = call <WIDTH x i32> @__masked_load_private_i32(i8 * %ptr, <WIDTH x MASK> %mask)
+  call void @__use32(<WIDTH x i32> %prml32)
+  %prmlf = call <WIDTH x float> @__masked_load_private_float(i8 * %ptr, <WIDTH x MASK> %mask)
+  call void @__usefloat(<WIDTH x float> %prmlf)
+  %prml64 = call <WIDTH x i64> @__masked_load_private_i64(i8 * %ptr, <WIDTH x MASK> %mask)
+  call void @__use64(<WIDTH x i64> %prml64)
+  %prmld = call <WIDTH x double> @__masked_load_private_double(i8 * %ptr, <WIDTH x MASK> %mask)
+  call void @__usedouble(<WIDTH x double> %prmld)
+
+  ;; blend loads
+  %prmb8  = call <WIDTH x i8>  @__masked_load_blend_i8(i8 * %ptr, <WIDTH x MASK> %mask)
+  call void @__use8(<WIDTH x i8> %prmb8)
+  %prmb16 = call <WIDTH x i16> @__masked_load_blend_i16(i8 * %ptr, <WIDTH x MASK> %mask)
+  call void @__use16(<WIDTH x i16> %prmb16)
+  %prmb32 = call <WIDTH x i32> @__masked_load_blend_i32(i8 * %ptr, <WIDTH x MASK> %mask)
+  call void @__use32(<WIDTH x i32> %prmb32)
+  %prmbf = call <WIDTH x float> @__masked_load_blend_float(i8 * %ptr, <WIDTH x MASK> %mask)
+  call void @__usefloat(<WIDTH x float> %prmbf)
+  %prmb64 = call <WIDTH x i64> @__masked_load_blend_i64(i8 * %ptr, <WIDTH x MASK> %mask)
+  call void @__use64(<WIDTH x i64> %prmb64)
+  %prmbd = call <WIDTH x double> @__masked_load_blend_double(i8 * %ptr, <WIDTH x MASK> %mask)
+  call void @__usedouble(<WIDTH x double> %prmbd)
+
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   ;; stores
   %pv8 = bitcast i8 * %ptr to <WIDTH x i8> *
@@ -7489,6 +7517,20 @@ declare <WIDTH x i32> @__idiv_int32(<WIDTH x i32>, <WIDTH x i32>) nounwind readn
 declare <WIDTH x i8> @__idiv_uint8(<WIDTH x i8>, <WIDTH x i8>) nounwind readnone
 declare <WIDTH x i16> @__idiv_uint16(<WIDTH x i16>, <WIDTH x i16>) nounwind readnone
 declare <WIDTH x i32> @__idiv_uint32(<WIDTH x i32>, <WIDTH x i32>) nounwind readnone
+
+declare <WIDTH x i8> @__masked_load_private_i8(i8 *, <WIDTH x MASK> %mask)
+declare <WIDTH x i16> @__masked_load_private_i16(i8 *, <WIDTH x MASK> %mask)
+declare <WIDTH x i32> @__masked_load_private_i32(i8 *, <WIDTH x MASK> %mask)
+declare <WIDTH x i64> @__masked_load_private_i64(i8 *, <WIDTH x MASK> %mask)
+declare <WIDTH x float> @__masked_load_private_float(i8 *, <WIDTH x MASK> %mask)
+declare <WIDTH x double> @__masked_load_private_double(i8 *, <WIDTH x MASK> %mask)
+
+declare <WIDTH x i8> @__masked_load_blend_i8(i8 *, <WIDTH x MASK> %mask)
+declare <WIDTH x i16> @__masked_load_blend_i16(i8 *, <WIDTH x MASK> %mask)
+declare <WIDTH x i32> @__masked_load_blend_i32(i8 *, <WIDTH x MASK> %mask)
+declare <WIDTH x i64> @__masked_load_blend_i64(i8 *, <WIDTH x MASK> %mask)
+declare <WIDTH x float> @__masked_load_blend_float(i8 *, <WIDTH x MASK> %mask)
+declare <WIDTH x double> @__masked_load_blend_double(i8 *, <WIDTH x MASK> %mask)
 ')
 
 define(`global_atomic_varying',`

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -3086,18 +3086,24 @@ static bool lImproveMaskedLoad(llvm::CallInst *callInst, llvm::BasicBlock::itera
     };
 
     llvm::Function *called = callInst->getCalledFunction();
-
+    // TODO: we should use dynamic data structure for MLInfo and fill
+    // it differently for GenX and CPU targets. It will also help
+    // to avoid declaration of GenX intrinsics for CPU targets.
+    // It should be changed seamlessly here and in all similar places in this file.
+    MLInfo mlInfo[] = {MLInfo("__masked_load_i8", 1),  MLInfo("__masked_load_i16", 2),
+                       MLInfo("__masked_load_i32", 4), MLInfo("__masked_load_float", 4),
+                       MLInfo("__masked_load_i64", 8), MLInfo("__masked_load_double", 8)};
+    MLInfo genxInfo[] = {MLInfo("__masked_load_i8", 1),          MLInfo("__masked_load_i16", 2),
+                         MLInfo("__masked_load_i32", 4),         MLInfo("__masked_load_float", 4),
+                         MLInfo("__masked_load_i64", 8),         MLInfo("__masked_load_double", 8),
+                         MLInfo("__masked_load_blend_i8", 1),    MLInfo("__masked_load_blend_i16", 2),
+                         MLInfo("__masked_load_blend_i32", 4),   MLInfo("__masked_load_blend_float", 4),
+                         MLInfo("__masked_load_blend_i64", 8),   MLInfo("__masked_load_blend_double", 8),
+                         MLInfo("__masked_load_private_i8", 1),  MLInfo("__masked_load_private_i16", 2),
+                         MLInfo("__masked_load_private_i32", 4), MLInfo("__masked_load_private_float", 4),
+                         MLInfo("__masked_load_private_i64", 8), MLInfo("__masked_load_private_double", 8)};
     MLInfo *info = NULL;
     if (g->target->isGenXTarget()) {
-        MLInfo genxInfo[] = {MLInfo("__masked_load_i8", 1),          MLInfo("__masked_load_i16", 2),
-                             MLInfo("__masked_load_i32", 4),         MLInfo("__masked_load_float", 4),
-                             MLInfo("__masked_load_i64", 8),         MLInfo("__masked_load_double", 8),
-                             MLInfo("__masked_load_blend_i8", 1),    MLInfo("__masked_load_blend_i16", 2),
-                             MLInfo("__masked_load_blend_i32", 4),   MLInfo("__masked_load_blend_float", 4),
-                             MLInfo("__masked_load_blend_i64", 8),   MLInfo("__masked_load_blend_double", 8),
-                             MLInfo("__masked_load_private_i8", 1),  MLInfo("__masked_load_private_i16", 2),
-                             MLInfo("__masked_load_private_i32", 4), MLInfo("__masked_load_private_float", 4),
-                             MLInfo("__masked_load_private_i64", 8), MLInfo("__masked_load_private_double", 8)};
         int nFuncs = sizeof(genxInfo) / sizeof(genxInfo[0]);
         for (int i = 0; i < nFuncs; ++i) {
             if (genxInfo[i].func != NULL && called == genxInfo[i].func) {
@@ -3106,9 +3112,6 @@ static bool lImproveMaskedLoad(llvm::CallInst *callInst, llvm::BasicBlock::itera
             }
         }
     } else {
-        MLInfo mlInfo[] = {MLInfo("__masked_load_i8", 1),  MLInfo("__masked_load_i16", 2),
-                           MLInfo("__masked_load_i32", 4), MLInfo("__masked_load_float", 4),
-                           MLInfo("__masked_load_i64", 8), MLInfo("__masked_load_double", 8)};
         int nFuncs = sizeof(mlInfo) / sizeof(mlInfo[0]);
         for (int i = 0; i < nFuncs; ++i) {
             if (mlInfo[i].func != NULL && called == mlInfo[i].func) {


### PR DESCRIPTION
This is the fix for https://github.com/ispc/ispc/issues/2082
To avoid uninitialized error from GCC I'm moving structs definition level up from the condition.
For successful compilation, it is required to declare genx specific intrisnics for CPU targets.