### PR TITLE
Use `xcrun --show-sdk-version` to determine macOS SDK version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,10 +156,11 @@ if (ISPC_MACOS_TARGET AND ISPC_MACOS_SDK_PATH)
         set(ISPC_MACOS_SDK_PATH "${ISPC_MACOS_SDK_PATH_NEW}")
     endif()
 
-    # Grepping path to figure out the version is not the most reliable way,
-    # but it seems to be the most practical.
-    string(REGEX MATCH "MacOSX([0-9]*.[0-9]*).sdk" _ ${ISPC_MACOS_SDK_PATH})
-    set(SDK_VER "${CMAKE_MATCH_1}")
+    set(command "xcrun" "-sdk" "${ISPC_MACOS_SDK_PATH}" "--show-sdk-version")
+    execute_process(COMMAND ${command}
+        OUTPUT_VARIABLE SDK_VER
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
     message(STATUS "MacOS_SDK version: ${SDK_VER}")
 
     if ("${SDK_VER}" STREQUAL "")


### PR DESCRIPTION
This approach should be more reliable than grepping the SDK path, and allow using an SDK whose path doesn’t indicate the version.

---

MacPorts provides a port for ispc. I notice that its builds for ispc 1.16.0 failed on macOS 10.15 and earlier: the SDK version fails to be detected, and this leads to trying to build ARM support when the SDK doesn’t support it:

```
-- Using macOS SDK path /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-- MacOS_SDK version: 
CMake Warning at CMakeLists.txt:166 (message):
  MacOS SDK version was not detected, assuming 11.0, enabling ARM support
```

```
In file included from builtins/builtins-c-cpu.cpp:69:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/unistd.h:71:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_types.h:27:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types.h:32:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:807:2: error: Unsupported architecture
#error Unsupported architecture
 ^
```

I based this approach on existing usage of `xcrun` in CMakeLists.txt, but I am not familiar with CMake, so I would appreciate others’ reviews.

Ping @dbabokin (author of the affected portions of CMakeLists.txt)