### PR TITLE
Switching to APFloat for representing 'ConstExpr' for all floating point types.

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1187,7 +1187,7 @@ Expr *UnaryExpr::Optimize() {
             int count = constExpr->GetValues(v);
             for (int i = 0; i < count; ++i)
                 v[i].changeSign();
-            return new ConstExpr(constExpr, v);
+            return new ConstExpr(type, v, pos);
         }
     }
     case BitNot: {
@@ -5392,66 +5392,6 @@ ConstExpr::ConstExpr(const Type *t, bool *b, SourcePos p) : Expr(p, ConstExprID)
                        Type::Equal(type, AtomicType::VaryingBool->GetAsConstType()));
     for (int j = 0; j < Count(); ++j)
         boolVal[j] = b[j];
-}
-
-// The llvm::APFloat value is guaranteed to be a double.
-ConstExpr::ConstExpr(ConstExpr *old, std::vector<llvm::APFloat> v) : Expr(old->pos, ConstExprID) {
-    type = old->type;
-
-    AtomicType::BasicType basicType = getBasicType();
-
-    switch (basicType) {
-    case AtomicType::TYPE_BOOL:
-        for (int i = 0; i < Count(); ++i)
-            boolVal[i] = v[i].isNonZero();
-        break;
-    case AtomicType::TYPE_INT8:
-        for (int i = 0; i < Count(); ++i)
-            int8Val[i] = (int)v[i].convertToDouble();
-        break;
-    case AtomicType::TYPE_UINT8:
-        for (int i = 0; i < Count(); ++i)
-            uint8Val[i] = (unsigned int)v[i].convertToDouble();
-        break;
-    case AtomicType::TYPE_INT16:
-        for (int i = 0; i < Count(); ++i)
-            int16Val[i] = (int)v[i].convertToDouble();
-        break;
-    case AtomicType::TYPE_UINT16:
-        for (int i = 0; i < Count(); ++i)
-            uint16Val[i] = (unsigned int)v[i].convertToDouble();
-        break;
-    case AtomicType::TYPE_INT32:
-        for (int i = 0; i < Count(); ++i)
-            int32Val[i] = (int)v[i].convertToDouble();
-        break;
-    case AtomicType::TYPE_UINT32:
-        for (int i = 0; i < Count(); ++i)
-            uint32Val[i] = (unsigned int)v[i].convertToDouble();
-        break;
-    case AtomicType::TYPE_FLOAT16:
-        for (int i = 0; i < Count(); ++i) {
-            llvm::APFloat apf = lCreateAPFloat(v[i], LLVMTypes::Float16Type);
-            fpVal.push_back(apf);
-        }
-        break;
-    case AtomicType::TYPE_FLOAT:
-        for (int i = 0; i < Count(); ++i) {
-            llvm::APFloat apf = lCreateAPFloat(v[i], LLVMTypes::FloatType);
-            fpVal.push_back(apf);
-        }
-        break;
-    case AtomicType::TYPE_DOUBLE:
-        fpVal = v;
-        break;
-    case AtomicType::TYPE_INT64:
-    case AtomicType::TYPE_UINT64:
-        // For now, this should never be reached
-        FATAL("fixme; we need another constructor so that we're not trying to pass "
-              "double values to init an int64 type...");
-    default:
-        FATAL("unimplemented const type");
-    }
 }
 
 ConstExpr::ConstExpr(ConstExpr *old, SourcePos p) : Expr(p, ConstExprID) {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1181,7 +1181,7 @@ Expr *UnaryExpr::Optimize() {
             // into a double, do the negate as a double, and then return a
             // ConstExpr with the same type as the original...
             std::vector<llvm::APFloat> v;
-            int count = constExpr->GetValues(v, LLVMTypes::DoubleType);
+            int count = constExpr->GetValues(v);
             for (int i = 0; i < count; ++i)
                 v[i].changeSign();
             return new ConstExpr(constExpr, v);
@@ -5621,6 +5621,14 @@ static void lConvert(const From *from, std::vector<llvm::APFloat> &to, llvm::Typ
     if (forceVarying && count == 1)
         for (int i = 1; i < g->target->getVectorWidth(); ++i)
             to.push_back(to[0]);
+}
+
+int ConstExpr::GetValues(std::vector<llvm::APFloat> &fpt) const {
+    AtomicType::BasicType bType = getBasicType();
+    AssertPos(pos, (bType == AtomicType::TYPE_FLOAT16) || (bType == AtomicType::TYPE_FLOAT) ||
+                       (bType == AtomicType::TYPE_DOUBLE));
+    fpt = fpVal;
+    return Count();
 }
 
 int ConstExpr::GetValues(int64_t *ip, bool forceVarying) const {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1177,9 +1177,12 @@ Expr *UnaryExpr::Optimize() {
                    Type::EqualIgnoringConst(type, AtomicType::VaryingUInt8)) {
             return lOptimizeNegate<uint8_t>(constExpr, type, pos);
         } else {
-            // For all the other types, it's safe to stuff whatever we have
-            // into a double, do the negate as a double, and then return a
-            // ConstExpr with the same type as the original...
+            AssertPos(pos, Type::EqualIgnoringConst(type, AtomicType::UniformFloat16) ||
+                               Type::EqualIgnoringConst(type, AtomicType::VaryingFloat16) ||
+                               Type::EqualIgnoringConst(type, AtomicType::UniformFloat) ||
+                               Type::EqualIgnoringConst(type, AtomicType::VaryingFloat) ||
+                               Type::EqualIgnoringConst(type, AtomicType::UniformDouble) ||
+                               Type::EqualIgnoringConst(type, AtomicType::VaryingDouble));
             std::vector<llvm::APFloat> v;
             int count = constExpr->GetValues(v);
             for (int i = 0; i < count; ++i)

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -3416,9 +3416,9 @@ Expr *SelectExpr::Optimize() {
         } else if (Type::Equal(exprType, AtomicType::VaryingFloat)) {
             return lConstFoldSelect<float>(bv, constExpr1, constExpr2, exprType, pos);
         } else if (Type::Equal(exprType, AtomicType::VaryingDouble)) {
-            return lConstFoldSelect<bool>(bv, constExpr1, constExpr2, exprType, pos);
-        } else if (Type::Equal(exprType, AtomicType::VaryingBool)) {
             return lConstFoldSelect<double>(bv, constExpr1, constExpr2, exprType, pos);
+        } else if (Type::Equal(exprType, AtomicType::VaryingBool)) {
+            return lConstFoldSelect<bool>(bv, constExpr1, constExpr2, exprType, pos);
         }
 
         return this;

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -5587,94 +5587,6 @@ int ConstExpr::GetValues(std::vector<llvm::APFloat> &fpt) const {
     return Count();
 }
 
-int ConstExpr::GetValues(int64_t *ip, bool forceVarying) const {
-    switch (getBasicType()) {
-    case AtomicType::TYPE_BOOL:
-        lConvert(boolVal, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT8:
-        lConvert(int8Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT8:
-        lConvert(uint8Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT16:
-        lConvert(int16Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT16:
-        lConvert(uint16Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT32:
-        lConvert(int32Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT32:
-        lConvert(uint32Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT16:
-        lConvert(&fpVal[0], ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT:
-        lConvert(&fpVal[0], ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_DOUBLE:
-        lConvert(&fpVal[0], ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT64:
-        lConvert(int64Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT64:
-        lConvert(uint64Val, ip, Count(), forceVarying);
-        break;
-    default:
-        FATAL("unimplemented const type");
-    }
-    return Count();
-}
-
-int ConstExpr::GetValues(uint64_t *up, bool forceVarying) const {
-    switch (getBasicType()) {
-    case AtomicType::TYPE_BOOL:
-        lConvert(boolVal, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT8:
-        lConvert(int8Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT8:
-        lConvert(uint8Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT16:
-        lConvert(int16Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT16:
-        lConvert(uint16Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT32:
-        lConvert(int32Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT32:
-        lConvert(uint32Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT16:
-        lConvert(&fpVal[0], up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT:
-        lConvert(&fpVal[0], up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_DOUBLE:
-        lConvert(&fpVal[0], up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT64:
-        lConvert(int64Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT64:
-        lConvert(uint64Val, up, Count(), forceVarying);
-        break;
-    default:
-        FATAL("unimplemented const type");
-    }
-    return Count();
-}
-
 int ConstExpr::GetValues(std::vector<llvm::APFloat> &fpt, llvm::Type *type, bool forceVarying) const {
     switch (getBasicType()) {
     case AtomicType::TYPE_BOOL:
@@ -5698,60 +5610,16 @@ int ConstExpr::GetValues(std::vector<llvm::APFloat> &fpt, llvm::Type *type, bool
     case AtomicType::TYPE_UINT32:
         lConvert(uint32Val, fpt, type, Count(), forceVarying);
         break;
-    case AtomicType::TYPE_FLOAT16:
-    case AtomicType::TYPE_FLOAT:
-    case AtomicType::TYPE_DOUBLE:
-        lConvert(&fpVal[0], fpt, type, Count(), forceVarying);
-        break;
     case AtomicType::TYPE_INT64:
         lConvert(int64Val, fpt, type, Count(), forceVarying);
         break;
     case AtomicType::TYPE_UINT64:
         lConvert(uint64Val, fpt, type, Count(), forceVarying);
         break;
-    default:
-        FATAL("unimplemented const type");
-    }
-    return Count();
-}
-
-int ConstExpr::GetValues(bool *b, bool forceVarying) const {
-    switch (getBasicType()) {
-    case AtomicType::TYPE_BOOL:
-        lConvert(boolVal, b, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT8:
-        lConvert(int8Val, b, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT8:
-        lConvert(uint8Val, b, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT16:
-        lConvert(int16Val, b, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT16:
-        lConvert(uint16Val, b, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT32:
-        lConvert(int32Val, b, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT32:
-        lConvert(uint32Val, b, Count(), forceVarying);
-        break;
     case AtomicType::TYPE_FLOAT16:
-        lConvert(&fpVal[0], b, Count(), forceVarying);
-        break;
     case AtomicType::TYPE_FLOAT:
-        lConvert(&fpVal[0], b, Count(), forceVarying);
-        break;
     case AtomicType::TYPE_DOUBLE:
-        lConvert(&fpVal[0], b, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT64:
-        lConvert(int64Val, b, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT64:
-        lConvert(uint64Val, b, Count(), forceVarying);
+        lConvert(&fpVal[0], fpt, type, Count(), forceVarying);
         break;
     default:
         FATAL("unimplemented const type");
@@ -5759,269 +5627,62 @@ int ConstExpr::GetValues(bool *b, bool forceVarying) const {
     return Count();
 }
 
-int ConstExpr::GetValues(int8_t *ip, bool forceVarying) const {
-    switch (getBasicType()) {
-    case AtomicType::TYPE_BOOL:
-        lConvert(boolVal, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT8:
-        lConvert(int8Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT8:
-        lConvert(uint8Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT16:
-        lConvert(int16Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT16:
-        lConvert(uint16Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT32:
-        lConvert(int32Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT32:
-        lConvert(uint32Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT16:
-        lConvert(&fpVal[0], ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT:
-        lConvert(&fpVal[0], ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_DOUBLE:
-        lConvert(&fpVal[0], ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT64:
-        lConvert(int64Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT64:
-        lConvert(uint64Val, ip, Count(), forceVarying);
-        break;
-    default:
-        FATAL("unimplemented const type");
-    }
+#define CONVERT_SWITCH                                                                                                 \
+    switch (getBasicType()) {                                                                                          \
+    case AtomicType::TYPE_BOOL:                                                                                        \
+        lConvert(boolVal, toPtr, Count(), forceVarying);                                                               \
+        break;                                                                                                         \
+    case AtomicType::TYPE_INT8:                                                                                        \
+        lConvert(int8Val, toPtr, Count(), forceVarying);                                                               \
+        break;                                                                                                         \
+    case AtomicType::TYPE_UINT8:                                                                                       \
+        lConvert(uint8Val, toPtr, Count(), forceVarying);                                                              \
+        break;                                                                                                         \
+    case AtomicType::TYPE_INT16:                                                                                       \
+        lConvert(int16Val, toPtr, Count(), forceVarying);                                                              \
+        break;                                                                                                         \
+    case AtomicType::TYPE_UINT16:                                                                                      \
+        lConvert(uint16Val, toPtr, Count(), forceVarying);                                                             \
+        break;                                                                                                         \
+    case AtomicType::TYPE_INT32:                                                                                       \
+        lConvert(int32Val, toPtr, Count(), forceVarying);                                                              \
+        break;                                                                                                         \
+    case AtomicType::TYPE_UINT32:                                                                                      \
+        lConvert(uint32Val, toPtr, Count(), forceVarying);                                                             \
+        break;                                                                                                         \
+    case AtomicType::TYPE_INT64:                                                                                       \
+        lConvert(int64Val, toPtr, Count(), forceVarying);                                                              \
+        break;                                                                                                         \
+    case AtomicType::TYPE_UINT64:                                                                                      \
+        lConvert(uint64Val, toPtr, Count(), forceVarying);                                                             \
+        break;                                                                                                         \
+    case AtomicType::TYPE_FLOAT16:                                                                                     \
+    case AtomicType::TYPE_FLOAT:                                                                                       \
+    case AtomicType::TYPE_DOUBLE:                                                                                      \
+        lConvert(&fpVal[0], toPtr, Count(), forceVarying);                                                             \
+        break;                                                                                                         \
+    default:                                                                                                           \
+        FATAL("unimplemented const type");                                                                             \
+    }                                                                                                                  \
     return Count();
-}
 
-int ConstExpr::GetValues(uint8_t *up, bool forceVarying) const {
-    switch (getBasicType()) {
-    case AtomicType::TYPE_BOOL:
-        lConvert(boolVal, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT8:
-        lConvert(int8Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT8:
-        lConvert(uint8Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT16:
-        lConvert(int16Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT16:
-        lConvert(uint16Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT32:
-        lConvert(int32Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT32:
-        lConvert(uint32Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT16:
-        lConvert(&fpVal[0], up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT:
-        lConvert(&fpVal[0], up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_DOUBLE:
-        lConvert(&fpVal[0], up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT64:
-        lConvert(int64Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT64:
-        lConvert(uint64Val, up, Count(), forceVarying);
-        break;
-    default:
-        FATAL("unimplemented const type");
-    }
-    return Count();
-}
+int ConstExpr::GetValues(bool *toPtr, bool forceVarying) const { CONVERT_SWITCH; }
 
-int ConstExpr::GetValues(int16_t *ip, bool forceVarying) const {
-    switch (getBasicType()) {
-    case AtomicType::TYPE_BOOL:
-        lConvert(boolVal, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT8:
-        lConvert(int8Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT8:
-        lConvert(uint8Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT16:
-        lConvert(int16Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT16:
-        lConvert(uint16Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT32:
-        lConvert(int32Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT32:
-        lConvert(uint32Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT16:
-        lConvert(&fpVal[0], ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT:
-        lConvert(&fpVal[0], ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_DOUBLE:
-        lConvert(&fpVal[0], ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT64:
-        lConvert(int64Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT64:
-        lConvert(uint64Val, ip, Count(), forceVarying);
-        break;
-    default:
-        FATAL("unimplemented const type");
-    }
-    return Count();
-}
+int ConstExpr::GetValues(int8_t *toPtr, bool forceVarying) const { CONVERT_SWITCH; }
 
-int ConstExpr::GetValues(uint16_t *up, bool forceVarying) const {
-    switch (getBasicType()) {
-    case AtomicType::TYPE_BOOL:
-        lConvert(boolVal, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT8:
-        lConvert(int8Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT8:
-        lConvert(uint8Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT16:
-        lConvert(int16Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT16:
-        lConvert(uint16Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT32:
-        lConvert(int32Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT32:
-        lConvert(uint32Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT16:
-        lConvert(&fpVal[0], up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT:
-        lConvert(&fpVal[0], up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_DOUBLE:
-        lConvert(&fpVal[0], up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT64:
-        lConvert(int64Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT64:
-        lConvert(uint64Val, up, Count(), forceVarying);
-        break;
-    default:
-        FATAL("unimplemented const type");
-    }
-    return Count();
-}
+int ConstExpr::GetValues(uint8_t *toPtr, bool forceVarying) const { CONVERT_SWITCH; }
 
-int ConstExpr::GetValues(int32_t *ip, bool forceVarying) const {
-    switch (getBasicType()) {
-    case AtomicType::TYPE_BOOL:
-        lConvert(boolVal, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT8:
-        lConvert(int8Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT8:
-        lConvert(uint8Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT16:
-        lConvert(int16Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT16:
-        lConvert(uint16Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT32:
-        lConvert(int32Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT32:
-        lConvert(uint32Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT16:
-        lConvert(&fpVal[0], ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT:
-        lConvert(&fpVal[0], ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_DOUBLE:
-        lConvert(&fpVal[0], ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT64:
-        lConvert(int64Val, ip, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT64:
-        lConvert(uint64Val, ip, Count(), forceVarying);
-        break;
-    default:
-        FATAL("unimplemented const type");
-    }
-    return Count();
-}
+int ConstExpr::GetValues(int16_t *toPtr, bool forceVarying) const { CONVERT_SWITCH; }
 
-int ConstExpr::GetValues(uint32_t *up, bool forceVarying) const {
-    switch (getBasicType()) {
-    case AtomicType::TYPE_BOOL:
-        lConvert(boolVal, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT8:
-        lConvert(int8Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT8:
-        lConvert(uint8Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT16:
-        lConvert(int16Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT16:
-        lConvert(uint16Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT32:
-        lConvert(int32Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT32:
-        lConvert(uint32Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT16:
-        lConvert(&fpVal[0], up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_FLOAT:
-        lConvert(&fpVal[0], up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_DOUBLE:
-        lConvert(&fpVal[0], up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_INT64:
-        lConvert(int64Val, up, Count(), forceVarying);
-        break;
-    case AtomicType::TYPE_UINT64:
-        lConvert(uint64Val, up, Count(), forceVarying);
-        break;
-    default:
-        FATAL("unimplemented const type");
-    }
-    return Count();
-}
+int ConstExpr::GetValues(uint16_t *toPtr, bool forceVarying) const { CONVERT_SWITCH; }
+
+int ConstExpr::GetValues(int32_t *toPtr, bool forceVarying) const { CONVERT_SWITCH; }
+
+int ConstExpr::GetValues(uint32_t *toPtr, bool forceVarying) const { CONVERT_SWITCH; }
+
+int ConstExpr::GetValues(int64_t *toPtr, bool forceVarying) const { CONVERT_SWITCH; }
+
+int ConstExpr::GetValues(uint64_t *toPtr, bool forceVarying) const { CONVERT_SWITCH; }
 
 int ConstExpr::Count() const { return GetType()->IsVaryingType() ? g->target->getVectorWidth() : 1; }
 

--- a/src/expr.h
+++ b/src/expr.h
@@ -407,20 +407,10 @@ class ConstExpr : public Expr {
     /** Create a ConstExpr from a varying uint32 value */
     ConstExpr(const Type *t, uint32_t *u, SourcePos p);
 
-    /** Create a ConstExpr from a uniform float16 value */
+    /** Create a ConstExpr from a llvm::APFloat value for uniform floating point types */
     ConstExpr(const Type *t, llvm::APFloat f, SourcePos p);
-    /** Create a ConstExpr from a varying float16 value */
-    ConstExpr(const Type *t, std::vector<llvm::APFloat> f, SourcePos p);
-
-    /** Create a ConstExpr from a uniform float value */
-    ConstExpr(const Type *t, float f, SourcePos p);
-    /** Create a ConstExpr from a varying float value */
-    ConstExpr(const Type *t, float *f, SourcePos p);
-
-    /** Create a ConstExpr from a uniform double value */
-    ConstExpr(const Type *t, double d, SourcePos p);
-    /** Create a ConstExpr from a varying double value */
-    ConstExpr(const Type *t, double *d, SourcePos p);
+    /** Create a ConstExpr from a llvm::APFloat value for varying floating point types */
+    ConstExpr(const Type *t, std::vector<llvm::APFloat> const &f, SourcePos p);
 
     /** Create a ConstExpr from a uniform int64 value */
     ConstExpr(const Type *t, int64_t i, SourcePos p);
@@ -438,7 +428,7 @@ class ConstExpr : public Expr {
 
     /** Create a ConstExpr of the same type as the given old ConstExpr,
         with values given by the "vales" parameter. */
-    ConstExpr(ConstExpr *old, double *values);
+    ConstExpr(ConstExpr *old, std::vector<llvm::APFloat> v);
 
     /** Create ConstExpr with the same type and values as the given one,
         but at the given position. */
@@ -467,13 +457,11 @@ class ConstExpr : public Expr {
     int GetValues(uint8_t *, bool forceVarying = false) const;
     int GetValues(int16_t *, bool forceVarying = false) const;
     int GetValues(uint16_t *, bool forceVarying = false) const;
-    int GetValues(std::vector<llvm::APFloat> &, bool forceVarying = false) const;
+    int GetValues(std::vector<llvm::APFloat> &, llvm::Type *, bool forceVarying = false) const;
     int GetValues(int32_t *, bool forceVarying = false) const;
     int GetValues(uint32_t *, bool forceVarying = false) const;
-    int GetValues(float *, bool forceVarying = false) const;
     int GetValues(int64_t *, bool forceVarying = false) const;
     int GetValues(uint64_t *, bool forceVarying = false) const;
-    int GetValues(double *, bool forceVarying = false) const;
 
     /** Return the number of values in the ConstExpr; should be either 1,
         if it has uniform type, or the target's vector width if it's
@@ -492,12 +480,10 @@ class ConstExpr : public Expr {
         int32_t int32Val[ISPC_MAX_NVEC];
         uint32_t uint32Val[ISPC_MAX_NVEC];
         bool boolVal[ISPC_MAX_NVEC];
-        float floatVal[ISPC_MAX_NVEC];
-        double doubleVal[ISPC_MAX_NVEC];
         int64_t int64Val[ISPC_MAX_NVEC];
         uint64_t uint64Val[ISPC_MAX_NVEC];
     };
-    std::vector<llvm::APFloat> float16Val;
+    std::vector<llvm::APFloat> fpVal;
 };
 
 /** @brief Expression representing a type cast of the given expression to a

--- a/src/expr.h
+++ b/src/expr.h
@@ -426,10 +426,6 @@ class ConstExpr : public Expr {
     /** Create a ConstExpr from a varying bool value */
     ConstExpr(const Type *t, bool *b, SourcePos p);
 
-    /** Create a ConstExpr of the same type as the given old ConstExpr,
-        with values given by the "vales" parameter. */
-    ConstExpr(ConstExpr *old, std::vector<llvm::APFloat> v);
-
     /** Create ConstExpr with the same type and values as the given one,
         but at the given position. */
     ConstExpr(ConstExpr *old, SourcePos pos);

--- a/src/expr.h
+++ b/src/expr.h
@@ -462,6 +462,7 @@ class ConstExpr : public Expr {
     int GetValues(uint32_t *, bool forceVarying = false) const;
     int GetValues(int64_t *, bool forceVarying = false) const;
     int GetValues(uint64_t *, bool forceVarying = false) const;
+    int GetValues(std::vector<llvm::APFloat> &) const;
 
     /** Return the number of values in the ConstExpr; should be either 1,
         if it has uniform type, or the target's vector width if it's

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -263,9 +263,9 @@ llvm::ConstantInt *LLVMUInt64(uint64_t ival) {
 
 llvm::Constant *LLVMFloat16(llvm::APFloat fv) { return llvm::ConstantFP::get(llvm::Type::getHalfTy(*g->ctx), fv); }
 
-llvm::Constant *LLVMFloat(float fval) { return llvm::ConstantFP::get(llvm::Type::getFloatTy(*g->ctx), fval); }
+llvm::Constant *LLVMFloat(llvm::APFloat fval) { return llvm::ConstantFP::get(llvm::Type::getFloatTy(*g->ctx), fval); }
 
-llvm::Constant *LLVMDouble(double dval) { return llvm::ConstantFP::get(llvm::Type::getDoubleTy(*g->ctx), dval); }
+llvm::Constant *LLVMDouble(llvm::APFloat dval) { return llvm::ConstantFP::get(llvm::Type::getDoubleTy(*g->ctx), dval); }
 
 llvm::Constant *LLVMInt8Vector(int8_t ival) {
     llvm::Constant *v = LLVMInt8(ival);
@@ -372,7 +372,7 @@ llvm::Constant *LLVMFloat16Vector(const std::vector<llvm::APFloat> &fvec) {
     return llvm::ConstantVector::get(vals);
 }
 
-llvm::Constant *LLVMFloatVector(float fval) {
+llvm::Constant *LLVMFloatVector(llvm::APFloat fval) {
     llvm::Constant *v = LLVMFloat(fval);
     std::vector<llvm::Constant *> vals;
     for (int i = 0; i < g->target->getVectorWidth(); ++i)
@@ -380,14 +380,14 @@ llvm::Constant *LLVMFloatVector(float fval) {
     return llvm::ConstantVector::get(vals);
 }
 
-llvm::Constant *LLVMFloatVector(const float *fvec) {
+llvm::Constant *LLVMFloatVector(const std::vector<llvm::APFloat> &fvec) {
     std::vector<llvm::Constant *> vals;
     for (int i = 0; i < g->target->getVectorWidth(); ++i)
         vals.push_back(LLVMFloat(fvec[i]));
     return llvm::ConstantVector::get(vals);
 }
 
-llvm::Constant *LLVMDoubleVector(double dval) {
+llvm::Constant *LLVMDoubleVector(llvm::APFloat dval) {
     llvm::Constant *v = LLVMDouble(dval);
     std::vector<llvm::Constant *> vals;
     for (int i = 0; i < g->target->getVectorWidth(); ++i)
@@ -395,7 +395,7 @@ llvm::Constant *LLVMDoubleVector(double dval) {
     return llvm::ConstantVector::get(vals);
 }
 
-llvm::Constant *LLVMDoubleVector(const double *dvec) {
+llvm::Constant *LLVMDoubleVector(const std::vector<llvm::APFloat> &dvec) {
     std::vector<llvm::Constant *> vals;
     for (int i = 0; i < g->target->getVectorWidth(); ++i)
         vals.push_back(LLVMDouble(dvec[i]));

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -142,9 +142,9 @@ extern llvm::ConstantInt *LLVMUInt64(uint64_t i);
 /** Returns an LLVM half constant of the given value */
 extern llvm::Constant *LLVMFloat16(llvm::APFloat f);
 /** Returns an LLVM float constant of the given value */
-extern llvm::Constant *LLVMFloat(float f);
+extern llvm::Constant *LLVMFloat(llvm::APFloat f);
 /** Returns an LLVM double constant of the given value */
-extern llvm::Constant *LLVMDouble(double f);
+extern llvm::Constant *LLVMDouble(llvm::APFloat f);
 
 /** Returns an LLVM boolean vector constant of the given value smeared
     across all elements */
@@ -187,10 +187,10 @@ extern llvm::Constant *LLVMUInt64Vector(uint64_t i);
 extern llvm::Constant *LLVMFloat16Vector(llvm::APFloat f);
 /** Returns an LLVM float vector constant of the given value smeared
     across all elements */
-extern llvm::Constant *LLVMFloatVector(float f);
+extern llvm::Constant *LLVMFloatVector(llvm::APFloat f);
 /** Returns an LLVM double vector constant of the given value smeared
     across all elements */
-extern llvm::Constant *LLVMDoubleVector(double f);
+extern llvm::Constant *LLVMDoubleVector(llvm::APFloat f);
 
 /** Returns a constant integer or vector (according to the given type) of
     the given signed integer value. */
@@ -242,10 +242,10 @@ extern llvm::Constant *LLVMUInt64Vector(const uint64_t *i);
 extern llvm::Constant *LLVMFloat16Vector(const std::vector<llvm::APFloat> &f);
 /** Returns an LLVM float vector based on the given array of values.
     The array should have g->target.vectorWidth elements. */
-extern llvm::Constant *LLVMFloatVector(const float *f);
+extern llvm::Constant *LLVMFloatVector(const std::vector<llvm::APFloat> &f);
 /** Returns an LLVM double vector based on the given array of values.
     The array should have g->target.vectorWidth elements. */
-extern llvm::Constant *LLVMDoubleVector(const double *f);
+extern llvm::Constant *LLVMDoubleVector(const std::vector<llvm::APFloat> &f);
 
 /** LLVM constant value representing an 'all on' SIMD lane mask */
 extern llvm::Constant *LLVMMaskAllOn;

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -343,17 +343,19 @@ primary_expression
          std::string sval = *(yylval.stringVal);
          llvm::Type *hType = llvm::Type::getHalfTy(*g->ctx);
          const llvm::fltSemantics &FS = hType->getFltSemantics();
-         llvm::APFloat f(FS, sval);
+         llvm::APFloat f16(FS, sval);
          $$ = new ConstExpr(AtomicType::UniformFloat16->GetAsConstType(),
-                           f, @1);
+                           f16, @1);
     }
     | TOKEN_FLOAT_CONSTANT {
+        llvm::APFloat f(yylval.floatVal);
         $$ = new ConstExpr(AtomicType::UniformFloat->GetAsConstType(),
-                           yylval.floatVal, @1);
+                           f, @1);
     }
     | TOKEN_DOUBLE_CONSTANT {
+        llvm::APFloat d(yylval.doubleVal);
         $$ = new ConstExpr(AtomicType::UniformDouble->GetAsConstType(),
-                           yylval.doubleVal, @1);
+                           d, @1);
     }
     | TOKEN_TRUE {
         $$ = new ConstExpr(AtomicType::UniformBool->GetAsConstType(), true, @1);

--- a/tests/lit-tests/2148.ispc
+++ b/tests/lit-tests/2148.ispc
@@ -1,0 +1,11 @@
+//; RUN: %{ispc} %s --target=host -o %t.o --nostdlib
+
+// Check that we don't fail in parser.
+
+struct S {
+    float d2;
+};
+
+export void foo(uniform S& dst) {
+    dst.d2 = 1;
+}

--- a/tests/lit-tests/constant_folding_double.ispc
+++ b/tests/lit-tests/constant_folding_double.ispc
@@ -1,0 +1,85 @@
+// RUN: %{ispc} %s -O2 --target=host --emit-llvm-text --nostdlib --opt=fast-math -o - | FileCheck %s
+
+// CHECK: @retAddD
+// CHECK: ret double 5.000000e+00
+uniform double retAddD() {
+    return 2.0d + 3.0d;
+}
+
+// CHECK: @retSubD
+// CHECK: ret double 5.000000e-01
+uniform double retSubD() {
+    return 3.0d - 2.5d;
+}
+
+// CHECK: @retMulD
+// CHECK: ret double 7.500000e+00
+uniform double retMulD() {
+    return 3.0d * 2.5d;
+}
+
+// CHECK: @retDivD
+// CHECK: ret double 3.000000e+00
+uniform double retDivD() {
+    return 7.5d / 2.5d;
+}
+
+// CHECK: @retNegD
+// CHECK: ret double -2.000000e+00
+uniform double retNegD() {
+    return -2.0d;
+}
+
+// CHECK: @retFastMathD
+// CHECK: fmul double %{{[a-zA-Z_][a-zA-Z0-9_]*}}, 5.000000e-01
+uniform double retFastMathD(uniform double arg) {
+    return arg / 2.d;
+}
+
+// CHECK: @retLessCompD
+// CHECK: ret i1 true
+uniform bool retLessCompD() {
+    return 2.0d < 3.0d;
+}
+
+// CHECK: @retLessEqCompD
+// CHECK: ret i1 false
+uniform bool retLessEqCompD() {
+    return 3.0d <= 2.5d;
+}
+
+// CHECK: @retGreatCompD
+// CHECK: ret i1 true
+uniform bool retGreatCompD() {
+    return 3.0d > 2.5d;
+}
+
+// CHECK: @retGreatEqCompD
+// CHECK: ret i1 true
+uniform bool retGreatEqCompD() {
+    return 7.5d >= 2.5d;
+}
+
+// CHECK: @retEqCompD
+// CHECK: ret i1 true
+uniform bool retEqCompD() {
+    return 2.0d == 2.0d;
+}
+
+// CHECK: @retNeqCompD
+// CHECK: ret i1 true
+uniform bool retNeqCompD() {
+    return 2.0d != -2.0d;
+}
+
+// CHECK: @retLogAndCompD
+// CHECK: ret i1 false
+uniform bool retLogAndCompD() {
+    return 0.0d && 7.9d;
+}
+
+// CHECK: @retLogOrCompD
+// CHECK: ret i1 true
+uniform bool retLogOrCompD() {
+    return 0.0d || 7.9d;
+}

--- a/tests/lit-tests/constant_folding_float.ispc
+++ b/tests/lit-tests/constant_folding_float.ispc
@@ -1,0 +1,85 @@
+// RUN: %{ispc} %s -O2 --target=host --emit-llvm-text --nostdlib --opt=fast-math -o - | FileCheck %s
+
+// CHECK: @retAddF
+// CHECK: ret float 5.000000e+00
+uniform float retAddF() {
+    return 2.0f + 3.0f;
+}
+
+// CHECK: @retSubF
+// CHECK: ret float 5.000000e-01
+uniform float retSubF() {
+    return 3.0f - 2.5f;
+}
+
+// CHECK: @retMulF
+// CHECK: ret float 7.500000e+00
+uniform float retMulF() {
+    return 3.0f * 2.5f;
+}
+
+// CHECK: @retDivF
+// CHECK: ret float 3.000000e+00
+uniform float retDivF() {
+    return 7.5f / 2.5f;
+}
+
+// CHECK: @retNegF
+// CHECK: ret float -2.000000e+00
+uniform float retNegF() {
+    return -2.0f;
+}
+
+// CHECK: @retFastMathF
+// CHECK: fmul float %{{[a-zA-Z_][a-zA-Z0-9_]*}}, 5.000000e-01
+uniform float retFastMathF(uniform float arg) {
+    return arg / 2.f;
+}
+
+// CHECK: @retLessCompF
+// CHECK: ret i1 true
+uniform bool retLessCompF() {
+    return 2.0f < 3.0f;
+}
+
+// CHECK: @retLessEqCompF
+// CHECK: ret i1 false
+uniform bool retLessEqCompF() {
+    return 3.0f <= 2.5f;
+}
+
+// CHECK: @retGreatCompF
+// CHECK: ret i1 true
+uniform bool retGreatCompF() {
+    return 3.0f > 2.5f;
+}
+
+// CHECK: @retGreatEqCompF
+// CHECK: ret i1 true
+uniform bool retGreatEqCompF() {
+    return 7.5f >= 2.5f;
+}
+
+// CHECK: @retEqCompF
+// CHECK: ret i1 true
+uniform bool retEqCompF() {
+    return 2.0f == 2.0f;
+}
+
+// CHECK: @retNeqCompF
+// CHECK: ret i1 true
+uniform bool retNeqCompF() {
+    return 2.0f != -2.0f;
+}
+
+// CHECK: @retLogAndCompF
+// CHECK: ret i1 false
+uniform bool retLogAndCompF() {
+    return 0.0f && 7.9f;
+}
+
+// CHECK: @retLogOrCompF
+// CHECK: ret i1 true
+uniform bool retLogOrCompF() {
+    return 0.0f || 7.9f;
+}

--- a/tests/lit-tests/constant_folding_float16.ispc
+++ b/tests/lit-tests/constant_folding_float16.ispc
@@ -1,0 +1,85 @@
+// RUN: %{ispc} %s -O2 --target=host --emit-llvm-text --nostdlib --opt=fast-math -o - | FileCheck %s
+
+// CHECK: @retAddF16
+// CHECK: ret half 0xH4500
+uniform float16 retAddF16() {
+    return 2.0f16 + 3.0f16;
+}
+
+// CHECK: @retSubF16
+// CHECK: ret half 0xH3800
+uniform float16 retSubF16() {
+    return 3.0f16 - 2.5f16;
+}
+
+// CHECK: @retMulF16
+// CHECK: ret half 0xH4780
+uniform float16 retMulF16() {
+    return 3.0f16 * 2.5f16;
+}
+
+// CHECK: @retDivF16
+// CHECK: ret half 0xH4200
+uniform float16 retDivF16() {
+    return 7.5f16 / 2.5f16;
+}
+
+// CHECK: @retNegF16
+// CHECK: ret half 0xHC000
+uniform float16 retNegF16() {
+    return -2.0f16;
+}
+
+// CHECK: @retFastMathF16
+// CHECK: fmul half %{{[a-zA-Z_][a-zA-Z0-9_]*}}, 0xH3800
+uniform float16 retFastMathF16(uniform float16 arg) {
+    return arg / 2.f16;
+}
+
+// CHECK: @retLessCompF16
+// CHECK: ret i1 true
+uniform bool retLessCompF16() {
+    return 2.0f16 < 3.0f16;
+}
+
+// CHECK: @retLessEqCompF16
+// CHECK: ret i1 false
+uniform bool retLessEqCompF16() {
+    return 3.0f16 <= 2.5f16;
+}
+
+// CHECK: @retGreatCompF16
+// CHECK: ret i1 true
+uniform bool retGreatCompF16() {
+    return 3.0f16 > 2.5f16;
+}
+
+// CHECK: @retGreatEqCompF16
+// CHECK: ret i1 true
+uniform bool retGreatEqCompF16() {
+    return 7.5f16 >= 2.5f16;
+}
+
+// CHECK: @retEqCompF16
+// CHECK: ret i1 true
+uniform bool retEqCompF16() {
+    return 2.0f16 == 2.0f16;
+}
+
+// CHECK: @retNeqCompF16
+// CHECK: ret i1 true
+uniform bool retNeqCompF16() {
+    return 2.0f16 != -2.0f16;
+}
+
+// CHECK: @retLogAndCompF16
+// CHECK: ret i1 false
+uniform bool retLogAndCompF16() {
+    return 0.0f16 && 7.9f16;
+}
+
+// CHECK: @retLogOrCompF16
+// CHECK: ret i1 true
+uniform bool retLogOrCompF16() {
+    return 0.0f16 || 7.9f16;
+}

--- a/tests/lit-tests/fast_math_opt.ispc
+++ b/tests/lit-tests/fast_math_opt.ispc
@@ -1,0 +1,32 @@
+// RUN: %{ispc} %s --target=host --opt=fast-math --nostdlib --nowrap 2>&1 | FileCheck %s -check-prefix=CHECK_WARN
+// RUN: %{ispc} %s --target=host --opt=fast-math -O0 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_NOFDIV
+
+// CHECK_NOFDIV-NOT: fdiv
+
+
+float16 f1(float16 a) {
+  return a/2.f16;
+}
+
+// CHECK_WARN: Warning: rcp(varying float16) not found from stdlib. Can't apply fast-math rcp optimization.
+float16 f2(float16 a, float16 b) {
+  return a/b;
+}
+
+float f3(float a) {
+  return a/2.f;
+}
+
+// CHECK_WARN: Warning: rcp(varying float) not found from stdlib. Can't apply fast-math rcp optimization.
+float f4(float a, float b) {
+  return a/b;
+}
+
+double f5(double a) {
+  return a/2.d;
+}
+
+// CHECK_WARN: Warning: rcp(varying double) not found from stdlib. Can't apply fast-math rcp optimization.
+double f6(double a, double b) {
+  return a/b;
+}

--- a/tests/lit-tests/select_folding.ispc
+++ b/tests/lit-tests/select_folding.ispc
@@ -1,0 +1,51 @@
+//; RUN: %{ispc} %s --target=host -o %t.o --nostdlib
+
+// Make sure it compiles and doesn't fail during const folding in the front-end
+
+bool f1() {
+  return (programIndex % 2) ? true : false;
+}
+
+int8 f2() {
+  return (programIndex % 2) ? (int8) -1 : (int8) -2;
+}
+
+uint8 f3() {
+  return (programIndex % 2) ? (uint8) 3 : (uint8) 4;
+}
+
+int16 f4() {
+  return (programIndex % 2) ? (int16) -5 : (int16) -6;
+}
+
+uint16 f5() {
+  return (programIndex % 2) ? (uint16) 7 : (uint16) 8;
+}
+
+int32 f6() {
+  return (programIndex % 2) ? -9 : -10;
+}
+
+uint32 f7() {
+  return (programIndex % 2) ? (uint32) 11 : (uint32) 12;
+}
+
+int64 f9() {
+  return (programIndex % 2) ? -13LL : -14LL;
+}
+
+uint64 f10() {
+  return (programIndex % 2) ? 15ULL : 16ULL;
+}
+
+float16 f11() {
+  return (programIndex % 2) ? 1.23f16 : 4.56f16;
+}
+
+float f12() {
+  return (programIndex % 2) ? 1.23e+30f : 4.56e+30f;
+}
+
+double f13() {
+  return (programIndex % 2) ? 1.23e+300d : 4.56e+300d;
+}


### PR DESCRIPTION
Switching ConstExpr representation of `float` and `double` types to APFloat. This is done for two reasons:
1. it's the right thing to do, as internal representation using `float` and `double` types is error prone and depends on build options and may have portability problems
2. consistency with handling of `float16` type
Note: these changes do not completely eliminate the use of host logic involving `float` and `double` types.

Along with switching `float` and `double` to APFloat, all optimizations / foldings available for these types were also enabled for `float16` (specifically for BinaryExpr and SelectExpr)

Other changes included in this PR:
- regression test for #2148 
- fix for the bug with constant folding of select expression with `double` and `bool` types
- enabling fast-math optimizations (a/C => a * (1/C); a/b => a * rcp(b)) for `float16` and `double`. This good for consistency with `float`. We should consider moving fast-math optimizations to backend.
- refactoring to reduce copy-paste code and improve consistency