### PR TITLE
Adding CI pipeline to test --math-lib=svml

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       flow_type:
-        description: 'Workflow flow type'
+        description: 'Workflow flow type (full or smoke)'
         required: true
         default: 'full'
 env:

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -1,0 +1,134 @@
+name: SVML
+
+on:
+  workflow_dispatch:
+    inputs:
+      flow_type:
+        description: 'Workflow flow type (full or smoke)'
+        required: true
+        default: 'full'
+env:
+  SDE_TAR_NAME: sde-external-8.69.1-2021-07-18
+  LLVM_REPO: https://github.com/ispc/llvm-project
+  TARGETS_SMOKE: '["avx2-i32x8"]'
+  OPTSETS_SMOKE: "-O2"
+  TARGETS_FULL:  '["sse2-i32x4", "sse2-i32x8",
+                   "sse4-i8x16", "sse4-i16x8", "sse4-i32x4", "sse4-i32x8",
+                   "avx1-i32x4", "avx1-i32x8", "avx1-i32x16", "avx1-i64x4",
+                   "avx2-i8x32", "avx2-i16x16", "avx2-i32x4", "avx2-i32x8", "avx2-i32x16", "avx2-i64x4",
+                   "avx512knl-i32x16",
+                   "avx512skx-i32x8", "avx512skx-i32x16", "avx512skx-i8x64", "avx512skx-i16x32"]'
+  OPTSETS_FULL: "-O0 -O1 -O2"
+
+jobs:
+  define-flow:
+    runs-on: ubuntu-latest
+    outputs:
+      tests_matrix_targets: ${{ steps.set-flow.outputs.matrix }}
+      tests_optsets: ${{ steps.set-flow.outputs.optsets }}
+      flow_type: ${{ steps.set-flow.outputs.type }}
+    env:
+      # for debug purposes
+      REF_NAME: ${{ github.ref }}
+      EVENT_NAME: ${{ github.event_name }}
+
+      # define rule when to run full flow
+      RUN_FULL: ${{ (github.ref == 'refs/heads/main' && github.event_name == 'schedule') ||
+                    (github.event_name == 'workflow_dispatch' && github.event.inputs.flow_type == 'full') }}
+
+      # define rule when to run smoke flow
+      RUN_SMOKE: ${{ github.event_name == 'pull_request' ||
+                    (github.event_name == 'workflow_dispatch' && github.event.inputs.flow_type == 'smoke') }}
+    steps:
+    - name: Set workflow jobs flow
+      id: set-flow
+      run: |
+        # one and only one var should be set
+        [[ $RUN_SMOKE == false && $RUN_FULL == true ]] || [[ $RUN_SMOKE == true && $RUN_FULL == false ]] || ( echo "One and only one env var must be set: RUN_SMOKE or RUN_FULL"; exit 1)
+        $RUN_SMOKE && echo "::set-output name=type::smoke" || true
+        $RUN_FULL &&  echo "::set-output name=type::full" || true
+        # set tests matrix depends on flow
+        $RUN_SMOKE && echo "::set-output name=matrix::${TARGETS_SMOKE}" || true
+        $RUN_FULL &&  echo "::set-output name=matrix::${TARGETS_FULL}" || true
+        # set tests optsets
+        $RUN_SMOKE && echo "::set-output name=optsets::${OPTSETS_SMOKE}" || true
+        $RUN_FULL &&  echo "::set-output name=optsets::${OPTSETS_FULL}" || true
+
+  linux-build-ispc-llvm12:
+    needs: [define-flow]
+    runs-on: ubuntu-latest
+    env:
+      LLVM_VERSION: "12.0"
+      LLVM_TAR: llvm-12.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Install dependencies
+      run: |
+        .github/workflows/scripts/install-build-deps.sh
+
+    - name: Check environment
+      run: |
+        ./check_env.py
+        which -a clang
+        cat /proc/cpuinfo
+
+    - name: Build package
+      run: |
+        .github/workflows/scripts/build-ispc.sh
+
+    - name: Sanity testing (make check-all, make test)
+      run: |
+        .github/workflows/scripts/check-ispc.sh
+
+    - name: Upload package
+      uses: actions/upload-artifact@v2
+      with:
+        name: ispc_llvm12_linux
+        path: build/ispc-trunk-linux.tar.gz
+
+
+  linux-test-llvm12:
+    needs: [define-flow, linux-build-ispc-llvm12]
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: ispc_llvm12_linux
+
+    - name: Install dependencies and unpack artifacts
+      run: |
+        .github/workflows/scripts/install-svml-test-deps.sh
+
+    - name: Check environment
+      run: |
+        cat /proc/cpuinfo
+
+    - name: Running tests
+      run: |
+        echo PATH=$PATH
+        . /opt/intel/oneapi/setvars.sh
+        ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP --ispc-flags="--math-lib=svml" --compiler=icx
+
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
+    - name: Upload fail_db.txt
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: fail_db.llvm12.${{matrix.target}}.txt
+        path: fail_db.txt
+

--- a/.github/workflows/scripts/install-build-deps.sh
+++ b/.github/workflows/scripts/install-build-deps.sh
@@ -6,7 +6,7 @@ for i in {1..5}
 do
   sudo apt-get update | tee log${i}.txt
   sudo apt-get install bison flex libc6-dev-i386 g++-multilib lib32stdc++6 ncurses-dev | tee -a log${i}.txt
-  if [[ ! `grep "Err:" log${i}.txt` ]]; then
+  if [[ ! `grep "^Err: " log${i}.txt` && ! `grep "^E: " log${i}.txt` ]]; then
     echo "APT packages installation was successful"
     break
   else

--- a/.github/workflows/scripts/install-svml-test-deps.sh
+++ b/.github/workflows/scripts/install-svml-test-deps.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+echo "APT::Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-retries
+
+# SVML requires installing Intel Compiler
+
+wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+
+# if apt-get fails, retry several time.
+for i in {1..5}
+do
+  sudo apt-get update 2>&1 | tee log${i}.txt
+  sudo apt-get install libc6-dev-i386 g++-multilib lib32stdc++6 2>&1 | tee -a log${i}.txt
+  sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2021.2.0 2>&1 | tee -a log${i}.txt
+  if [[ ! `grep "^Err: " log${i}.txt` && ! `grep "^E: " log${i}.txt` ]]; then
+    echo "APT packages installation was successful"
+    break
+  else
+    if [[ ${i} -eq 5 ]]; then
+      echo "APT had unrecoverable errors, exiting"
+      exit 1
+    else
+      sleep_time=$((${i} * 10))
+      echo "APT packages installation failed, sleeping ${sleep_time} seconds"
+      sleep ${sleep_time}
+      sudo rm -rf /var/lib/apt/lists/*
+    fi
+  fi
+done
+
+find /usr -name cdefs.h || echo "Find errors were ignored"
+wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://software.intel.com/content/dam/develop/external/us/en/documents/downloads/"$SDE_TAR_NAME"-lin.tar.bz2
+tar xf "$SDE_TAR_NAME"-lin.tar.bz2
+tar xf ispc-trunk-linux.tar.gz
+
+#GA requires to set env putting value to $GITHUB_ENV & $GITHUB_PATH
+echo "SDE_HOME=$GITHUB_WORKSPACE/$SDE_TAR_NAME-lin" >> $GITHUB_ENV
+echo "$GITHUB_WORKSPACE/ispc-trunk-linux/bin" >> $GITHUB_PATH
+echo "ISPC_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+echo "LLVM_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV

--- a/.github/workflows/scripts/install-test-deps.sh
+++ b/.github/workflows/scripts/install-test-deps.sh
@@ -6,7 +6,7 @@ for i in {1..5}
 do
   sudo apt-get update | tee log${i}.txt
   sudo apt-get install libc6-dev-i386 g++-multilib lib32stdc++6 | tee -a log${i}.txt
-  if [[ ! `grep "Err:" log${i}.txt` ]]; then
+  if [[ ! `grep "^Err: " log${i}.txt` && ! `grep "^E: " log${i}.txt` ]]; then
     echo "APT packages installation was successful"
     break
   else

--- a/alloy.py
+++ b/alloy.py
@@ -570,7 +570,7 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
 # stability constant options
         stability.save_bin = False
         stability.random = False
-        stability.ispc_flags = ""
+        stability.ispc_flags = options.ispc_flags
         stability.compiler_exe = None
         stability.num_jobs = speed_number
         stability.verbose = False
@@ -1040,7 +1040,9 @@ if __name__ == '__main__':
     run_group = OptionGroup(parser, "Options for validation run",
                     "These options must be used with -r option.")
     run_group.add_option('--compare-with', dest='branch',
-        help='set performance reference point. Dafault: main', default="main")
+        help='set performance reference point. Default: main', default="main")
+    run_group.add_option('--ispc-flags', dest='ispc_flags',
+        help='extra ispc flags.', default="")
     run_group.add_option('--number', dest='number_for_performance',
         help='number of performance runs for each test. Default: 5', default=5)
     run_group.add_option('--notify', dest='notify',

--- a/alloy.py
+++ b/alloy.py
@@ -130,7 +130,7 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     if  version_LLVM == "trunk":
         GIT_TAG="main"
     elif  version_LLVM == "13_0":
-        GIT_TAG="origin/release/13.x"
+        GIT_TAG="llvmorg-13.0.0"
     elif  version_LLVM == "12_0":
         GIT_TAG="llvmorg-12.0.1"
     elif  version_LLVM == "11_1":

--- a/alloy.py
+++ b/alloy.py
@@ -571,7 +571,7 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
         stability.save_bin = False
         stability.random = False
         stability.ispc_flags = options.ispc_flags
-        stability.compiler_exe = None
+        stability.compiler_exe = options.compiler_exe
         stability.num_jobs = speed_number
         stability.verbose = False
         stability.time = time
@@ -1041,6 +1041,8 @@ if __name__ == '__main__':
                     "These options must be used with -r option.")
     run_group.add_option('--compare-with', dest='branch',
         help='set performance reference point. Default: main', default="main")
+    run_group.add_option('--compiler', dest='compiler_exe',
+        help='C/C++ compiler binary to use to run tests.', default=None)
     run_group.add_option('--ispc-flags', dest='ispc_flags',
         help='extra ispc flags.', default="")
     run_group.add_option('--number', dest='number_for_performance',


### PR DESCRIPTION
* `alloy.py` to support two new switches `--compiler` and `--ispc-flags`
* Github Action pipeline to test SVML on Linux - triggered manually.
* More robust code in CI scripts to catch `apt-get` errors
* Move git tag used to build LLVM 13 in alloy.py to `13.0.0`.