### PR TITLE
Add testing with released LLVM 13.0 to CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@
 configuration: Release
 
 environment:
-  LLVM_LATEST: 12.0
+  LLVM_LATEST: 13.0
   DOCKER_PATH: "ispc/test_repo"
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1604
@@ -40,7 +40,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: latest
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      LLVM_VERSION: 11.1
+      LLVM_VERSION: 12.0
 
 for:
 -
@@ -58,7 +58,8 @@ for:
         if "%LLVM_VERSION%"=="latest" (set WASM=ON)
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( (set generator="Visual Studio 15 Win64") & (set vsversion=2017))
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vsversion=2019))
-        set LLVM_TAR=llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        set LLVM_TAR=llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        if "%LLVM_VERSION%"=="12.0" (set LLVM_TAR=llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
         if "%LLVM_VERSION%"=="11.1" (set LLVM_TAR=llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
   install:
     - ps: choco install --no-progress winflexbison3 wget 7zip
@@ -109,7 +110,7 @@ for:
         export LLVM_HOME=$APPVEYOR_BUILD_FOLDER/llvm
         export CROSS_TOOLS=/usr/local/src/cross
         export WASM=OFF
-        export LLVM_TAR=llvm-12.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        export LLVM_TAR=llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
   install:
     - sh: |-
         sudo apt-get update

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -95,7 +95,6 @@ jobs:
         name: ispc_llvm11_linux
         path: build/ispc-trunk-linux.tar.gz
 
-
   linux-build-ispc-llvm12:
     needs: [define-flow]
     runs-on: ubuntu-latest
@@ -132,6 +131,42 @@ jobs:
         name: ispc_llvm12_linux
         path: build/ispc-trunk-linux.tar.gz
 
+  linux-build-ispc-llvm13:
+    needs: [define-flow]
+    runs-on: ubuntu-latest
+    env:
+      LLVM_VERSION: "13.0"
+      LLVM_TAR: llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Install dependencies
+      run: |
+        .github/workflows/scripts/install-build-deps.sh
+
+    - name: Check environment
+      run: |
+        ./check_env.py
+        which -a clang
+        cat /proc/cpuinfo
+
+    - name: Build package
+      run: |
+        .github/workflows/scripts/build-ispc.sh
+
+    - name: Sanity testing (make check-all, make test)
+      run: |
+        .github/workflows/scripts/check-ispc.sh
+
+    - name: Upload package
+      uses: actions/upload-artifact@v2
+      with:
+        name: ispc_llvm13_linux
+        path: build/ispc-trunk-linux.tar.gz
+
   linux-test-llvm11:
     needs: [define-flow, linux-build-ispc-llvm11]
     runs-on: ubuntu-latest
@@ -158,7 +193,8 @@ jobs:
     - name: Running tests
       run: |
         echo PATH=$PATH
-        ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+        # Just sanity check for 11.1
+        ./alloy.py -r --only="stability current -O2" --only-targets="avx2-i32x8" --time --update-errors=FP
 
     - name: Check
       run: |
@@ -212,11 +248,51 @@ jobs:
         name: fail_db.llvm12.${{matrix.target}}.txt
         path: fail_db.txt
 
+  linux-test-llvm13:
+    needs: [define-flow, linux-build-ispc-llvm13]
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: ispc_llvm13_linux
+
+    - name: Install dependencies and unpack artifacts
+      run: |
+        .github/workflows/scripts/install-test-deps.sh
+
+    - name: Check environment
+      run: |
+        cat /proc/cpuinfo
+
+    - name: Running tests
+      run: |
+        echo PATH=$PATH
+        ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
+    - name: Upload fail_db.txt
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: fail_db.llvm13.${{matrix.target}}.txt
+        path: fail_db.txt
+
   # Debug run is experimental with the purpose to see if it's capable to catch anything.
   # So it's running in "full" mode only for now.
   # Single target, as it should be representative enough.
-  linux-test-debug-llvm12:
-    needs: [define-flow, linux-build-ispc-llvm12]
+  linux-test-debug-llvm13:
+    needs: [define-flow, linux-build-ispc-llvm13]
     if: ${{ needs.define-flow.outputs.flow_type == 'full' }}
     runs-on: ubuntu-latest
     continue-on-error: false
@@ -227,7 +303,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: ispc_llvm12_linux
+        name: ispc_llvm13_linux
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -251,7 +327,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: fail_db.llvm12.debug.txt
+        name: fail_db.llvm13.debug.txt
         path: fail_db.txt
 
   win-build-ispc-llvm11:
@@ -336,6 +412,46 @@ jobs:
         name: ispc_llvm12_win
         path: build/ispc-trunk-windows.msi
 
+  win-build-ispc-llvm13:
+    needs: [define-flow]
+    runs-on: windows-latest
+    env:
+      LLVM_VERSION: "13.0"
+      LLVM_TAR: llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_HOME: "C:\\projects\\llvm"
+      CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
+      BUILD_TYPE: "Release"
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Install dependencies
+      run: |
+        .github/workflows/scripts/install-build-deps.ps1
+
+    - name: Check environment
+      shell: cmd
+      run: |
+        wmic cpu get caption, deviceid, name, numberofcores, maxclockspeed, status
+
+    - name: Build package
+      run: |
+        .github/workflows/scripts/build-ispc.ps1
+
+    - name: Sanity testing (make check-all, make test)
+      run: |
+        .github/workflows/scripts/check-ispc.ps1
+
+    - name: Upload package
+      uses: actions/upload-artifact@v2
+      with:
+        name: ispc_llvm13_win
+        path: build/ispc-trunk-windows.msi
 
   win-test-llvm11:
     needs: [define-flow, win-build-ispc-llvm11]
@@ -369,7 +485,8 @@ jobs:
       run: |
         $env:ISPC_HOME = "$pwd"
         .github/workflows/scripts/load-vs-env.ps1 "${{ matrix.arch }}"
-        python .\alloy.py -r --only="stability ${{ matrix.arch }} current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+        # Just sanity check for 11.1
+        python .\alloy.py -r --only="stability ${{ matrix.arch }} current -O2" --only-targets="avx2-i32x8" --time --update-errors=FP
 
     - name: Check
       run: |
@@ -428,5 +545,51 @@ jobs:
       if: failure()
       with:
         name: fail_db.llvm12.${{matrix.arch}}.${{matrix.target}}.txt
+        path: fail_db.txt
+
+  win-test-llvm13:
+    needs: [define-flow, win-build-ispc-llvm13]
+    env:
+      LLVM_HOME: "C:\\projects\\llvm"
+    runs-on: windows-latest
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86, x86-64]
+        target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: ispc_llvm13_win
+
+    - name: Install dependencies
+      run: |
+        .github/workflows/scripts/install-test-deps.ps1
+
+    - name: Check environment
+      shell: cmd
+      run: |
+        wmic cpu get caption, deviceid, name, numberofcores, maxclockspeed, status
+
+    - name: Running tests
+      run: |
+        $env:ISPC_HOME = "$pwd"
+        .github/workflows/scripts/load-vs-env.ps1 "${{ matrix.arch }}"
+        python .\alloy.py -r --only="stability ${{ matrix.arch }} current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
+    - name: Upload fail_db.txt
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: fail_db.llvm13.${{matrix.arch}}.${{matrix.target}}.txt
         path: fail_db.txt
 

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -54,12 +54,12 @@ jobs:
         $RUN_SMOKE && echo "::set-output name=optsets::${OPTSETS_SMOKE}" || true
         $RUN_FULL &&  echo "::set-output name=optsets::${OPTSETS_FULL}" || true
 
-  linux-build-ispc-llvm12:
+  linux-build-ispc-llvm13:
     needs: [define-flow]
     runs-on: ubuntu-latest
     env:
-      LLVM_VERSION: "12.0"
-      LLVM_TAR: llvm-12.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "13.0"
+      LLVM_TAR: llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@v2
@@ -87,12 +87,12 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: ispc_llvm12_linux
+        name: ispc_llvm13_linux
         path: build/ispc-trunk-linux.tar.gz
 
 
-  linux-test-llvm12:
-    needs: [define-flow, linux-build-ispc-llvm12]
+  linux-test-llvm13:
+    needs: [define-flow, linux-build-ispc-llvm13]
     runs-on: ubuntu-latest
     continue-on-error: false
     strategy:
@@ -104,7 +104,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: ispc_llvm12_linux
+        name: ispc_llvm13_linux
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -129,6 +129,6 @@ jobs:
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: fail_db.llvm12.${{matrix.target}}.txt
+        name: fail_db.llvm13.${{matrix.target}}.txt
         path: fail_db.txt
 

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -1,4 +1,4 @@
-name: Linux benchmarks / LLVM 12.0
+name: Linux benchmarks / LLVM 13.0
 
 on:
   pull_request_target:
@@ -10,9 +10,9 @@ on:
   workflow_dispatch:
 
 env:
-  LLVM_VERSION: "12.0"
+  LLVM_VERSION: "13.0"
   LLVM_REPO: https://github.com/ispc/llvm-project
-  LLVM_TAR: llvm-12.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+  LLVM_TAR: llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
 
 jobs:
   linux-build:
@@ -58,7 +58,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: ispc_llvm11_linux_bench
+        name: ispc_llvm13_linux_bench
         path: build/ispc-trunk-linux.tar.gz
 
   benchmarks:
@@ -69,7 +69,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: ispc_llvm11_linux_bench
+        name: ispc_llvm13_linux_bench
     - name: Install dependencies and unpack artifacts
       run: |
         tar xvf ispc-trunk-linux.tar.gz

--- a/.github/workflows/nightly-13.yml
+++ b/.github/workflows/nightly-13.yml
@@ -1,14 +1,15 @@
 # Nightly Linux run.
 
+####################################################################
+# Currently disabled. To be reenabled for 14.0 when it's branched. #
+####################################################################
+
 name: Nightly tests / LLVM 13.0
 
 # Run daily - test sse2-avx512 targets @ -O0/-O1/-O2
 on:
-  schedule:
-    - cron:  '0 7 * * *'
-  push:
-    branches:
-      - '**test_nightly**'
+  #  schedule:
+  #    - cron:  '0 7 * * *'
   workflow_dispatch:
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ sudo: required
 jobs:
   include:
     # ARM build
-    # LLVM 12.0 + Ubuntu 18.04:
+    # LLVM 13.0 + Ubuntu 18.04:
     #   - ARM only (default): build, lit tests, examples (build)
     #   - ARM + x86: build, lit tests, examples (build), tests (aarch64)
     - stage: test
@@ -50,8 +50,8 @@ jobs:
       arch: arm64
       dist: bionic
       env:
-        - LLVM_VERSION=12.0 OS=Ubuntu18.04aarch64
-        - LLVM_TAR=llvm-12.0.1-ubuntu16.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_VERSION=13.0 OS=Ubuntu18.04aarch64
+        - LLVM_TAR=llvm-13.0.0-ubuntu16.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
         - LLVM_REPO=https://github.com/ispc/llvm-project
         - ISPC_HOME=$TRAVIS_BUILD_DIR
       before_install:

--- a/alloy.py
+++ b/alloy.py
@@ -687,13 +687,6 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
                     print_debug("Warning: target " + stability.target + " is not supported in LLVM " + LLVM[i] + "\n", False, stability_log)
                     continue
 
-                # *always* specify default values for global variables on each loop iteration
-                stability.wrapexe = ""
-                stability.compiler_exe = None
-                # choosing right compiler for a given target
-                # sometimes clang++ is not avaluable. if --ispc-build-compiler = gcc we will pass in g++ compiler
-                if options.ispc_build_compiler == "gcc":
-                    stability.compiler_exe = "g++"
                 # now set archs for targets
                 arch = archs
                 for i1 in range(0,len(arch)):
@@ -712,13 +705,7 @@ def validation_run(only, only_targets, reference_branch, number, notify, update,
                 if (stability.target in unsupported_llvm_targets(LLVM[i])):
                     print_debug("Warning: target " + stability.target + " is not supported in LLVM " + LLVM[i] + "\n", False, stability_log)
                     continue
-                # *always* specify default values for global variables on each loop iteration
-                stability.wrapexe = ""
-                stability.compiler_exe = None
-                # choosing right compiler for a given target
-                # sometimes clang++ is not avaluable. if --ispc-build-compiler = gcc we will pass in g++ compiler
-                if options.ispc_build_compiler == "gcc":
-                    stability.compiler_exe = "g++"
+
                 stability.wrapexe = get_sde() + " " + sde_targets[j][0] + " -- "
                 arch = archs
                 for i1 in range(0,len(arch)):


### PR DESCRIPTION
This also has a missing patch for `alloy.py` to work properly with `--compiler` switch is defined.