### PR TITLE
Fixes #2116: Fixing crash while using unary expression with reference type as rvalue.

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1082,6 +1082,11 @@ const Type *UnaryExpr::GetType() const {
     if (type == NULL)
         return NULL;
 
+    // Unary expressions should be returning target types after updating
+    // reference address.
+    if (CastType<ReferenceType>(type) != NULL) {
+        type = type->GetReferenceTarget();
+    }
     // For all unary expressions besides logical not, the returned type is
     // the same as the source type.  Logical not always returns a bool
     // type, with the same shape as the input type.

--- a/tests/lit-tests/2116.ispc
+++ b/tests/lit-tests/2116.ispc
@@ -10,7 +10,7 @@ void foo0(uniform int &param_inout) {
     }
 }
 
-// Case 1: 'if' in 'foo1' uses result of pre inc operation '++param_inout'
+// Case 2: 'if' in 'foo1' uses result of pre inc operation '++param_inout'
 void foo1(uniform int &param_inout) {
     if (++param_inout > 0) {
         param_inout++;

--- a/tests/lit-tests/2116.ispc
+++ b/tests/lit-tests/2116.ispc
@@ -1,0 +1,18 @@
+// Issue #2116 : This test ensures that using the result of
+// unary expression on a reference type for other operations
+// doesn't cause a crash.
+// RUN: %{ispc} %s -O2 --target=host
+
+// Case 1: 'if' in 'foo0' uses result of post inc operation 'param_inout++'
+void foo0(uniform int &param_inout) {
+    if (param_inout++ > 0) {
+        param_inout++;
+    }
+}
+
+// Case 1: 'if' in 'foo1' uses result of pre inc operation '++param_inout'
+void foo1(uniform int &param_inout) {
+    if (++param_inout > 0) {
+        param_inout++;
+    }
+}


### PR DESCRIPTION
This change contains the following
- Unary operations on reference type should update the referenced address and return value(updated or not depending on post/pre). This means, the unary expressions 'type' is the reference target type and not the reference type. This commit fixes this.
-  Test to check the behavior and crash. 
With no fix : https://ispc.godbolt.org/z/rov7axnqW
This test also checks for correctness to ensure that prefix/postfix properties hold.