### PR TITLE
Switch to LLVM 13.0.1 in CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,7 +58,7 @@ for:
         if "%LLVM_VERSION%"=="latest" (set WASM=ON)
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( (set generator="Visual Studio 15 Win64") & (set vsversion=2017))
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vsversion=2019))
-        set LLVM_TAR=llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        set LLVM_TAR=llvm-13.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
         if "%LLVM_VERSION%"=="12.0" (set LLVM_TAR=llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
         if "%LLVM_VERSION%"=="11.1" (set LLVM_TAR=llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
   install:
@@ -110,7 +110,7 @@ for:
         export LLVM_HOME=$APPVEYOR_BUILD_FOLDER/llvm
         export CROSS_TOOLS=/usr/local/src/cross
         export WASM=OFF
-        export LLVM_TAR=llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+        export LLVM_TAR=llvm-13.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
   install:
     - sh: |-
         sudo apt-get update

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "13.0"
-      LLVM_TAR: llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-13.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@v2
@@ -416,7 +416,7 @@ jobs:
     runs-on: windows-latest
     env:
       LLVM_VERSION: "13.0"
-      LLVM_TAR: llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_TAR: llvm-13.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "13.0"
-      LLVM_TAR: llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-13.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -12,7 +12,7 @@ on:
 env:
   LLVM_VERSION: "13.0"
   LLVM_REPO: https://github.com/ispc/llvm-project
-  LLVM_TAR: llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+  LLVM_TAR: llvm-13.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
 jobs:
   linux-build:

--- a/.github/workflows/nightly-14.yml
+++ b/.github/workflows/nightly-14.yml
@@ -4,7 +4,7 @@
 # Currently disabled. To be reenabled for 14.0 when it's branched. #
 ####################################################################
 
-name: Nightly tests / LLVM 13.0
+name: Nightly tests / LLVM 14.0
 
 # Run daily - test sse2-avx512 targets @ -O0/-O1/-O2
 on:
@@ -21,7 +21,7 @@ jobs:
   # makes the resulting build not usable on other Ubuntu 18.04 images.
   # Doing Linux build in two stages, as self-build is required, but Github Action runners are not always capable
   # to finish the full job in less than 6 hours.
-  linux-build-llvm-13-1:
+  linux-build-llvm-14-1:
     runs-on: ubuntu-latest
 
     steps:
@@ -42,11 +42,11 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: llvm13_linux_stage1_cache
+        name: llvm14_linux_stage1_cache
         path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
-  linux-build-llvm-13-2:
-    needs: [linux-build-llvm-13-1]
+  linux-build-llvm-14-2:
+    needs: [linux-build-llvm-14-1]
     runs-on: ubuntu-latest
 
     steps:
@@ -61,7 +61,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: llvm13_linux_stage1_cache
+        name: llvm14_linux_stage1_cache
         path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
     - name: Build LLVM
@@ -69,28 +69,28 @@ jobs:
         cd docker/ubuntu/18.04/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=14.0 --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
         cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
-        mv usr/local/src/llvm/bin-13.0 .
+        mv usr/local/src/llvm/bin-14.0 .
         # Note using gzip here, instead of xz - trading of space for speed, as it's just for passing to another stage.
-        tar czvf llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-13.0
+        tar czvf llvm-14.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-14.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: llvm_13_linux
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+        name: llvm_14_linux
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
-  linux-build-ispc-llvm-13:
-    needs: [linux-build-llvm-13-2]
+  linux-build-ispc-llvm-14:
+    needs: [linux-build-llvm-14-2]
     runs-on: ubuntu-latest
     env:
-      LLVM_VERSION: "13.0"
-      LLVM_TAR: llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+      LLVM_VERSION: "14.0"
+      LLVM_TAR: llvm-14.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
     steps:
     - uses: actions/checkout@v2
@@ -100,7 +100,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: llvm_13_linux
+        name: llvm_14_linux
 
     - name: Install dependencies
       run: |
@@ -123,11 +123,11 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: ispc_llvm_13_linux
+        name: ispc_llvm_14_linux
         path: build/ispc-trunk-linux.tar.gz
 
-  linux-test-llvm-13:
-    needs: [linux-build-ispc-llvm-13]
+  linux-test-llvm-14:
+    needs: [linux-build-ispc-llvm-14]
     runs-on: ubuntu-latest
     continue-on-error: false
     strategy:
@@ -144,7 +144,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: ispc_llvm_13_linux
+        name: ispc_llvm_14_linux
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -174,7 +174,7 @@ jobs:
         [ -z "`git diff`" ]
 
 
-  win-build-llvm-13:
+  win-build-llvm-14:
     runs-on: windows-latest
 
     steps:
@@ -200,30 +200,30 @@ jobs:
     - name: Build LLVM
       shell: cmd
       run: |
-        python ./alloy.py -b --version=13.0 --verbose
+        python ./alloy.py -b --version=14.0 --verbose
         cd alloy_results* && type alloy_build.log
 
     - name: Pack LLVM
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm
-        7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-13.0
+        set TAR_BASE_NAME=llvm-14.0.0-win.vs2019-Release+Asserts-x86.arm.wasm
+        7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-14.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: llvm_13_win
-        path: llvm/llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        name: llvm_14_win
+        path: llvm/llvm-14.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
 
-  win-build-ispc-llvm-13:
-    needs: [win-build-llvm-13]
+  win-build-ispc-llvm-14:
+    needs: [win-build-llvm-14]
     runs-on: windows-latest
     env:
-      LLVM_VERSION: "13.0"
-      LLVM_TAR: llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_VERSION: "14.0"
+      LLVM_TAR: llvm-14.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"
@@ -236,7 +236,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: llvm_13_win
+        name: llvm_14_win
         path: ${{env.LLVM_HOME}}
 
     - name: Add msbuild to PATH
@@ -262,12 +262,12 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: ispc_llvm13_win
+        name: ispc_llvm14_win
         path: build/ispc-trunk-windows.msi
 
 
-  win-test-llvm13:
-    needs: [win-build-ispc-llvm-13]
+  win-test-llvm14:
+    needs: [win-build-ispc-llvm-14]
     env:
       LLVM_HOME: "C:\\projects\\llvm"
     runs-on: windows-latest
@@ -288,7 +288,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: ispc_llvm13_win
+        name: ispc_llvm14_win
 
     - name: Install dependencies
       run: |
@@ -314,6 +314,6 @@ jobs:
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: fail_db.llvm13.${{matrix.arch}}.${{matrix.target}}.txt
+        name: fail_db.llvm14.${{matrix.arch}}.${{matrix.target}}.txt
         path: fail_db.txt
 

--- a/.github/workflows/rebuild-llvm13.yml
+++ b/.github/workflows/rebuild-llvm13.yml
@@ -71,13 +71,13 @@ jobs:
         cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-13.0 .
-        tar cJvf llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz bin-13.0
+        tar cJvf llvm-13.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz bin-13.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm13_linux
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-13.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-13.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
   linux-build-release-1:
     runs-on: ubuntu-latest
@@ -134,13 +134,13 @@ jobs:
         cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-13.0 .
-        tar cJvf llvm-13.0.0-ubuntu18.04-Release-x86.arm.wasm.tar.xz bin-13.0
+        tar cJvf llvm-13.0.1-ubuntu18.04-Release-x86.arm.wasm.tar.xz bin-13.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm13rel_linux
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-13.0.0-ubuntu18.04-Release-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-13.0.1-ubuntu18.04-Release-x86.arm.wasm.tar.xz
 
   win-build:
     runs-on: windows-latest
@@ -175,7 +175,7 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-13.0.1-win.vs2019-Release+Asserts-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-13.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -183,7 +183,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: llvm13_win
-        path: llvm/llvm-13.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        path: llvm/llvm-13.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
   win-build-release:
     runs-on: windows-latest
@@ -218,7 +218,7 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-13.0.0-win.vs2019-Release-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-13.0.1-win.vs2019-Release-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-13.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -226,7 +226,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: llvm13rel_win
-        path: llvm/llvm-13.0.0-win.vs2019-Release-x86.arm.wasm.tar.7z
+        path: llvm/llvm-13.0.1-win.vs2019-Release-x86.arm.wasm.tar.7z
 
   mac-build:
     runs-on: macos-10.15
@@ -263,13 +263,13 @@ jobs:
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-13.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz bin-13.0
+        tar cJvf llvm-13.0.1-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz bin-13.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm13_macos
-        path: llvm/llvm-13.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
+        path: llvm/llvm-13.0.1-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
 
   mac-build-release:
     runs-on: macos-10.15
@@ -306,11 +306,11 @@ jobs:
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-13.0.0-macos10.15-Release-x86.arm.wasm.tar.xz bin-13.0
+        tar cJvf llvm-13.0.1-macos10.15-Release-x86.arm.wasm.tar.xz bin-13.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm13rel_macos
-        path: llvm/llvm-13.0.0-macos10.15-Release-x86.arm.wasm.tar.xz
+        path: llvm/llvm-13.0.1-macos10.15-Release-x86.arm.wasm.tar.xz
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
       dist: bionic
       env:
         - LLVM_VERSION=13.0 OS=Ubuntu18.04aarch64
-        - LLVM_TAR=llvm-13.0.0-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_TAR=llvm-13.0.1-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
         - LLVM_REPO=https://github.com/ispc/llvm-project
         - ISPC_HOME=$TRAVIS_BUILD_DIR
       before_install:


### PR DESCRIPTION
- Switch CI (Github Actions, Appveyor, TravisCI) to use LLVM 13.0.1 instead of 13.0.0
- Retarget "Nightly 13" action to 14, as it's just branched. It's not enabled in cron yet (but still can be triggered manually).