### PR TITLE
Fix a warning and a failing test

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,7 +69,6 @@ using namespace ispc;
 #ifndef BUILD_DATE
 #define BUILD_DATE __DATE__
 #endif
-#define BUILD_VERSION ""
 #if _MSC_VER >= 1900
 #define ISPC_VS_VERSION "Visual Studio 2015 and later"
 #else


### PR DESCRIPTION
- missed removing `BUILD_VERSION` in recent commit, that caused a warning on Windows
- missed that `rsqrt28` and `rcp28` precision is not enough for `double` on KNL, so doing on NR iteration to have better precision