### PR TITLE
Avoid build errors due to depricated function. This is due to Opaque Pointers changes in LLVM

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -2150,7 +2150,7 @@ llvm::Value *FunctionEmitContext::AddElementOffset(llvm::Value *fullBasePtr, int
 
     llvm::PointerType *llvmPtrType = llvm::dyn_cast<llvm::PointerType>(fullBasePtr->getType());
     if (llvmPtrType != NULL) {
-        llvm::StructType *llvmStructType = llvm::dyn_cast<llvm::StructType>(llvmPtrType->getElementType());
+        llvm::StructType *llvmStructType = llvm::dyn_cast<llvm::StructType>(llvmPtrType->PTR_ELT_TYPE());
         if (llvmStructType != NULL && llvmStructType->isSized() == false) {
             AssertPos(currentPos, m->errorCount > 0);
             return NULL;
@@ -2283,7 +2283,7 @@ llvm::Value *FunctionEmitContext::LoadInst(llvm::Value *ptr, const Type *type, c
         new llvm::LoadInst(ptr, name.isTriviallyEmpty() ? (llvm::Twine(ptr->getName()) + "_load") : name, bblock);
 #endif
 
-    if (g->opt.forceAlignedMemory && llvm::dyn_cast<llvm::VectorType>(pt->getElementType())) {
+    if (g->opt.forceAlignedMemory && llvm::dyn_cast<llvm::VectorType>(pt->PTR_ELT_TYPE())) {
         inst->setAlignment(llvm::MaybeAlign(g->target->getNativeVectorAlignment()).valueOrOne());
     }
 
@@ -2972,7 +2972,7 @@ void FunctionEmitContext::StoreInst(llvm::Value *value, llvm::Value *ptr, const 
 
     llvm::StoreInst *inst = new llvm::StoreInst(value, ptr, bblock);
 
-    if (g->opt.forceAlignedMemory && llvm::dyn_cast<llvm::VectorType>(pt->getElementType())) {
+    if (g->opt.forceAlignedMemory && llvm::dyn_cast<llvm::VectorType>(pt->PTR_ELT_TYPE())) {
         inst->setAlignment(llvm::MaybeAlign(g->target->getNativeVectorAlignment()).valueOrOne());
     }
 
@@ -3271,7 +3271,7 @@ static unsigned int lCalleeArgCount(llvm::Value *callee, const FunctionType *fun
             // function that takes a mask
             return funcType->GetNumParameters() + 1;
         }
-        ft = llvm::dyn_cast<llvm::FunctionType>(pt->getElementType());
+        ft = llvm::dyn_cast<llvm::FunctionType>(pt->PTR_ELT_TYPE());
     }
 
     Assert(ft != NULL);
@@ -3617,8 +3617,8 @@ llvm::Value *FunctionEmitContext::LaunchInst(llvm::Value *callee, std::vector<ll
 
     llvm::PointerType *pt = llvm::dyn_cast<llvm::PointerType>(argType);
     AssertPos(currentPos, pt);
-    AssertPos(currentPos, llvm::StructType::classof(pt->getElementType()));
-    llvm::StructType *argStructType = static_cast<llvm::StructType *>(pt->getElementType());
+    AssertPos(currentPos, llvm::StructType::classof(pt->PTR_ELT_TYPE()));
+    llvm::StructType *argStructType = static_cast<llvm::StructType *>(pt->PTR_ELT_TYPE());
 
     llvm::Function *falloc = m->module->getFunction("ISPCAlloc");
     AssertPos(currentPos, falloc != NULL);

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -7604,8 +7604,8 @@ llvm::Value *AllocaExpr::GetValue(FunctionEmitContext *ctx) const {
     llvm::Value *llvmValue = expr->GetValue(ctx);
     if (llvmValue == NULL)
         return NULL;
-    llvm::Value *resultPtr = ctx->AllocaInst((LLVMTypes::VoidPointerType)->getElementType(), llvmValue, "allocaExpr",
-                                             16, false); // 16 byte stack alignment.
+    llvm::Value *resultPtr = ctx->AllocaInst((LLVMTypes::VoidPointerType)->PTR_ELT_TYPE(), llvmValue, "allocaExpr", 16,
+                                             false); // 16 byte stack alignment.
     return resultPtr;
 }
 

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2021, Intel Corporation
+  Copyright (c) 2011-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -175,7 +175,7 @@ static void lCopyInTaskParameter(int i, llvm::Value *structArgPtr, const std::ve
     Assert(llvm::isa<llvm::PointerType>(structArgType));
     const llvm::PointerType *pt = llvm::dyn_cast<const llvm::PointerType>(structArgType);
     Assert(pt);
-    Assert(llvm::isa<llvm::StructType>(pt->getElementType()));
+    Assert(llvm::isa<llvm::StructType>(pt->PTR_ELT_TYPE()));
 
     // Get the type of the argument we're copying in and its Symbol pointer
     Symbol *sym = args[i];

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -45,7 +45,15 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Type.h>
 
-#define PTYPE(p) (llvm::cast<llvm::PointerType>((p)->getType()->getScalarType())->getElementType())
+// In the transition to Opaque Pointers getElementType() was deprecated, getPointerElementType() will live a little
+// longer. But we need another solution eventually. Issue #2245 was filed to track this.
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_14_0
+#define PTR_ELT_TYPE getPointerElementType
+#else
+#define PTR_ELT_TYPE getElementType
+#endif
+
+#define PTYPE(p) (llvm::cast<llvm::PointerType>((p)->getType()->getScalarType())->PTR_ELT_TYPE())
 
 namespace llvm {
 class PHINode;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2748,7 +2748,7 @@ static void lExtractOrCheckGlobals(llvm::Module *msrc, llvm::Module *mdst, bool 
         llvm::GlobalVariable *gv = &*iter;
         // Is it a global definition?
         if (gv->getLinkage() == llvm::GlobalValue::ExternalLinkage && gv->hasInitializer()) {
-            llvm::Type *type = gv->getType()->getElementType();
+            llvm::Type *type = gv->getType()->PTR_ELT_TYPE();
             Symbol *sym = m->symbolTable->LookupVariable(gv->getName().str().c_str());
             Assert(sym != NULL);
 

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -4327,7 +4327,7 @@ static bool lIsSafeToBlend(llvm::Value *lvalue) {
             llvm::Type *type = ai->getType();
             llvm::PointerType *pt = llvm::dyn_cast<llvm::PointerType>(type);
             Assert(pt != NULL);
-            type = pt->getElementType();
+            type = pt->PTR_ELT_TYPE();
             llvm::ArrayType *at;
             while ((at = llvm::dyn_cast<llvm::ArrayType>(type))) {
                 type = at->getElementType();


### PR DESCRIPTION
This is the fix to make ISPC building with LLVM trunk, but more meaningful changes are required to support Opaque Pointers.

The current breakage was caused by LLVM commit https://github.com/llvm/llvm-project/commit/184591a.

Opaque Pointers are tracked in #2245