### PR TITLE
Docker / CI update: move Ubuntu build from 16.04 to 18.04

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-#  Copyright (c) 2018-2021, Intel Corporation
+#  Copyright (c) 2018-2022, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,7 @@ environment:
   LLVM_LATEST: 13.0
   DOCKER_PATH: "ispc/test_repo"
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1604
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
       LLVM_VERSION: latest
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: latest
@@ -103,14 +103,14 @@ for:
 -
   matrix:
     only:
-      - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1604
+      - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
   init:
     - sh: |-
         export ISPC_HOME=$APPVEYOR_BUILD_FOLDER
         export LLVM_HOME=$APPVEYOR_BUILD_FOLDER/llvm
         export CROSS_TOOLS=/usr/local/src/cross
         export WASM=OFF
-        export LLVM_TAR=llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        export LLVM_TAR=llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
   install:
     - sh: |-
         sudo apt-get update

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "11.1"
-      LLVM_TAR: llvm-11.1.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-11.1.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@v2
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "12.0"
-      LLVM_TAR: llvm-12.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-12.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@v2
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "13.0"
-      LLVM_TAR: llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "13.0"
-      LLVM_TAR: llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -12,7 +12,7 @@ on:
 env:
   LLVM_VERSION: "13.0"
   LLVM_REPO: https://github.com/ispc/llvm-project
-  LLVM_TAR: llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+  LLVM_TAR: llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
 jobs:
   linux-build:

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -15,8 +15,8 @@ env:
   SDE_TAR_NAME: sde-external-8.69.1-2021-07-18
 
 jobs:
-  # Building LLVM in docker, as using native Ubuntu 16.04 github-hosted image contains newer-than-expected libs and
-  # makes the resulting build not usable on other Ubuntu 16.04 images.
+  # Building LLVM in docker, as using native Ubuntu 18.04 github-hosted image contains newer-than-expected libs and
+  # makes the resulting build not usable on other Ubuntu 18.04 images.
   # Doing Linux build in two stages, as self-build is required, but Github Action runners are not always capable
   # to finish the full job in less than 6 hours.
   linux-build-llvm-trunk-1:
@@ -33,15 +33,15 @@ jobs:
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=trunk .
+        docker buildx build --tag ispc/ubuntu18.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=trunk .
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm_trunk_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
   linux-build-llvm-trunk-2:
     needs: [linux-build-llvm-trunk-1]
@@ -60,35 +60,35 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: llvm_trunk_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=trunk --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=trunk --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-trunk .
         # Note using gzip here, instead of xz - trading of space for speed, as it's just for passing to another stage.
-        tar czvf llvm-trunk-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.gz bin-trunk
+        tar czvf llvm-trunk-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-trunk
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm_trunk_linux
-        path: docker/ubuntu/16.04/cpu_ispc_build/llvm-trunk-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.gz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-trunk-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
   linux-build-ispc-llvm-trunk:
     needs: [linux-build-llvm-trunk-2]
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "trunk"
-      LLVM_TAR: llvm-trunk-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.gz
+      LLVM_TAR: llvm-trunk-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nightly-13.yml
+++ b/.github/workflows/nightly-13.yml
@@ -17,8 +17,8 @@ env:
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
 
 jobs:
-  # Building LLVM in docker, as using native Ubuntu 16.04 github-hosted image contains newer-than-expected libs and
-  # makes the resulting build not usable on other Ubuntu 16.04 images.
+  # Building LLVM in docker, as using native Ubuntu 18.04 github-hosted image contains newer-than-expected libs and
+  # makes the resulting build not usable on other Ubuntu 18.04 images.
   # Doing Linux build in two stages, as self-build is required, but Github Action runners are not always capable
   # to finish the full job in less than 6 hours.
   linux-build-llvm-13-1:
@@ -35,15 +35,15 @@ jobs:
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 .
+        docker buildx build --tag ispc/ubuntu18.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 .
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm13_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
   linux-build-llvm-13-2:
     needs: [linux-build-llvm-13-1]
@@ -62,35 +62,35 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: llvm13_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-13.0 .
         # Note using gzip here, instead of xz - trading of space for speed, as it's just for passing to another stage.
-        tar czvf llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.gz bin-13.0
+        tar czvf llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-13.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm_13_linux
-        path: docker/ubuntu/16.04/cpu_ispc_build/llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.gz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
   linux-build-ispc-llvm-13:
     needs: [linux-build-llvm-13-2]
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "13.0"
-      LLVM_TAR: llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.gz
+      LLVM_TAR: llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rebuild-llvm11.yml
+++ b/.github/workflows/rebuild-llvm11.yml
@@ -12,8 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Building LLVM in docker, as using native Ubuntu 16.04 github-hosted image contains newer-than-expected libs and
-  # makes the resulting build not usable on other Ubuntu 16.04 images.
+  # Building LLVM in docker, as using native Ubuntu 18.04 github-hosted image contains newer-than-expected libs and
+  # makes the resulting build not usable on other Ubuntu 18.04 images.
   # Doing Linux build in two stages, as self-build is required, but Github Action runners are not always capable
   # to finish the full job in less than 6 hours.
   linux-build-1:
@@ -30,15 +30,15 @@ jobs:
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=11.1 .
+        docker buildx build --tag ispc/ubuntu18.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=11.1 .
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
   linux-build-2:
     needs: [linux-build-1]
@@ -57,27 +57,27 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: llvm11_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=11.1 --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=11.1 --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-11.1 .
-        tar cJvf llvm-11.1.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz bin-11.1
+        tar cJvf llvm-11.1.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz bin-11.1
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11_linux
-        path: docker/ubuntu/16.04/cpu_ispc_build/llvm-11.1.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-11.1.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
   linux-build-release-1:
     runs-on: ubuntu-latest
@@ -93,15 +93,15 @@ jobs:
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=11.1 --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" .
+        docker buildx build --tag ispc/ubuntu18.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=11.1 --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" .
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11rel_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
   linux-build-release-2:
     needs: [linux-build-release-1]
@@ -120,27 +120,27 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: llvm11rel_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=11.1 --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=11.1 --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-11.1 .
-        tar cJvf llvm-11.1.0-ubuntu16.04-Release-x86.arm.wasm.tar.xz bin-11.1
+        tar cJvf llvm-11.1.0-ubuntu18.04-Release-x86.arm.wasm.tar.xz bin-11.1
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm11rel_linux
-        path: docker/ubuntu/16.04/cpu_ispc_build/llvm-11.1.0-ubuntu16.04-Release-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-11.1.0-ubuntu18.04-Release-x86.arm.wasm.tar.xz
 
   win-build:
     runs-on: windows-latest

--- a/.github/workflows/rebuild-llvm12.yml
+++ b/.github/workflows/rebuild-llvm12.yml
@@ -12,8 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Building LLVM in docker, as using native Ubuntu 16.04 github-hosted image contains newer-than-expected libs and
-  # makes the resulting build not usable on other Ubuntu 16.04 images.
+  # Building LLVM in docker, as using native Ubuntu 18.04 github-hosted image contains newer-than-expected libs and
+  # makes the resulting build not usable on other Ubuntu 18.04 images.
   # Doing Linux build in two stages, as self-build is required, but Github Action runners are not always capable
   # to finish the full job in less than 6 hours.
   linux-build-1:
@@ -30,15 +30,15 @@ jobs:
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=12.0 .
+        docker buildx build --tag ispc/ubuntu18.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=12.0 .
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm12_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
   linux-build-2:
     needs: [linux-build-1]
@@ -57,27 +57,27 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: llvm12_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=12.0 --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=12.0 --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-12.0 .
-        tar cJvf llvm-12.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz bin-12.0
+        tar cJvf llvm-12.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz bin-12.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm12_linux
-        path: docker/ubuntu/16.04/cpu_ispc_build/llvm-12.0.1-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-12.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
   linux-build-release-1:
     runs-on: ubuntu-latest
@@ -93,15 +93,15 @@ jobs:
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=12.0 --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" .
+        docker buildx build --tag ispc/ubuntu18.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=12.0 --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" .
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm12rel_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
   linux-build-release-2:
     needs: [linux-build-release-1]
@@ -120,27 +120,27 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: llvm12rel_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=12.0 --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=12.0 --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-12.0 .
-        tar cJvf llvm-12.0.1-ubuntu16.04-Release-x86.arm.wasm.tar.xz bin-12.0
+        tar cJvf llvm-12.0.1-ubuntu18.04-Release-x86.arm.wasm.tar.xz bin-12.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm12rel_linux
-        path: docker/ubuntu/16.04/cpu_ispc_build/llvm-12.0.1-ubuntu16.04-Release-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-12.0.1-ubuntu18.04-Release-x86.arm.wasm.tar.xz
 
   win-build:
     runs-on: windows-latest

--- a/.github/workflows/rebuild-llvm13.yml
+++ b/.github/workflows/rebuild-llvm13.yml
@@ -12,8 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Building LLVM in docker, as using native Ubuntu 16.04 github-hosted image contains newer-than-expected libs and
-  # makes the resulting build not usable on other Ubuntu 16.04 images.
+  # Building LLVM in docker, as using native Ubuntu 18.04 github-hosted image contains newer-than-expected libs and
+  # makes the resulting build not usable on other Ubuntu 18.04 images.
   # Doing Linux build in two stages, as self-build is required, but Github Action runners are not always capable
   # to finish the full job in less than 6 hours.
   linux-build-1:
@@ -30,15 +30,15 @@ jobs:
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 .
+        docker buildx build --tag ispc/ubuntu18.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 .
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm13_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
   linux-build-2:
     needs: [linux-build-1]
@@ -57,27 +57,27 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: llvm13_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-13.0 .
-        tar cJvf llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz bin-13.0
+        tar cJvf llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz bin-13.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm13_linux
-        path: docker/ubuntu/16.04/cpu_ispc_build/llvm-13.0.0-ubuntu16.04-Release+Asserts-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
   linux-build-release-1:
     runs-on: ubuntu-latest
@@ -93,15 +93,15 @@ jobs:
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" .
+        docker buildx build --tag ispc/ubuntu18.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" .
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm13rel_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
   linux-build-release-2:
     needs: [linux-build-release-1]
@@ -120,27 +120,27 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: llvm13rel_linux_stage1_cache
-        path: docker/ubuntu/16.04/cpu_ispc_build/cache.local
+        path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu16.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
-        cd docker/ubuntu/16.04/cpu_ispc_build
+        cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-13.0 .
-        tar cJvf llvm-13.0.0-ubuntu16.04-Release-x86.arm.wasm.tar.xz bin-13.0
+        tar cJvf llvm-13.0.0-ubuntu18.04-Release-x86.arm.wasm.tar.xz bin-13.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm13rel_linux
-        path: docker/ubuntu/16.04/cpu_ispc_build/llvm-13.0.0-ubuntu16.04-Release-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-13.0.0-ubuntu18.04-Release-x86.arm.wasm.tar.xz
 
   win-build:
     runs-on: windows-latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,7 +19,8 @@ Note that adding all of these `Dockerfile`s to regular CI runs is currently prob
 
 By default `Dockerfile`s are assumed to be built as `x86` images, but some can be built as `aarch64` images (note that `ispc` is a cross-compiler, so regardless the host arch, it can target any supported CPU architecuture, if it's enabled in `ispc` build).
 
- * [ubuntu/16.04/cpu\_ispc\_build/Dockerfile](ubuntu/16.04/cpu_ispc_build/Dockerfile) `Ubuntu 16.04` image. CPU only. Ubuntu 16.04 is used to enabled maximum compatibility. This Dockerfile does LLVM selfbuild in two stages, which enables splitting it to two separate CI jobs. The image is used in CI for nightly LLVM builds.
+ * [ubuntu/16.04/cpu\_ispc\_build/Dockerfile](ubuntu/16.04/cpu_ispc_build/Dockerfile) `Ubuntu 16.04` image. CPU only. It's outdated due to EOL for Python 3.6 repo for Ubuntu 16.04.
+ * [ubuntu/18.04/cpu\_ispc\_build/Dockerfile](ubuntu/16.04/cpu_ispc_build/Dockerfile) `Ubuntu 18.04` image. CPU only. Ubuntu 18.04 is used to enabled maximum compatibility. This Dockerfile does LLVM selfbuild in two stages, which enables splitting it to two separate CI jobs. The image is used in CI for nightly LLVM builds.
  * [ubuntu/20.04/cpu\_ispc\_build/Dockerfile](ubuntu/20.04/cpu_ispc_build/Dockerfile) `Ubuntu 20.04` image. CPU only. Works on both `x86` and `aarch64`.
  * [ubuntu/20.04/xpu\_ispc\_build/Dockerfile](ubuntu/20.04/xpu_ispc_build/Dockerfile) `Ubuntu 20.04` image. XPU (CPU+GPU). This is the recommended environment for XPU experiments.
  * [centos/7/cpu\_ispc\_build/Dockerfile](centos/7/cpu_ispc_build/Dockerfile) `CentOS 7` image. CPU only. Works on both `x86` and `aarch64`.

--- a/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
@@ -1,0 +1,85 @@
+ARG LLVM_VERSION=12.0
+
+FROM ubuntu:18.04 AS llvm_build_step1
+MAINTAINER Dmitry Babokin <dmitry.y.babokin@intel.com>
+SHELL ["/bin/bash", "-c"]
+
+ARG REPO=ispc/ispc
+ARG SHA=main
+ARG LLVM_VERSION
+ARG EXTRA_BUILD_ARG
+
+# !!! Make sure that your docker config provides enough memory to the container,
+# otherwise LLVM build may fail, as it will use all the cores available to container.
+
+RUN uname -a
+
+# Packages required to build ISPC and Clang.
+RUN apt-get -y update && apt-get install -y wget build-essential gcc g++ git python3 ncurses-dev libtinfo-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and install required version of cmake (3.13) for ISPC build
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/Kitware/CMake/releases/download/v3.13.5/cmake-3.13.5-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.13.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.13.5-Linux-x86_64.sh
+
+# If you are behind a proxy, you need to configure git.
+RUN if [ -v "$http_proxy" ]; then git config --global --add http.proxy "$http_proxy"; fi
+
+WORKDIR /usr/local/src
+
+# Fork ispc on github and clone *your* fork.
+RUN git clone https://github.com/$REPO.git ispc
+RUN cd ispc && git checkout $SHA && cd ..
+
+# This is home for Clang builds
+RUN mkdir /usr/local/src/llvm
+
+ENV ISPC_HOME=/usr/local/src/ispc
+ENV LLVM_HOME=/usr/local/src/llvm
+
+# If you are going to run test for future platforms, go to
+# http://www.intel.com/software/sde and download the latest version,
+# extract it, add to path and set SDE_HOME.
+
+WORKDIR /usr/local/src/ispc
+
+# Build Clang with all required patches.
+# Pass required LLVM_VERSION with --build-arg LLVM_VERSION=<version>.
+# Note self-build options, it's required to build clang and ispc with the same compiler,
+# i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
+# or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
+# "rm" are just to keep docker image small.
+RUN python3 ./alloy.py -b --version=$LLVM_VERSION --selfbuild-phase1 --verbose $EXTRA_BUILD_ARG && \
+    rm -rf $LLVM_HOME/build-"$LLVM_VERSION"_temp
+
+FROM llvm_build_step1 AS llvm_build_step2
+ARG LLVM_VERSION
+ARG EXTRA_BUILD_ARG
+
+RUN python3 ./alloy.py -b --version=$LLVM_VERSION --selfbuild-phase2 --verbose $EXTRA_BUILD_ARG && \
+    rm -rf $LLVM_HOME/build-$LLVM_VERSION $LLVM_HOME/llvm-$LLVM_VERSION $LLVM_HOME/bin-"$LLVM_VERSION"_temp
+ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+
+FROM llvm_build_step2 AS ispc_build
+ARG LLVM_VERSION
+
+# ISPC builds in C++17 mode and will fail without modern libstdc++
+# Also install regular ISPC dependencies
+RUN apt-get -y update && apt-get install -y software-properties-common && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test -y && apt-get -y update && \
+    apt-get -y update && apt-get install -y libstdc++-9-dev && \
+    apt-get install -y m4 bison flex zlib1g-dev libc6-dev-i386 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Configure ISPC build
+RUN mkdir build_$LLVM_VERSION
+WORKDIR build_$LLVM_VERSION
+RUN cmake ../ -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/usr/local/src/ispc/bin-$LLVM_VERSION -DCMAKE_CXX_FLAGS=-Werror
+
+# Build ISPC
+RUN make ispc -j8 && make check-all && make install
+WORKDIR ../
+RUN rm -rf build_$LLVM_VERSION
+
+#export path for ispc
+ENV PATH=/usr/local/src/ispc/bin-$LLVM_VERSION/bin:$PATH


### PR DESCRIPTION
Support for Python 3.6 on Ubuntu 16.04 is EOL (more details here: https://github.com/deadsnakes/issues/issues/195). So Ubuntu 16.04 [Dockerfile](https://github.com/ispc/ispc/blob/fdf009cce84c741b5a74ea3c0e2d75c0c0d4cd45/docker/ubuntu/16.04/cpu_ispc_build/Dockerfile) stopped working. We could manually build and install Python 3.6, but I think it's time to move to Ubuntu 18.04 as a minimum version we use to build ISPC in CI.

The PR does the following:
- introduces Ubuntu 18.04 Dockerfile
- switches GitHub Actions CI to use Ubuntu 18.04 Dockerfile to build LLVM when LLVM re-build is needed
- switches GitHub Actions CI to use prebuilt LLVM binaries built on Ubuntu 18.04
- switches Appveyor CI to run on Ubuntu 18.04 image and use LLVM built on Ubuntu 18.04

What's still missing:
- aarch64 builds and TravisCI to use Ubuntu 18.04.