### PR TITLE
Centos 8 Dockerfile - lack of ncurses-static workaround

### DIFF
--- a/docker/centos/8/cpu_ispc_build/Dockerfile
+++ b/docker/centos/8/cpu_ispc_build/Dockerfile
@@ -17,9 +17,12 @@ RUN dnf -y update && dnf install -y wget yum-utils gcc gcc-c++ git python3 make 
     dnf clean -y all
 
 # These packages are required if you need to link IPSC with -static.
-# TODO: build ncurses static version manually.
 RUN dnf -y --enablerepo=powertools install libstdc++-static zlib-static && \
     dnf clean -y all
+
+# Ncurses for g++ --static -lcurses -ltinfo. Despite setting --enable-overwrite it doesn't link(only static not linked?) libncurses as libcurses so symlinked manually
+RUN git clone https://github.com/ThomasDickey/ncurses-snapshots.git --depth=1 && cd ncurses-snapshots && ./configure --with-termlib --with-libtool --with-libtool-opts=-static --enable-static --enable-overwrite && make -j8 && make install && \
+  ln -s /usr/lib/libncurses.a /usr/lib/libcurses.a && ln -s /usr/lib/libncurses++.a /usr/lib/libcurses++.a
 
 # Download and install required version of cmake (3.14 for x86, 3.20 for aarch64, as earlier versions are not available as binary distribution) for ISPC build
 RUN if [[ `uname -m` =~ "x86" ]]; then export CMAKE_URL="https://cmake.org/files/v3.14/cmake-3.14.0-Linux-x86_64.sh"; else export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.20.3/cmake-3.20.3-linux-aarch64.sh"; fi && \

--- a/docker/centos/8/cpu_ispc_build/Dockerfile
+++ b/docker/centos/8/cpu_ispc_build/Dockerfile
@@ -11,8 +11,8 @@ ARG LLVM_VERSION
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
 
-# Packages required to build ISPC and Clang.
-RUN dnf -y update && dnf install -y wget yum-utils gcc gcc-c++ git python3 make ncurses-devel zlib-devel xz && \
+# Packages required to build ISPC and Clang. libtool is needed to build ncurses.
+RUN dnf -y update && dnf install -y wget yum-utils gcc gcc-c++ git python3 make ncurses-devel zlib-devel xz libtool && \
 #    yum install -y libtool autopoint gettext-devel texinfo help2man && \
     dnf clean -y all
 

--- a/docker/centos/8/cpu_ispc_build/Dockerfile
+++ b/docker/centos/8/cpu_ispc_build/Dockerfile
@@ -1,6 +1,6 @@
 ARG LLVM_VERSION=12.0
 
-FROM centos:8 AS llvm_only
+FROM rockylinux:8 AS llvm_only
 MAINTAINER Dmitry Babokin <dmitry.y.babokin@intel.com>
 SHELL ["/bin/bash", "-c"]
 
@@ -21,7 +21,7 @@ RUN dnf -y --enablerepo=powertools install libstdc++-static zlib-static && \
     dnf clean -y all
 
 # Ncurses for g++ --static -lcurses -ltinfo. Despite setting --enable-overwrite it doesn't link(only static not linked?) libncurses as libcurses so symlinked manually
-RUN git clone https://github.com/ThomasDickey/ncurses-snapshots.git --depth=1 && cd ncurses-snapshots && ./configure --with-termlib --with-libtool --with-libtool-opts=-static --enable-static --enable-overwrite && make -j8 && make install && \
+RUN git clone https://github.com/ThomasDickey/ncurses-snapshots.git --depth=1 --branch=v6_3 && cd ncurses-snapshots && ./configure --with-termlib --with-libtool --with-libtool-opts=-static --enable-static --enable-overwrite && make -j8 && make install && \
   ln -s /usr/lib/libncurses.a /usr/lib/libcurses.a && ln -s /usr/lib/libncurses++.a /usr/lib/libcurses++.a
 
 # Download and install required version of cmake (3.14 for x86, 3.20 for aarch64, as earlier versions are not available as binary distribution) for ISPC build


### PR DESCRIPTION
Building static ncurses and symlinking  so -lcurses works as -lncurses(libcurses.a linked to libncurses.a). Not required for LLVM-only version but required for package build