### PR TITLE
Update broken GitHub Pages links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Additional Resources
 --------------------
 
 Prebuilt ``ispc`` binaries for Windows, macOS and Linux can be downloaded
-from the [ispc downloads page](http://ispc.github.com/downloads.html).
+from the [ispc downloads page](https://ispc.github.io/downloads.html).
 Latest ``ispc`` binaries corresponding to main branch can be downloaded
 from Appveyor for [Linux](https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-linux.tar.gz?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DUbuntu1604%2C%20LLVM_VERSION%3Dlatest) and Windows ([msi](https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.msi?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202019%2C%20LLVM_VERSION%3Dlatest) or [zip](https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.zip?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202019%2C%20LLVM_VERSION%3Dlatest))
 See also additional
-[documentation](http://ispc.github.com/documentation.html) and additional
-[performance information](http://ispc.github.com/perf.html).
+[documentation](https://ispc.github.io/documentation.html) and additional
+[performance information](https://ispc.github.io/perf.html).

--- a/examples/cpu/README.txt
+++ b/examples/cpu/README.txt
@@ -79,7 +79,7 @@ Mandelbrot
 ==========
 
 Mandelbrot set generation.  This example is extensively documented at the
-http://ispc.github.com/example.html page.
+https://ispc.github.io/example.html page.
 
 
 Mandelbrot_tasks

--- a/examples/xpu/README.txt
+++ b/examples/xpu/README.txt
@@ -61,7 +61,7 @@ Mandelbrot
 ==========
 
 Mandelbrot set generation.  This example is extensively documented at the
-http://ispc.github.com/example.html page. The comamnd line arguments are:
+https://ispc.github.io/example.html page. The comamnd line arguments are:
 mandelbrot [--scale=<factor>] [tasks iterations] [serial iterations]
 
 This examples also demontrates usage of C++ interface of ispcrt so you can see how to


### PR DESCRIPTION
Update links to ispc GitHub Pages resulted from ispc.github.com to ispc.github.io.

The ispc.github.com links are broken and take you to this 404 page:

> 404
> 
> There isn't a GitHub Pages site here.
> 
> Did you mean to visit ispc.github.io? Please note that this site belongs to a GitHub user and is not an official GitHub site.
> 
> If you're the owner of this site, please update your links to use ispc.github.io instead. Subdomains of github.com are deprecated for GitHub Pages. They will not redirect to github.io after April 15, 2021.
> Contact Support — GitHub Status — @githubstatus

![image](https://user-images.githubusercontent.com/36176/121784107-e42a1d00-cb66-11eb-861e-38db227a4233.png)
