### PR TITLE
aos<->soa to use unaligned stores

### DIFF
--- a/builtins/util.m4
+++ b/builtins/util.m4
@@ -2490,16 +2490,16 @@ define void
 
   %r0 = shufflevector <4 x float> %t2, <4 x float> %t0,  ; r0 r1 r2 r3
           <4 x i32> <i32 0, i32 1, i32 4, i32 5>
-  store <4 x float> %r0, <4 x float> * %out0
+  store <4 x float> %r0, <4 x float> * %out0, align 4
   %r1 = shufflevector <4 x float> %t2, <4 x float> %t0,  ; g0 g1 g2 g3
           <4 x i32> <i32 2, i32 3, i32 6, i32 7>
-  store <4 x float> %r1, <4 x float> * %out1
+  store <4 x float> %r1, <4 x float> * %out1, align 4
   %r2 = shufflevector <4 x float> %t3, <4 x float> %t1,  ; b0 b1 b2 b3
           <4 x i32> <i32 0, i32 1, i32 4, i32 5>
-  store <4 x float> %r2, <4 x float> * %out2
+  store <4 x float> %r2, <4 x float> * %out2, align 4
   %r3 = shufflevector <4 x float> %t3, <4 x float> %t1,  ; a0 a1 a2 a3
           <4 x i32> <i32 2, i32 3, i32 6, i32 7>
-  store <4 x float> %r3, <4 x float> * %out3
+  store <4 x float> %r3, <4 x float> * %out3, align 4
   ret void
 }
 
@@ -2536,16 +2536,16 @@ define void
 
   %r0 = shufflevector <4 x double> %t2, <4 x double> %t0,  ; r0 r1 r2 r3
           <4 x i32> <i32 0, i32 1, i32 4, i32 5>
-  store <4 x double> %r0, <4 x double> * %out0
+  store <4 x double> %r0, <4 x double> * %out0, align 4
   %r1 = shufflevector <4 x double> %t2, <4 x double> %t0,  ; g0 g1 g2 g3
           <4 x i32> <i32 2, i32 3, i32 6, i32 7>
-  store <4 x double> %r1, <4 x double> * %out1
+  store <4 x double> %r1, <4 x double> * %out1, align 4
   %r2 = shufflevector <4 x double> %t3, <4 x double> %t1,  ; b0 b1 b2 b3
           <4 x i32> <i32 0, i32 1, i32 4, i32 5>
-  store <4 x double> %r2, <4 x double> * %out2
+  store <4 x double> %r2, <4 x double> * %out2, align 4
   %r3 = shufflevector <4 x double> %t3, <4 x double> %t1,  ; a0 a1 a2 a3
           <4 x i32> <i32 2, i32 3, i32 6, i32 7>
-  store <4 x double> %r3, <4 x double> * %out3
+  store <4 x double> %r3, <4 x double> * %out3, align 4
   ret void
 }
 
@@ -2580,18 +2580,18 @@ define void
 
   %r0 = shufflevector <4 x float> %t0, <4 x float> %t1, ; x0 x1 x1 x3
     <4 x i32> <i32 0, i32 1, i32 4, i32 5>
-  store <4 x float> %r0, <4 x float> * %out0
+  store <4 x float> %r0, <4 x float> * %out0, align 4
 
   %r1 = shufflevector <4 x float> %t0, <4 x float> %t1, ; y0 y1 y2 y3
     <4 x i32> <i32 2, i32 3, i32 6, i32 7>
-  store <4 x float> %r1, <4 x float> * %out1
+  store <4 x float> %r1, <4 x float> * %out1, align 4
 
   %t2 = shufflevector <4 x float> %v0, <4 x float> %v1, ; z0 z1 x x
     <4 x i32> <i32 2, i32 5, i32 undef, i32 undef>
 
   %r2 = shufflevector <4 x float> %t2, <4 x float> %v2, ; z0 z1 z2 z3
     <4 x i32> <i32 0, i32 1, i32 4, i32 7>
-  store <4 x float> %r2, <4 x float> * %out2
+  store <4 x float> %r2, <4 x float> * %out2, align 4
   ret void
 }
 
@@ -2611,17 +2611,17 @@ define void
 
   %r0 = shufflevector <4 x float> %t0, <4 x float> %t1, ; x0 y0 z0 x1
     <4 x i32> <i32 0, i32 3, i32 6, i32 1>
-  store <4 x float> %r0, <4 x float> * %out0
+  store <4 x float> %r0, <4 x float> * %out0, align 4
   %r1 = shufflevector <4 x float> %t0, <4 x float> %t1, ; y1 z1 x2 y2
     <4 x i32> <i32 4, i32 7, i32 2, i32 5>
-  store <4 x float> %r1, <4 x float> * %out1
+  store <4 x float> %r1, <4 x float> * %out1, align 4
 
   %t2 = shufflevector <4 x float> %v0, <4 x float> %v1, ; x3 y3 x x
     <4 x i32> <i32 3, i32 7, i32 undef, i32 undef>
 
   %r2 = shufflevector <4 x float> %t2, <4 x float> %v2, ; z2 x3 y3 z3
     <4 x i32> <i32 6, i32 0, i32 1, i32 7>
-  store <4 x float> %r2, <4 x float> * %out2
+  store <4 x float> %r2, <4 x float> * %out2, align 4
   ret void
 }
 
@@ -2636,18 +2636,18 @@ define void
 
   %r0 = shufflevector <4 x double> %t0, <4 x double> %t1, ; x0 x1 x1 x3
     <4 x i32> <i32 0, i32 1, i32 4, i32 5>
-  store <4 x double> %r0, <4 x double> * %out0
+  store <4 x double> %r0, <4 x double> * %out0, align 4
 
   %r1 = shufflevector <4 x double> %t0, <4 x double> %t1, ; y0 y1 y2 y3
     <4 x i32> <i32 2, i32 3, i32 6, i32 7>
-  store <4 x double> %r1, <4 x double> * %out1
+  store <4 x double> %r1, <4 x double> * %out1, align 4
 
   %t2 = shufflevector <4 x double> %v0, <4 x double> %v1, ; z0 z1 x x
     <4 x i32> <i32 2, i32 5, i32 undef, i32 undef>
 
   %r2 = shufflevector <4 x double> %t2, <4 x double> %v2, ; z0 z1 z2 z3
     <4 x i32> <i32 0, i32 1, i32 4, i32 7>
-  store <4 x double> %r2, <4 x double> * %out2
+  store <4 x double> %r2, <4 x double> * %out2, align 4
   ret void
 }
 
@@ -2662,17 +2662,17 @@ define void
 
   %r0 = shufflevector <4 x double> %t0, <4 x double> %t1, ; x0 y0 z0 x1
     <4 x i32> <i32 0, i32 3, i32 6, i32 1>
-  store <4 x double> %r0, <4 x double> * %out0
+  store <4 x double> %r0, <4 x double> * %out0, align 4
   %r1 = shufflevector <4 x double> %t0, <4 x double> %t1, ; y1 z1 x2 y2
     <4 x i32> <i32 4, i32 7, i32 2, i32 5>
-  store <4 x double> %r1, <4 x double> * %out1
+  store <4 x double> %r1, <4 x double> * %out1, align 4
 
   %t2 = shufflevector <4 x double> %v0, <4 x double> %v1, ; x3 y3 x x
     <4 x i32> <i32 3, i32 7, i32 undef, i32 undef>
 
   %r2 = shufflevector <4 x double> %t2, <4 x double> %v2, ; z2 x3 y3 z3
     <4 x i32> <i32 6, i32 0, i32 1, i32 7>
-  store <4 x double> %r2, <4 x double> * %out2
+  store <4 x double> %r2, <4 x double> * %out2, align 4
   ret void
 }
 
@@ -2687,8 +2687,8 @@ define void
     <4 x i32> <i32 0, i32 2, i32 4, i32 6>
   %t1 = shufflevector <4 x float> %v0, <4 x float> %v1, ; y0 y1 y2 y3
     <4 x i32> <i32 1, i32 3, i32 5, i32 7>
-  store <4 x float> %t0, <4 x float> * %out0
-  store <4 x float> %t1, <4 x float> * %out1
+  store <4 x float> %t0, <4 x float> * %out0, align 4
+  store <4 x float> %t1, <4 x float> * %out1, align 4
   ret void
 }
 
@@ -2704,8 +2704,8 @@ define void
     <4 x i32> <i32 0, i32 4, i32 1, i32 5>
   %t1 = shufflevector <4 x float> %v0, <4 x float> %v1, ; x2 y2 x3 y3
     <4 x i32> <i32 2, i32 6, i32 3, i32 7>
-  store <4 x float> %t0, <4 x float> * %out0
-  store <4 x float> %t1, <4 x float> * %out1
+  store <4 x float> %t0, <4 x float> * %out0, align 4
+  store <4 x float> %t1, <4 x float> * %out1, align 4
   ret void
 }
 
@@ -2716,8 +2716,8 @@ define void
     <4 x i32> <i32 0, i32 2, i32 4, i32 6>
   %t1 = shufflevector <4 x double> %v0, <4 x double> %v1, ; y0 y1 y2 y3
     <4 x i32> <i32 1, i32 3, i32 5, i32 7>
-  store <4 x double> %t0, <4 x double> * %out0
-  store <4 x double> %t1, <4 x double> * %out1
+  store <4 x double> %t0, <4 x double> * %out0, align 4
+  store <4 x double> %t1, <4 x double> * %out1, align 4
   ret void
 }
 
@@ -2733,8 +2733,8 @@ define void
     <4 x i32> <i32 0, i32 4, i32 1, i32 5>
   %t1 = shufflevector <4 x double> %v0, <4 x double> %v1, ; x2 y2 x3 y3
     <4 x i32> <i32 2, i32 6, i32 3, i32 7>
-  store <4 x double> %t0, <4 x double> * %out0
-  store <4 x double> %t1, <4 x double> * %out1
+  store <4 x double> %t0, <4 x double> * %out0, align 4
+  store <4 x double> %t1, <4 x double> * %out1, align 4
   ret void
 }
 ')
@@ -2769,16 +2769,16 @@ define void
   ;; Produce output vectors
   %r0 = shufflevector <8 x float> %t2, <8 x float> %t0,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 8, i32 9, i32 10, i32 11>
-  store <8 x float> %r0, <8 x float> * %out0
+  store <8 x float> %r0, <8 x float> * %out0, align 4
   %r1 = shufflevector <8 x float> %t2, <8 x float> %t0,
           <8 x i32> <i32 4, i32 5, i32 6, i32 7, i32 12, i32 13, i32 14, i32 15>
-  store <8 x float> %r1, <8 x float> * %out1
+  store <8 x float> %r1, <8 x float> * %out1, align 4
   %r2 = shufflevector <8 x float> %t3, <8 x float> %t1,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 8, i32 9, i32 10, i32 11>
-  store <8 x float> %r2, <8 x float> * %out2
+  store <8 x float> %r2, <8 x float> * %out2, align 4
   %r3 = shufflevector <8 x float> %t3, <8 x float> %t1,
           <8 x i32> <i32 4, i32 5, i32 6, i32 7, i32 12, i32 13, i32 14, i32 15>
-  store <8 x float> %r3, <8 x float> * %out3
+  store <8 x float> %r3, <8 x float> * %out3, align 4
   ret void
 }
 
@@ -2804,16 +2804,16 @@ define void
   ;; Produce output vectors
   %r0 = shufflevector <8 x float> %t2, <8 x float> %t0,
           <8 x i32> <i32 0, i32 4, i32 8, i32 12, i32 1, i32 5, i32 9, i32 13>
-  store <8 x float> %r0, <8 x float> * %out0
+  store <8 x float> %r0, <8 x float> * %out0, align 4
   %r1 = shufflevector <8 x float> %t2, <8 x float> %t0,
           <8 x i32> <i32 2, i32 6, i32 10, i32 14, i32 3, i32 7, i32 11, i32 15>
-  store <8 x float> %r1, <8 x float> * %out1
+  store <8 x float> %r1, <8 x float> * %out1, align 4
   %r2 = shufflevector <8 x float> %t3, <8 x float> %t1,
           <8 x i32> <i32 0, i32 4, i32 8, i32 12,  i32 1, i32 5, i32 9, i32 13>
-  store <8 x float> %r2, <8 x float> * %out2
+  store <8 x float> %r2, <8 x float> * %out2, align 4
   %r3 = shufflevector <8 x float> %t3, <8 x float> %t1,
           <8 x i32> <i32 2, i32 6, i32 10, i32 14, i32 3, i32 7, i32 11, i32 15>
-  store <8 x float> %r3, <8 x float> * %out3
+  store <8 x float> %r3, <8 x float> * %out3, align 4
   ret void
 }
 
@@ -2838,16 +2838,16 @@ define void
   ;; Produce output vectors
   %r0 = shufflevector <8 x double> %t2, <8 x double> %t0,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 8, i32 9, i32 10, i32 11>
-  store <8 x double> %r0, <8 x double> * %out0
+  store <8 x double> %r0, <8 x double> * %out0, align 4
   %r1 = shufflevector <8 x double> %t2, <8 x double> %t0,
           <8 x i32> <i32 4, i32 5, i32 6, i32 7, i32 12, i32 13, i32 14, i32 15>
-  store <8 x double> %r1, <8 x double> * %out1
+  store <8 x double> %r1, <8 x double> * %out1, align 4
   %r2 = shufflevector <8 x double> %t3, <8 x double> %t1,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 8, i32 9, i32 10, i32 11>
-  store <8 x double> %r2, <8 x double> * %out2
+  store <8 x double> %r2, <8 x double> * %out2, align 4
   %r3 = shufflevector <8 x double> %t3, <8 x double> %t1,
           <8 x i32> <i32 4, i32 5, i32 6, i32 7, i32 12, i32 13, i32 14, i32 15>
-  store <8 x double> %r3, <8 x double> * %out3
+  store <8 x double> %r3, <8 x double> * %out3, align 4
   ret void
 }
 
@@ -2923,16 +2923,16 @@ define void
   ;; Produce output vectors
   %r0 = shufflevector <8 x double> %t2, <8 x double> %t0,
           <8 x i32> <i32 0, i32 4, i32 8, i32 12, i32 1, i32 5, i32 9, i32 13>
-  store <8 x double> %r0, <8 x double> * %out0
+  store <8 x double> %r0, <8 x double> * %out0, align 4
   %r1 = shufflevector <8 x double> %t2, <8 x double> %t0,
           <8 x i32> <i32 2, i32 6, i32 10, i32 14, i32 3, i32 7, i32 11, i32 15>
-  store <8 x double> %r1, <8 x double> * %out1
+  store <8 x double> %r1, <8 x double> * %out1, align 4
   %r2 = shufflevector <8 x double> %t3, <8 x double> %t1,
           <8 x i32> <i32 0, i32 4, i32 8, i32 12, i32 1, i32 5, i32 9, i32 13>
-  store <8 x double> %r2, <8 x double> * %out2
+  store <8 x double> %r2, <8 x double> * %out2, align 4
   %r3 = shufflevector <8 x double> %t3, <8 x double> %t1,
           <8 x i32> <i32 2, i32 6, i32 10, i32 14, i32 3, i32 7, i32 11, i32 15>
-  store <8 x double> %r3, <8 x double> * %out3
+  store <8 x double> %r3, <8 x double> * %out3, align 4
   ret void
 }
 ')
@@ -2951,10 +2951,10 @@ define void
   ;; Produce output vectors
   %r0 = shufflevector <8 x float> %t0, <8 x float> %t1,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 8, i32 9, i32 10, i32 11>
-  store <8 x float> %r0, <8 x float> * %out0
+  store <8 x float> %r0, <8 x float> * %out0, align 4
   %r1 = shufflevector <8 x float> %t0, <8 x float> %t1,
           <8 x i32> <i32 4, i32 5, i32 6, i32 7, i32 12, i32 13, i32 14, i32 15>
-  store <8 x float> %r1, <8 x float> * %out1
+  store <8 x float> %r1, <8 x float> * %out1, align 4
 
   ;; t2 = <c0 ... c4 undef ... undef>
   %t2 = shufflevector <8 x float> %v0, <8 x float> %v1,
@@ -2963,7 +2963,7 @@ define void
   ;; Produce output vector
   %r2 = shufflevector <8 x float> %t2, <8 x float> %v2,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 9, i32 12, i32 15>
-  store <8 x float> %r2, <8 x float> * %out2
+  store <8 x float> %r2, <8 x float> * %out2, align 4
   ret void
 }
 
@@ -2982,10 +2982,10 @@ define void
   ;; Produce output vectors
   %r0 = shufflevector <8 x float> %t0, <8 x float> %t1,
           <8 x i32> <i32 0, i32 6, i32 11, i32 1, i32 7, i32 12, i32 2, i32 8>
-  store <8 x float> %r0, <8 x float> * %out0
+  store <8 x float> %r0, <8 x float> * %out0, align 4
   %r1 = shufflevector <8 x float> %t0, <8 x float> %t1,
           <8 x i32> <i32 13, i32 3, i32 9, i32 14, i32 4, i32 10, i32 15, i32 5>
-  store <8 x float> %r1, <8 x float> * %out1
+  store <8 x float> %r1, <8 x float> * %out1, align 4
 
   ;; t2 = <a6 ... a7 b5 ... b7 undef ... undef>
   %t2 = shufflevector <8 x float> %v0, <8 x float> %v1,
@@ -2993,7 +2993,7 @@ define void
   ;; Produce output vector
   %r2 = shufflevector <8 x float> %t2, <8 x float> %v2,
           <8 x i32> <i32 2, i32 13, i32 0, i32 3, i32 14, i32 1, i32 4, i32 15>
-  store <8 x float> %r2, <8 x float> * %out2
+  store <8 x float> %r2, <8 x float> * %out2, align 4
   ret void
 }
 
@@ -3033,12 +3033,12 @@ define void
   %b1_ptr = getelementptr inbounds <4 x double>, <4 x double> * %b0_ptr, i32 1
   %c1_ptr = getelementptr inbounds <4 x double>, <4 x double> * %c0_ptr, i32 1
 
-  store <4 x double> %a0, <4 x double> * %a0_ptr
-  store <4 x double> %a1, <4 x double> * %a1_ptr
-  store <4 x double> %b0, <4 x double> * %b0_ptr
-  store <4 x double> %b1, <4 x double> * %b1_ptr
-  store <4 x double> %c0, <4 x double> * %c0_ptr
-  store <4 x double> %c1, <4 x double> * %c1_ptr
+  store <4 x double> %a0, <4 x double> * %a0_ptr, align 4
+  store <4 x double> %a1, <4 x double> * %a1_ptr, align 4
+  store <4 x double> %b0, <4 x double> * %b0_ptr, align 4
+  store <4 x double> %b1, <4 x double> * %b1_ptr, align 4
+  store <4 x double> %c0, <4 x double> * %c0_ptr, align 4
+  store <4 x double> %c1, <4 x double> * %c1_ptr, align 4
   ret void
 }
 
@@ -3057,10 +3057,10 @@ define void
   ;; Produce output vectors
   %r0 = shufflevector <8 x double> %t0, <8 x double> %t1,
           <8 x i32> <i32 0, i32 6, i32 11, i32 1, i32 7, i32 12, i32 2, i32 8>
-  store <8 x double> %r0, <8 x double> * %out0
+  store <8 x double> %r0, <8 x double> * %out0, align 4
   %r1 = shufflevector <8 x double> %t0, <8 x double> %t1,
           <8 x i32> <i32 13, i32 3, i32 9, i32 14, i32 4, i32 10, i32 15, i32 5>
-  store <8 x double> %r1, <8 x double> * %out1
+  store <8 x double> %r1, <8 x double> * %out1, align 4
 
   ;; t2 = <a6 ... a7 b5 ... b7 undef ... undef>
   %t2 = shufflevector <8 x double> %v0, <8 x double> %v1,
@@ -3068,7 +3068,7 @@ define void
   ;; Produce output vector
   %r2 = shufflevector <8 x double> %t2, <8 x double> %v2,
           <8 x i32> <i32 2, i32 13, i32 0, i32 3, i32 14, i32 1, i32 4, i32 15>
-  store <8 x double> %r2, <8 x double> * %out2
+  store <8 x double> %r2, <8 x double> * %out2, align 4
   ret void
 }
 
@@ -3089,8 +3089,8 @@ define void
   %t1 = shufflevector <8 x float> %v0, <8 x float> %v1,
           <8 x i32> <i32 1, i32 3, i32 5, i32 7, i32 9, i32 11, i32 13, i32 15>
 
-  store <8 x float> %t0, <8 x float> * %out0
-  store <8 x float> %t1, <8 x float> * %out1
+  store <8 x float> %t0, <8 x float> * %out0, align 4
+  store <8 x float> %t1, <8 x float> * %out1, align 4
   ret void
 }
 
@@ -3108,8 +3108,8 @@ define void
           <8 x i32> <i32 0, i32 8, i32 1, i32 9, i32 2, i32 10, i32 3, i32 11>
   %t1 = shufflevector <8 x float> %v0, <8 x float> %v1,
           <8 x i32> <i32 4, i32 12, i32 5, i32 13, i32 6, i32 14, i32 7, i32 15>
-  store <8 x float> %t0, <8 x float> * %out0
-  store <8 x float> %t1, <8 x float> * %out1
+  store <8 x float> %t0, <8 x float> * %out0, align 4
+  store <8 x float> %t1, <8 x float> * %out1, align 4
   ret void
 }
 
@@ -3130,8 +3130,8 @@ define void
   %t1 = shufflevector <8 x double> %v0, <8 x double> %v1,
           <8 x i32> <i32 1, i32 3, i32 5, i32 7, i32 9, i32 11, i32 13, i32 15>
 
-  store <8 x double> %t0, <8 x double> * %out0
-  store <8 x double> %t1, <8 x double> * %out1
+  store <8 x double> %t0, <8 x double> * %out0, align 4
+  store <8 x double> %t1, <8 x double> * %out1, align 4
   ret void
 }
 
@@ -3149,8 +3149,8 @@ define void
           <8 x i32> <i32 0, i32 8, i32 1, i32 9, i32 2, i32 10, i32 3, i32 11>
   %t1 = shufflevector <8 x double> %v0, <8 x double> %v1,
           <8 x i32> <i32 4, i32 12, i32 5, i32 13, i32 6, i32 14, i32 7, i32 15>
-  store <8 x double> %t0, <8 x double> * %out0
-  store <8 x double> %t1, <8 x double> * %out1
+  store <8 x double> %t0, <8 x double> * %out0, align 4
+  store <8 x double> %t1, <8 x double> * %out1, align 4
   ret void
 }
 ')
@@ -3188,19 +3188,19 @@ define void
   %r0 = shufflevector <16 x float> %t2, <16 x float> %t0,
           <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  store <16 x float> %r0, <16 x float> * %out0
+  store <16 x float> %r0, <16 x float> * %out0, align 4
   %r1 = shufflevector <16 x float> %t2, <16 x float> %t0,
           <16 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  store <16 x float> %r1, <16 x float> * %out1
+  store <16 x float> %r1, <16 x float> * %out1, align 4
   %r2 = shufflevector <16 x float> %t3, <16 x float> %t1,
           <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  store <16 x float> %r2, <16 x float> * %out2
+  store <16 x float> %r2, <16 x float> * %out2, align 4
   %r3 = shufflevector <16 x float> %t3, <16 x float> %t1,
           <16 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  store <16 x float> %r3, <16 x float> * %out3
+  store <16 x float> %r3, <16 x float> * %out3, align 4
   ret void
 }
 
@@ -3231,19 +3231,19 @@ define void
   %r0 = shufflevector <16 x float> %t2, <16 x float> %t0,
           <16 x i32> <i32 0, i32 8, i32 16, i32 24, i32 1, i32 9, i32 17, i32 25,
                       i32 2, i32 10, i32 18, i32 26, i32 3, i32 11, i32 19, i32 27>
-  store <16 x float> %r0, <16 x float> * %out0
+  store <16 x float> %r0, <16 x float> * %out0, align 4
   %r1 = shufflevector <16 x float> %t2, <16 x float> %t0,
           <16 x i32> <i32 4, i32 12, i32 20, i32 28, i32 5, i32 13, i32 21, i32 29,
                       i32 6, i32 14, i32 22, i32 30, i32 7, i32 15, i32 23, i32 31>
-  store <16 x float> %r1, <16 x float> * %out1
+  store <16 x float> %r1, <16 x float> * %out1, align 4
   %r2 = shufflevector <16 x float> %t3, <16 x float> %t1,
           <16 x i32> <i32 0, i32 8, i32 16, i32 24, i32 1, i32 9, i32 17, i32 25,
                       i32 2, i32 10, i32 18, i32 26, i32 3, i32 11, i32 19, i32 27>
-  store <16 x float> %r2, <16 x float> * %out2
+  store <16 x float> %r2, <16 x float> * %out2, align 4
   %r3 = shufflevector <16 x float> %t3, <16 x float> %t1,
           <16 x i32> <i32 4, i32 12, i32 20, i32 28, i32 5, i32 13, i32 21, i32 29,
                       i32 6, i32 14, i32 22, i32 30, i32 7, i32 15, i32 23, i32 31>
-  store <16 x float> %r3, <16 x float> * %out3
+  store <16 x float> %r3, <16 x float> * %out3, align 4
   ret void
 }
 
@@ -3274,19 +3274,19 @@ define void
   %r0 = shufflevector <16 x double> %t2, <16 x double> %t0,
           <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  store <16 x double> %r0, <16 x double> * %out0
+  store <16 x double> %r0, <16 x double> * %out0, align 4
   %r1 = shufflevector <16 x double> %t2, <16 x double> %t0,
           <16 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  store <16 x double> %r1, <16 x double> * %out1
+  store <16 x double> %r1, <16 x double> * %out1, align 4
   %r2 = shufflevector <16 x double> %t3, <16 x double> %t1,
           <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  store <16 x double> %r2, <16 x double> * %out2
+  store <16 x double> %r2, <16 x double> * %out2, align 4
   %r3 = shufflevector <16 x double> %t3, <16 x double> %t1,
           <16 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  store <16 x double> %r3, <16 x double> * %out3
+  store <16 x double> %r3, <16 x double> * %out3, align 4
   ret void
 }
 
@@ -3389,19 +3389,19 @@ define void
   %r0 = shufflevector <16 x double> %t2, <16 x double> %t0,
           <16 x i32> <i32 0, i32 8, i32 16, i32 24, i32 1, i32 9, i32 17, i32 25,
                       i32 2, i32 10, i32 18, i32 26, i32 3, i32 11, i32 19, i32 27>
-  store <16 x double> %r0, <16 x double> * %out0
+  store <16 x double> %r0, <16 x double> * %out0, align 4
   %r1 = shufflevector <16 x double> %t2, <16 x double> %t0,
           <16 x i32> <i32 4, i32 12, i32 20, i32 28, i32 5, i32 13, i32 21, i32 29,
                       i32 6, i32 14, i32 22, i32 30, i32 7, i32 15, i32 23, i32 31>
-  store <16 x double> %r1, <16 x double> * %out1
+  store <16 x double> %r1, <16 x double> * %out1, align 4
   %r2 = shufflevector <16 x double> %t3, <16 x double> %t1,
           <16 x i32> <i32 0, i32 8, i32 16, i32 24, i32 1, i32 9, i32 17, i32 25,
                       i32 2, i32 10, i32 18, i32 26, i32 3, i32 11, i32 19, i32 27>
-  store <16 x double> %r2, <16 x double> * %out2
+  store <16 x double> %r2, <16 x double> * %out2, align 4
   %r3 = shufflevector <16 x double> %t3, <16 x double> %t1,
           <16 x i32> <i32 4, i32 12, i32 20, i32 28, i32 5, i32 13, i32 21, i32 29,
                       i32 6, i32 14, i32 22, i32 30, i32 7, i32 15, i32 23, i32 31>
-  store <16 x double> %r3, <16 x double> * %out3
+  store <16 x double> %r3, <16 x double> * %out3, align 4
   ret void
 }
 ')
@@ -3423,11 +3423,11 @@ define void
   %r0 = shufflevector <16 x float> %t0, <16 x float> %t1,
           <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  store <16 x float> %r0, <16 x float> * %out0
+  store <16 x float> %r0, <16 x float> * %out0, align 4
   %r1 = shufflevector <16 x float> %t0, <16 x float> %t1,
           <16 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  store <16 x float> %r1, <16 x float> * %out1
+  store <16 x float> %r1, <16 x float> * %out1, align 4
 
   ;; t2 = <c0 ... c9 undef ... undef>
   %t2 = shufflevector <16 x float> %v0, <16 x float> %v1,
@@ -3438,7 +3438,7 @@ define void
   %r2 = shufflevector <16 x float> %t2, <16 x float> %v2,
           <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                       i32 8, i32 9, i32 16, i32 19, i32 22, i32 25, i32 28, i32 31>
-  store <16 x float> %r2, <16 x float> * %out2
+  store <16 x float> %r2, <16 x float> * %out2, align 4
   ret void
 }
 
@@ -3460,11 +3460,11 @@ define void
   %r0 = shufflevector <16 x float> %t0, <16 x float> %t1,
           <16 x i32> <i32 0, i32 11, i32 22, i32 1, i32 12, i32 23, i32 2, i32 13,
                       i32 24, i32 3, i32 14, i32 25, i32 4, i32 15, i32 26, i32 5>
-  store <16 x float> %r0, <16 x float> * %out0
+  store <16 x float> %r0, <16 x float> * %out0, align 4
   %r1 = shufflevector <16 x float> %t0, <16 x float> %t1,
           <16 x i32> <i32 16, i32 27, i32 6, i32 17, i32 28, i32 7, i32 18, i32 29,
                       i32 8, i32 19, i32 30, i32 9, i32 20, i32 31, i32 10, i32 21>
-  store <16 x float> %r1, <16 x float> * %out1
+  store <16 x float> %r1, <16 x float> * %out1, align 4
 
   ;; t2 = <a11 ... a15 b11 ... b15 undef ... undef>
   %t2 = shufflevector <16 x float> %v0, <16 x float> %v1,
@@ -3474,7 +3474,7 @@ define void
   %r2 = shufflevector <16 x float> %t2, <16 x float> %v2,
           <16 x i32> <i32 26, i32 0, i32 5, i32 27, i32 1, i32 6, i32 28, i32 2,
                       i32 7, i32 29, i32 3, i32 8, i32 30, i32 4, i32 9, i32 31>
-  store <16 x float> %r2, <16 x float> * %out2
+  store <16 x float> %r2, <16 x float> * %out2, align 4
   ret void
 }
 
@@ -3496,11 +3496,11 @@ define void
   %r0 = shufflevector <16 x double> %t0, <16 x double> %t1,
           <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  store <16 x double> %r0, <16 x double> * %out0
+  store <16 x double> %r0, <16 x double> * %out0, align 4
   %r1 = shufflevector <16 x double> %t0, <16 x double> %t1,
           <16 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  store <16 x double> %r1, <16 x double> * %out1
+  store <16 x double> %r1, <16 x double> * %out1, align 4
 
   ;; t2 = <c0 ... c9 undef ... undef>
   %t2 = shufflevector <16 x double> %v0, <16 x double> %v1,
@@ -3511,7 +3511,7 @@ define void
   %r2 = shufflevector <16 x double> %t2, <16 x double> %v2,
           <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                       i32 8, i32 9, i32 16, i32 19, i32 22, i32 25, i32 28, i32 31>
-  store <16 x double> %r2, <16 x double> * %out2
+  store <16 x double> %r2, <16 x double> * %out2, align 4
   ret void
 }
 
@@ -3533,11 +3533,11 @@ define void
   %r0 = shufflevector <16 x double> %t0, <16 x double> %t1,
           <16 x i32> <i32 0, i32 11, i32 22, i32 1, i32 12, i32 23, i32 2, i32 13,
                       i32 24, i32 3, i32 14, i32 25, i32 4, i32 15, i32 26, i32 5>
-  store <16 x double> %r0, <16 x double> * %out0
+  store <16 x double> %r0, <16 x double> * %out0, align 4
   %r1 = shufflevector <16 x double> %t0, <16 x double> %t1,
           <16 x i32> <i32 16, i32 27, i32 6, i32 17, i32 28, i32 7, i32 18, i32 29,
                       i32 8, i32 19, i32 30, i32 9, i32 20, i32 31, i32 10, i32 21>
-  store <16 x double> %r1, <16 x double> * %out1
+  store <16 x double> %r1, <16 x double> * %out1, align 4
 
   ;; t2 = <a11 ... a15 b11 ... b15 undef ... undef>
   %t2 = shufflevector <16 x double> %v0, <16 x double> %v1,
@@ -3547,7 +3547,7 @@ define void
   %r2 = shufflevector <16 x double> %t2, <16 x double> %v2,
           <16 x i32> <i32 26, i32 0, i32 5, i32 27, i32 1, i32 6, i32 28, i32 2,
                       i32 7, i32 29, i32 3, i32 8, i32 30, i32 4, i32 9, i32 31>
-  store <16 x double> %r2, <16 x double> * %out2
+  store <16 x double> %r2, <16 x double> * %out2, align 4
   ret void
 }
 
@@ -3567,8 +3567,8 @@ define void
   ;; t1 = <b0 ... b31>
   %t1 = shufflevector <16 x float> %v0, <16 x float> %v1,
           <16 x i32>  <i32 1, i32 3, i32 5, i32 7, i32 9, i32 11, i32 13, i32 15, i32 17, i32 19, i32 21, i32 23, i32 25, i32 27, i32 29, i32 31>
-  store <16 x float> %t0, <16 x float> * %out0
-  store <16 x float> %t1, <16 x float> * %out1
+  store <16 x float> %t0, <16 x float> * %out0, align 4
+  store <16 x float> %t1, <16 x float> * %out1, align 4
   ret void
 }
 
@@ -3586,8 +3586,8 @@ define void
           <16 x i32> <i32 0, i32 16, i32 1, i32 17, i32 2, i32 18, i32 3, i32 19, i32 4, i32 20, i32 5, i32 21, i32 6, i32 22, i32 7, i32 23>
   %t1 = shufflevector <16 x float> %v0, <16 x float> %v1,
           <16 x i32> <i32 8, i32 24, i32 9, i32 25, i32 10, i32 26, i32 11, i32 27, i32 12, i32 28, i32 13, i32 29, i32 14, i32 30, i32 15, i32 31>
-  store <16 x float> %t0, <16 x float> * %out0
-  store <16 x float> %t1, <16 x float> * %out1
+  store <16 x float> %t0, <16 x float> * %out0, align 4
+  store <16 x float> %t1, <16 x float> * %out1, align 4
   ret void
 }
 
@@ -3608,8 +3608,8 @@ define void
   ;; t1 = <b0 ... b31>
   %t1 = shufflevector <16 x double> %v0, <16 x double> %v1,
           <16 x i32> <i32 1, i32 3, i32 5, i32 7, i32 9, i32 11, i32 13, i32 15, i32 17, i32 19, i32 21, i32 23, i32 25, i32 27, i32 29, i32 31>
-  store <16 x double> %t0, <16 x double> * %out0
-  store <16 x double> %t1, <16 x double> * %out1
+  store <16 x double> %t0, <16 x double> * %out0, align 4
+  store <16 x double> %t1, <16 x double> * %out1, align 4
   ret void
 }
 
@@ -3627,8 +3627,8 @@ define void
           <16 x i32> <i32 0, i32 16, i32 1, i32 17, i32 2, i32 18, i32 3, i32 19, i32 4, i32 20, i32 5, i32 21, i32 6, i32 22, i32 7, i32 23>
   %t1 = shufflevector <16 x double> %v0, <16 x double> %v1,
           <16 x i32> <i32 8, i32 24, i32 9, i32 25, i32 10, i32 26, i32 11, i32 27, i32 12, i32 28, i32 13, i32 29, i32 14, i32 30, i32 15, i32 31>
-  store <16 x double> %t0, <16 x double> * %out0
-  store <16 x double> %t1, <16 x double> * %out1
+  store <16 x double> %t0, <16 x double> * %out0, align 4
+  store <16 x double> %t1, <16 x double> * %out1, align 4
   ret void
 }
 ')
@@ -3674,19 +3674,19 @@ define void
   %r0 = shufflevector <32 x float> %t2, <32 x float> %t0,
           <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  store <32 x float> %r0, <32 x float> * %out0
+  store <32 x float> %r0, <32 x float> * %out0, align 4
   %r1 = shufflevector <32 x float> %t2, <32 x float> %t0,
           <32 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-  store <32 x float> %r1, <32 x float> * %out1
+  store <32 x float> %r1, <32 x float> * %out1, align 4
   %r2 = shufflevector <32 x float> %t3, <32 x float> %t1,
           <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  store <32 x float> %r2, <32 x float> * %out2
+  store <32 x float> %r2, <32 x float> * %out2, align 4
   %r3 = shufflevector <32 x float> %t3, <32 x float> %t1,
           <32 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-  store <32 x float> %r3, <32 x float> * %out3
+  store <32 x float> %r3, <32 x float> * %out3, align 4
   ret void
 }
 
@@ -3727,19 +3727,19 @@ define void
   %r0 = shufflevector <32 x float> %t2, <32 x float> %t0,
           <32 x i32> <i32 0, i32 16, i32 32, i32 48, i32 1, i32 17, i32 33, i32 49, i32 2, i32 18, i32 34, i32 50, i32 3, i32 19, i32 35, i32 51,
                       i32 4, i32 20, i32 36, i32 52, i32 5, i32 21, i32 37, i32 53, i32 6, i32 22, i32 38, i32 54, i32 7, i32 23, i32 39, i32 55>
-  store <32 x float> %r0, <32 x float> * %out0
+  store <32 x float> %r0, <32 x float> * %out0, align 4
   %r1 = shufflevector <32 x float> %t2, <32 x float> %t0,
           <32 x i32> <i32 8, i32 24, i32 40, i32 56, i32 9, i32 25, i32 41, i32 57, i32 10, i32 26, i32 42, i32 58, i32 11, i32 27, i32 43, i32 59,
                       i32 12, i32 28, i32 44, i32 60, i32 13, i32 29, i32 45, i32 61, i32 14, i32 30, i32 46, i32 62, i32 15, i32 31, i32 47, i32 63>
-  store <32 x float> %r1, <32 x float> * %out1
+  store <32 x float> %r1, <32 x float> * %out1, align 4
   %r2 = shufflevector <32 x float> %t3, <32 x float> %t1,
           <32 x i32> <i32 0, i32 16, i32 32, i32 48, i32 1, i32 17, i32 33, i32 49, i32 2, i32 18, i32 34, i32 50, i32 3, i32 19, i32 35, i32 51,
                       i32 4, i32 20, i32 36, i32 52, i32 5, i32 21, i32 37, i32 53, i32 6, i32 22, i32 38, i32 54, i32 7, i32 23, i32 39, i32 55>
-  store <32 x float> %r2, <32 x float> * %out2
+  store <32 x float> %r2, <32 x float> * %out2, align 4
   %r3 = shufflevector <32 x float> %t3, <32 x float> %t1,
           <32 x i32> <i32 8, i32 24, i32 40, i32 56, i32 9, i32 25, i32 41, i32 57, i32 10, i32 26, i32 42, i32 58, i32 11, i32 27, i32 43, i32 59,
                       i32 12, i32 28, i32 44, i32 60, i32 13, i32 29, i32 45, i32 61, i32 14, i32 30, i32 46, i32 62, i32 15, i32 31, i32 47, i32 63>
-  store <32 x float> %r3, <32 x float> * %out3
+  store <32 x float> %r3, <32 x float> * %out3, align 4
   ret void
 }
 
@@ -3780,19 +3780,19 @@ define void
   %r0 = shufflevector <32 x double> %t2, <32 x double> %t0,
           <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  store <32 x double> %r0, <32 x double> * %out0
+  store <32 x double> %r0, <32 x double> * %out0, align 4
   %r1 = shufflevector <32 x double> %t2, <32 x double> %t0,
           <32 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-  store <32 x double> %r1, <32 x double> * %out1
+  store <32 x double> %r1, <32 x double> * %out1, align 4
   %r2 = shufflevector <32 x double> %t3, <32 x double> %t1,
           <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  store <32 x double> %r2, <32 x double> * %out2
+  store <32 x double> %r2, <32 x double> * %out2, align 4
   %r3 = shufflevector <32 x double> %t3, <32 x double> %t1,
           <32 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-  store <32 x double> %r3, <32 x double> * %out3
+  store <32 x double> %r3, <32 x double> * %out3, align 4
   ret void
 }
 
@@ -3833,19 +3833,19 @@ define void
   %r0 = shufflevector <32 x double> %t2, <32 x double> %t0,
           <32 x i32> <i32 0, i32 16, i32 32, i32 48, i32 1, i32 17, i32 33, i32 49, i32 2, i32 18, i32 34, i32 50, i32 3, i32 19, i32 35, i32 51,
                       i32 4, i32 20, i32 36, i32 52, i32 5, i32 21, i32 37, i32 53, i32 6, i32 22, i32 38, i32 54, i32 7, i32 23, i32 39, i32 55>
-  store <32 x double> %r0, <32 x double> * %out0
+  store <32 x double> %r0, <32 x double> * %out0, align 4
   %r1 = shufflevector <32 x double> %t2, <32 x double> %t0,
           <32 x i32> <i32 8, i32 24, i32 40, i32 56, i32 9, i32 25, i32 41, i32 57, i32 10, i32 26, i32 42, i32 58, i32 11, i32 27, i32 43, i32 59,
                       i32 12, i32 28, i32 44, i32 60, i32 13, i32 29, i32 45, i32 61, i32 14, i32 30, i32 46, i32 62, i32 15, i32 31, i32 47, i32 63>
-  store <32 x double> %r1, <32 x double> * %out1
+  store <32 x double> %r1, <32 x double> * %out1, align 4
   %r2 = shufflevector <32 x double> %t3, <32 x double> %t1,
           <32 x i32> <i32 0, i32 16, i32 32, i32 48, i32 1, i32 17, i32 33, i32 49, i32 2, i32 18, i32 34, i32 50, i32 3, i32 19, i32 35, i32 51,
                       i32 4, i32 20, i32 36, i32 52, i32 5, i32 21, i32 37, i32 53, i32 6, i32 22, i32 38, i32 54, i32 7, i32 23, i32 39, i32 55>
-  store <32 x double> %r2, <32 x double> * %out2
+  store <32 x double> %r2, <32 x double> * %out2, align 4
   %r3 = shufflevector <32 x double> %t3, <32 x double> %t1,
           <32 x i32> <i32 8, i32 24, i32 40, i32 56, i32 9, i32 25, i32 41, i32 57, i32 10, i32 26, i32 42, i32 58, i32 11, i32 27, i32 43, i32 59,
                       i32 12, i32 28, i32 44, i32 60, i32 13, i32 29, i32 45, i32 61, i32 14, i32 30, i32 46, i32 62, i32 15, i32 31, i32 47, i32 63>
-  store <32 x double> %r3, <32 x double> * %out3
+  store <32 x double> %r3, <32 x double> * %out3, align 4
   ret void
 }
 
@@ -3875,11 +3875,11 @@ define void
   %r0 = shufflevector <32 x float> %t0, <32 x float> %t1,
           <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  store <32 x float> %r0, <32 x float> * %out0
+  store <32 x float> %r0, <32 x float> * %out0, align 4
   %r1 = shufflevector <32 x float> %t0, <32 x float> %t1,
           <32 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-  store <32 x float> %r1, <32 x float> * %out1
+  store <32 x float> %r1, <32 x float> * %out1, align 4
 
   ;; t2 = <c0 ... c20 undef ... undef>
   %t2 = shufflevector <32 x float> %v0, <32 x float> %v1,
@@ -3890,7 +3890,7 @@ define void
   %r2 = shufflevector <32 x float> %t2, <32 x float> %v2,
           <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 33, i32 36, i32 39, i32 42, i32 45, i32 48, i32 51, i32 54, i32 57, i32 60, i32 63>
-  store <32 x float> %r2, <32 x float> * %out2
+  store <32 x float> %r2, <32 x float> * %out2, align 4
   ret void
 }
 
@@ -3920,11 +3920,11 @@ define void
   %r0 = shufflevector <32 x float> %t0, <32 x float> %t1,
           <32 x i32> <i32 0, i32 22, i32 43, i32 1, i32 23, i32 44, i32 2, i32 24, i32 45, i32 3, i32 25, i32 46, i32 4, i32 26, i32 47, i32 5,
                       i32 27, i32 48, i32 6, i32 28, i32 49, i32 7, i32 29, i32 50, i32 8, i32 30, i32 51, i32 9, i32 31, i32 52, i32 10, i32 32>
-  store <32 x float> %r0, <32 x float> * %out0
+  store <32 x float> %r0, <32 x float> * %out0, align 4
   %r1 = shufflevector <32 x float> %t0, <32 x float> %t1,
           <32 x i32> <i32 53, i32 11, i32 33, i32 54, i32 12, i32 34, i32 55, i32 13, i32 35, i32 56, i32 14, i32 36, i32 57, i32 15, i32 37, i32 58,
                       i32 16, i32 38, i32 59, i32 17, i32 39, i32 60, i32 18, i32 40, i32 61, i32 19, i32 41, i32 62, i32 20, i32 42, i32 63, i32 21>
-  store <32 x float> %r1, <32 x float> * %out1
+  store <32 x float> %r1, <32 x float> * %out1, align 4
 
   ;; t2 = <a22 ... a31 b21 ... b31 undef ... undef>
   %t2 = shufflevector <32 x float> %v0, <32 x float> %v1,
@@ -3934,7 +3934,7 @@ define void
   %r2 = shufflevector <32 x float> %t2, <32 x float> %v2,
           <32 x i32> <i32 10, i32 53, i32 0, i32 11, i32 54, i32 1, i32 12, i32 55, i32 2, i32 13, i32 56, i32 3, i32 14, i32 57, i32 4, i32 15,
                       i32 58, i32 5, i32 16, i32 59, i32 6, i32 17, i32 60, i32 7, i32 18, i32 61, i32 8, i32 19, i32 62, i32 9, i32 20, i32 63>
-  store <32 x float> %r2, <32 x float> * %out2
+  store <32 x float> %r2, <32 x float> * %out2, align 4
   ret void
 }
 
@@ -3964,11 +3964,11 @@ define void
   %r0 = shufflevector <32 x double> %t0, <32 x double> %t1,
           <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  store <32 x double> %r0, <32 x double> * %out0
+  store <32 x double> %r0, <32 x double> * %out0, align 4
   %r1 = shufflevector <32 x double> %t0, <32 x double> %t1,
           <32 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-  store <32 x double> %r1, <32 x double> * %out1
+  store <32 x double> %r1, <32 x double> * %out1, align 4
 
   ;; t2 = <c0 ... c20 undef ... undef>
   %t2 = shufflevector <32 x double> %v0, <32 x double> %v1,
@@ -3979,7 +3979,7 @@ define void
   %r2 = shufflevector <32 x double> %t2, <32 x double> %v2,
           <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 33, i32 36, i32 39, i32 42, i32 45, i32 48, i32 51, i32 54, i32 57, i32 60, i32 63>
-  store <32 x double> %r2, <32 x double> * %out2
+  store <32 x double> %r2, <32 x double> * %out2, align 4
   ret void
 }
 
@@ -4009,11 +4009,11 @@ define void
   %r0 = shufflevector <32 x double> %t0, <32 x double> %t1,
           <32 x i32> <i32 0, i32 22, i32 43, i32 1, i32 23, i32 44, i32 2, i32 24, i32 45, i32 3, i32 25, i32 46, i32 4, i32 26, i32 47, i32 5,
                       i32 27, i32 48, i32 6, i32 28, i32 49, i32 7, i32 29, i32 50, i32 8, i32 30, i32 51, i32 9, i32 31, i32 52, i32 10, i32 32>
-  store <32 x double> %r0, <32 x double> * %out0
+  store <32 x double> %r0, <32 x double> * %out0, align 4
   %r1 = shufflevector <32 x double> %t0, <32 x double> %t1,
           <32 x i32> <i32 53, i32 11, i32 33, i32 54, i32 12, i32 34, i32 55, i32 13, i32 35, i32 56, i32 14, i32 36, i32 57, i32 15, i32 37, i32 58,
                       i32 16, i32 38, i32 59, i32 17, i32 39, i32 60, i32 18, i32 40, i32 61, i32 19, i32 41, i32 62, i32 20, i32 42, i32 63, i32 21>
-  store <32 x double> %r1, <32 x double> * %out1
+  store <32 x double> %r1, <32 x double> * %out1, align 4
 
   ;; t2 = <a22 ... a31 b21 ... b31 undef ... undef>
   %t2 = shufflevector <32 x double> %v0, <32 x double> %v1,
@@ -4023,7 +4023,7 @@ define void
   %r2 = shufflevector <32 x double> %t2, <32 x double> %v2,
           <32 x i32> <i32 10, i32 53, i32 0, i32 11, i32 54, i32 1, i32 12, i32 55, i32 2, i32 13, i32 56, i32 3, i32 14, i32 57, i32 4, i32 15,
                       i32 58, i32 5, i32 16, i32 59, i32 6, i32 17, i32 60, i32 7, i32 18, i32 61, i32 8, i32 19, i32 62, i32 9, i32 20, i32 63>
-  store <32 x double> %r2, <32 x double> * %out2
+  store <32 x double> %r2, <32 x double> * %out2, align 4
   ret void
 }
 
@@ -4046,8 +4046,8 @@ define void
           <32 x i32> <i32 1, i32 3, i32 5, i32 7, i32 9, i32 11, i32 13, i32 15, i32 17, i32 19, i32 21, i32 23, i32 25, i32 27, i32 29, i32 31,
                       i32 33, i32 35, i32 37, i32 39, i32 41, i32 43, i32 45, i32 47, i32 49, i32 51, i32 53, i32 55, i32 57, i32 59, i32 61, i32 63>
 
-  store <32 x float> %t0, <32 x float> * %out0
-  store <32 x float> %t1, <32 x float> * %out1
+  store <32 x float> %t0, <32 x float> * %out0, align 4
+  store <32 x float> %t1, <32 x float> * %out1, align 4
   ret void
 }
 
@@ -4067,8 +4067,8 @@ define void
   %t1 = shufflevector <32 x float> %v0, <32 x float> %v1,
           <32 x i32> <i32 16, i32 48, i32 17, i32 49, i32 18, i32 50, i32 19, i32 51, i32 20, i32 52, i32 21, i32 53, i32 22, i32 54, i32 23, i32 55,
                       i32 24, i32 56, i32 25, i32 57, i32 26, i32 58, i32 27, i32 59, i32 28, i32 60, i32 29, i32 61, i32 30, i32 62, i32 31, i32 63>
-  store <32 x float> %t0, <32 x float> * %out0
-  store <32 x float> %t1, <32 x float> * %out1
+  store <32 x float> %t0, <32 x float> * %out0, align 4
+  store <32 x float> %t1, <32 x float> * %out1, align 4
   ret void
 }
 
@@ -4091,8 +4091,8 @@ define void
           <32 x i32> <i32 1, i32 3, i32 5, i32 7, i32 9, i32 11, i32 13, i32 15, i32 17, i32 19, i32 21, i32 23, i32 25, i32 27, i32 29, i32 31,
                       i32 33, i32 35, i32 37, i32 39, i32 41, i32 43, i32 45, i32 47, i32 49, i32 51, i32 53, i32 55, i32 57, i32 59, i32 61, i32 63>
 
-  store <32 x double> %t0, <32 x double> * %out0
-  store <32 x double> %t1, <32 x double> * %out1
+  store <32 x double> %t0, <32 x double> * %out0, align 4
+  store <32 x double> %t1, <32 x double> * %out1, align 4
   ret void
 }
 
@@ -4112,8 +4112,8 @@ define void
   %t1 = shufflevector <32 x double> %v0, <32 x double> %v1,
           <32 x i32> <i32 16, i32 48, i32 17, i32 49, i32 18, i32 50, i32 19, i32 51, i32 20, i32 52, i32 21, i32 53, i32 22, i32 54, i32 23, i32 55,
                       i32 24, i32 56, i32 25, i32 57, i32 26, i32 58, i32 27, i32 59, i32 28, i32 60, i32 29, i32 61, i32 30, i32 62, i32 31, i32 63>
-  store <32 x double> %t0, <32 x double> * %out0
-  store <32 x double> %t1, <32 x double> * %out1
+  store <32 x double> %t0, <32 x double> * %out0, align 4
+  store <32 x double> %t1, <32 x double> * %out1, align 4
   ret void
 }
 ')
@@ -4169,25 +4169,25 @@ define void
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
                       i32 64, i32 65, i32 66, i32 67, i32 68, i32 69, i32 70, i32 71, i32 72, i32 73, i32 74, i32 75, i32 76, i32 77, i32 78, i32 79,
                       i32 80, i32 81, i32 82, i32 83, i32 84, i32 85, i32 86, i32 87, i32 88, i32 89, i32 90, i32 91, i32 92, i32 93, i32 94, i32 95>
-  store <64 x float> %r0, <64 x float> * %out0
+  store <64 x float> %r0, <64 x float> * %out0, align 4
   %r1 = shufflevector <64 x float> %t2, <64 x float> %t0,
           <64 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63,
                       i32 96, i32 97, i32 98, i32 99, i32 100, i32 101, i32 102, i32 103, i32 104, i32 105, i32 106, i32 107, i32 108, i32 109, i32 110, i32 111,
                       i32 112, i32 113, i32 114, i32 115, i32 116, i32 117, i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127>
-  store <64 x float> %r1, <64 x float> * %out1
+  store <64 x float> %r1, <64 x float> * %out1, align 4
   %r2 = shufflevector <64 x float> %t3, <64 x float> %t1,
           <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
                       i32 64, i32 65, i32 66, i32 67, i32 68, i32 69, i32 70, i32 71, i32 72, i32 73, i32 74, i32 75, i32 76, i32 77, i32 78, i32 79,
                       i32 80, i32 81, i32 82, i32 83, i32 84, i32 85, i32 86, i32 87, i32 88, i32 89, i32 90, i32 91, i32 92, i32 93, i32 94, i32 95>
-  store <64 x float> %r2, <64 x float> * %out2
+  store <64 x float> %r2, <64 x float> * %out2, align 4
   %r3 = shufflevector <64 x float> %t3, <64 x float> %t1,
           <64 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63,
                       i32 96, i32 97, i32 98, i32 99, i32 100, i32 101, i32 102, i32 103, i32 104, i32 105, i32 106, i32 107, i32 108, i32 109, i32 110, i32 111,
                       i32 112, i32 113, i32 114, i32 115, i32 116, i32 117, i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127>
-  store <64 x float> %r3, <64 x float> * %out3
+  store <64 x float> %r3, <64 x float> * %out3, align 4
   ret void
 }
 
@@ -4238,25 +4238,25 @@ define void
                       i32 4, i32 36, i32 68, i32 100, i32 5, i32 37, i32 69, i32 101, i32 6, i32 38, i32 70, i32 102, i32 7, i32 39, i32 71, i32 103,
                       i32 8, i32 40, i32 72, i32 104, i32 9, i32 41, i32 73, i32 105, i32 10, i32 42, i32 74, i32 106, i32 11, i32 43, i32 75, i32 107,
                       i32 12, i32 44, i32 76, i32 108, i32 13, i32 45, i32 77, i32 109, i32 14, i32 46, i32 78, i32 110, i32 15, i32 47, i32 79, i32 111>
-  store <64 x float> %r0, <64 x float> * %out0
+  store <64 x float> %r0, <64 x float> * %out0, align 4
   %r1 = shufflevector <64 x float> %t2, <64 x float> %t0,
           <64 x i32> <i32 16, i32 48, i32 80, i32 112, i32 17, i32 49, i32 81, i32 113, i32 18, i32 50, i32 82, i32 114, i32 19, i32 51, i32 83, i32 115,
                       i32 20, i32 52, i32 84, i32 116, i32 21, i32 53, i32 85, i32 117, i32 22, i32 54, i32 86, i32 118, i32 23, i32 55, i32 87, i32 119,
                       i32 24, i32 56, i32 88, i32 120, i32 25, i32 57, i32 89, i32 121, i32 26, i32 58, i32 90, i32 122, i32 27, i32 59, i32 91, i32 123,
                       i32 28, i32 60, i32 92, i32 124, i32 29, i32 61, i32 93, i32 125, i32 30, i32 62, i32 94, i32 126, i32 31, i32 63, i32 95, i32 127>
-  store <64 x float> %r1, <64 x float> * %out1
+  store <64 x float> %r1, <64 x float> * %out1, align 4
   %r2 = shufflevector <64 x float> %t3, <64 x float> %t1,
           <64 x i32> <i32 0, i32 32, i32 64, i32 96, i32 1, i32 33, i32 65, i32 97, i32 2, i32 34, i32 66, i32 98, i32 3, i32 35, i32 67, i32 99,
                       i32 4, i32 36, i32 68, i32 100, i32 5, i32 37, i32 69, i32 101, i32 6, i32 38, i32 70, i32 102, i32 7, i32 39, i32 71, i32 103,
                       i32 8, i32 40, i32 72, i32 104, i32 9, i32 41, i32 73, i32 105, i32 10, i32 42, i32 74, i32 106, i32 11, i32 43, i32 75, i32 107,
                       i32 12, i32 44, i32 76, i32 108, i32 13, i32 45, i32 77, i32 109, i32 14, i32 46, i32 78, i32 110, i32 15, i32 47, i32 79, i32 111>
-  store <64 x float> %r2, <64 x float> * %out2
+  store <64 x float> %r2, <64 x float> * %out2, align 4
   %r3 = shufflevector <64 x float> %t3, <64 x float> %t1,
           <64 x i32> <i32 16, i32 48, i32 80, i32 112, i32 17, i32 49, i32 81, i32 113, i32 18, i32 50, i32 82, i32 114, i32 19, i32 51, i32 83, i32 115,
                       i32 20, i32 52, i32 84, i32 116, i32 21, i32 53, i32 85, i32 117, i32 22, i32 54, i32 86, i32 118, i32 23, i32 55, i32 87, i32 119,
                       i32 24, i32 56, i32 88, i32 120, i32 25, i32 57, i32 89, i32 121, i32 26, i32 58, i32 90, i32 122, i32 27, i32 59, i32 91, i32 123,
                       i32 28, i32 60, i32 92, i32 124, i32 29, i32 61, i32 93, i32 125, i32 30, i32 62, i32 94, i32 126, i32 31, i32 63, i32 95, i32 127>
-  store <64 x float> %r3, <64 x float> * %out3
+  store <64 x float> %r3, <64 x float> * %out3, align 4
   ret void
 }
 
@@ -4307,25 +4307,25 @@ define void
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
                       i32 64, i32 65, i32 66, i32 67, i32 68, i32 69, i32 70, i32 71, i32 72, i32 73, i32 74, i32 75, i32 76, i32 77, i32 78, i32 79,
                       i32 80, i32 81, i32 82, i32 83, i32 84, i32 85, i32 86, i32 87, i32 88, i32 89, i32 90, i32 91, i32 92, i32 93, i32 94, i32 95>
-  store <64 x double> %r0, <64 x double> * %out0
+  store <64 x double> %r0, <64 x double> * %out0, align 4
   %r1 = shufflevector <64 x double> %t2, <64 x double> %t0,
           <64 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63,
                       i32 96, i32 97, i32 98, i32 99, i32 100, i32 101, i32 102, i32 103, i32 104, i32 105, i32 106, i32 107, i32 108, i32 109, i32 110, i32 111,
                       i32 112, i32 113, i32 114, i32 115, i32 116, i32 117, i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127>
-  store <64 x double> %r1, <64 x double> * %out1
+  store <64 x double> %r1, <64 x double> * %out1, align 4
   %r2 = shufflevector <64 x double> %t3, <64 x double> %t1,
           <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
                       i32 64, i32 65, i32 66, i32 67, i32 68, i32 69, i32 70, i32 71, i32 72, i32 73, i32 74, i32 75, i32 76, i32 77, i32 78, i32 79,
                       i32 80, i32 81, i32 82, i32 83, i32 84, i32 85, i32 86, i32 87, i32 88, i32 89, i32 90, i32 91, i32 92, i32 93, i32 94, i32 95>
-  store <64 x double> %r2, <64 x double> * %out2
+  store <64 x double> %r2, <64 x double> * %out2, align 4
   %r3 = shufflevector <64 x double> %t3, <64 x double> %t1,
           <64 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63,
                       i32 96, i32 97, i32 98, i32 99, i32 100, i32 101, i32 102, i32 103, i32 104, i32 105, i32 106, i32 107, i32 108, i32 109, i32 110, i32 111,
                       i32 112, i32 113, i32 114, i32 115, i32 116, i32 117, i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127>
-  store <64 x double> %r3, <64 x double> * %out3
+  store <64 x double> %r3, <64 x double> * %out3, align 4
   ret void
 }
 
@@ -4376,25 +4376,25 @@ define void
                       i32 4, i32 36, i32 68, i32 100, i32 5, i32 37, i32 69, i32 101, i32 6, i32 38, i32 70, i32 102, i32 7, i32 39, i32 71, i32 103,
                       i32 8, i32 40, i32 72, i32 104, i32 9, i32 41, i32 73, i32 105, i32 10, i32 42, i32 74, i32 106, i32 11, i32 43, i32 75, i32 107,
                       i32 12, i32 44, i32 76, i32 108, i32 13, i32 45, i32 77, i32 109, i32 14, i32 46, i32 78, i32 110, i32 15, i32 47, i32 79, i32 111>
-  store <64 x double> %r0, <64 x double> * %out0
+  store <64 x double> %r0, <64 x double> * %out0, align 4
   %r1 = shufflevector <64 x double> %t2, <64 x double> %t0,
           <64 x i32> <i32 16, i32 48, i32 80, i32 112, i32 17, i32 49, i32 81, i32 113, i32 18, i32 50, i32 82, i32 114, i32 19, i32 51, i32 83, i32 115,
                       i32 20, i32 52, i32 84, i32 116, i32 21, i32 53, i32 85, i32 117, i32 22, i32 54, i32 86, i32 118, i32 23, i32 55, i32 87, i32 119,
                       i32 24, i32 56, i32 88, i32 120, i32 25, i32 57, i32 89, i32 121, i32 26, i32 58, i32 90, i32 122, i32 27, i32 59, i32 91, i32 123,
                       i32 28, i32 60, i32 92, i32 124, i32 29, i32 61, i32 93, i32 125, i32 30, i32 62, i32 94, i32 126, i32 31, i32 63, i32 95, i32 127>
-  store <64 x double> %r1, <64 x double> * %out1
+  store <64 x double> %r1, <64 x double> * %out1, align 4
   %r2 = shufflevector <64 x double> %t3, <64 x double> %t1,
           <64 x i32> <i32 0, i32 32, i32 64, i32 96, i32 1, i32 33, i32 65, i32 97, i32 2, i32 34, i32 66, i32 98, i32 3, i32 35, i32 67, i32 99,
                       i32 4, i32 36, i32 68, i32 100, i32 5, i32 37, i32 69, i32 101, i32 6, i32 38, i32 70, i32 102, i32 7, i32 39, i32 71, i32 103,
                       i32 8, i32 40, i32 72, i32 104, i32 9, i32 41, i32 73, i32 105, i32 10, i32 42, i32 74, i32 106, i32 11, i32 43, i32 75, i32 107,
                       i32 12, i32 44, i32 76, i32 108, i32 13, i32 45, i32 77, i32 109, i32 14, i32 46, i32 78, i32 110, i32 15, i32 47, i32 79, i32 111>
-  store <64 x double> %r2, <64 x double> * %out2
+  store <64 x double> %r2, <64 x double> * %out2, align 4
   %r3 = shufflevector <64 x double> %t3, <64 x double> %t1,
           <64 x i32> <i32 16, i32 48, i32 80, i32 112, i32 17, i32 49, i32 81, i32 113, i32 18, i32 50, i32 82, i32 114, i32 19, i32 51, i32 83, i32 115,
                       i32 20, i32 52, i32 84, i32 116, i32 21, i32 53, i32 85, i32 117, i32 22, i32 54, i32 86, i32 118, i32 23, i32 55, i32 87, i32 119,
                       i32 24, i32 56, i32 88, i32 120, i32 25, i32 57, i32 89, i32 121, i32 26, i32 58, i32 90, i32 122, i32 27, i32 59, i32 91, i32 123,
                       i32 28, i32 60, i32 92, i32 124, i32 29, i32 61, i32 93, i32 125, i32 30, i32 62, i32 94, i32 126, i32 31, i32 63, i32 95, i32 127>
-  store <64 x double> %r3, <64 x double> * %out3
+  store <64 x double> %r3, <64 x double> * %out3, align 4
   ret void
 }
 
@@ -4430,13 +4430,13 @@ define void
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
                       i32 64, i32 65, i32 66, i32 67, i32 68, i32 69, i32 70, i32 71, i32 72, i32 73, i32 74, i32 75, i32 76, i32 77, i32 78, i32 79,
                       i32 80, i32 81, i32 82, i32 83, i32 84, i32 85, i32 86, i32 87, i32 88, i32 89, i32 90, i32 91, i32 92, i32 93, i32 94, i32 95>
-  store <64 x float> %r0, <64 x float> * %out0
+  store <64 x float> %r0, <64 x float> * %out0, align 4
   %r1 = shufflevector <64 x float> %t0, <64 x float> %t1,
           <64 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63,
                       i32 96, i32 97, i32 98, i32 99, i32 100, i32 101, i32 102, i32 103, i32 104, i32 105, i32 106, i32 107, i32 108, i32 109, i32 110, i32 111,
                       i32 112, i32 113, i32 114, i32 115, i32 116, i32 117, i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127>
-  store <64 x float> %r1, <64 x float> * %out1
+  store <64 x float> %r1, <64 x float> * %out1, align 4
 
   ;; t2 = <c0 ... c41 undef ... undef>
   %t2 = shufflevector <64 x float> %v0, <64 x float> %v1,
@@ -4452,7 +4452,7 @@ define void
                       i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 64, i32 67, i32 70, i32 73, i32 76, i32 79,
                       i32 82, i32 85, i32 88, i32 91, i32 94, i32 97, i32 100, i32 103, i32 106, i32 109, i32 112, i32 115, i32 118, i32 121, i32 124, i32 127>
 
-  store <64 x float> %r2, <64 x float> * %out2
+  store <64 x float> %r2, <64 x float> * %out2, align 4
   ret void
 }
 
@@ -4488,13 +4488,13 @@ define void
                       i32 48, i32 91, i32 6, i32 49, i32 92, i32 7, i32 50, i32 93, i32 8, i32 51, i32 94, i32 9, i32 52, i32 95, i32 10, i32 53,
                       i32 96, i32 11, i32 54, i32 97, i32 12, i32 55, i32 98, i32 13, i32 56, i32 99, i32 14, i32 57, i32 100, i32 15, i32 58, i32 101,
                       i32 16, i32 59, i32 102, i32 17, i32 60, i32 103, i32 18, i32 61, i32 104, i32 19, i32 62, i32 105, i32 20, i32 63, i32 106, i32 21>
-  store <64 x float> %r0, <64 x float> * %out0
+  store <64 x float> %r0, <64 x float> * %out0, align 4
   %r1 = shufflevector <64 x float> %t0, <64 x float> %t1,
           <64 x i32> <i32 64, i32 107, i32 22, i32 65, i32 108, i32 23, i32 66, i32 109, i32 24, i32 67, i32 110, i32 25, i32 68, i32 111, i32 26, i32 69,
                       i32 112, i32 27, i32 70, i32 113, i32 28, i32 71, i32 114, i32 29, i32 72, i32 115, i32 30, i32 73, i32 116, i32 31, i32 74, i32 117,
                       i32 32, i32 75, i32 118, i32 33, i32 76, i32 119, i32 34, i32 77, i32 120, i32 35, i32 78, i32 121, i32 36, i32 79, i32 122, i32 37,
                       i32 80, i32 123, i32 38, i32 81, i32 124, i32 39, i32 82, i32 125, i32 40, i32 83, i32 126, i32 41, i32 84, i32 127, i32 42, i32 85>
-  store <64 x float> %r1, <64 x float> * %out1
+  store <64 x float> %r1, <64 x float> * %out1, align 4
 
   ;; t2 = <a43 ... a63 b43 ... b63 undef ... undef>
   %t2 = shufflevector <64 x float> %v0, <64 x float> %v1,
@@ -4508,7 +4508,7 @@ define void
                       i32 5, i32 26, i32 112, i32 6, i32 27, i32 113, i32 7, i32 28, i32 114, i32 8, i32 29, i32 115, i32 9, i32 30, i32 116, i32 10,
                       i32 31, i32 117, i32 11, i32 32, i32 118, i32 12, i32 33, i32 119, i32 13, i32 34, i32 120, i32 14, i32 35, i32 121, i32 15, i32 36,
                       i32 122, i32 16, i32 37, i32 123, i32 17, i32 38, i32 124, i32 18, i32 39, i32 125, i32 19, i32 40, i32 126, i32 20, i32 41, i32 127>
-  store <64 x float> %r2, <64 x float> * %out2
+  store <64 x float> %r2, <64 x float> * %out2, align 4
 
   ret void
 }
@@ -4545,13 +4545,13 @@ define void
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
                       i32 64, i32 65, i32 66, i32 67, i32 68, i32 69, i32 70, i32 71, i32 72, i32 73, i32 74, i32 75, i32 76, i32 77, i32 78, i32 79,
                       i32 80, i32 81, i32 82, i32 83, i32 84, i32 85, i32 86, i32 87, i32 88, i32 89, i32 90, i32 91, i32 92, i32 93, i32 94, i32 95>
-  store <64 x double> %r0, <64 x double> * %out0
+  store <64 x double> %r0, <64 x double> * %out0, align 4
   %r1 = shufflevector <64 x double> %t0, <64 x double> %t1,
           <64 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63,
                       i32 96, i32 97, i32 98, i32 99, i32 100, i32 101, i32 102, i32 103, i32 104, i32 105, i32 106, i32 107, i32 108, i32 109, i32 110, i32 111,
                       i32 112, i32 113, i32 114, i32 115, i32 116, i32 117, i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127>
-  store <64 x double> %r1, <64 x double> * %out1
+  store <64 x double> %r1, <64 x double> * %out1, align 4
 
   ;; t3 = <c0 ... c41 undef ... undef>
   %t2 = shufflevector <64 x double> %v0, <64 x double> %v1,
@@ -4567,7 +4567,7 @@ define void
                       i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 64, i32 67, i32 70, i32 73, i32 76, i32 79,
                       i32 82, i32 85, i32 88, i32 91, i32 94, i32 97, i32 100, i32 103, i32 106, i32 109, i32 112, i32 115, i32 118, i32 121, i32 124, i32 127>
 
-  store <64 x double> %r2, <64 x double> * %out2
+  store <64 x double> %r2, <64 x double> * %out2, align 4
   ret void
 }
 
@@ -4603,13 +4603,13 @@ define void
                       i32 48, i32 91, i32 6, i32 49, i32 92, i32 7, i32 50, i32 93, i32 8, i32 51, i32 94, i32 9, i32 52, i32 95, i32 10, i32 53,
                       i32 96, i32 11, i32 54, i32 97, i32 12, i32 55, i32 98, i32 13, i32 56, i32 99, i32 14, i32 57, i32 100, i32 15, i32 58, i32 101,
                       i32 16, i32 59, i32 102, i32 17, i32 60, i32 103, i32 18, i32 61, i32 104, i32 19, i32 62, i32 105, i32 20, i32 63, i32 106, i32 21>
-  store <64 x double> %r0, <64 x double> * %out0
+  store <64 x double> %r0, <64 x double> * %out0, align 4
   %r1 = shufflevector <64 x double> %t0, <64 x double> %t1,
           <64 x i32> <i32 64, i32 107, i32 22, i32 65, i32 108, i32 23, i32 66, i32 109, i32 24, i32 67, i32 110, i32 25, i32 68, i32 111, i32 26, i32 69,
                       i32 112, i32 27, i32 70, i32 113, i32 28, i32 71, i32 114, i32 29, i32 72, i32 115, i32 30, i32 73, i32 116, i32 31, i32 74, i32 117,
                       i32 32, i32 75, i32 118, i32 33, i32 76, i32 119, i32 34, i32 77, i32 120, i32 35, i32 78, i32 121, i32 36, i32 79, i32 122, i32 37,
                       i32 80, i32 123, i32 38, i32 81, i32 124, i32 39, i32 82, i32 125, i32 40, i32 83, i32 126, i32 41, i32 84, i32 127, i32 42, i32 85>
-  store <64 x double> %r1, <64 x double> * %out1
+  store <64 x double> %r1, <64 x double> * %out1, align 4
 
   ;; t2 = <a43 ... a63 b43 ... b63 undef ... undef>
   %t2 = shufflevector <64 x double> %v0, <64 x double> %v1, ; 21a[43:63] + 21b[43:63]
@@ -4624,7 +4624,7 @@ define void
                       i32 5, i32 26, i32 112, i32 6, i32 27, i32 113, i32 7, i32 28, i32 114, i32 8, i32 29, i32 115, i32 9, i32 30, i32 116, i32 10,
                       i32 31, i32 117, i32 11, i32 32, i32 118, i32 12, i32 33, i32 119, i32 13, i32 34, i32 120, i32 14, i32 35, i32 121, i32 15, i32 36,
                       i32 122, i32 16, i32 37, i32 123, i32 17, i32 38, i32 124, i32 18, i32 39, i32 125, i32 19, i32 40, i32 126, i32 20, i32 41, i32 127>
-  store <64 x double> %r2, <64 x double> * %out2
+  store <64 x double> %r2, <64 x double> * %out2, align 4
 
   ret void
 }
@@ -4652,8 +4652,8 @@ define void
                       i32 65, i32 67, i32 69, i32 71, i32 73, i32 75, i32 77, i32 79, i32 81, i32 83, i32 85, i32 87, i32 89, i32 91, i32 93, i32 95,
                       i32 97, i32 99, i32 101, i32 103, i32 105, i32 107, i32 109, i32 111, i32 113, i32 115, i32 117, i32 119, i32 121, i32 123, i32 125, i32 127>
 
-  store <64 x float> %t0, <64 x float> * %out0
-  store <64 x float> %t1, <64 x float> * %out1
+  store <64 x float> %t0, <64 x float> * %out0, align 4
+  store <64 x float> %t1, <64 x float> * %out1, align 4
   ret void
 }
 
@@ -4677,8 +4677,8 @@ define void
                       i32 40, i32 104, i32 41, i32 105, i32 42, i32 106, i32 43, i32 107, i32 44, i32 108, i32 45, i32 109, i32 46, i32 110, i32 47, i32 111,
                       i32 48, i32 112, i32 49, i32 113, i32 50, i32 114, i32 51, i32 115, i32 52, i32 116, i32 53, i32 117, i32 54, i32 118, i32 55, i32 119,
                       i32 56, i32 120, i32 57, i32 121, i32 58, i32 122, i32 59, i32 123, i32 60, i32 124, i32 61, i32 125, i32 62, i32 126, i32 63, i32 127>
-  store <64 x float> %t0, <64 x float> * %out0
-  store <64 x float> %t1, <64 x float> * %out1
+  store <64 x float> %t0, <64 x float> * %out0, align 4
+  store <64 x float> %t1, <64 x float> * %out1, align 4
   ret void
 }
 
@@ -4705,8 +4705,8 @@ define void
                       i32 65, i32 67, i32 69, i32 71, i32 73, i32 75, i32 77, i32 79, i32 81, i32 83, i32 85, i32 87, i32 89, i32 91, i32 93, i32 95,
                       i32 97, i32 99, i32 101, i32 103, i32 105, i32 107, i32 109, i32 111, i32 113, i32 115, i32 117, i32 119, i32 121, i32 123, i32 125, i32 127>
 
-  store <64 x double> %t0, <64 x double> * %out0
-  store <64 x double> %t1, <64 x double> * %out1
+  store <64 x double> %t0, <64 x double> * %out0, align 4
+  store <64 x double> %t1, <64 x double> * %out1, align 4
   ret void
 }
 
@@ -4730,8 +4730,8 @@ define void
                       i32 40, i32 104, i32 41, i32 105, i32 42, i32 106, i32 43, i32 107, i32 44, i32 108, i32 45, i32 109, i32 46, i32 110, i32 47, i32 111,
                       i32 48, i32 112, i32 49, i32 113, i32 50, i32 114, i32 51, i32 115, i32 52, i32 116, i32 53, i32 117, i32 54, i32 118, i32 55, i32 119,
                       i32 56, i32 120, i32 57, i32 121, i32 58, i32 122, i32 59, i32 123, i32 60, i32 124, i32 61, i32 125, i32 62, i32 126, i32 63, i32 127>
-  store <64 x double> %t0, <64 x double> * %out0
-  store <64 x double> %t1, <64 x double> * %out1
+  store <64 x double> %t0, <64 x double> * %out0, align 4
+  store <64 x double> %t1, <64 x double> * %out1, align 4
   ret void
 }
 ')

--- a/tests/lit-tests/aossoa_alignment.ispc
+++ b/tests/lit-tests/aossoa_alignment.ispc
@@ -1,0 +1,34 @@
+// RUN: %{ispc} %s --target=avx2-i32x4 --emit-asm -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx2-i32x8 --emit-asm -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx512skx-i32x16 --emit-asm -o - | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// The test checks that aos_to_soa uses unaligned stores by default, but aligning pointers
+// makes them aligned.
+
+// The test supposed to work on single-pumped targets only.
+
+// CHECK-LABEL: Begin function unaligned
+// CHECK-COUNT-3: vmovup{{[sd]}} %{{[xyz]mm[0-9]+}}, {{[0-9]*}}(%{{.*}})
+// CHECK-NOT: vmovup{{[sd]}} %{{[xyz]mm[0-9]+}}, {{[0-9]*}}(%{{.*}})
+void unaligned(uniform float * uniform input,
+       varying float * uniform out1,
+       varying float * uniform out2,
+       varying float * uniform out3) {
+    aos_to_soa3(input, out1, out2, out3);
+}
+
+// CHECK-LABEL: Begin function aligned
+// CHECK-COUNT-3: vmovap{{[sd]}} %{{[xyz]mm[0-9]+}}, {{[0-9]*}}(%{{.*}})
+// CHECK-NOT: vmovap{{[sd]}} %{{[xyz]mm[0-9]+}}, {{[0-9]*}}(%{{.*}})
+void aligned(uniform float * uniform input,
+       varying float * uniform out1,
+       varying float * uniform out2,
+       varying float * uniform out3) {
+    assume((((uniform int64)input) % (TARGET_WIDTH * sizeof(float))) == 0);
+    assume((((uniform int64)out1) % (TARGET_WIDTH * sizeof(float))) == 0);
+    assume((((uniform int64)out2) % (TARGET_WIDTH * sizeof(float))) == 0);
+    assume((((uniform int64)out3) % (TARGET_WIDTH * sizeof(float))) == 0);
+    aos_to_soa3(input, out1, out2, out3);
+}


### PR DESCRIPTION
Recent changes in `aos_to_soa` and `soa_to_aos` stdlib calls made them use wide stores and these stores are aligned by default. This increases the alignment requirements, which potentially may cause stability regressions. At the same time, modern hardware handles unaligned stores as efficiently as aligned. So we should use unaligned stores.