### PR TITLE
CMake and CI updates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -133,7 +133,7 @@ for:
   before_build:
     - sh: |-
         cd $ISPC_HOME && mkdir build && cd build
-        cmake ../ -DISPC_PREPARE_PACKAGE=ON -DCMAKE_INSTALL_PREFIX=$ISPC_HOME/install -DISPC_CROSS=ON -DWASM_ENABLED=$WASM
+        cmake ../ -DISPC_PREPARE_PACKAGE=ON -DCMAKE_INSTALL_PREFIX=$ISPC_HOME/install -DISPC_CROSS=ON -DWASM_ENABLED=$WASM -DCMAKE_CXX_FLAGS=-Werror
   build_script:
     - sh: make package -j4
 

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -12,7 +12,7 @@ on:
         required: true
         default: 'full'
 env:
-  SDE_TAR_NAME: sde-external-8.59.0-2020-10-05
+  SDE_TAR_NAME: sde-external-8.63.0-2021-01-18
   LLVM_REPO: https://github.com/ispc/llvm-project
   TARGETS_SMOKE: '["avx2-i32x8"]'
   OPTSETS_SMOKE: "-O2"

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  SDE_TAR_NAME: sde-external-8.59.0-2020-10-05
+  SDE_TAR_NAME: sde-external-8.63.0-2021-01-18
 
 jobs:
   # Building LLVM in docker, as using native Ubuntu 16.04 github-hosted image contains newer-than-expected libs and

--- a/.github/workflows/scripts/build-ispc.sh
+++ b/.github/workflows/scripts/build-ispc.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 echo PATH=$PATH
-cmake -B build -DISPC_PREPARE_PACKAGE=ON -DISPC_INCLUDE_BENCHMARKS=ON
+cmake -B build -DISPC_PREPARE_PACKAGE=ON -DISPC_INCLUDE_BENCHMARKS=ON -DCMAKE_CXX_FLAGS=-Werror
 cmake --build build --target package -j4

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,14 +74,14 @@ jobs:
       script:
         # "Native-only" build (i.e. only arm and aarch64 are supported).
         - mkdir build-arm && cd build-arm
-        - cmake ..
+        - cmake .. -DCMAKE_CXX_FLAGS=-Werror
         - make -j32
         - make check-all
         - bin/ispc --support-matrix
         # Cross build (x86, x86-64, arm, aarch64 are supported, Linux only).
         - cd ..
         - mkdir build-all && cd build-all
-        - cmake .. -DX86_ENABLED=ON
+        - cmake .. -DX86_ENABLED=ON -DCMAKE_CXX_FLAGS=-Werror
         - make -j32
         - make check-all
         - bin/ispc --support-matrix

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,7 +430,7 @@ if (MSVC)
     set_source_files_properties(${FLEX_OUTPUT} PROPERTIES COMPILE_FLAGS "/wd4005 /wd4003")
     set_source_files_properties(${BISON_OUTPUT} PROPERTIES COMPILE_FLAGS "/wd4005 /wd4065")
 else()
-    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wno-sign-compare -Wno-unused-function -Werror ${LLVM_CPP_FLAGS})
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wno-sign-compare -Wno-unused-function ${LLVM_CPP_FLAGS})
     # The change implementing -Wno-unused-but-set-variable in clang was reverted, so commenting out for now.
     #if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "13.0.0")
     #    set_source_files_properties(${BISON_CPP_OUTPUT} PROPERTIES COMPILE_FLAGS "-Wno-unused-but-set-variable")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,10 @@ find_package(FLEX 2.6 REQUIRED)
 
 set (ISPC_MASKS 1 8 16 32 64)
 
+if (NOT X86_ENABLED AND NOT ARM_ENABLED AND NOT WASM_ENABLED AND NOT GENX_ENABLED)
+    message( FATAL_ERROR "Either X86, ARM, WASM or GENX targets need to be enabled.")
+endif ()
+
 if (X86_ENABLED)
     list(APPEND ISPC_TARGETS
         sse2-i32x4 sse2-i32x8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,10 +431,6 @@ if (MSVC)
     set_source_files_properties(${BISON_OUTPUT} PROPERTIES COMPILE_FLAGS "/wd4005 /wd4065")
 else()
     target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wno-sign-compare -Wno-unused-function ${LLVM_CPP_FLAGS})
-    # The change implementing -Wno-unused-but-set-variable in clang was reverted, so commenting out for now.
-    #if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "13.0.0")
-    #    set_source_files_properties(${BISON_CPP_OUTPUT} PROPERTIES COMPILE_FLAGS "-Wno-unused-but-set-variable")
-    #endif()
     # Security options
     target_compile_options(${PROJECT_NAME} PRIVATE -fstack-protector-strong
                            -fdata-sections -ffunction-sections -fno-delete-null-pointer-checks

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -59,6 +59,10 @@ set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Suppressing benchmark's tests" FORC
 set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "Suppressing benchmark's install" FORCE)
 add_subdirectory(vendor/google/benchmark)
 
+# Suppress warnings, as benchmarks are built with -Werror and trunk version of clang may trigger
+# new warnings, which are not yet fixed in Google Benchmark sources.
+target_compile_options(benchmark PRIVATE "-w")
+
 # Warn if build type is not release.
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     # NDEBUG may be excluded from build options globally, if LLVM build doesn't have that.

--- a/docker/ubuntu/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/cpu_ispc_build/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get -y update && apt-get install -y m4 bison flex zlib1g-dev libc6-dev-i
 # Configure ISPC build
 RUN mkdir build_$LLVM_VERSION
 WORKDIR build_$LLVM_VERSION
-RUN cmake ../ -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/usr/local/src/ispc/bin-$LLVM_VERSION
+RUN cmake ../ -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/usr/local/src/ispc/bin-$LLVM_VERSION -DCMAKE_CXX_FLAGS=-Werror
 
 # Build ISPC
 RUN make ispc -j8 && make check-all && make install


### PR DESCRIPTION
* Update `sde` version used in CI `8.59`->`8.63`.
* Fix #2080: fail in CMake if no targets are specified for ISPC.
* Remove `-Werror` from default build flags, add it manually in CI instead.
* Suppress warnings during Google Benchmark build, as this appears to be a problem with clang trunk.