### PR TITLE
Add ISPC and LLVM version strings to !llvm.ident metadata.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2021, Intel Corporation
+#  Copyright (c) 2018-2022, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -386,10 +386,10 @@ endif()
 
 # Build definitions
 target_compile_definitions(${PROJECT_NAME} PRIVATE ${LLVM_VERSION})
+string(TIMESTAMP BUILD_DATE "%Y%m%d")
+target_compile_definitions(${PROJECT_NAME} PRIVATE BUILD_DATE=\"${BUILD_DATE}\"
+                                                   BUILD_VERSION=\"${GIT_COMMIT_HASH}\")
 if (UNIX)
-    string(TIMESTAMP BUILD_DATE "%Y%m%d")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE BUILD_DATE=\"${BUILD_DATE}\"
-                            BUILD_VERSION=\"${GIT_COMMIT_HASH}\")
     # Compile-time protection against static sized buffer overflows.
     target_compile_definitions(${PROJECT_NAME} PRIVATE "_FORTIFY_SOURCE=2")
 else()

--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -1008,6 +1008,12 @@ void ispc::AddBitcodeToModule(const BitcodeLib *lib, llvm::Module *module, Symbo
             }
         }
 
+        // Remove clang ID metadata from the bitcode module, as we don't need it.
+        llvm::NamedMDNode *identMD = bcModule->getNamedMetadata("llvm.ident");
+        if (identMD) {
+            identMD->eraseFromParent();
+        }
+
         std::unique_ptr<llvm::Module> M(bcModule);
         if (llvm::Linker::linkModules(*module, std::move(M))) {
             Error(SourcePos(), "Error linking stdlib bitcode.");

--- a/src/ispc_version.h
+++ b/src/ispc_version.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2015-2021, Intel Corporation
+  Copyright (c) 2015-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -66,3 +66,7 @@
 #if ISPC_LLVM_VERSION < OLDEST_SUPPORTED_LLVM || ISPC_LLVM_VERSION > LATEST_SUPPORTED_LLVM
 #error "Unhandled LLVM version"
 #endif
+
+#define ISPC_VERSION_STRING                                                                                            \
+    "Intel(r) Implicit SPMD Program Compiler (Intel(r) ISPC), " ISPC_VERSION " (build " BUILD_VERSION " @ " BUILD_DATE \
+    ", LLVM " ISPC_LLVM_VERSION_STRING ")"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -78,13 +78,9 @@ using namespace ispc;
 #endif // ISPC_HOST_IS_WINDOWS
 
 static void lPrintVersion() {
+    printf("%s\n", ISPC_VERSION_STRING);
 #ifdef ISPC_HOST_IS_WINDOWS
-    printf("Intel(r) Implicit SPMD Program Compiler (Intel(r) ISPC), %s (build date %s, LLVM %s)\n"
-           "Supported Visual Studio versions: %s.\n",
-           ISPC_VERSION, BUILD_DATE, ISPC_LLVM_VERSION_STRING, ISPC_VS_VERSION);
-#else
-    printf("Intel(r) Implicit SPMD Program Compiler (Intel(r) ISPC), %s (build %s @ %s, LLVM %s)\n", ISPC_VERSION,
-           BUILD_VERSION, BUILD_DATE, ISPC_LLVM_VERSION_STRING);
+    printf("Supported Visual Studio versions: %s.\n", ISPC_VS_VERSION);
 #endif
 
 // The recommended way to build ISPC assumes custom LLVM build with a set of patches.

--- a/tests/lit-tests/llvm_ident.ispc
+++ b/tests/lit-tests/llvm_ident.ispc
@@ -1,0 +1,9 @@
+// RUN: %{ispc} %s --emit-llvm-text -o - | FileCheck %s
+// RUN: %{ispc} %s --emit-llvm-text --nostdlib -o - | FileCheck %s
+
+// Check that version string embeded in !llvm.ident metadata is formed correctly.
+
+// CHECK: Intel(r) Implicit SPMD Program Compiler (Intel(r) ISPC), {{1\.[[:digit:]]+\.[[:digit:]]+(dev)?}} (build commit {{[[:xdigit:]]+}} @ {{([[:digit:]]{8})}}, LLVM [[LLVM_VERSION:[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+]])
+// CHECK: LLVM version [[LLVM_VERSION]] ({{[[:graph:]]+}} {{[[:xdigit:]]+}})
+
+int i;


### PR DESCRIPTION
- removes existing `!llvm.ident` metadata with clang version used to build stdlib bitcode file. If ISPC is built correctly, this should be also correct, but not it's not guaranteed.
- explicitly add the correct info in two separate strings for ISPC itself and LLVM.
- use the same ISPC version string in LLVM IR metadata and for `ispc --version` output.
- unify Unix and Windows output for version strings. The current divergence seem to be a heritage of separate build system on Unix and Windows before CMake.

Here's how it looks like now for a trivial file:
```llvm
source_filename = "foo.ispc"
target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-apple-macosx"

@i = local_unnamed_addr global <8 x i32> zeroinitializer

!llvm.ident = !{!0, !1}
!llvm.module.flags = !{!2, !3, !4, !5}

!0 = !{!"Intel(r) Implicit SPMD Program Compiler (Intel(r) ISPC), 1.17.0dev (build commit 10dd48623dbae131 @ 20220110, LLVM 13.0.0)"}
!1 = !{!"LLVM version 13.0.0 (https://github.com/llvm/llvm-project.git d7b669b3a30345cfcdb2fde2af6f48aa4b94845d)"}
!2 = !{i32 1, !"wchar_size", i32 4}
!3 = !{i32 7, !"PIC Level", i32 2}
!4 = !{i32 7, !"uwtable", i32 1}
!5 = !{i32 7, !"frame-pointer", i32 2}
```