### PR TITLE
CI: fix LLVM13 based build on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,9 +58,8 @@ for:
         if "%LLVM_VERSION%"=="latest" (set WASM=ON)
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( (set generator="Visual Studio 15 Win64") & (set vsversion=2017))
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vsversion=2019))
-        set LLVM_TAR=llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.7z
-        if "%LLVM_VERSION%"=="11.1" (set LLVM_TAR=llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z)
-        if "%LLVM_VERSION%"=="10.0" (set LLVM_TAR=llvm-10.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.zip)
+        set LLVM_TAR=llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        if "%LLVM_VERSION%"=="11.1" (set LLVM_TAR=llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
   install:
     - ps: choco install --no-progress winflexbison3 wget 7zip
     - cmd: |-
@@ -79,6 +78,7 @@ for:
         mkdir %LLVM_HOME% && cd %LLVM_HOME%
         wget -q https://github.com/ispc/llvm-project/releases/download/llvm-%LLVM_VERSION%-ispc-dev/%LLVM_TAR%
         7z.exe x -t7z %LLVM_TAR%
+        7z.exe x -ttar llvm*tar
         set PATH=%LLVM_HOME%\bin-%LLVM_VERSION%\bin;%PATH%
   before_build:
     - cmd: |-

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -259,7 +259,7 @@ jobs:
     runs-on: windows-latest
     env:
       LLVM_VERSION: "11.1"
-      LLVM_TAR: llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z
+      LLVM_TAR: llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"
@@ -300,7 +300,7 @@ jobs:
     runs-on: windows-latest
     env:
       LLVM_VERSION: "12.0"
-      LLVM_TAR: llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.7z
+      LLVM_TAR: llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"

--- a/.github/workflows/nightly-13.yml
+++ b/.github/workflows/nightly-13.yml
@@ -171,13 +171,15 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z bin-13.0
+        set TAR_BASE_NAME=llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm
+        7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-13.0
+        7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm_13_win
-        path: llvm/llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z
+        path: llvm/llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
 
   win-build-ispc-llvm-13:
@@ -185,7 +187,7 @@ jobs:
     runs-on: windows-latest
     env:
       LLVM_VERSION: "13.0"
-      LLVM_TAR: llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z
+      LLVM_TAR: llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"

--- a/.github/workflows/nightly-13.yml
+++ b/.github/workflows/nightly-13.yml
@@ -226,7 +226,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: ispc_llvm_13_win
+        name: ispc_llvm13_win
         path: build/ispc-trunk-windows.msi
 
 

--- a/.github/workflows/rebuild-llvm11.yml
+++ b/.github/workflows/rebuild-llvm11.yml
@@ -109,13 +109,15 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z bin-11.1
+        set TAR_BASE_NAME=llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm
+        7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-11.1
+        7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11_win
-        path: llvm/llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z
+        path: llvm/llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
   win-build-release:
     runs-on: windows-latest
@@ -150,13 +152,15 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-11.1.0-win.vs2019-Release-x86.arm.wasm.7z bin-11.1
+        set TAR_BASE_NAME=llvm-11.1.0-win.vs2019-Release-x86.arm.wasm
+        7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-11.1
+        7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11rel_win
-        path: llvm/llvm-11.1.0-win.vs2019-Release-x86.arm.wasm.7z
+        path: llvm/llvm-11.1.0-win.vs2019-Release-x86.arm.wasm.tar.7z
 
   mac-build:
     runs-on: macos-10.15

--- a/.github/workflows/rebuild-llvm12.yml
+++ b/.github/workflows/rebuild-llvm12.yml
@@ -109,13 +109,15 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.7z bin-12.0
+        set TAR_BASE_NAME=llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm
+        7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-12.0
+        7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm12_win
-        path: llvm/llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.7z
+        path: llvm/llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
   win-build-release:
     runs-on: windows-latest
@@ -150,13 +152,15 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-12.0.1-win.vs2019-Release-x86.arm.wasm.7z bin-12.0
+        set TAR_BASE_NAME=llvm-12.0.1-win.vs2019-Release-x86.arm.wasm
+        7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-12.0
+        7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm12rel_win
-        path: llvm/llvm-12.0.1-win.vs2019-Release-x86.arm.wasm.7z
+        path: llvm/llvm-12.0.1-win.vs2019-Release-x86.arm.wasm.tar.7z
 
   mac-build:
     runs-on: macos-10.15

--- a/.github/workflows/rebuild-llvm13.yml
+++ b/.github/workflows/rebuild-llvm13.yml
@@ -109,13 +109,15 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z bin-13.0
+        set TAR_BASE_NAME=llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm
+        7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-13.0
+        7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm13_win
-        path: llvm/llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.7z
+        path: llvm/llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
   win-build-release:
     runs-on: windows-latest
@@ -150,13 +152,15 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        7z.exe a -t7z llvm-13.0.0-win.vs2019-Release-x86.arm.wasm.7z bin-13.0
+        set TAR_BASE_NAME=llvm-13.0.0-win.vs2019-Release-x86.arm.wasm
+        7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-13.0
+        7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm13rel_win
-        path: llvm/llvm-13.0.0-win.vs2019-Release-x86.arm.wasm.7z
+        path: llvm/llvm-13.0.0-win.vs2019-Release-x86.arm.wasm.tar.7z
 
   mac-build:
     runs-on: macos-10.15

--- a/.github/workflows/scripts/install-build-deps.ps1
+++ b/.github/workflows/scripts/install-build-deps.ps1
@@ -12,8 +12,9 @@ echo "C:\tools\cygwin\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 
 # Download and unpack llvm
 if ( !(Test-Path ${env:LLVM_HOME}) ) { mkdir ${env:LLVM_HOME} }
 cd ${env:LLVM_HOME}
-if ( Test-Path env:LLVM_REPO ) { wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/ispc/llvm-project/releases/download/llvm-${env:LLVM_VERSION}-ispc-dev/${env:LLVM_TAR} }
+if ( Test-Path env:LLVM_REPO ) { wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 ${env:LLVM_REPO}/releases/download/llvm-${env:LLVM_VERSION}-ispc-dev/${env:LLVM_TAR} }
 7z.exe x -t7z ${env:LLVM_TAR}
+7z.exe x -ttar llvm*tar
 echo "${env:LLVM_HOME}\bin-${env:LLVM_VERSION}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
 # Download and unpack gnuwin32


### PR DESCRIPTION
Starting LLVM 13, `clang++`  and some other binaries on Windows are created using symlinks (they used to be a copy of other binaries). `7zip` doesn't preserve symlink by default, so we need to do an extra step to preserve them. We create tar and then archive it using `7z` algorithm. So LLVM archive now has `.tar.7z` extension.

Note that to preserve symlinks when creating tar file, we need to use `7zip` and use `-snl` switch. Using stock `tar` which comes with Windows image doesn't work out of the box.