### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/rebuild-llvm11.yml
+++ b/.github/workflows/rebuild-llvm11.yml
@@ -143,7 +143,7 @@ jobs:
         path: docker/ubuntu/18.04/cpu_ispc_build/llvm-11.1.0-ubuntu18.04-Release-x86.arm.wasm.tar.xz
 
   win-build:
-    runs-on: windows-2022
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2
@@ -186,7 +186,7 @@ jobs:
         path: llvm/llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
   win-build-release:
-    runs-on: windows-2022
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rebuild-llvm12.yml
+++ b/.github/workflows/rebuild-llvm12.yml
@@ -143,7 +143,7 @@ jobs:
         path: docker/ubuntu/18.04/cpu_ispc_build/llvm-12.0.1-ubuntu18.04-Release-x86.arm.wasm.tar.xz
 
   win-build:
-    runs-on: windows-2022
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2
@@ -186,7 +186,7 @@ jobs:
         path: llvm/llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
   win-build-release:
-    runs-on: windows-2022
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Fix two issues introduced by recent commits to CI:
- LLVM 11 & 12 rebuild pipelines need to use `windows-2019` images
- remove mistakenly added empty file