### PR TITLE
Follow LLVM trunk with AttrBuilder changes

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -1444,7 +1444,11 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_is32Bit = (getDataLayout()->getPointerSize() == 4);
 
         // TO-DO : Revisit addition of "target-features" and "target-cpu" for ARM support.
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_14_0
+        llvm::AttrBuilder *fattrBuilder = new llvm::AttrBuilder(*g->ctx);
+#else
         llvm::AttrBuilder *fattrBuilder = new llvm::AttrBuilder();
+#endif
 #ifdef ISPC_ARM_ENABLED
         if (m_isa == Target::NEON)
             fattrBuilder->addAttribute("target-cpu", this->m_cpu);


### PR DESCRIPTION
The build was broken after this commit: https://github.com/llvm/llvm-project/commit/d2cc6c2d0c2f8a6e272110416a3fd579ed5a3ac1 which changed `llvm::AttrBuilder` interface.