### PR TITLE
Apple cpu definitions

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1186,7 +1186,18 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         if (arch == Arch::arm) {
             CPUID = CPU_CortexA9;
         } else if (arch == Arch::aarch64) {
-            CPUID = CPU_CortexA35;
+            if (g->target_os == TargetOS::ios) {
+                CPUID = CPU_AppleA7;
+            } else if (g->target_os == TargetOS::macos) {
+                // Open source LLVM doesn't has definition for M1 CPU, so use the latest iPhone CPU.
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_12_0
+                CPUID = CPU_AppleA14;
+#else
+                CPUID = CPU_AppleA13;
+#endif
+            } else {
+                CPUID = CPU_CortexA35;
+            }
         } else {
             UNREACHABLE();
         }

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -294,6 +294,16 @@ typedef enum {
     CPU_CortexA35,
     CPU_CortexA53,
     CPU_CortexA57,
+
+    // Apple CPUs.
+    CPU_AppleA7,
+    CPU_AppleA10,
+    CPU_AppleA11,
+    CPU_AppleA12,
+    CPU_AppleA13,
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_12_0
+    CPU_AppleA14,
+#endif
 #endif
 #ifdef ISPC_GENX_ENABLED
     CPU_GENX,
@@ -337,6 +347,14 @@ std::map<CPUtype, std::set<std::string>> CPUFeatures = {
     {CPU_CortexA35, {}},
     {CPU_CortexA53, {}},
     {CPU_CortexA57, {}},
+    {CPU_AppleA7, {}},
+    {CPU_AppleA10, {}},
+    {CPU_AppleA11, {}},
+    {CPU_AppleA12, {}},
+    {CPU_AppleA13, {}},
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_12_0
+    {CPU_AppleA14, {}},
+#endif
 #endif
 #ifdef ISPC_GENX_ENABLED
     {CPU_GENX, {}},
@@ -418,14 +436,19 @@ class AllCPUs {
 
 #ifdef ISPC_ARM_ENABLED
         names[CPU_CortexA9].push_back("cortex-a9");
-
         names[CPU_CortexA15].push_back("cortex-a15");
-
         names[CPU_CortexA35].push_back("cortex-a35");
-
         names[CPU_CortexA53].push_back("cortex-a53");
-
         names[CPU_CortexA57].push_back("cortex-a57");
+
+        names[CPU_AppleA7].push_back("apple-a7");
+        names[CPU_AppleA10].push_back("apple-a10");
+        names[CPU_AppleA11].push_back("apple-a11");
+        names[CPU_AppleA12].push_back("apple-a12");
+        names[CPU_AppleA13].push_back("apple-a13");
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_12_0
+        names[CPU_AppleA14].push_back("apple-a14");
+#endif
 #endif
 
 #ifdef ISPC_GENX_ENABLED
@@ -484,6 +507,14 @@ class AllCPUs {
         compat[CPU_CortexA35] = Set(CPU_CortexA35, CPU_None);
         compat[CPU_CortexA53] = Set(CPU_CortexA53, CPU_None);
         compat[CPU_CortexA57] = Set(CPU_CortexA57, CPU_None);
+        compat[CPU_AppleA7] = Set(CPU_AppleA7, CPU_None);
+        compat[CPU_AppleA10] = Set(CPU_AppleA10, CPU_None);
+        compat[CPU_AppleA11] = Set(CPU_AppleA11, CPU_None);
+        compat[CPU_AppleA12] = Set(CPU_AppleA12, CPU_None);
+        compat[CPU_AppleA13] = Set(CPU_AppleA13, CPU_None);
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_12_0
+        compat[CPU_AppleA14] = Set(CPU_AppleA14, CPU_None);
+#endif
 #endif
 
 #ifdef ISPC_GENX_ENABLED
@@ -575,6 +606,14 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         case CPU_CortexA35:
         case CPU_CortexA53:
         case CPU_CortexA57:
+        case CPU_AppleA7:
+        case CPU_AppleA10:
+        case CPU_AppleA11:
+        case CPU_AppleA12:
+        case CPU_AppleA13:
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_12_0
+        case CPU_AppleA14:
+#endif
             m_ispc_target = ISPCTarget::neon_i32x4;
             break;
 #endif

--- a/tests/lit-tests/cpu_arm.ispc
+++ b/tests/lit-tests/cpu_arm.ispc
@@ -1,0 +1,18 @@
+// The test checks that cpu definitions (including all synonyms) are successfully consumed by compiler.
+
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=cortex-a9
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=cortex-a15
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=cortex-a35
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=cortex-a53
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=cortex-a57
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a7
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a10
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a11
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a12
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a13
+
+// REQUIRES: ARM_ENABLED
+
+uniform int i;
+
+void foo() {}

--- a/tests/lit-tests/cpu_arm.ispc
+++ b/tests/lit-tests/cpu_arm.ispc
@@ -11,7 +11,7 @@
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a12
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a13
 
-// REQUIRES: ARM_ENABLED
+// REQUIRES: ARM_ENABLED && !WINDOWS_ENABLED
 
 uniform int i;
 

--- a/tests/lit-tests/cpu_arm_llvm12.ispc
+++ b/tests/lit-tests/cpu_arm_llvm12.ispc
@@ -1,0 +1,10 @@
+// The test checks that cpu definitions (including all synonyms) are successfully consumed by compiler.
+
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a14
+
+// REQUIRES: ARM_ENABLED
+// REQUIRES: LLVM_12_0+
+
+uniform int i;
+
+void foo() {}

--- a/tests/lit-tests/cpu_arm_llvm12.ispc
+++ b/tests/lit-tests/cpu_arm_llvm12.ispc
@@ -2,7 +2,7 @@
 
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a14
 
-// REQUIRES: ARM_ENABLED
+// REQUIRES: ARM_ENABLED && !WINDOWS_ENABLED
 // REQUIRES: LLVM_12_0+
 
 uniform int i;


### PR DESCRIPTION
* Adding definition for Apple ARM CPUs: A7, A10-A14 (missing A8 and A9, as they are just aliases for A7).
* Change default CPU target for ARM macOS and iOS.

Note, there's not M1 definition in open source LLVM right now, so using the latest A-series definition, which is good enough approximation for our purposes.