### PR TITLE
Do not use deprecated file open flags

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1314,7 +1314,7 @@ bool Module::writeObjectFileOrAssembly(llvm::TargetMachine *targetMachine, llvm:
     llvm::CodeGenFileType fileType = (outputType == Object) ? llvm::CGFT_ObjectFile : llvm::CGFT_AssemblyFile;
     bool binary = (fileType == llvm::CGFT_ObjectFile);
 
-    llvm::sys::fs::OpenFlags flags = binary ? llvm::sys::fs::F_None : llvm::sys::fs::F_Text;
+    llvm::sys::fs::OpenFlags flags = binary ? llvm::sys::fs::OF_None : llvm::sys::fs::OF_Text;
 
     std::error_code error;
 

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -4687,7 +4687,7 @@ void DebugPassFile::run(llvm::Module &module, bool init) {
     std::error_code EC;
     char fname[100];
     snprintf(fname, sizeof(fname), "%s_%d_%s.ll", init ? "init" : "ir", pnum, sanitize(std::string(pname)).c_str());
-    llvm::raw_fd_ostream OS(fname, EC, llvm::sys::fs::F_None);
+    llvm::raw_fd_ostream OS(fname, EC, llvm::sys::fs::OF_None);
     Assert(!EC && "IR dump file creation failed!");
     module.print(OS, 0);
 }


### PR DESCRIPTION
Deprecate attributes were removed in LLVM trunk (13.0).
No changes in behavior is expected.