### PR TITLE
CI updates: VS2022, SDE 9.0.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,7 +37,7 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
       LLVM_VERSION: latest
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       LLVM_VERSION: latest
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: 12.0
@@ -46,8 +46,8 @@ for:
 -
   matrix:
     only:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
   init:
     - cmd: |-
         set ISPC_HOME=%APPVEYOR_BUILD_FOLDER%
@@ -56,9 +56,9 @@ for:
         set CHOCO_DIR=%ProgramData%\chocolatey
         set WASM=OFF
         if "%LLVM_VERSION%"=="latest" (set WASM=ON)
-        if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( (set generator="Visual Studio 15 Win64") & (set vsversion=2017))
-        if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vsversion=2019))
-        set LLVM_TAR=llvm-13.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vspath="C:\Program Files (x86)\Microsoft Visual Studio\2019"))
+        if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2022" ( (set generator="Visual Studio 17") & (set vspath="C:\Program Files\Microsoft Visual Studio\2022"))
+        set LLVM_TAR=llvm-13.0.1-win.vs2022-Release+Asserts-x86.arm.wasm.tar.7z
         if "%LLVM_VERSION%"=="12.0" (set LLVM_TAR=llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
         if "%LLVM_VERSION%"=="11.1" (set LLVM_TAR=llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
   install:
@@ -83,7 +83,7 @@ for:
         set PATH=%LLVM_HOME%\bin-%LLVM_VERSION%\bin;%PATH%
   before_build:
     - cmd: |-
-        call "C:\Program Files (x86)\Microsoft Visual Studio\%vsversion%\Community\VC\Auxiliary\Build\vcvars64.bat"
+        call %vspath%\Community\VC\Auxiliary\Build\vcvars64.bat
         cd %ISPC_HOME%
         check_env.py
         mkdir build && cd build

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -12,7 +12,8 @@ on:
         required: true
         default: 'full'
 env:
-  SDE_TAR_NAME: sde-external-8.69.1-2021-07-18
+  SDE_MIRROR_ID: 684899
+  SDE_TAR_NAME: sde-external-9.0.0-2021-11-07
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
   LLVM_REPO: https://github.com/ispc/llvm-project
   TARGETS_SMOKE: '["avx2-i32x8"]'

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -331,7 +331,7 @@ jobs:
 
   win-build-ispc-llvm11:
     needs: [define-flow]
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       LLVM_VERSION: "11.1"
       LLVM_TAR: llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
@@ -372,7 +372,7 @@ jobs:
 
   win-build-ispc-llvm12:
     needs: [define-flow]
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       LLVM_VERSION: "12.0"
       LLVM_TAR: llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
@@ -413,7 +413,7 @@ jobs:
 
   win-build-ispc-llvm13:
     needs: [define-flow]
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       LLVM_VERSION: "13.0"
       LLVM_TAR: llvm-13.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
@@ -454,7 +454,7 @@ jobs:
 
   win-test-llvm11:
     needs: [define-flow, win-build-ispc-llvm11]
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       LLVM_HOME: "C:\\projects\\llvm"
     continue-on-error: false
@@ -503,7 +503,7 @@ jobs:
     needs: [define-flow, win-build-ispc-llvm12]
     env:
       LLVM_HOME: "C:\\projects\\llvm"
-    runs-on: windows-latest
+    runs-on: windows-2022
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -549,7 +549,7 @@ jobs:
     needs: [define-flow, win-build-ispc-llvm13]
     env:
       LLVM_HOME: "C:\\projects\\llvm"
-    runs-on: windows-latest
+    runs-on: windows-2022
     continue-on-error: false
     strategy:
       fail-fast: false

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -8,7 +8,8 @@ on:
         required: true
         default: 'full'
 env:
-  SDE_TAR_NAME: sde-external-8.69.1-2021-07-18
+  SDE_MIRROR_ID: 684899
+  SDE_TAR_NAME: sde-external-9.0.0-2021-11-07
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
   LLVM_REPO: https://github.com/ispc/llvm-project
   TARGETS_SMOKE: '["avx2-i32x8"]'

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 env:
-  SDE_TAR_NAME: sde-external-8.69.1-2021-07-18
+  SDE_MIRROR_ID: 684899
+  SDE_TAR_NAME: sde-external-9.0.0-2021-11-07
 
 jobs:
   # Building LLVM in docker, as using native Ubuntu 18.04 github-hosted image contains newer-than-expected libs and

--- a/.github/workflows/nightly-14.yml
+++ b/.github/workflows/nightly-14.yml
@@ -175,7 +175,7 @@ jobs:
 
 
   win-build-llvm-14:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -220,7 +220,7 @@ jobs:
 
   win-build-ispc-llvm-14:
     needs: [win-build-llvm-14]
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       LLVM_VERSION: "14.0"
       LLVM_TAR: llvm-14.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
@@ -270,7 +270,7 @@ jobs:
     needs: [win-build-ispc-llvm-14]
     env:
       LLVM_HOME: "C:\\projects\\llvm"
-    runs-on: windows-latest
+    runs-on: windows-2022
     continue-on-error: false
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-14.yml
+++ b/.github/workflows/nightly-14.yml
@@ -13,7 +13,8 @@ on:
   workflow_dispatch:
 
 env:
-  SDE_TAR_NAME: sde-external-8.69.1-2021-07-18
+  SDE_MIRROR_ID: 684899
+  SDE_TAR_NAME: sde-external-9.0.0-2021-11-07
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
 
 jobs:

--- a/.github/workflows/rebuild-llvm11.yml
+++ b/.github/workflows/rebuild-llvm11.yml
@@ -143,7 +143,7 @@ jobs:
         path: docker/ubuntu/18.04/cpu_ispc_build/llvm-11.1.0-ubuntu18.04-Release-x86.arm.wasm.tar.xz
 
   win-build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -186,7 +186,7 @@ jobs:
         path: llvm/llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
   win-build-release:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rebuild-llvm11.yml
+++ b/.github/workflows/rebuild-llvm11.yml
@@ -168,7 +168,7 @@ jobs:
     - name: Build LLVM
       shell: cmd
       run: |
-        python ./alloy.py -b --version=11.1 --verbose
+        python ./alloy.py -b --version=11.1 --verbose --generator="Visual Studio 16 2019"
         cd alloy_results* && type alloy_build.log
 
     - name: Pack LLVM
@@ -211,7 +211,7 @@ jobs:
     - name: Build LLVM
       shell: cmd
       run: |
-        python ./alloy.py -b --version=11.1 --verbose --llvm-disable-assertions
+        python ./alloy.py -b --version=11.1 --verbose --llvm-disable-assertions --generator="Visual Studio 16 2019"
         cd alloy_results* && type alloy_build.log
 
     - name: Pack LLVM

--- a/.github/workflows/rebuild-llvm12.yml
+++ b/.github/workflows/rebuild-llvm12.yml
@@ -143,7 +143,7 @@ jobs:
         path: docker/ubuntu/18.04/cpu_ispc_build/llvm-12.0.1-ubuntu18.04-Release-x86.arm.wasm.tar.xz
 
   win-build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -186,7 +186,7 @@ jobs:
         path: llvm/llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
   win-build-release:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rebuild-llvm12.yml
+++ b/.github/workflows/rebuild-llvm12.yml
@@ -168,7 +168,7 @@ jobs:
     - name: Build LLVM
       shell: cmd
       run: |
-        python ./alloy.py -b --version=12.0 --verbose
+        python ./alloy.py -b --version=12.0 --verbose --generator="Visual Studio 16 2019"
         cd alloy_results* && type alloy_build.log
 
     - name: Pack LLVM
@@ -211,7 +211,7 @@ jobs:
     - name: Build LLVM
       shell: cmd
       run: |
-        python ./alloy.py -b --version=12.0 --verbose --llvm-disable-assertions
+        python ./alloy.py -b --version=12.0 --verbose --llvm-disable-assertions --generator="Visual Studio 16 2019"
         cd alloy_results* && type alloy_build.log
 
     - name: Pack LLVM

--- a/.github/workflows/rebuild-llvm13.yml
+++ b/.github/workflows/rebuild-llvm13.yml
@@ -168,14 +168,14 @@ jobs:
     - name: Build LLVM
       shell: cmd
       run: |
-        python ./alloy.py -b --version=13.0 --verbose
+        python ./alloy.py -b --version=13.0 --verbose --generator="Visual Studio 17 2022"
         cd alloy_results* && type alloy_build.log
 
     - name: Pack LLVM
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-13.0.1-win.vs2019-Release+Asserts-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-13.0.1-win.vs2022-Release+Asserts-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-13.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -183,7 +183,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: llvm13_win
-        path: llvm/llvm-13.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        path: llvm/llvm-13.0.1-win.vs2022-Release+Asserts-x86.arm.wasm.tar.7z
 
   win-build-release:
     runs-on: windows-2022
@@ -211,14 +211,14 @@ jobs:
     - name: Build LLVM
       shell: cmd
       run: |
-        python ./alloy.py -b --version=13.0 --verbose --llvm-disable-assertions
+        python ./alloy.py -b --version=13.0 --verbose --llvm-disable-assertions --generator="Visual Studio 17 2022"
         cd alloy_results* && type alloy_build.log
 
     - name: Pack LLVM
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-13.0.1-win.vs2019-Release-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-13.0.1-win.vs2022-Release-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-13.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -226,7 +226,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: llvm13rel_win
-        path: llvm/llvm-13.0.1-win.vs2019-Release-x86.arm.wasm.tar.7z
+        path: llvm/llvm-13.0.1-win.vs2022-Release-x86.arm.wasm.tar.7z
 
   mac-build:
     runs-on: macos-10.15

--- a/.github/workflows/rebuild-llvm13.yml
+++ b/.github/workflows/rebuild-llvm13.yml
@@ -143,7 +143,7 @@ jobs:
         path: docker/ubuntu/18.04/cpu_ispc_build/llvm-13.0.1-ubuntu18.04-Release-x86.arm.wasm.tar.xz
 
   win-build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -186,7 +186,7 @@ jobs:
         path: llvm/llvm-13.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
   win-build-release:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/scripts/install-build-deps.ps1
+++ b/.github/workflows/scripts/install-build-deps.ps1
@@ -20,5 +20,5 @@ echo "${env:LLVM_HOME}\bin-${env:LLVM_VERSION}\bin" | Out-File -FilePath $env:GI
 # Download and unpack gnuwin32
 mkdir ${env:CROSS_TOOLS_GNUWIN32}
 cd ${env:CROSS_TOOLS_GNUWIN32}
-wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 -O libgw32c-0.4-lib.zip https://sourceforge.net/projects/gnuwin32/files/libgw32c/0.4/libgw32c-0.4-lib.zip/download
+wget --retry-connrefused --waitretry=10 --read-timeout=20 --timeout=15 -t 5 -O libgw32c-0.4-lib.zip https://sourceforge.net/projects/gnuwin32/files/libgw32c/0.4/libgw32c-0.4-lib.zip/download
 7z.exe x libgw32c-0.4-lib.zip

--- a/.github/workflows/scripts/install-svml-test-deps.sh
+++ b/.github/workflows/scripts/install-svml-test-deps.sh
@@ -31,7 +31,7 @@ do
 done
 
 find /usr -name cdefs.h || echo "Find errors were ignored"
-wget -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://software.intel.com/content/dam/develop/external/us/en/documents/downloads/"$SDE_TAR_NAME"-lin.tar.bz2
+wget -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
 tar xf "$SDE_TAR_NAME"-lin.tar.bz2
 tar xf ispc-trunk-linux.tar.gz
 

--- a/.github/workflows/scripts/install-test-deps.ps1
+++ b/.github/workflows/scripts/install-test-deps.ps1
@@ -15,7 +15,7 @@ cat install.log
 echo "$pwd\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
 # Download and unpack SDE
-wget -U "${env:USER_AGENT}" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://software.intel.com/content/dam/develop/external/us/en/documents/downloads/${env:SDE_TAR_NAME}-win.tar.bz2
-7z.exe x -tbzip2 ${env:SDE_TAR_NAME}-win.tar.bz2
+wget -U "${env:USER_AGENT}" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/${env:SDE_MIRROR_ID}/${env:SDE_TAR_NAME}-win.tar.xz
+7z.exe x -txz ${env:SDE_TAR_NAME}-win.tar.xz
 7z.exe x -ttar ${env:SDE_TAR_NAME}-win.tar
 echo "$pwd\${env:SDE_TAR_NAME}-win" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/scripts/install-test-deps.sh
+++ b/.github/workflows/scripts/install-test-deps.sh
@@ -25,8 +25,9 @@ done
 find /usr -name cdefs.h || echo "Find errors were ignored"
 # Remark about user agent: it might or might now work with default user agent, but
 # from time to time the settings are changed and browser-like user agent is required to make it work.
-wget -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://software.intel.com/content/dam/develop/external/us/en/documents/downloads/"$SDE_TAR_NAME"-lin.tar.bz2
-tar xf "$SDE_TAR_NAME"-lin.tar.bz2
+echo -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
+wget -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
+tar xf "$SDE_TAR_NAME"-lin.tar.xz
 tar xf ispc-trunk-linux.tar.gz
 
 #GA requires to set env putting value to $GITHUB_ENV & $GITHUB_PATH

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Additional Resources
 Prebuilt ``ispc`` binaries for Windows, macOS and Linux can be downloaded
 from the [ispc downloads page](https://ispc.github.io/downloads.html).
 Latest ``ispc`` binaries corresponding to main branch can be downloaded
-from Appveyor for [Linux](https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-linux.tar.gz?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DUbuntu1804%2C%20LLVM_VERSION%3Dlatest) and Windows ([msi](https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.msi?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202019%2C%20LLVM_VERSION%3Dlatest) or [zip](https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.zip?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202019%2C%20LLVM_VERSION%3Dlatest))
+from Appveyor for [Linux](https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-linux.tar.gz?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DUbuntu1804%2C%20LLVM_VERSION%3Dlatest) and Windows ([msi](https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.msi?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202022%2C%20LLVM_VERSION%3Dlatest) or [zip](https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.zip?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202022%2C%20LLVM_VERSION%3Dlatest))
 See also additional
 [documentation](https://ispc.github.io/documentation.html) and additional
 [performance information](https://ispc.github.io/perf.html).

--- a/alloy.py
+++ b/alloy.py
@@ -846,7 +846,7 @@ def Main():
         generator = options.generator
     else:
         if current_OS == "Windows":
-            generator = "Visual Studio 16"
+            generator = "Visual Studio 17 2022"
         else:
             generator = "Unix Makefiles"
     try:


### PR DESCRIPTION
- use VS2022 as a default toolchain on Windows. Would need to use `generator="Visual Studio 16 2019"` for `alloy.py` to use VS2019.
- Actions / Appveyor with LLVM13 to use VS2022. LLVM 11 & 12 to stay on VS2019.
- SDE version upgraded to 9.0.0. They use another download location now (sigh...)
- GnuWin32 download not to use quite mode, as it's failing frequently lately

The decision to move to VS2022 is debatable. And we might choose to postpone it. Though I don't see the reasons not to move to VS2022 now. Earlier we move, more experience we'll get with it before releasing.

