### PR TITLE
Fixing float16 tests.

### DIFF
--- a/tests/exp-uniform-float16.ispc
+++ b/tests/exp-uniform-float16.ispc
@@ -1,13 +1,13 @@
 // rule: skip on arch=x86
 // rule: skip on arch=x86-64
-// rule: skip on cpu=TGLLP
 uniform bool ok(uniform float16 x, uniform float16 ref) {
-    return (abs(x - ref) < 1d - 4) || abs((x - ref) / ref) < 1d - 3;
+    return (abs(x - ref) < 1e-2f16) || abs((x - ref) / ref) < 1e-1f16;
 }
-export void f_du(uniform float RET[], uniform double aFOO[], uniform double b) {
+export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
     for (uniform int i = 0; i != programCount; ++i) {
-        uniform float16 ref = exp((uniform float16)aFOO[i]);
-        RET[i] = ok(exp(aFOO[i]), ref) ? 0. : 1.;
+        uniform float16 ref = exp((uniform float16)((aFOO[i] / programCount) * 2));
+        uniform float res = exp((aFOO[i] / programCount) * 2);
+        RET[i] = ok(res, ref) ? 0. : 1.;
     }
 }
 

--- a/tests/exp-varying-float16.ispc
+++ b/tests/exp-varying-float16.ispc
@@ -1,9 +1,8 @@
 // rule: skip on arch=x86
 // rule: skip on arch=x86-64
-// rule: skip on cpu=TGLLP
-bool ok(float16 x, float16 ref) { return (abs(x - ref) < 1d - 4) || abs((x - ref) / ref) < 1d - 3; }
+bool ok(float16 x, float16 ref) { return (abs(x - ref) < 1e-2f16) || abs((x - ref) / ref) < 1e-1f16; }
 export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    varying float16 arg = aFOO[programIndex] - (programCount / 2);
+    varying float16 arg = ((aFOO[programIndex] / programCount) * 2);
     varying float16 ref = exp((float)arg);
     varying float16 res = exp((float16)arg);
     RET[programIndex] = ok(res, ref) ? 0. : 1.;

--- a/tests/log-uniform-float16.ispc
+++ b/tests/log-uniform-float16.ispc
@@ -1,8 +1,7 @@
 // rule: skip on arch=x86
 // rule: skip on arch=x86-64
-// rule: skip on cpu=TGLLP
 uniform bool ok(uniform float16 x, uniform float16 ref) {
-    return (abs(x - ref) < 1d - 4) || abs((x - ref) / ref) < 1d - 3;
+    return (abs(x - ref) < 1e-2f16) || abs((x - ref) / ref) < 1e-1f16;
 }
 export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
     for (uniform int i = 0; i != programCount; ++i) {

--- a/tests/log-varying-float16.ispc
+++ b/tests/log-varying-float16.ispc
@@ -1,7 +1,6 @@
 // rule: skip on arch=x86
 // rule: skip on arch=x86-64
-// rule: skip on cpu=TGLLP
-bool ok(float16 x, float16 ref) { return (abs(x - ref) < 1d - 4) || abs((x - ref) / ref) < 1d - 3; }
+bool ok(float16 x, float16 ref) { return (abs(x - ref) < 1e-2f16) || abs((x - ref) / ref) < 1e-1f16; }
 export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
     varying float16 arg = aFOO[programIndex] + b;
     varying float16 ref = log((float)arg);

--- a/tests/pow-uniform-float16.ispc
+++ b/tests/pow-uniform-float16.ispc
@@ -11,29 +11,32 @@ static float float4(uniform float16 a, uniform float16 b, uniform float16 c, uni
     return ret;
 }
 
-bool ok(uniform float16 x, uniform float16 ref) { return (abs(x - ref) < 1e-4) || abs((x - ref) / ref) < 1e-3; }
+bool ok(uniform float16 x, uniform float16 ref) { return (abs(x - ref) < 1e-2f16) || abs((x - ref) / ref) < 1e-1f16; }
 
 export void f_v(uniform float RET[]) {
 
     uniform float16 a = 1.96484;
     uniform float16 b = 6.80859;
     uniform float16 ref = 99.375;
-    RET[programIndex] = ok(pow(a, b), ref) ? 1. : 0.;
+    uniform float16 res = pow(a, b);
+    RET[programIndex] = ok(res, ref) ? 1. : 0.;
 
     a = 2.4668;
     b = -3.62695;
     ref = 99.375;
+    res = pow(a, b);
     RET[programIndex] = ok(pow(a, b), ref) ? 1. : 0.;
 
     a = 0.155884;
     b = 1.68164;
     ref = 0.0439148;
+    res = pow(a, b);
     RET[programIndex] = ok(pow(a, b), ref) ? 1. : 0.;
 
     a = 3.83789;
     b = 0.000000;
     ref = 1.000000;
-
+    res = pow(a, b);
     RET[programIndex] = ok(pow(a, b), ref) ? 1. : 0.;
 }
 export void result(uniform float RET[]) { RET[programIndex] = 1.; }

--- a/tests/pow-varying-float16.ispc
+++ b/tests/pow-varying-float16.ispc
@@ -11,12 +11,13 @@ static float float4(uniform float16 a, uniform float16 b, uniform float16 c, uni
     return ret;
 }
 
-bool ok(float16 x, float16 ref) { return (abs(x - ref) < 1e-4) || abs((x - ref) / ref) < 1e-3; }
+bool ok(float16 x, float16 ref) { return (abs(x - ref) < 1e-2f16) || abs((x - ref) / ref) < 1e-1f16; }
 
 export void f_v(uniform float RET[]) {
     float16 a = float4((1.96484), (2.4668), (0.155884), (3.83789));
     float16 b = float4((6.80859), (-3.62695), (1.68164), (0.000000));
     float16 ref = float4((99.375), (0.0378113), (0.0439148), (1.00000));
-    RET[programIndex] = ok(pow(a, b), ref) ? 1. : 0.;
+    float16 res = pow(a, b);
+    RET[programIndex] = ok(res, ref) ? 1. : 0.;
 }
 export void result(uniform float RET[]) { RET[programIndex] = 1.; }

--- a/tests/shuffle2-12.ispc
+++ b/tests/shuffle2-12.ispc
@@ -1,4 +1,3 @@
-// rule: skip on cpu=TGLLP
 // rule: skip on arch=x86
 // rule: skip on arch=x86-64
 export void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {


### PR DESCRIPTION
This commit includes
1. Fixing precision check for float16 pow/exp tests
2. Fixing range of arg for exp() tests so that values remain in valid range for float16
3. Removing unnecessary skip
4. Cleaning up reference value calculation for better understanding.
