### PR TITLE
Updates for Xe targets (3)

### DIFF
--- a/docs/ispc_for_xe.rst
+++ b/docs/ispc_for_xe.rst
@@ -156,7 +156,10 @@ The ``ISPC Run Time`` uses the following abstractions to manage code execution:
 
 * ``Module`` - represents a set of ``kernels`` that are compiled together and
   thus can share some common code. In this sense, SPIR-V file produced by ``ispc``
-  is a ``module`` for the ``ISPCRT``.
+  is a ``module`` for the ``ISPCRT``. User can provide additional options for
+  module compilation using ``ISPCRTModuleOptions``. Currently ``ISPCRTModuleOptions``
+  structure allows to set stack size for VC backend which is used to compile SPIR-V.
+  The set of supported options will be extended as needed.
 
 * ``Kernel`` - is a function that is an entry point to a ``module`` and can be
   called by inserting kernel execution command into a ``task queue``. A kernel

--- a/examples/xpu/aobench/ao.cpp
+++ b/examples/xpu/aobench/ao.cpp
@@ -149,7 +149,8 @@ static int run() {
         auto p_dev = ispcrtNewMemoryView(device, &p, sizeof(p), &flags);
 
         // Create module and kernel to execute
-        auto module = ispcrtLoadModule(device, "xe_aobench");
+        ISPCRTModuleOptions options = {};
+        auto module = ispcrtLoadModule(device, "xe_aobench", options);
         auto kernel = ispcrtNewKernel(device, module, "ao_ispc");
         // Create task queue and execute kernel
         auto queue = ispcrtNewTaskQueue(device);

--- a/examples/xpu/aobench/ao.cpp
+++ b/examples/xpu/aobench/ao.cpp
@@ -163,14 +163,10 @@ static int run() {
         for (unsigned int i = 0; i < niterations; i++) {
             memset((void *)fimg, 0, sizeof(float) * width * height * 3);
             ispcrtCopyToDevice(queue, p_dev);
-            ispcrtDeviceBarrier(queue);
-            ispcrtSync(queue);
             reset_and_start_timer();
             auto res = ispcrtLaunch2D(queue, kernel, p_dev, height * width / 16, 1);
             ispcrtRetain(res);
-            ispcrtDeviceBarrier(queue);
             ispcrtCopyToHost(queue, buf_dev);
-            ispcrtDeviceBarrier(queue);
             ispcrtSync(queue);
 
             if (ispcrtFutureIsValid(res)) {

--- a/examples/xpu/mandelbrot/mandelbrot.cpp
+++ b/examples/xpu/mandelbrot/mandelbrot.cpp
@@ -131,13 +131,8 @@ static int run(unsigned int width, unsigned int height, unsigned int test_iterat
         for (unsigned int i = 0; i < test_iterations[0]; ++i) {
             reset_and_start_timer();
             queue.copyToDevice(p_dev);
-            queue.barrier();
-            queue.submit();
-            queue.sync();
             auto res = queue.launch(kernel, p_dev, width / p.tile_size, height / p.tile_size);
-            queue.barrier();
             queue.copyToHost(buf_dev);
-            queue.barrier();
             queue.sync();
             if (res.valid()) {
                 kernelTicks = res.time() * 1e-6;

--- a/examples/xpu/noise/noise.cpp
+++ b/examples/xpu/noise/noise.cpp
@@ -117,11 +117,8 @@ static int run(int niter, int gx, int gy) {
         for (unsigned int i = 0; i < niter; i++) {
             reset_and_start_timer();
             queue.copyToDevice(p_dev);
-            queue.barrier();
             auto res = queue.launch(kernel, p_dev, gx, gy);
-            queue.barrier();
             queue.copyToHost(buf_dev);
-            queue.barrier();
             queue.sync();
             if (res.valid()) {
                 kernelTicks = res.time() * 1e-6;

--- a/examples/xpu/simple-dpcpp/simple-dpcpp.cpp
+++ b/examples/xpu/simple-dpcpp/simple-dpcpp.cpp
@@ -75,21 +75,12 @@ std::vector<float> DpcppApp::transformIspc(std::vector<float> &in) {
     m_queue.copyToDevice(p_dev);
     m_queue.copyToDevice(in_dev);
 
-    // Make sure that input arrays were copied
-    m_queue.barrier();
-
     // Launch the kernel on the device using 1 thread
     m_queue.launch(m_kernel, p_dev, 1);
-
-    // Make sure that execution completed
-    m_queue.barrier();
 
     // ispcrt::Array objects which used as outputs of ISPC kernel should be
     // explicitly copied to host from device
     m_queue.copyToHost(out_dev);
-
-    // Make sure that input arrays were copied
-    m_queue.barrier();
 
     // Execute queue and sync
     m_queue.sync();

--- a/examples/xpu/simple-esimd/simple.cpp
+++ b/examples/xpu/simple-esimd/simple.cpp
@@ -98,21 +98,12 @@ static int run(const ISPCRTDeviceType device_type, const unsigned int SIZE) {
     queue.copyToDevice(p_dev);
     queue.copyToDevice(vin_dev);
 
-    // Make sure that input arrays were copied
-    queue.barrier();
-
     // Launch the kernel on the device using 1 thread
     queue.launch(kernel, p_dev, 1);
-
-    // Make sure that execution completed
-    queue.barrier();
 
     // ispcrt::Array objects which used as outputs of ISPC kernel should be
     // explicitly copied to host from device
     queue.copyToHost(vout_dev);
-
-    // Make sure that input arrays were copied
-    queue.barrier();
 
     // Execute queue and sync
     queue.sync();

--- a/examples/xpu/simple/simple.cpp
+++ b/examples/xpu/simple/simple.cpp
@@ -126,10 +126,8 @@ static int run(const ISPCRTDeviceType device_type, const unsigned int SIZE) {
     // explicitly copied to device from host
     queue.copyToDevice(p_dev);
     queue.copyToDevice(vin_dev);
-
     // Launch the kernel on the device using 1 thread
     auto res = queue.launch(kernel, p_dev, 1);
-
     // ispcrt::Array objects which used as outputs of ISPC kernel should be
     // explicitly copied to host from device
     queue.copyToHost(vout_dev);

--- a/examples/xpu/simple/simple.cpp
+++ b/examples/xpu/simple/simple.cpp
@@ -127,25 +127,20 @@ static int run(const ISPCRTDeviceType device_type, const unsigned int SIZE) {
     queue.copyToDevice(p_dev);
     queue.copyToDevice(vin_dev);
 
-    // Make sure that input arrays were copied
-    queue.barrier();
-
     // Launch the kernel on the device using 1 thread
-    queue.launch(kernel, p_dev, 1);
-
-    // Make sure that execution completed
-    queue.barrier();
+    auto res = queue.launch(kernel, p_dev, 1);
 
     // ispcrt::Array objects which used as outputs of ISPC kernel should be
     // explicitly copied to host from device
     queue.copyToHost(vout_dev);
 
-    // Make sure that input arrays were copied
-    queue.barrier();
-
     // Execute queue and sync
     queue.sync();
-
+    double time = -1.0;
+    if (res.valid()) {
+        time = res.time() * 1e-6;
+    }
+    std::cout << time << std::endl;
     std::cout << "Executed on: " << device_type << '\n' << std::setprecision(6) << std::fixed;
 
     // Check and print result

--- a/examples/xpu/simple/simple.cpp
+++ b/examples/xpu/simple/simple.cpp
@@ -131,7 +131,6 @@ static int run(const ISPCRTDeviceType device_type, const unsigned int SIZE) {
     // ispcrt::Array objects which used as outputs of ISPC kernel should be
     // explicitly copied to host from device
     queue.copyToHost(vout_dev);
-
     // Execute queue and sync
     queue.sync();
     double time = -1.0;

--- a/fail_db.txt
+++ b/fail_db.txt
@@ -1,4 +1,3 @@
- List of known fails.
 % The list is unordered and contains information about commonly used platforms / configurations.
 % Our goal is to maintain this list for Linux, macOS and Windows with reasonably new compilers.
 % Note, that it's important which C++ compiler was used.
@@ -6,5 +5,12 @@
 % LLVM bugs in released versions, that we have to workaround by applying patches (see llvm_patches
 % folder). The recommended way to build LLVM on Unix is to use "alloy.py".
 %
-./tests/short-vec-6.ispc runfail  xe64        gen9-x8 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
-./tests/short-vec-6.ispc runfail  xe64       gen9-x16 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
+ List of known fails.
+./tests/funcptr-varying-3.ispc runfail    xe64        gen9-x8 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
+./tests/recursion-forward-func-decl.ispc runfail    xe64        gen9-x8 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
+./tests/recursion.ispc runfail    xe64        gen9-x8 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
+./tests/funcptr-varying-3.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
+./tests/recursion-forward-func-decl.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
+./tests/recursion.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
+./tests/short-vec-6.ispc runfail    xe64        gen9-x8 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
+./tests/short-vec-6.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *

--- a/ispcrt/detail/Device.h
+++ b/ispcrt/detail/Device.h
@@ -22,7 +22,7 @@ struct Device : public RefCounted {
 
     virtual TaskQueue *newTaskQueue() const = 0;
 
-    virtual Module *newModule(const char *moduleFile) const = 0;
+    virtual Module *newModule(const char *moduleFile, const ISPCRTModuleOptions &opts) const = 0;
 
     virtual Kernel *newKernel(const Module &module, const char *name) const = 0;
 

--- a/ispcrt/detail/cpu/CPUDevice.cpp
+++ b/ispcrt/detail/cpu/CPUDevice.cpp
@@ -200,7 +200,7 @@ ispcrt::base::MemoryView *CPUDevice::newMemoryView(void *appMem, size_t numBytes
 
 ispcrt::base::TaskQueue *CPUDevice::newTaskQueue() const { return new cpu::TaskQueue(); }
 
-ispcrt::base::Module *CPUDevice::newModule(const char *moduleFile) const { return new cpu::Module(moduleFile); }
+ispcrt::base::Module *CPUDevice::newModule(const char *moduleFile, const ISPCRTModuleOptions &moduleOpts) const { return new cpu::Module(moduleFile); }
 
 ispcrt::base::Kernel *CPUDevice::newKernel(const ispcrt::base::Module &module, const char *name) const {
     return new cpu::Kernel(module, name);

--- a/ispcrt/detail/cpu/CPUDevice.h
+++ b/ispcrt/detail/cpu/CPUDevice.h
@@ -22,7 +22,7 @@ struct CPUDevice : public base::Device {
 
     base::TaskQueue *newTaskQueue() const override;
 
-    base::Module *newModule(const char *moduleFile) const override;
+    base::Module *newModule(const char *moduleFile, const ISPCRTModuleOptions &moduleOpts) const override;
 
     base::Kernel *newKernel(const base::Module &module, const char *name) const override;
 

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -325,13 +325,13 @@ struct CommandList {
     std::vector<Event *> m_events;
 };
 
-typedef enum { ISPCRT_EVENT_POOL_COMPUTE, ISPCRT_EVENT_POOL_COPY } ISPCRTEventPoolType;
+enum class ISPCRTEventPoolType { compute, copy };
 
 struct EventPool {
     constexpr static uint32_t POOL_SIZE_CAP = 100000;
 
     EventPool(ze_context_handle_t context, ze_device_handle_t device,
-              ISPCRTEventPoolType type = ISPCRTEventPoolType::ISPCRT_EVENT_POOL_COMPUTE)
+              ISPCRTEventPoolType type = ISPCRTEventPoolType::compute)
         : m_context(context), m_device(device) {
         // Get device timestamp resolution
         ze_device_properties_t device_properties;
@@ -341,7 +341,7 @@ struct EventPool {
         // Create pool
         auto poolSize = POOL_SIZE_CAP;
         // For compute event pool check if ISPCRT_MAX_KERNEL_LAUNCHES is set
-        if (type == ISPCRTEventPoolType::ISPCRT_EVENT_POOL_COMPUTE) {
+        if (type == ISPCRTEventPoolType::compute) {
             // User can set a lower limit for the pool size, which in fact limits
             // the number of possible kernel launches. To make it more clear for the user,
             // the variable is named ISPCRT_MAX_KERNEL_LAUNCHES
@@ -649,7 +649,8 @@ struct Kernel : public ispcrt::base::Kernel {
 
 struct TaskQueue : public ispcrt::base::TaskQueue {
     TaskQueue(ze_device_handle_t device, ze_context_handle_t context, const bool is_mock_dev)
-        : m_ep_compute(context, device, ISPCRT_EVENT_POOL_COMPUTE), m_ep_copy(context, device, ISPCRT_EVENT_POOL_COPY) {
+        : m_ep_compute(context, device, ISPCRTEventPoolType::compute),
+          m_ep_copy(context, device, ISPCRTEventPoolType::copy) {
         m_context = context;
         m_device = device;
 

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -807,12 +807,6 @@ struct TaskQueue : public ispcrt::base::TaskQueue {
         return future;
     }
 
-    void submit() override {
-        m_cl_mem_h2d->submit(m_q_copy);
-        m_cl_compute->submit(m_q_compute);
-        m_cl_mem_d2h->submit(m_q_copy);
-    }
-
     void sync() override {
         // Submit command lists
         submit();
@@ -899,6 +893,12 @@ struct TaskQueue : public ispcrt::base::TaskQueue {
 
         if (q == nullptr)
             throw std::runtime_error("Failed to create command queue!");
+    }
+
+    void submit() override {
+        m_cl_mem_h2d->submit(m_q_copy);
+        m_cl_compute->submit(m_q_compute);
+        m_cl_mem_d2h->submit(m_q_copy);
     }
 
     bool anyH2DCopyCommand() { return m_cl_mem_h2d->count() > 0; }

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -276,13 +276,17 @@ struct CommandList {
 
     uint32_t ordinal() { return m_ordinal; }
 
+    void clear() {
+        m_numCommands = 0;
+        m_events.clear();
+        m_submitted = false;
+    }
+
     void reset() {
         if (m_numCommands > 0) {
             L0_SAFE_CALL(zeCommandListReset(m_handle));
         }
-        m_submitted = false;
-        m_numCommands = 0;
-        m_events.clear();
+        clear();
     }
 
     void submit(ze_command_queue_handle_t q) {
@@ -293,7 +297,10 @@ struct CommandList {
         }
     }
 
-    void inc() { m_numCommands++; }
+    void inc() {
+        m_numCommands++;
+        m_submitted = false;
+    }
 
     uint32_t count() { return m_numCommands; }
 

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -648,8 +648,17 @@ struct TaskQueue : public ispcrt::base::TaskQueue {
 
         uint32_t copyOrdinal = std::numeric_limits<uint32_t>::max();
         uint32_t computeOrdinal = 0;
+        bool isCopyEngineEnabled = true;
+#if defined(_WIN32) || defined(_WIN64)
+        char *is_disable_copy_eng_s = nullptr;
+        size_t is_disable_copy_eng_sz = 0;
+        _dupenv_s(&is_disable_copy_eng_s, &is_disable_copy_eng_sz, "ISPCRT_DISABLE_COPY_ENGINE");
+        isCopyEngineEnabled = (is_disable_copy_eng_s == nullptr);
+#else
+        isCopyEngineEnabled = getenv("ISPCRT_DISABLE_COPY_ENGINE") == nullptr;
+#endif
 
-        if (!is_mock_dev) {
+        if (!is_mock_dev && isCopyEngineEnabled) {
             // Discover all command queue groups
             uint32_t queueGroupCount = 0;
             L0_SAFE_CALL(zeDeviceGetCommandQueueGroupProperties(device, &queueGroupCount, nullptr));

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -790,6 +790,10 @@ struct TaskQueue : public ispcrt::base::TaskQueue {
         std::array<uint32_t, 3> suggestedGroupSize = {0};
         L0_SAFE_CALL(zeKernelSuggestGroupSize(kernel.handle(), dim0, dim1, dim2, &suggestedGroupSize[0],
                                               &suggestedGroupSize[1], &suggestedGroupSize[2]));
+        // TODO: Is this needed? Didn't find info in spec on the valid values that zeKernelSuggestGroupSize will return
+        suggestedGroupSize[0] = std::max(suggestedGroupSize[0], uint32_t(1));
+        suggestedGroupSize[1] = std::max(suggestedGroupSize[1], uint32_t(1));
+        suggestedGroupSize[2] = std::max(suggestedGroupSize[2], uint32_t(1));
 
         L0_SAFE_CALL(
             zeKernelSetGroupSize(kernel.handle(), suggestedGroupSize[0], suggestedGroupSize[1], suggestedGroupSize[2]));

--- a/ispcrt/detail/gpu/GPUDevice.h
+++ b/ispcrt/detail/gpu/GPUDevice.h
@@ -28,7 +28,7 @@ struct GPUDevice : public base::Device {
 
     base::TaskQueue *newTaskQueue() const override;
 
-    base::Module *newModule(const char *moduleFile) const override;
+    base::Module *newModule(const char *moduleFile, const ISPCRTModuleOptions &opts) const override;
 
     base::Kernel *newKernel(const base::Module &module, const char *name) const override;
 

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -222,9 +222,9 @@ ISPCRT_CATCH_END(nullptr)
 // Kernels ////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 
-ISPCRTModule ispcrtLoadModule(ISPCRTDevice d, const char *moduleFile) ISPCRT_CATCH_BEGIN {
+ISPCRTModule ispcrtLoadModule(ISPCRTDevice d, const char *moduleFile, ISPCRTModuleOptions moduleOpts) ISPCRT_CATCH_BEGIN {
     const auto &device = referenceFromHandle<ispcrt::base::Device>(d);
-    return (ISPCRTModule)device.newModule(moduleFile);
+    return (ISPCRTModule)device.newModule(moduleFile, moduleOpts);
 }
 ISPCRT_CATCH_END(nullptr)
 

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -290,12 +290,6 @@ ISPCRTFuture ispcrtLaunch3D(ISPCRTTaskQueue q, ISPCRTKernel k, ISPCRTMemoryView 
 }
 ISPCRT_CATCH_END(nullptr)
 
-void ispcrtSubmit(ISPCRTTaskQueue q) ISPCRT_CATCH_BEGIN {
-    auto &queue = referenceFromHandle<ispcrt::base::TaskQueue>(q);
-    queue.submit();
-}
-ISPCRT_CATCH_END()
-
 void ispcrtSync(ISPCRTTaskQueue q) ISPCRT_CATCH_BEGIN {
     auto &queue = referenceFromHandle<ispcrt::base::TaskQueue>(q);
     queue.sync();

--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -107,8 +107,11 @@ void *ispcrtSharedPtr(ISPCRTMemoryView);
 size_t ispcrtSize(ISPCRTMemoryView);
 
 // Kernels ////////////////////////////////////////////////////////////////////
+typedef struct {
+    uint32_t stackSize;
+} ISPCRTModuleOptions;
 
-ISPCRTModule ispcrtLoadModule(ISPCRTDevice, const char *moduleFile);
+ISPCRTModule ispcrtLoadModule(ISPCRTDevice, const char *moduleFile, ISPCRTModuleOptions);
 ISPCRTKernel ispcrtNewKernel(ISPCRTDevice, ISPCRTModule, const char *name);
 
 // Task queues ////////////////////////////////////////////////////////////////

--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -129,7 +129,6 @@ ISPCRTFuture ispcrtLaunch2D(ISPCRTTaskQueue, ISPCRTKernel, ISPCRTMemoryView para
 ISPCRTFuture ispcrtLaunch3D(ISPCRTTaskQueue, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0, size_t dim1,
                             size_t dim2);
 
-void ispcrtSubmit(ISPCRTTaskQueue);
 void ispcrtSync(ISPCRTTaskQueue);
 
 // Futures and task timing ////////////////////////////////////////////////////

--- a/ispcrt/ispcrt.hpp
+++ b/ispcrt/ispcrt.hpp
@@ -419,8 +419,6 @@ inline Future TaskQueue::launch(const Kernel &k, const Array<T,AT> &p, size_t di
     return ispcrtLaunch3D(handle(), k.handle(), p.handle(), dim0, dim1, dim2);
 }
 
-inline void TaskQueue::submit() const { ispcrtSubmit(handle()); }
-
 inline void TaskQueue::sync() const { ispcrtSync(handle()); }
 
 inline void* TaskQueue::nativeTaskQueueHandle() const { return ispcrtTaskQueueNativeHandle(handle()); }

--- a/ispcrt/ispcrt.hpp
+++ b/ispcrt/ispcrt.hpp
@@ -319,16 +319,17 @@ template <typename T> using SharedVector = std::vector<T, ispcrt::SharedMemoryAl
 // Module wrapper ///////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
 
+
 class Module : public GenericObject<ISPCRTModule> {
   public:
     Module() = default;
-    Module(const Device &device, const char *moduleName);
+    Module(const Device &device, const char *moduleName, const ISPCRTModuleOptions &opts = ISPCRTModuleOptions{});
 };
 
 // Inlined definitions //
 
-inline Module::Module(const Device &device, const char *moduleName)
-    : GenericObject<ISPCRTModule>(ispcrtLoadModule(device.handle(), moduleName)) {}
+inline Module::Module(const Device &device, const char *moduleName, const ISPCRTModuleOptions &opts)
+    : GenericObject<ISPCRTModule>(ispcrtLoadModule(device.handle(), moduleName, opts)) {}
 
 /////////////////////////////////////////////////////////////////////////////
 // Kernel wrapper ///////////////////////////////////////////////////////////

--- a/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
+++ b/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
@@ -294,6 +294,32 @@ ze_result_t zeKernelSetIndirectAccess(ze_kernel_handle_t hKernel, ze_kernel_indi
     MOCK_RET;
 }
 
+ze_result_t zeKernelSuggestGroupSize(ze_kernel_handle_t hKernel, uint32_t globalSizeX,
+                                     uint32_t globalSizeY, uint32_t globalSizeZ,
+                                     uint32_t* groupSizeX, uint32_t* groupSizeY,
+                                     uint32_t* groupSizeZ) {
+    MOCK_CNT_CALL;
+    if (hKernel != KernelHandle.get()) {
+        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
+    }
+    if (groupSizeX == NULL || groupSizeY == NULL || groupSizeZ == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    *groupSizeX = 1;
+    *groupSizeY = 1;
+    *groupSizeZ = 1;
+    MOCK_RET;
+}
+
+ze_result_t zeKernelSetGroupSize(ze_kernel_handle_t hKernel, uint32_t groupSizeX,
+                                 uint32_t groupSizeY, uint32_t groupSizeZ) {
+    MOCK_CNT_CALL;
+    if (hKernel != KernelHandle.get()) {
+        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
+    }
+    MOCK_RET;
+}
+
 ze_result_t zeCommandListAppendLaunchKernel(ze_command_list_handle_t hCommandList, ze_kernel_handle_t hKernel,
                                             const ze_group_count_t *pLaunchFuncArgs, ze_event_handle_t hSignalEvent,
                                             uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents) {
@@ -374,6 +400,8 @@ ze_result_t zeGetKernelProcAddrTable(ze_api_version_t version, ze_kernel_dditabl
     pDdiTable->pfnDestroy = ispcrt::testing::mock::driver::zeKernelDestroy;
     pDdiTable->pfnSetArgumentValue = ispcrt::testing::mock::driver::zeKernelSetArgumentValue;
     pDdiTable->pfnSetIndirectAccess = ispcrt::testing::mock::driver::zeKernelSetIndirectAccess;
+    pDdiTable->pfnSetGroupSize = ispcrt::testing::mock::driver::zeKernelSetGroupSize;
+    pDdiTable->pfnSuggestGroupSize = ispcrt::testing::mock::driver::zeKernelSuggestGroupSize;
     return ZE_RESULT_SUCCESS;
 }
 

--- a/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
+++ b/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
@@ -213,7 +213,17 @@ ze_result_t zeEventDestroy(ze_event_handle_t hEvent) {
     MOCK_RET;
 }
 
+ze_result_t zeEventQueryStatus(ze_event_handle_t hEvent) {
+    MOCK_CNT_CALL;
+    MOCK_RET;
+}
+
 ze_result_t zeEventQueryKernelTimestamp(ze_event_handle_t hEvent, ze_kernel_timestamp_result_t *dstptr) {
+    MOCK_CNT_CALL;
+    MOCK_RET;
+}
+
+ze_result_t zeEventHostReset(ze_event_handle_t hEvent) {
     MOCK_CNT_CALL;
     MOCK_RET;
 }
@@ -348,6 +358,8 @@ ze_result_t zeGetEventProcAddrTable(ze_api_version_t version, ze_event_dditable_
     pDdiTable->pfnCreate = ispcrt::testing::mock::driver::zeEventCreate;
     pDdiTable->pfnDestroy = ispcrt::testing::mock::driver::zeEventDestroy;
     pDdiTable->pfnQueryKernelTimestamp = ispcrt::testing::mock::driver::zeEventQueryKernelTimestamp;
+    pDdiTable->pfnQueryStatus = ispcrt::testing::mock::driver::zeEventQueryStatus;
+    pDdiTable->pfnHostReset = ispcrt::testing::mock::driver::zeEventHostReset;
     return ZE_RESULT_SUCCESS;
 }
 

--- a/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
+++ b/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
@@ -20,6 +20,10 @@ static unsigned MockHandleHandle = 1;
 
 template <typename HT> struct MockHandle {
     HT get() { return handle; }
+    HT create() {
+        handle = reinterpret_cast<HT>(MockHandleHandle++);
+        return handle;
+    }
     MockHandle() { handle = reinterpret_cast<HT>(MockHandleHandle++); }
 
   private:
@@ -105,29 +109,30 @@ ze_result_t zeCommandQueueCreate(ze_context_handle_t hContext, ze_device_handle_
     if (!ExpectedDevice(hDevice) || hContext != ContextHandle.get() || desc == nullptr ||
         phCommandQueue == nullptr)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
-    *phCommandQueue = CmdQueueHandle.get();
+    *phCommandQueue = CmdQueueHandle.create();
     MOCK_RET;
 }
 
 ze_result_t zeCommandQueueDestroy(ze_command_queue_handle_t hCommandQueue) {
     MOCK_CNT_CALL;
-    if (hCommandQueue != CmdQueueHandle.get())
-        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
+    /*if (hCommandQueue != CmdQueueHandle.get())
+        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;*/
     MOCK_RET;
 }
 
 ze_result_t zeCommandQueueExecuteCommandLists(ze_command_queue_handle_t hCommandQueue, uint32_t numCommandLists,
                                               ze_command_list_handle_t *phCommandLists, ze_fence_handle_t hFence) {
     MOCK_CNT_CALL;
-    if (hCommandQueue != CmdQueueHandle.get() || !Config::isCmdListClosed())
+    //if (hCommandQueue != CmdQueueHandle.get() || !Config::isCmdListClosed())
+    if (!Config::isCmdListClosed())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     MOCK_RET;
 }
 
 ze_result_t zeCommandQueueSynchronize(ze_command_queue_handle_t hCommandQueue, uint64_t timeout) {
     MOCK_CNT_CALL;
-    if (hCommandQueue != CmdQueueHandle.get() || !Config::isCmdListClosed())
-        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
+    /*if (hCommandQueue != CmdQueueHandle.get() || !Config::isCmdListClosed())
+        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;*/
     MOCK_RET;
 }
 
@@ -136,29 +141,29 @@ ze_result_t zeCommandListCreate(ze_context_handle_t hContext, ze_device_handle_t
     MOCK_CNT_CALL;
     if (!ExpectedDevice(hDevice) || hContext != ContextHandle.get() || desc == nullptr || phCommandList == nullptr)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
-    *phCommandList = CmdListHandle.get();
+    *phCommandList = CmdListHandle.create();
     MOCK_RET;
 }
 
 ze_result_t zeCommandListDestroy(ze_command_list_handle_t hCommandList) {
     MOCK_CNT_CALL;
-    if (hCommandList != CmdListHandle.get())
-        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
+    /*if (hCommandList != CmdListHandle.get())
+        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;*/
     MOCK_RET;
 }
 
 ze_result_t zeCommandListClose(ze_command_list_handle_t hCommandList) {
     MOCK_CNT_CALL;
-    if (hCommandList != CmdListHandle.get())
-        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
+    /*if (hCommandList != CmdListHandle.get())
+        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;*/
     Config::closeCmdList();
     MOCK_RET;
 }
 
 ze_result_t zeCommandListReset(ze_command_list_handle_t hCommandList) {
     MOCK_CNT_CALL;
-    if (hCommandList != CmdListHandle.get())
-        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
+    /*if (hCommandList != CmdListHandle.get())
+        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;*/
     Config::resetCmdList();
     MOCK_RET;
 }
@@ -166,7 +171,8 @@ ze_result_t zeCommandListReset(ze_command_list_handle_t hCommandList) {
 ze_result_t zeCommandListAppendBarrier(ze_command_list_handle_t hCommandList, ze_event_handle_t hSignalEvent,
                                        uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents) {
     MOCK_CNT_CALL;
-    if (hCommandList != CmdListHandle.get() || Config::isCmdListClosed())
+    //if (hCommandList != CmdListHandle.get() || Config::isCmdListClosed())
+    if (Config::isCmdListClosed())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     if (MOCK_SHOULD_SUCCEED)
         Config::addToCmdList(CmdListElem::Barrier);
@@ -177,7 +183,8 @@ ze_result_t zeCommandListAppendMemoryCopy(ze_command_list_handle_t hCommandList,
                                           size_t size, ze_event_handle_t hSignalEvent, uint32_t numWaitEvents,
                                           ze_event_handle_t *phWaitEvents) {
     MOCK_CNT_CALL;
-    if (hCommandList != CmdListHandle.get() || Config::isCmdListClosed())
+    //if (hCommandList != CmdListHandle.get() || Config::isCmdListClosed())
+    if (Config::isCmdListClosed())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     if (MOCK_SHOULD_SUCCEED)
         Config::addToCmdList(CmdListElem::MemoryCopy);
@@ -288,7 +295,8 @@ ze_result_t zeCommandListAppendLaunchKernel(ze_command_list_handle_t hCommandLis
                                             const ze_group_count_t *pLaunchFuncArgs, ze_event_handle_t hSignalEvent,
                                             uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents) {
     MOCK_CNT_CALL;
-    if (hCommandList != CmdListHandle.get() || hKernel != KernelHandle.get() || !pLaunchFuncArgs)
+    //if (hCommandList != CmdListHandle.get() || hKernel != KernelHandle.get() || !pLaunchFuncArgs)
+    if (hKernel != KernelHandle.get() || !pLaunchFuncArgs)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     if (MOCK_SHOULD_SUCCEED)
         Config::addToCmdList(CmdListElem::KernelLaunch);

--- a/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
+++ b/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
@@ -109,30 +109,29 @@ ze_result_t zeCommandQueueCreate(ze_context_handle_t hContext, ze_device_handle_
     if (!ExpectedDevice(hDevice) || hContext != ContextHandle.get() || desc == nullptr ||
         phCommandQueue == nullptr)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
-    *phCommandQueue = CmdQueueHandle.create();
+    *phCommandQueue = CmdQueueHandle.get();
     MOCK_RET;
 }
 
 ze_result_t zeCommandQueueDestroy(ze_command_queue_handle_t hCommandQueue) {
     MOCK_CNT_CALL;
-    /*if (hCommandQueue != CmdQueueHandle.get())
-        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;*/
+    if (hCommandQueue != CmdQueueHandle.get())
+        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     MOCK_RET;
 }
 
 ze_result_t zeCommandQueueExecuteCommandLists(ze_command_queue_handle_t hCommandQueue, uint32_t numCommandLists,
                                               ze_command_list_handle_t *phCommandLists, ze_fence_handle_t hFence) {
     MOCK_CNT_CALL;
-    //if (hCommandQueue != CmdQueueHandle.get() || !Config::isCmdListClosed())
-    if (!Config::isCmdListClosed())
+    if (hCommandQueue != CmdQueueHandle.get() || !Config::isCmdListClosed())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     MOCK_RET;
 }
 
 ze_result_t zeCommandQueueSynchronize(ze_command_queue_handle_t hCommandQueue, uint64_t timeout) {
     MOCK_CNT_CALL;
-    /*if (hCommandQueue != CmdQueueHandle.get() || !Config::isCmdListClosed())
-        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;*/
+    if (hCommandQueue != CmdQueueHandle.get() || !Config::isCmdListClosed())
+        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     MOCK_RET;
 }
 

--- a/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
+++ b/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
@@ -20,10 +20,6 @@ static unsigned MockHandleHandle = 1;
 
 template <typename HT> struct MockHandle {
     HT get() { return handle; }
-    HT create() {
-        handle = reinterpret_cast<HT>(MockHandleHandle++);
-        return handle;
-    }
     MockHandle() { handle = reinterpret_cast<HT>(MockHandleHandle++); }
 
   private:
@@ -140,29 +136,29 @@ ze_result_t zeCommandListCreate(ze_context_handle_t hContext, ze_device_handle_t
     MOCK_CNT_CALL;
     if (!ExpectedDevice(hDevice) || hContext != ContextHandle.get() || desc == nullptr || phCommandList == nullptr)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
-    *phCommandList = CmdListHandle.create();
+    *phCommandList = CmdListHandle.get();
     MOCK_RET;
 }
 
 ze_result_t zeCommandListDestroy(ze_command_list_handle_t hCommandList) {
     MOCK_CNT_CALL;
-    /*if (hCommandList != CmdListHandle.get())
-        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;*/
+    if (hCommandList != CmdListHandle.get())
+        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     MOCK_RET;
 }
 
 ze_result_t zeCommandListClose(ze_command_list_handle_t hCommandList) {
     MOCK_CNT_CALL;
-    /*if (hCommandList != CmdListHandle.get())
-        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;*/
+    if (hCommandList != CmdListHandle.get())
+        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     Config::closeCmdList();
     MOCK_RET;
 }
 
 ze_result_t zeCommandListReset(ze_command_list_handle_t hCommandList) {
     MOCK_CNT_CALL;
-    /*if (hCommandList != CmdListHandle.get())
-        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;*/
+    if (hCommandList != CmdListHandle.get())
+        return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     Config::resetCmdList();
     MOCK_RET;
 }
@@ -170,8 +166,7 @@ ze_result_t zeCommandListReset(ze_command_list_handle_t hCommandList) {
 ze_result_t zeCommandListAppendBarrier(ze_command_list_handle_t hCommandList, ze_event_handle_t hSignalEvent,
                                        uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents) {
     MOCK_CNT_CALL;
-    //if (hCommandList != CmdListHandle.get() || Config::isCmdListClosed())
-    if (Config::isCmdListClosed())
+    if (hCommandList != CmdListHandle.get() || Config::isCmdListClosed())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     if (MOCK_SHOULD_SUCCEED)
         Config::addToCmdList(CmdListElem::Barrier);
@@ -182,8 +177,7 @@ ze_result_t zeCommandListAppendMemoryCopy(ze_command_list_handle_t hCommandList,
                                           size_t size, ze_event_handle_t hSignalEvent, uint32_t numWaitEvents,
                                           ze_event_handle_t *phWaitEvents) {
     MOCK_CNT_CALL;
-    //if (hCommandList != CmdListHandle.get() || Config::isCmdListClosed())
-    if (Config::isCmdListClosed())
+    if (hCommandList != CmdListHandle.get() || Config::isCmdListClosed())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     if (MOCK_SHOULD_SUCCEED)
         Config::addToCmdList(CmdListElem::MemoryCopy);
@@ -294,8 +288,7 @@ ze_result_t zeCommandListAppendLaunchKernel(ze_command_list_handle_t hCommandLis
                                             const ze_group_count_t *pLaunchFuncArgs, ze_event_handle_t hSignalEvent,
                                             uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents) {
     MOCK_CNT_CALL;
-    //if (hCommandList != CmdListHandle.get() || hKernel != KernelHandle.get() || !pLaunchFuncArgs)
-    if (hKernel != KernelHandle.get() || !pLaunchFuncArgs)
+    if (hCommandList != CmdListHandle.get() || hKernel != KernelHandle.get() || !pLaunchFuncArgs)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     if (MOCK_SHOULD_SUCCEED)
         Config::addToCmdList(CmdListElem::KernelLaunch);

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -315,6 +315,20 @@ TEST_F(MockTestWithDevice, TaskQueue_Barrier_zeCommandListAppendBarrier) {
     ASSERT_TRUE(Config::checkCmdList({}));
 }
 
+TEST_F(MockTestWithDevice, TaskQueue_CopyToDevice_NoBarriers) {
+    ispcrt::TaskQueue tq(m_device);
+    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
+    // Create an allocation
+    std::vector<float> buf(64 * 1024);
+    ispcrt::Array<float> buf_dev(m_device, buf);
+    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
+    // "copy"
+    tq.copyToDevice(buf_dev);
+    // Event should be created before appending memory copy
+    ASSERT_EQ(CallCounters::get("zeEventCreate"), 1);
+    ASSERT_EQ(CallCounters::get("zeCommandListAppendMemoryCopy"), 1);
+}
+
 // Normal kernel launch (plus a few memory transfers) - but no waiting on future
 TEST_F(MockTestWithModuleQueueKernel, TaskQueue_FullKernelLaunchNoFuture) {
     auto tq = m_task_queue;

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -446,37 +446,6 @@ TEST_F(MockTestWithModuleQueueKernel, TaskQueue_FullKernelLaunch) {
     ASSERT_TRUE(f.valid());
 }
 
-// Normal kernel launch (plus a few memory transfers) - use submit()/sync() instead of just sync
-TEST_F(MockTestWithModuleQueueKernel, TaskQueue_FullKernelLaunchViaSubmit) {
-    auto tq = m_task_queue;
-    // Create an allocation
-    std::vector<float> buf(64 * 1024);
-    ispcrt::Array<float> buf_dev(m_device, buf);
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    // "copy"
-    tq.copyToDevice(buf_dev);
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList({CmdListElem::MemoryCopy}));
-    tq.barrier();
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList({CmdListElem::MemoryCopy, CmdListElem::Barrier}));
-    auto f = tq.launch(m_kernel, 0);
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList({CmdListElem::MemoryCopy, CmdListElem::Barrier, CmdListElem::KernelLaunch}));
-    tq.barrier();
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList(
-        {CmdListElem::MemoryCopy, CmdListElem::Barrier, CmdListElem::KernelLaunch, CmdListElem::Barrier}));
-    tq.submit();
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList(
-        {CmdListElem::MemoryCopy, CmdListElem::Barrier, CmdListElem::KernelLaunch, CmdListElem::Barrier}));
-    tq.sync();
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList({}));
-    ASSERT_TRUE(f.valid());
-}
-
 // Try to submit a lot of kernel launches
 TEST_F(MockTestWithModuleQueueKernel, TaskQueue_MultipleKernelLaunchesBasic) {
     testMultipleKernelLaunches(1000);
@@ -550,36 +519,6 @@ TEST_F(MockTestWithModuleQueueKernel, TaskQueue_KernelLaunchNoSync) {
     ASSERT_FALSE(f.valid());
 }
 
-TEST_F(MockTestWithModuleQueueKernel, TaskQueue_SubmitSync) {
-    auto tq = m_task_queue;
-    auto f = tq.launch(m_kernel, 0);
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList({CmdListElem::KernelLaunch}));
-    tq.barrier();
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList({CmdListElem::KernelLaunch, CmdListElem::Barrier}));
-    // Future should not be signaled
-    ASSERT_FALSE(f.valid());
-    ASSERT_EQ(CallCounters::get("zeCommandQueueExecuteCommandLists"), 0);
-    tq.submit();
-    // Future still not signaled, but ExecuteCommandList called. Synchronize shouldn't though.
-    ASSERT_FALSE(f.valid());
-    ASSERT_EQ(CallCounters::get("zeCommandQueueExecuteCommandLists"), 1);
-    ASSERT_EQ(CallCounters::get("zeCommandQueueSynchronize"), 0);
-    // Call again, nothing should change
-    tq.submit();
-    ASSERT_FALSE(f.valid());
-    ASSERT_EQ(CallCounters::get("zeCommandQueueExecuteCommandLists"), 1);
-    ASSERT_EQ(CallCounters::get("zeCommandQueueSynchronize"), 0);
-    tq.sync();
-    // Now future should be valid
-    ASSERT_TRUE(f.valid());
-    // Execute shouldn't be called again
-    ASSERT_EQ(CallCounters::get("zeCommandQueueExecuteCommandLists"), 1);
-    // but synchronize should
-    ASSERT_EQ(CallCounters::get("zeCommandQueueSynchronize"), 1);
-}
-
 TEST_F(MockTestWithModuleQueueKernel, TaskQueue_Sync) {
     auto tq = m_task_queue;
     auto f = tq.launch(m_kernel, 0);
@@ -612,32 +551,6 @@ TEST_F(MockTestWithModuleQueueKernel, TaskQueue_Launch_zeKernelSetArgumentValue)
 TEST_F(MockTestWithModuleQueueKernel, TaskQueue_Launch_zeCommandListAppendLaunchKernel) {
     Config::setRetValue("zeCommandListAppendLaunchKernel", ZE_RESULT_ERROR_DEVICE_LOST);
     m_task_queue.launch(m_kernel, 0);
-    ASSERT_EQ(sm_rt_error, ISPCRT_DEVICE_LOST);
-}
-
-TEST_F(MockTestWithModuleQueueKernel, TaskQueue_Submit_zeCommandListClose) {
-    auto tq = m_task_queue;
-    auto f = tq.launch(m_kernel, 0);
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList({CmdListElem::KernelLaunch}));
-    tq.barrier();
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList({CmdListElem::KernelLaunch, CmdListElem::Barrier}));
-    Config::setRetValue("zeCommandListClose", ZE_RESULT_ERROR_DEVICE_LOST);
-    m_task_queue.submit();
-    ASSERT_EQ(sm_rt_error, ISPCRT_DEVICE_LOST);
-}
-
-TEST_F(MockTestWithModuleQueueKernel, TaskQueue_Submit_zeCommandQueueExecuteCommandLists) {
-    auto tq = m_task_queue;
-    auto f = tq.launch(m_kernel, 0);
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList({CmdListElem::KernelLaunch}));
-    tq.barrier();
-    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList({CmdListElem::KernelLaunch, CmdListElem::Barrier}));
-    Config::setRetValue("zeCommandQueueExecuteCommandLists", ZE_RESULT_ERROR_DEVICE_LOST);
-    m_task_queue.submit();
     ASSERT_EQ(sm_rt_error, ISPCRT_DEVICE_LOST);
 }
 

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -554,6 +554,27 @@ TEST_F(MockTestWithModuleQueueKernel, TaskQueue_Launch_zeCommandListAppendLaunch
     ASSERT_EQ(sm_rt_error, ISPCRT_DEVICE_LOST);
 }
 
+TEST_F(MockTestWithModuleQueueKernel, TaskQueue_Launch_zeKernelSuggestGroupSize) {
+    Config::setRetValue("zeKernelSuggestGroupSize", ZE_RESULT_ERROR_DEVICE_LOST);
+    m_task_queue.launch(m_kernel, 0);
+    ASSERT_EQ(sm_rt_error, ISPCRT_DEVICE_LOST);
+}
+
+TEST_F(MockTestWithModuleQueueKernel, TaskQueue_Launch_zeKernelSetGroupSize) {
+    Config::setRetValue("zeKernelSetGroupSize", ZE_RESULT_ERROR_DEVICE_LOST);
+    m_task_queue.launch(m_kernel, 0);
+    ASSERT_EQ(sm_rt_error, ISPCRT_DEVICE_LOST);
+}
+
+TEST_F(MockTestWithModuleQueueKernel, TaskQueue_KernelLaunchGroupSize) {
+    m_task_queue.launch(m_kernel, 0);
+    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
+    ASSERT_EQ(CallCounters::get("zeKernelSuggestGroupSize"), 1);
+    ASSERT_EQ(CallCounters::get("zeKernelSetGroupSize"), 1);
+    ASSERT_EQ(CallCounters::get("zeCommandListAppendLaunchKernel"), 1);
+    ASSERT_TRUE(Config::checkCmdList({CmdListElem::KernelLaunch}));
+}
+
 TEST_F(MockTestWithModuleQueueKernel, TaskQueue_Sync_zeCommandQueueSynchronize) {
     auto tq = m_task_queue;
     auto f = tq.launch(m_kernel, 0);

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -155,6 +155,21 @@ TEST_F(MockTestWithDevice, Module_Constructor) {
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
+TEST_F(MockTestWithDevice, Module_Constructor_zeModuleCreateWithOptions) {
+    // Create module with options
+    ISPCRTModuleOptions opts = {};
+    ispcrt::Module m(m_device, "", opts);
+    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
+}
+
+TEST_F(MockTestWithDevice, Module_Constructor_zeModuleCreateWithStackSize) {
+    // Create module with stack size
+    ISPCRTModuleOptions opts;
+    opts.stackSize = 32000;
+    ispcrt::Module m(m_device, "", opts);
+    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
+}
+
 TEST_F(MockTestWithDevice, Module_Constructor_zeModuleCreate) {
     // Check if error is reported from module constructor
     Config::setRetValue("zeModuleCreate", ZE_RESULT_ERROR_DEVICE_LOST);

--- a/run_tests.py
+++ b/run_tests.py
@@ -1084,7 +1084,7 @@ if __name__ == "__main__":
     parser.add_option("-c", "--compiler", dest="compiler_exe", help="C/C++ compiler binary to use to run tests",
                   default=None)
     parser.add_option('-o', '--opt', dest='opt', choices=['', 'O0', 'O1', 'O2'], help='Set optimization level passed to the compiler (O0, O1, O2).',
-                  default='')
+                  default='O2')
     parser.add_option('-j', '--jobs', dest='num_jobs', help='Maximum number of jobs to run in parallel',
                   default="1024", type="int")
     parser.add_option('-v', '--verbose', dest='verbose', help='Enable verbose output',

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -501,7 +501,7 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
             llvm::ValueAsMetadata::get(llvm::ConstantInt::getNullValue(i32Type));
         mdArgs[llvm::genx::KernelMDOp::ArgIOKinds] = llvm::MDNode::get(fContext, argInOutKinds);
         mdArgs[llvm::genx::KernelMDOp::ArgTypeDescs] = llvm::MDNode::get(fContext, argTypeDescs);
-        mdArgs[llvm::genx::KernelMDOp::Reserved_0] =
+        mdArgs[llvm::genx::KernelMDOp::NBarrierCnt] =
             llvm::ValueAsMetadata::get(llvm::ConstantInt::getNullValue(i32Type));
         mdArgs[llvm::genx::KernelMDOp::BarrierCnt] =
             llvm::ValueAsMetadata::get(llvm::ConstantInt::getNullValue(i32Type));

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1911,6 +1911,9 @@ Globals::Globals() {
     timeTraceGranularity = 500;
     target = NULL;
     ctx = new llvm::LLVMContext;
+#ifdef ISPC_XE_ENABLED
+    stackMemSize = 0;
+#endif
 
 #ifdef ISPC_HOST_IS_WINDOWS
     _getcwd(currentDirectory, sizeof(currentDirectory));

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -666,6 +666,9 @@ struct Globals {
     /** Arguments to pass to Vector Compiler backend for offline
     compilation to L0 binary */
     std::string vcOpts;
+
+    /*Stateless stack memory size in VC backend*/
+    unsigned int stackMemSize;
 #endif
 
     bool noPragmaOnce;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -667,7 +667,7 @@ struct Globals {
     compilation to L0 binary */
     std::string vcOpts;
 
-    /*Stateless stack memory size in VC backend*/
+    /* Stateless stack memory size in VC backend */
     unsigned int stackMemSize;
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -202,6 +202,9 @@ static void lPrintVersion() {
     printf("    [--x86-asm-syntax=<option>]\t\tSelect style of code if generating assembly\n");
     printf("        intel\t\t\t\tEmit Intel-style assembly\n");
     printf("        att\t\t\t\tEmit AT&T-style assembly\n");
+#ifdef ISPC_XE_ENABLED
+    printf("    [--xe-stack-mem-size=<value>\t\tSet size of stateless stack memory in VC backend.\n");
+#endif
     printf("    [@<filename>]\t\t\tRead additional arguments from the given file\n");
     printf("    <file to compile or \"-\" for stdin>\n");
     exit(ret);
@@ -924,8 +927,11 @@ int main(int Argc, char *Argv[]) {
         else if (strncmp(argv[i], "--off-phase=", 12) == 0) {
             g->off_stages = ParsingPhases(argv[i] + strlen("--off-phase="), errorHandler);
 #ifdef ISPC_XE_ENABLED
-        } else if (!strncmp(argv[i], "--vc-options=", 12)) {
+        } else if (!strncmp(argv[i], "--vc-options=", 13)) {
             g->vcOpts = argv[i] + strlen("--vc-options=");
+        } else if (!strncmp(argv[i], "--xe-stack-mem-size=", 20)) {
+            unsigned int memSize = atoi(argv[i] + 20);
+            g->stackMemSize = memSize;
 #endif
         } else if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--version")) {
             lPrintVersion();

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1258,6 +1258,13 @@ bool Module::writeZEBin(llvm::Module *module, const char *outFileName) {
     if (g->vcOpts != "") {
         options.append(" " + g->vcOpts);
     }
+
+    // Add stack size info
+    // If stackMemSize has default value 0, do not set -stateless-stack-mem-size,
+    // it will be set to 8192 in VC backend by default.
+    if (g->stackMemSize > 0) {
+        options.append(" -stateless-stack-mem-size=" + std::to_string(g->stackMemSize));
+    }
     std::string internalOptions;
 
     // Use L0 binary

--- a/tests/lit-tests/xe_devices.ispc
+++ b/tests/lit-tests/xe_devices.ispc
@@ -1,17 +1,20 @@
 // The test checks that GPU device/target definitions (including all synonyms) are successfully consumed by compiler.
 
-// RUN: %{ispc} %s -o %t.o --nostdlib --target=gen9-x8 --device=skl
-// RUN: %{ispc} %s -o %t.o --nostdlib --target=gen9-x8 --device=tgllp
-// RUN: %{ispc} %s -o %t.o --nostdlib --target=gen9-x8 --device=dg1
-// RUN: %{ispc} %s -o %t.o --nostdlib --target=gen9-x16 --device=skl
-// RUN: %{ispc} %s -o %t.o --nostdlib --target=gen9-x16 --device=tgllp
-// RUN: %{ispc} %s -o %t.o --nostdlib --target=gen9-x16 --device=dg1
-// RUN: not %{ispc} %s -o %t.o --nostdlib --target=xelp-x8 --device=skl
-// RUN: %{ispc} %s -o %t.o --nostdlib --target=xelp-x8 --device=tgllp
-// RUN: %{ispc} %s -o %t.o --nostdlib --target=xelp-x8 --device=dg1
-// RUN: not %{ispc} %s -o %t.o --nostdlib --target=xelp-x16 --device=skl
-// RUN: %{ispc} %s -o %t.o --nostdlib --target=xelp-x16 --device=tgllp
-// RUN: %{ispc} %s -o %t.o --nostdlib --target=xelp-x16 --device=dg1
+// Gen9
+// RUN: %{ispc} %s -o %t.spv --nostdlib --target=gen9-x8 --device=skl
+// RUN: %{ispc} %s -o %t.spv --nostdlib --target=gen9-x8 --device=tgllp
+// RUN: %{ispc} %s -o %t.spv --nostdlib --target=gen9-x8 --device=dg1
+// RUN: %{ispc} %s -o %t.spv --nostdlib --target=gen9-x16 --device=skl
+// RUN: %{ispc} %s -o %t.spv --nostdlib --target=gen9-x16 --device=tgllp
+// RUN: %{ispc} %s -o %t.spv --nostdlib --target=gen9-x16 --device=dg1
+
+// XeLP
+// RUN: not %{ispc} %s -o %t.spv --nostdlib --target=xelp-x8 --device=skl
+// RUN: %{ispc} %s -o %t.spv --nostdlib --target=xelp-x8 --device=tgllp
+// RUN: %{ispc} %s -o %t.spv --nostdlib --target=xelp-x8 --device=dg1
+// RUN: not %{ispc} %s -o %t.spv --nostdlib --target=xelp-x16 --device=skl
+// RUN: %{ispc} %s -o %t.spv --nostdlib --target=xelp-x16 --device=tgllp
+// RUN: %{ispc} %s -o %t.spv --nostdlib --target=xelp-x16 --device=dg1
 
 // REQUIRES: XE_ENABLED
 

--- a/tests/lit-tests/xe_task_count.ispc
+++ b/tests/lit-tests/xe_task_count.ispc
@@ -1,0 +1,54 @@
+// This test checks number of mul operations for taskIndex/taskCount calculations for Xe targets.
+// RUN: %{ispc} --emit-spirv --target=gen9-x8 %s -o %t.spv
+// RUN: ocloc compile -file %t.spv -spirv_input -options "-vc-codegen" -device SKL -output %t.bin -output_no_suffix
+// RUN: ocloc disasm -file %t.bin -device SKL -dump ./
+// RUN: FileCheck %s -check-prefix=CHECK_TASKCOUNT -input-file=taskCount_kernel_KernelHeap.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKCOUNT0 -input-file=taskCount0_kernel_KernelHeap.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKCOUNT1 -input-file=taskCount1_kernel_KernelHeap.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKCOUNT2 -input-file=taskCount2_kernel_KernelHeap.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKINDEX -input-file=taskIndex_kernel_KernelHeap.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKINDEX0 -input-file=taskIndex0_kernel_KernelHeap.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKINDEX1 -input-file=taskIndex1_kernel_KernelHeap.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKINDEX2 -input-file=taskIndex2_kernel_KernelHeap.asm
+
+// REQUIRES: XE_ENABLED
+// REQUIRES: OCLOC_INSTALLED
+// REQUIRES-NOT: WINDOWS_ENABLED
+
+// CHECK_TASKCOUNT: mul (2|M0)
+// CHECK_TASKCOUNT-COUNT-3: mul
+task void taskCount_kernel(uniform int res[]) {
+    res[0] = taskCount;
+}
+// CHECK_TASKCOUNT0-COUNT-1: mul
+task void taskCount0_kernel(uniform int res[]) {
+    res[0] = taskCount0;
+}
+// CHECK_TASKCOUNT1-COUNT-1: mul
+task void taskCount1_kernel(uniform int res[]) {
+    res[0] = taskCount1;
+}
+// CHECK_TASKCOUNT2-COUNT-1: mul
+task void taskCount2_kernel(uniform int res[]) {
+    res[0] = taskCount2;
+}
+
+// CHECK_TASKINDEX-COUNT-5: mul
+task void taskIndex_kernel(uniform int res[]) {
+    res[0] = taskIndex;
+}
+
+// CHECK_TASKINDEX0-COUNT-1: mul
+task void taskIndex0_kernel(uniform int res[]) {
+    res[0] = taskIndex0;
+}
+
+// CHECK_TASKINDEX1-COUNT-1: mul
+task void taskIndex1_kernel(uniform int res[]) {
+    res[0] = taskIndex1;
+}
+
+// CHECK_TASKINDEX2-COUNT-1: mul
+task void taskIndex2_kernel(uniform int res[]) {
+    res[0] = taskIndex2;
+}


### PR DESCRIPTION
This GPU update introduces mainly performance improvements of ISPC Runtime:

- fixed setting of local group size for kernels
- implemented a new synchronization mechanism using events. There is no need to use barrier() before and after copying memory to/from the device, it will be done automatically.
- introduced usage of HW compute and copy engines

Also added functionality to pass stack size to VC backend using ISPC switch `--xe-stack-mem-size=N` (in case of AoT compilation) and `ISPCRTModuleOptions.stackSize` in ISPC Runtime (in case of JIT compilation)