### PR TITLE
Fix #1308: reset struct cache for every target in multi-target compilation

### DIFF
--- a/src/module.h
+++ b/src/module.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -182,6 +182,16 @@ class Module {
     llvm::DIBuilder *diBuilder;
 
     llvm::DICompileUnit *diCompileUnit;
+
+    /** StructType cache.  This needs to be in the context of Module, so it's reset for
+        any new Module in multi-target compilation.
+
+        We maintain a map from struct names to LLVM struct types so that we can
+        uniquely get the llvm::StructType * for a given ispc struct type.  Note
+        that we need to mangle the name a bit so that we can e.g. differentiate
+        between the uniform and varying variants of a given struct type.  This
+        is handled by lMangleStructName() below. */
+    std::map<std::string, llvm::StructType *> structTypeMap;
 
   private:
     const char *filename;

--- a/tests/lit-tests/1308.ispc
+++ b/tests/lit-tests/1308.ispc
@@ -1,0 +1,25 @@
+// RUN: %{ispc} %s --target=avx512skx-x8,avx2-i32x8 --nostdlib -o %t.o
+// RUN: %{ispc} %s --target=avx2-i32x8,avx512skx-x8 --nostdlib -o %t.o
+// RUN: %{ispc} %s --target=avx512skx-x16,avx2-i32x16 --nostdlib -o %t.o
+// RUN: %{ispc} %s --target=avx512skx-x4,avx2-i32x4 --nostdlib -o %t.o
+
+// REQUIRES: X86_ENABLED
+
+// Struct cache should be reset between compilation of different targets in multi-target compialtion.
+// If it's not done, in this test case it will cause a compiler fail, if targets of the same width
+// have different mask definition (i.e. <i1 x 8> vs <i32 x 8>).
+
+struct Sampler {
+  varying float (*uniform computeSample_varying)(const Sampler *uniform _self);
+};
+
+varying float computeSample(const Sampler *uniform self)
+{
+  return 1.f;
+}
+
+export void func_call_with_ptr(void *uniform _sampler)
+{
+  Sampler *uniform sampler = (Sampler *uniform) _sampler;
+  sampler->computeSample_varying = computeSample;
+}

--- a/tests/lit-tests/1323.ispc
+++ b/tests/lit-tests/1323.ispc
@@ -1,4 +1,4 @@
-  // RUN: %{ispc} %s --target=sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16 -h %t.h --emit-llvm -o %t.bc
+// RUN: %{ispc} %s --target=sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16 -h %t.h --emit-llvm -o %t.bc
 // RUN: llvm-dis %t.bc -o - | FileCheck %s -check-prefix=CHECK_TYPES
 // RUN: FileCheck --input-file=%t.h %s -check-prefix=CHECK_ALIGN
 // REQUIRES: X86_ENABLED


### PR DESCRIPTION
Fix #1308 

Types in ISPC are created in the heap, not in the pool. So when we do multi-target compilation, any type caches should be reset, if they may contain any target-specific type. In the reported test case, the problem was unintentional reuse of function pointer type of the same width, but with different mask type (i.e. `<i1 x 8>` for AVX512 vs `i32 x 8` for AVX2).