### PR TITLE
PS5 support

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -452,6 +452,7 @@ class AllCPUs {
 
         names[CPU_ZNVER1].push_back("znver1");
         names[CPU_ZNVER2].push_back("znver2");
+        names[CPU_ZNVER2].push_back("ps5");
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_12_0
         names[CPU_ZNVER3].push_back("znver3");
 #endif
@@ -1613,6 +1614,16 @@ std::string Target::GetTripleString() const {
             exit(1);
         }
         // "x86_64-scei-ps4"
+        triple.setArch(llvm::Triple::ArchType::x86_64);
+        triple.setVendor(llvm::Triple::VendorType::SCEI);
+        triple.setOS(llvm::Triple::OSType::PS4);
+        break;
+    case TargetOS::ps5:
+        if (m_arch != Arch::x86_64) {
+            Error(SourcePos(), "PS5 target supports only x86_64.");
+            exit(1);
+        }
+        // "x86_64-scei-ps4", as "ps5" was not yet officially upstreamed to LLVM.
         triple.setArch(llvm::Triple::ArchType::x86_64);
         triple.setVendor(llvm::Triple::VendorType::SCEI);
         triple.setOS(llvm::Triple::OSType::PS4);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -959,19 +959,19 @@ int main(int Argc, char *Argv[]) {
     }
 
     // Default settings for PS4
-    if (g->target_os == TargetOS::ps4) {
+    if (g->target_os == TargetOS::ps4 || g->target_os == TargetOS::ps5) {
         flags |= Module::GeneratePIC;
         if (!cpu) {
-            // Default is btver2, but do not enforce it.
-            cpu = "btver2";
+            if (g->target_os == TargetOS::ps4) {
+                // Default for PS4 is btver2, but do not enforce it.
+                cpu = "btver2";
+            } else {
+                // Default for PS5 is znver2, but do not enforce it.
+                cpu = "znver2";
+            }
         }
-        /*
-        if (cpu && std::string(cpu) != "btver2" && std::string(cpu) != "ps4") {
-            Warning(SourcePos(), "--cpu switch is ignored for PS4 target OS. btver2 (ps4) cpu is used.");
-        }
-        */
         if (arch != Arch::x86_64) {
-            Warning(SourcePos(), "--arch switch is ignored for PS4 target OS. x86-64 arch is used.");
+            Warning(SourcePos(), "--arch switch is ignored for PS4/PS5 target OS. x86-64 arch is used.");
             arch = Arch::x86_64;
         }
     }

--- a/src/target_enums.cpp
+++ b/src/target_enums.cpp
@@ -354,6 +354,8 @@ TargetOS ParseOS(std::string os) {
         return TargetOS::ios;
     } else if (os == "ps4") {
         return TargetOS::ps4;
+    } else if (os == "ps5") {
+        return TargetOS::ps5;
     } else if (os == "web") {
         return TargetOS::web;
     }
@@ -378,6 +380,8 @@ std::string OSToString(TargetOS os) {
         return "iOS";
     case TargetOS::ps4:
         return "PS4";
+    case TargetOS::ps5:
+        return "PS5";
     case TargetOS::web:
         return "web";
     case TargetOS::error:
@@ -404,6 +408,8 @@ std::string OSToLowerString(TargetOS os) {
         return "ios";
     case TargetOS::ps4:
         return "ps4";
+    case TargetOS::ps5:
+        return "ps5";
     case TargetOS::web:
         return "web";
     case TargetOS::error:

--- a/src/target_enums.h
+++ b/src/target_enums.h
@@ -44,7 +44,7 @@ namespace ispc {
 
 enum class CallingConv { uninitialized, defaultcall, x86_vectorcall };
 
-enum class TargetOS { windows, linux, custom_linux, freebsd, macos, android, ios, ps4, web, error };
+enum class TargetOS { windows, linux, custom_linux, freebsd, macos, android, ios, ps4, ps5, web, error };
 
 TargetOS ParseOS(std::string os);
 std::string OSToString(TargetOS os);

--- a/src/target_registry.cpp
+++ b/src/target_registry.cpp
@@ -167,6 +167,7 @@ const BitcodeLib *TargetLibRegistry::getISPCTargetLib(ISPCTarget target, TargetO
     case TargetOS::android:
     case TargetOS::ios:
     case TargetOS::ps4:
+    case TargetOS::ps5:
         os = TargetOS::linux;
         break;
     case TargetOS::error:

--- a/tests/lit-tests/cpus_x86.ispc
+++ b/tests/lit-tests/cpus_x86.ispc
@@ -20,6 +20,7 @@
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=broadwell
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=znver1
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=znver2
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=ps5
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=knl
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=skx
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=icelake-client

--- a/tests/lit-tests/ps5_cpu.ispc
+++ b/tests/lit-tests/ps5_cpu.ispc
@@ -1,0 +1,25 @@
+// RUN: %{ispc} %s --target=avx2-i32x8 --cpu=znver2 --print-target --arch=x86-64 --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=avx2-i32x8 --cpu=ps5 --print-target --arch=x86-64 --nostdlib | FileCheck %s
+
+// RUN: %{ispc} %s --target=sse2-i32x4 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=sse2-i32x8 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=sse4-i32x4 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=sse4-i32x8 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=sse4-i16x8 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=sse4-i8x16 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=avx1-i32x4 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=avx1-i32x8 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=avx1-i32x16 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=avx1-i64x4 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=avx2-i8x32 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=avx2-i16x16 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=avx2-i32x4 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=avx2-i32x8 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=avx2-i32x16 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+// RUN: %{ispc} %s --target=avx2-i64x4 --cpu=ps5 --print-target --nostdlib | FileCheck %s
+
+
+// REQUIRES: X86_ENABLED
+
+// CHECK: Target CPU: znver2
+int i;


### PR DESCRIPTION
This PR adds support for PS5 target "OS". What it really does:
- sets target triple to `x86_64-scei-ps4`
- defaults CPU to `zen2` (which is what PS5 has according to Wikipedia) and adds `ps5` alias for it
- restricts `--arch` to `x86_64`
- enables `--pic`

This was not tested on PS5 hardware, but as PS5 is backward compatible with PS4, it should work out of the box.