### PR TITLE
Updates for Gen target

### DIFF
--- a/builtins/util-genx.m4
+++ b/builtins/util-genx.m4
@@ -4215,9 +4215,11 @@ define void @__memset64(i8 * %dst, i8 %val, i64 %len) alwaysinline {
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; assume dummy function
+;; assume
+declare void @llvm.assume(i1)
 
 define void @__do_assume_uniform(i1 %test) alwaysinline {
+  call void @llvm.assume(i1 %test)
   ret void
 }
 

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -4077,7 +4077,7 @@ The ``ispc`` standard library includes a mechanism for adding ``assume()``
 statements to ``ispc`` program code. The ``assume()`` function takes a
 single uniform boolean expression as an argument. This expression is
 assumed to be ``true`` and this information will be used for optimization
-when possible. This feature is currently only available on CPU targets.
+when possible.
 
 The condition used in ``assume()`` statement will not be code generated and
 does not imply runtime checks. It will solely be used as optimization hint,

--- a/src/builtins-info.h
+++ b/src/builtins-info.h
@@ -101,6 +101,8 @@ inline Encoding getCorrespondingEncoding4Uniform(Encoding type) {
     return static_cast<Encoding>(type - (Encoding::VecBool - Encoding::Bool));
 }
 
+inline bool isUniformEncoding(Encoding type) { return type < Encoding::VecBool; }
+
 // same as getEncoding4Uniform, but it is a functor
 struct Encoding4Uniform {
     template <typename T> constexpr Encoding call() const { return getEncoding4Uniform<T>(); }

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -41,6 +41,7 @@
 
 #include <map>
 
+#include <llvm/ADT/StringRef.h>
 #include <llvm/IR/DIBuilder.h>
 #include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/InstrTypes.h>
@@ -577,8 +578,16 @@ class FunctionEmitContext {
         ISPCSIMDCFLowering expect that execMask have alloca+load+store. */
     void GenXEndUnmaskedRegion(llvm::Value *execMask);
 
-    /** Emit L0 format string using genx_print_format_index intrinsics. */
-    llvm::CallInst *GenXLZFormatStr(const std::string &str);
+    /** Emit a string in constant space and get pointer to its first element.
+        GEP constexpr is returned.
+        Args:
+          \p str - constant initializer;
+          \p name - constant name */
+    llvm::Constant *GenXCreateConstantString(llvm::StringRef str, llvm::StringRef name = "");
+    /** Similar to GenXCreateConstantString but searches for the constant with the provided name first.
+        If there's such constant returns pointer to its first element, otherwise creates new constant
+        and returns pointer to its first element. */
+    llvm::Constant *GenXGetOrCreateConstantString(llvm::StringRef str, llvm::StringRef name);
 
     /** Change scalar condition to vector condition before branching if
         emulated uniform condition was found in external scopes and start SIMD control

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -7997,10 +7997,6 @@ Expr *AllocaExpr::TypeCheck() {
         return NULL;
     }
 
-    if (g->target->isGenXTarget()) {
-        Error(pos, "\"alloca()\" is not supported for genx-* targets yet.");
-        return NULL;
-    }
     const Type *argType = expr ? expr->GetType() : NULL;
     const Type *sizeType = m->symbolTable->LookupType("size_t");
     Assert(sizeType != NULL);

--- a/src/gen/GlobalsLocalization.cpp
+++ b/src/gen/GlobalsLocalization.cpp
@@ -623,7 +623,9 @@ void GlobalsLocalization::AnalyzeGlobals(CallGraph &CG) {
             // don't localize global constant format string if it's used by
             // print_index intrinsic
             bool UsesPrintIndex = std::any_of(GV.use_begin(), GV.use_end(), UsesPrintChecker);
-            return (GV.hasAttribute(genx::FunctionMD::GenXVolatile) || UsesPrintIndex);
+            // Avoid localizing constant addrspace as a workaround for print implementation.
+            // Constant strings should stay constant strings till spirv.
+            return GV.hasAttribute(genx::FunctionMD::GenXVolatile) || UsesPrintIndex || GV.getAddressSpace() != 0;
         },
         [&DL](const GlobalVariable &GV) { return calcGVWeight(GV, DL); });
     for (auto I = Funcs.begin(), E = Funcs.end(); I != E; ++I) {

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -6028,8 +6028,7 @@ restart:
                     modifiedAny = true;
                     goto restart;
                 }
-            } else if (func->getName().equals("llvm.assume") ||
-                       func->getName().equals("llvm.experimental.noalias.scope.decl")) {
+            } else if (func->getName().equals("llvm.experimental.noalias.scope.decl")) {
                 // These intrinsics are not supported by backend so remove them.
                 ci->eraseFromParent();
                 modifiedAny = true;

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -3075,7 +3075,7 @@ class PrintArgsBuilder {
         enum { LeftParenthesisIdx = 0, RightParenthesisIdx, EmptyIdx, FalseIdx, TrueIdx, NumStrings };
         std::array<llvm::Value *, NumStrings> strings;
 
-        AdditionalData() {}
+        AdditionalData() { mask = NULL; }
         AdditionalData(FunctionEmitContext *ctx) {
             if (ctx->emitGenXHardwareMask())
                 mask = ctx->GenXSimdCFPredicate(LLVMMaskAllOn);

--- a/tests/allocate.ispc
+++ b/tests/allocate.ispc
@@ -1,6 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=genx32
-// rule: skip on arch=genx64
 
 void noinline check_val_all(uniform float *uniform alloca_ptr, uniform float RET[], uniform float aFOO[]) {
     if (alloca_ptr[programIndex] != aFOO[programIndex]) {

--- a/tests/asin_f64.ispc
+++ b/tests/asin_f64.ispc
@@ -1,7 +1,5 @@
 #include "../test_static.isph"
-// rule: skip on arch=genx32
-// rule: skip on arch=genx64
-// currently cos/sin/pow/sincos is very slow on gen so skip it
+// rule: skip on cpu=TGLLP
 bool ok(double x, double ref) { return (abs(x - ref) < 1e-6) || abs((x-ref)/ref) < 1e-4; }
 
 task void f_v(uniform float RET[]) {

--- a/tests/lit-tests/alloca.ispc
+++ b/tests/lit-tests/alloca.ispc
@@ -1,41 +1,55 @@
 // Test to check 'alloca()' implementation.
 // RUN: %{ispc} %s --target=host --nowrap -O0 --emit-llvm-text -o - | FileCheck %s
+// RUN: %{ispc} %s --target=genx-x8 --nowrap -O0 --emit-llvm-text -o - | FileCheck %s -check-prefix=CHECK-GEN
 
 // REQUIRES: X86_ENABLED
+// REQUIRES: GENX_ENABLED
 
 extern void goo(uniform int *uniform alloca_ptr);
 // CHECK: @foo0
 // CHECK: alloca i8, i32 8, align 16
-void foo0() {
+// CHECK-GEN: @foo0
+// CHECK-GEN: alloca i8, i64 8, align 16
+extern void foo0() {
     goo((uniform int *uniform)alloca(8));
 }
 
 // CHECK: @foo1
 // CHECK: alloca i8, i32 %size_load, align 16
-void foo1(uniform size_t size) {
+// CHECK-GEN: @foo1
+// CHECK-GEN: alloca i8, i64 %size, align 16
+extern void foo1(uniform size_t size) {
     goo((uniform int *uniform)alloca(size));
 }
 
 // CHECK: @foo2
 // CHECK:  alloca i8, i32 %size_load_to_uint32, align 16
-void foo2(uniform int8 size) {
+// CHECK-GEN: @foo2
+// CHECK-GEN:  alloca i8, i64 %size_load_to_uint64, align 16
+extern void foo2(uniform int8 size) {
     goo((uniform int *uniform)alloca(size));
 }
 
 // CHECK: @foo3
 // CHECK:  alloca i8, i32 %size_load_to_uint32, align 16
-void foo3(uniform float size) {
+// CHECK-GEN: @foo3
+// CHECK-GEN:  alloca i8, i64 %size_load_to_uint64, align 16
+extern void foo3(uniform float size) {
     goo((uniform int *uniform)alloca(size));
 }
 
 // CHECK: @foo4
 // CHECK: alloca i8, i32 %size_load_load_to_uint32, align 16
-void foo4(uniform float *uniform size) {
+// CHECK-GEN: @foo4
+// CHECK-GEN: alloca i8, i64 %size_load_load_to_uint64, align 16
+extern void foo4(uniform float *uniform size) {
     goo((uniform int *uniform)alloca(*size));
 }
 
 // CHECK: @foo5
 // CHECK: alloca i8, i32 8, align 16
-void foo5() {
+// CHECK-GEN: @foo5
+// CHECK-GEN: alloca i8, i64 8, align 16
+extern void foo5() {
     goo((uniform int *uniform)alloca(sizeof(uniform double)));
 }

--- a/tests/lit-tests/assume_uniform_gen.ispc
+++ b/tests/lit-tests/assume_uniform_gen.ispc
@@ -1,0 +1,53 @@
+// RUN: %{ispc} --emit-spirv --target=genx-x8 %s -o %s.spv
+// RUN: ocloc compile -file %s.spv -spirv_input -options "-vc-codegen" -device SKL -output %s.bin -output_no_suffix
+// RUN: ocloc disasm -file %s.bin -device SKL -dump ./
+// RUN: FileCheck %s -check-prefix=CHECK_FOO1 -input-file=foo1_kernel_KernelHeap.asm
+// RUN: FileCheck %s -check-prefix=CHECK_FOO2 -input-file=foo2_kernel_KernelHeap.asm
+// RUN: FileCheck %s -check-prefix=CHECK_FOO3 -input-file=foo3_kernel_KernelHeap.asm
+
+// REQUIRES: GENX_ENABLED
+// REQUIRES: OCLOC_INSTALLED
+// REQUIRES-NOT: WINDOWS_ENABLED
+
+// CHECK_FOO1-NOT: cmp
+
+// Case 1 : assume() can be used to choose branch/remove
+inline uniform int bar1(uniform int a, uniform int b){
+    if (a < b)
+        return 2;
+    return 5;
+}
+uniform int foo1(uniform int a, uniform int b){
+    assume(a < b);
+    return bar1(a, b);
+}
+
+task void foo1_kernel(uniform int a[], uniform int res[]) {
+    res[0] = foo1(a[0], a[1]);
+}
+
+// CHECK_FOO2-NOT: cmp
+// CHECK_FOO2-NOT: jmpi
+
+// Case 2 : pointer null check removed.
+inline void bar2(uniform int * uniform a) {
+    if (a != NULL) {
+        a[2] = 9;
+    }
+}
+task void foo2_kernel(uniform int a[]) {
+    assume(a != NULL);
+    bar2(a);
+}
+
+// CHECK_FOO3: jmpi
+// CHECK_FOO3: cmp
+// CHECK_FOO3-NOT: cmp
+
+// Case 3 : loop : remove remainder loop.
+task void foo3_kernel(uniform int a[], uniform int res[], uniform int count) {
+    assume(count % programCount == 0);
+    foreach (i = 0 ... count) {
+        res[i] += a[i];
+    }
+}

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from distutils.version import LooseVersion
 
 import lit.formats
@@ -96,3 +97,11 @@ elif genx_enabled == "OFF":
     print("GENX_ENABLED: NO")
 else:
     sys.exit("Cannot parse genx_enabled: " + genx_enabled)
+
+# Ocloc
+status, output = subprocess.getstatusoutput("ocloc")
+if status == 0:
+    print("OCLOC_INSTALLED: YES")
+    config.available_features.add("OCLOC_INSTALLED")
+else:
+    print("OCLOC_INSTALLED: NO")

--- a/tests/transcendentals-10-0.ispc
+++ b/tests/transcendentals-10-0.ispc
@@ -2,10 +2,7 @@
 // sincos() function is available only on Linux.
 // rule: skip on OS=*
 // rule: run on OS=linux
-// rule: skip on arch=genx32
-// rule: skip on arch=genx64
-
-
+// rule: skip on cpu=TGLLP
 task void f_du(uniform float RET[], uniform double aFOO[], uniform double b) {
     double a = aFOO[programIndex];
     uniform double sin_a[] = {0.8414709848078965, 0.9092974268256817, 0.1411200080598672, -0.7568024953079282, -0.9589242746631385, -0.2794154981989259, 0.6569865987187891, 0.9893582466233818,

--- a/tests/transcendentals-cos-uniform.ispc
+++ b/tests/transcendentals-cos-uniform.ispc
@@ -1,8 +1,5 @@
 #include "../test_static.isph"
-// rule: skip on arch=genx32
-// rule: skip on arch=genx64
 // rule: skip on cpu=TGLLP
-// currently cos/sin/pow/sincos is very slow on gen so skip it
 uniform bool ok(uniform double x, uniform double ref) { return (abs(x - ref) < 1d-5) || abs((x-ref)/ref) < 1d-4; }
 task void f_du(uniform float RET[], uniform double aFOO[], uniform double b) {
   for (uniform int i = 0; i != programCount; ++i) {

--- a/tests/transcendentals-cos-varying.ispc
+++ b/tests/transcendentals-cos-varying.ispc
@@ -1,8 +1,5 @@
 #include "../test_static.isph"
-// rule: skip on arch=genx32
-// rule: skip on arch=genx64
 // rule: skip on cpu=TGLLP
-// currently cos/sin/pow/sincos is very slow on gen so skip it
 bool ok(double x, double ref) { return (abs(x - ref) < 1d-5) || abs((x-ref)/ref) < 1d-4; }
 task void f_du(uniform float RET[], uniform double aFOO[], uniform double b) {
   varying double arg = aFOO[programIndex] + b;

--- a/tests/transcendentals-pow-uniform.ispc
+++ b/tests/transcendentals-pow-uniform.ispc
@@ -1,8 +1,5 @@
 #include "../test_static.isph"
-// rule: skip on arch=genx32
-// rule: skip on arch=genx64
 // rule: skip on cpu=TGLLP
-// currently cos/sin/pow/sincos is very slow on gen so skip it
 uniform bool ok(uniform double x, uniform double ref) { return (abs(x - ref) < 1d-6) || abs((x-ref)/ref) < 1d-5; }
 task void f_du(uniform float RET[], uniform double aFOO[], uniform double b) {
   for (uniform int i = 0; i != programCount; ++i) {

--- a/tests/transcendentals-pow-varying.ispc
+++ b/tests/transcendentals-pow-varying.ispc
@@ -1,8 +1,5 @@
 #include "../test_static.isph"
-// rule: skip on arch=genx32
-// rule: skip on arch=genx64
 // rule: skip on cpu=TGLLP
-// currently cos/sin/pow/sincos is very slow on gen so skip it
 bool ok(double x, double ref) { return (abs(x - ref) < 1d-6) || abs((x-ref)/ref) < 1d-5; }
 task void f_du(uniform float RET[], uniform double aFOO[], uniform double b) {
   varying double arg = aFOO[programIndex];

--- a/tests/transcendentals-sin-uniform.ispc
+++ b/tests/transcendentals-sin-uniform.ispc
@@ -1,8 +1,5 @@
 #include "../test_static.isph"
-// rule: skip on arch=genx32
-// rule: skip on arch=genx64
 // rule: skip on cpu=TGLLP
-// currently cos/sin/pow/sincos is very slow on gen so skip it
 uniform bool ok(uniform double x, uniform double ref) { return (abs(x - ref) < 1d-5) || abs((x-ref)/ref) < 1d-4; }
 task void f_du(uniform float RET[], uniform double aFOO[], uniform double b) {
   for (uniform int i = 0; i != programCount; ++i) {

--- a/tests/transcendentals-sin-varying.ispc
+++ b/tests/transcendentals-sin-varying.ispc
@@ -1,8 +1,5 @@
 #include "../test_static.isph"
-// rule: skip on arch=genx32
-// rule: skip on arch=genx64
 // rule: skip on cpu=TGLLP
-// currently cos/sin/pow/sincos is very slow on gen so skip it
 bool ok(double x, double ref) { return (abs(x - ref) < 1d-5) || abs((x-ref)/ref) < 1d-4; }
 task void f_du(uniform float RET[], uniform double aFOO[], uniform double b) {
   varying double arg = aFOO[programIndex] + b;

--- a/tests/transcendentals-sincos-uniform.ispc
+++ b/tests/transcendentals-sincos-uniform.ispc
@@ -2,10 +2,7 @@
 // sincos() function is available only on Linux.
 // rule: skip on OS=*
 // rule: run on OS=linux
-// rule: skip on arch=genx32
-// rule: skip on arch=genx64
 // rule: skip on cpu=TGLLP
-// currently cos/sin/pow/sincos is very slow on gen so skip it
 uniform bool ok(uniform double x, uniform double ref) { return (abs(x - ref) < 1d-5) || abs((x-ref)/ref) < 1d-4; }
 task void f_du(uniform float RET[], uniform double aFOO[], uniform double b) {
   for (uniform int i = 0; i != programCount; ++i) {

--- a/tests/transcendentals-sincos-varying.ispc
+++ b/tests/transcendentals-sincos-varying.ispc
@@ -2,10 +2,7 @@
 // sincos() function is available only on Linux.
 // rule: skip on OS=*
 // rule: run on OS=linux
-// rule: skip on arch=genx32
-// rule: skip on arch=genx64
 // rule: skip on cpu=TGLLP
-// currently cos/sin/pow/sincos is very slow on gen so skip it
 bool ok(double x, double ref) { return (abs(x - ref) < 1d-5) || abs((x-ref)/ref) < 1d-4; }
 task void f_du(uniform float RET[], uniform double aFOO[], uniform double b) {
   varying double arg = aFOO[programIndex];


### PR DESCRIPTION
* Enable `assume()` for Gen target
* Enable `alloca()` for Gen target
* Enable `double` trigonometric tests for Gen target
* `print()` function on Gen to use standard SPIR-V intrinsics instead of L0 functions.