### PR TITLE
LLVM 13.0 patch to disable DIArgList for Xe targets

### DIFF
--- a/llvm_patches/13_0_disable-DIArgList-in-SPIR-V.patch
+++ b/llvm_patches/13_0_disable-DIArgList-in-SPIR-V.patch
@@ -1,0 +1,23 @@
+# This patch is needed for ISPC for Xe only
+# It disables using of DIArgList for dbg.val if SPIR-V target is used.
+# It is needed till DIArgList is supported in SPIR-V Translator.
+diff --git a/llvm/lib/Transforms/Utils/Local.cpp b/llvm/lib/Transforms/Utils/Local.cpp
+index d03d76f57ca1..0b86e454df57 100644
+--- a/llvm/lib/Transforms/Utils/Local.cpp
++++ b/llvm/lib/Transforms/Utils/Local.cpp
+@@ -1771,7 +1771,14 @@ void llvm::salvageDebugInfoForDbgValues(
+     } else if (isa<DbgValueInst>(DII) &&
+                DII->getNumVariableLocationOps() + AdditionalValues.size() <=
+                    MaxDebugArgs) {
+-      DII->addVariableLocationOps(AdditionalValues, SalvagedExpr);
++      if (!Triple(I.getModule()->getTargetTriple()).isSPIR()) {
++        DII->addVariableLocationOps(AdditionalValues, SalvagedExpr);
++      } else {
++        // Do not salvage using DIArgList for dbg.val fpr SPIR-V target, as it is
++        // not currently supported by SPIR-V Translator.
++        Value *Undef = UndefValue::get(I.getOperand(0)->getType());
++        DII->replaceVariableLocationOp(I.getOperand(0), Undef);
++      }
+     } else {
+       // Do not salvage using DIArgList for dbg.addr/dbg.declare, as it is
+       // currently only valid for stack value expressions.

--- a/tests/lit-tests/xe_diarglist.ispc
+++ b/tests/lit-tests/xe_diarglist.ispc
@@ -1,0 +1,26 @@
+// This test checks that DIArgList introduced in LLVM 13 does not appear for
+// Xe targets when debug information is used.
+// RUN: %{ispc} %s --target=gen9-x8 -g --emit-llvm-text -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_XE
+// RUN: %{ispc} %s --target=avx2-i32x8 -g --emit-llvm-text -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_CPU
+
+// REQUIRES: XE_ENABLED
+// REQUIRES: LLVM_13_0+
+struct Parameters
+{
+  int width;
+  int height;
+  int *output;
+};
+// CHECK_XE-NOT: call void @llvm.dbg.value(metadata !DIArgList
+// CHECK_CPU: call void @llvm.dbg.value(metadata !DIArgList
+task void test(void *uniform _p)
+{
+  Parameters *uniform p = (Parameters * uniform) _p;
+
+  foreach (y = 0 ... p->height, x = 0 ... p->width) {
+    int index        = y * p->width + x;
+    p->output[index] = 1;
+  }
+}


### PR DESCRIPTION
This is a patch to LLVM 13 to disable generation of DIArgList for dbg.val for Xe targets plus lit test.
DIArgList construction is not supported by SPIR-V translator yet.
With this patch debug info for the cases when DIArgList looks the same as for LLVM 12.