### PR TITLE
Update vim syntax file

### DIFF
--- a/contrib/ispc.vim
+++ b/contrib/ispc.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
-" Language:	ISPC
-" Maintainer:	Andreas Wendleder <andreas.wendleder@gmail.com>
-" Last Change:	2016 May 04
+" Language:		ISPC
+" Maintainer:		Dmitry Babokin <dmitry.y.babokin@intel.com>
+" Previous Maintainer:	Andreas Wendleder <andreas.wendleder@gmail.com>
+" Last Change:		December 7, 2021
 
 " Quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -13,29 +14,48 @@ runtime! syntax/c.vim
 unlet b:current_syntax
 
 " New keywords
-syn keyword	ispcStatement	cbreak ccontinue creturn launch print reference soa sync
-syn keyword	ispcConditional	cif
-syn keyword	ispcRepeat	cdo cfor cwhile foreach foreach_tiled foreach_unique foreach_active
-syn keyword	ispcBuiltin	programCount programIndex taskCount taskCount0 taskCount1 taskCount3 taskIndex taskIndex0 taskIndex1 taskIndex2
-syn keyword	ispcType	export uniform varying int8 int16 int32 int64 task new delete
-syn keyword	ispcOperator	operator
+syn keyword	ispcStatement		assert assume cbreak ccontinue creturn delete launch new print soa sync task unmasked
+syn keyword	ispcConditional		cif
+syn keyword	ispcRepeat		cdo cfor cwhile foreach foreach_tiled foreach_unique foreach_active
+syn keyword	ispcBuiltin		programCount programIndex taskCount taskCount0 taskCount1 taskCount3 taskIndex taskIndex0 taskIndex1 taskIndex2
+syn keyword	ispcType		export uniform varying int8 int16 int32 int64 uint8 uint16 uint32 uint64 float16
+syn keyword	ispcOperator		operator in
+syn keyword	ispcStorageClass	noinline __vectorcall
+syn keyword	ispcDefine		ISPC ISPC_POINTER_SIZE ISPC_MAJOR_VERSION ISPC_MINOR_VERSION TARGET_WIDTH PI
+					\ TARGET_ELEMENT_WIDTH ISPC_UINT_IS_DEFINED ISPC_FP64_SUPPORTED ISPC_LLVM_INTRINSICS_ENABLED
+					\ ISPC_TARGET_NEON ISPC_TARGET_SSE2 ISPC_TARGET_SSE4 ISPC_TARGET_AVX ISPC_TARGET_AVX2 ISPC_TARGET_AVX512KNL ISPC_TARGET_AVX512SKX
 
-"double precision floating point number, with dot, optional exponent
-syn match	cFloat		display contained "\d\+\.\d*d[-+]\=\d*\>"
-"double precision floating point number, starting with dot, optional exponent
-syn match	cFloat		display contained ".\d*d[-+]\=\d*\>"
-"double precision floating point number, without dot, with exponent
-syn match	cFloat		display contained "\d\+d[-+]\=\d\+\>"
+
+" LLVM intrinsics are ISPC intrinsics
+syn match	ispcLLVMIntrin	display "@llvm\(\.\w\+\)\+"
+" ... operator
+syn match	ispcOperator	display "\.\.\."
+
+" Integer literals (in binary, decimal, or hex form), with k/M/G suffix and u/U, l/L, ll/LL suffixes.
+syn match	cNumber		display contained "\(\d\+\|0[xX]\x\+\|0[bB][01]\+\)[kMG]\=\([uU]\=\([lL]\|ll\|LL\)\|\([lL]\|ll\|LL\)\=[uU]\)\>"
+
+" Decimal floating point literal with optional suffix
+syn match	cFloat		display contained "\(\(\d\+\.\d*\)\|\(\.\d\+\)\)\([fF]16\|[dDfF]\)\=\>"
+" [Depricated] decimal floating point literal with "f" suffix, but " without radix separator
+syn match	cFloat		display contained "\d\+[fF]\>"
+" Scientific notation floating point literals with optional suffix
+syn match	cFloat		display contained "\(\(\d\+\.\d*\)\|\(\.\d\+\)\|\d\+\)[eE][-+]\=\d\+\([fF]16\|[dDfF]\)\=\>"
+" Hexadecimal floating point numbers - subset of C++17 hexadecimals, with optional suffix
+syn match	cFloat		display contained "0[xX][01]\(.\x\+\)\=[pP][-+]\=\d\+\([fF]16\|[dDfF]\)\=\>"
+" "Fortran double format" - same as scientific notation, but with d/D instead of e/E
+syn match	cFloat		display contained "\(\(\d\+\.\d*\)\|\(\.\d\+\)\|\d\+\)[dD][-+]\=\d\+\>"
 
 " Default highlighting
 command -nargs=+ HiLink hi def link <args>
 HiLink ispcStatement	Statement
+HiLink ispcLLVMIntrin	Statement
 HiLink ispcConditional	Conditional
 HiLink ispcRepeat	Repeat
 HiLink ispcBuiltin	Statement
 HiLink ispcType		Type
 HiLink ispcOperator	Operator
+HiLink ispcDefine	Define
+HiLink ispcStorageClass	StorageClass
 delcommand HiLink
 
 let b:current_syntax = "ispc"
-


### PR DESCRIPTION
Update vim syntax highlighting file to accommodate ISPC language changes, and fix inaccuracies:
- add `assert`, `assume`, `task`, and `unmasked` to statements
- moved `new` and `delete` from types to statements
- remove `reference` from statement list (not sure why it was there)
- add `uint8`, `uint16`, `uint32`, `uint64`, and `float16` types
- add `in` and `...` operators
- add `noinline` and `__vectorcall` as "storage class". Note `inline` is part of C syntax
- add all macros defined in ISPC.
- add llvm instrinsic calls support (@llvm.x86.blah-blah)
- properly define ISPC integer literals. Key differences are binary format support and [kMG] suffixes. Note that the suffix syntax is more restrictive that real patterns accepted by ISPC. The intent is to fix the parser to match this syntax file
- properly define ISPC fp literals, including `float16` literals. These literals are not exactly what is supported by C. The differences are: (1) `f16`/`F16` suffix, (2) `d`/`D` suffix, which is not supported by C in general, but exists as gcc extension only (not supported by vim C syntax), (3) hexadecimal are more restrictive that C++17 hexadecimal (though they are not in C anyway), (4) Fortran double format (it was there already, I've compacted 3 rules to 1).

Things that need improvement:
- operator `...` is not recognized when used without spaces around it, i.e. `foreach (i = 1...100) {}`. The problem is that `1.` will be matched by FP literals pattern (those from C syntax file). To fix this we need remove `cFloat` definition from C and keep our own only. And finish it with the rule "not match an extra trailing dot", i.e. `\.\@!`. This is not possible when including C syntax.

After committing these changes and letting them sit for a while, I plan to start discussion on vim mailing list about adding this to vim official distribution.

CC @Twinklebear as I noticed you have a dedicated repo for ISPC vim syntax.