### PR TITLE
run_tests.py improvements

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -905,7 +905,9 @@ def run_tests(options1, args, print_version):
         exit_code = 1
         return 0
 
-    print_debug("Testing ispc: " + host.ispc_exe + "\n", s, run_tests_log)
+    print_debug("Testing ISPC compiler: " + host.ispc_exe + "\n", s, run_tests_log)
+    print_debug("Testing ISPC target: %s\n" % options.target, s, run_tests_log)
+    print_debug("Testing ISPC arch: %s\n" % options.arch, s, run_tests_log)
 
     set_compiler_exe(host, options)
     set_ispc_output(target, options)

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-#  Copyright (c) 2013-2020, Intel Corporation
+#  Copyright (c) 2013-2021, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -1040,6 +1040,24 @@ print_debug = common.print_debug
 error = common.error
 exit_code = 0
 
+# Use different default targets on different architectures.
+default_target = "sse4-i32x4"
+default_arch = "x86-64"
+if platform.machine() == "arm":
+    default_target = "neon-i32x4"
+    default_arch = "arm"
+elif platform.machine() == "aarch64":
+    default_target = "neon-i32x4"
+    default_arch = "aarch64"
+elif platform.machine() == "arm64":
+    default_target = "neon-i32x4"
+    default_arch = "aarch64"
+elif "86" in platform.machine():
+    # Some variant of x86: x86_64, i386, i486, i586, i686
+    pass
+else:
+    print_debug("WARNING: host machine was not recognized", False, "")
+
 if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option("-r", "--random-shuffle", dest="random", help="Randomly order tests",
@@ -1047,9 +1065,9 @@ if __name__ == "__main__":
     parser.add_option("-f", "--ispc-flags", dest="ispc_flags", help="Additional flags for ispc (-g, -O1, ...)",
                   default="")
     parser.add_option('-t', '--target', dest='target',
-                  help=('Set compilation target. For example: sse4-i32x4, avx2-i32x8, avx512skx-i32x16, etc.'), default="sse4-i32x4")
+                  help=('Set compilation target. For example: sse4-i32x4, avx2-i32x8, avx512skx-i32x16, etc.'), default=default_target)
     parser.add_option('-a', '--arch', dest='arch',
-                  help='Set architecture (arm, aarch64, x86, x86-64, genx32, genx64)', default="x86-64")
+                  help='Set architecture (arm, aarch64, x86, x86-64, genx32, genx64)', default=default_arch)
     parser.add_option("-c", "--compiler", dest="compiler_exe", help="C/C++ compiler binary to use to run tests",
                   default=None)
     parser.add_option('-o', '--opt', dest='opt', choices=['', 'O0', 'O1', 'O2'], help='Set optimization level passed to the compiler (O0, O1, O2).',

--- a/run_tests.py
+++ b/run_tests.py
@@ -505,8 +505,6 @@ def run_test(testname, host, target):
                 cc_cmd = "%s -O2 -I. %s test_static.cpp -DTEST_SIG=%d -DTEST_WIDTH=%d %s -o %s" % \
                     (options.compiler_exe, gcc_arch, match, width, obj_name, exe_name)
 
-                if platform.system() == 'Darwin':
-                    cc_cmd += ' -Wl,-no_pie'
                 if should_fail:
                     cc_cmd += " -DEXPECT_FAILURE"
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -540,7 +540,7 @@ def run_test(testname, host, target):
             exe_wd = os.path.realpath("./tests")
         # compile the ispc code, make the executable, and run it...
         ispc_cmd += " -h " + filename + ".h"
-        cc_cmd += " -DTEST_HEADER=<" + filename + ".h>"
+        cc_cmd += " -DTEST_HEADER=\"<" + filename + ".h>\""
         status = run_cmds([ispc_cmd, cc_cmd], options.wrapexe + " " + exe_name,
                           testname, should_fail, match, exe_wd=exe_wd)
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -498,7 +498,7 @@ def run_test(testname, host, target):
                 elif target.arch == 'x86' or target.arch == "wasm32" or target.arch == 'genx32':
                     gcc_arch = '-m32'
                 elif target.arch == 'aarch64':
-                    gcc_arch = '-march=armv8-a -target aarch64-linux-gnueabi --static'
+                    gcc_arch = '-march=armv8-a'
                 else:
                     gcc_arch = '-m64'
 


### PR DESCRIPTION
* default to different targets based on host
* make verbose output copy-pastable
* remove -no_pie on macOS, it's not needed on x86 and doesn't work on ARM
* assume that aarch64 compiler targets aarch64 by default
* report target and arch