### PR TITLE
Preprocessor Fixes and Updates

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -663,6 +663,16 @@ To generate a text assembly file, pass ``--emit-asm``:
 To generate LLVM bitcode, use the ``--emit-llvm`` flag.
 To generate LLVM bitcode in textual form, use the ``--emit-llvm-text`` flag.
 
+To generate a stub after running the preprocessor, use the ``-E`` flag.
+
+::
+
+    ispc foo.ispc -E -o foo.i  OR  ispc foo.ispc -E -o foo.ispi
+
+In this mode, the preprocessor will assume ``stdout`` if no output file is
+specified.
+Both ``.i`` or ``.ispi`` are valid suffixes.
+
 Optimizations are on by default; they can be turned off with ``-O0``:
 
 ::

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1959,6 +1959,7 @@ Globals::Globals() {
 
     includeStdlib = true;
     runCPP = true;
+    onlyCPP = false;
     debugPrint = false;
     dumpFile = false;
     printTarget = false;

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1960,6 +1960,7 @@ Globals::Globals() {
     includeStdlib = true;
     runCPP = true;
     onlyCPP = false;
+    ignoreCPP = false;
     debugPrint = false;
     dumpFile = false;
     printTarget = false;

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1960,7 +1960,7 @@ Globals::Globals() {
     includeStdlib = true;
     runCPP = true;
     onlyCPP = false;
-    ignoreCPP = false;
+    ignoreCPPErrors = false;
     debugPrint = false;
     dumpFile = false;
     printTarget = false;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -614,6 +614,10 @@ struct Globals {
         program source before compiling it.  (Default is true.) */
     bool runCPP;
 
+    /** If enabled, only runs the C pre-processor (if enabled),
+        dumping its output. (Default is false.) */
+    bool onlyCPP;
+
     /** When \c true, voluminous debugging output will be printed during
         ispc's execution. */
     bool debugPrint;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -618,6 +618,10 @@ struct Globals {
         dumping its output. (Default is false.) */
     bool onlyCPP;
 
+    /** If enabled, suppresses errors C pre-processor (if enabled)
+        (Default is false.) */
+    bool ignoreCPP;
+
     /** When \c true, voluminous debugging output will be printed during
         ispc's execution. */
     bool debugPrint;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -614,13 +614,12 @@ struct Globals {
         program source before compiling it.  (Default is true.) */
     bool runCPP;
 
-    /** If enabled, only runs the C pre-processor (if enabled),
-        dumping its output. (Default is false.) */
+    /** When \c true, only runs the C pre-processor. (Default is false.) */
     bool onlyCPP;
 
-    /** If enabled, suppresses errors C pre-processor (if enabled)
+    /** When \c true, suppresses errors from the C pre-processor.
         (Default is false.) */
-    bool ignoreCPP;
+    bool ignoreCPPErrors;
 
     /** When \c true, voluminous debugging output will be printed during
         ispc's execution. */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -691,6 +691,7 @@ int main(int Argc, char *Argv[]) {
             g->generateDebuggingSymbols = true;
         } else if (!strcmp(argv[i], "-E")) {
             g->onlyCPP = true;
+            ot = Module::CPPStub;
         } else if (!strcmp(argv[i], "--emit-asm"))
             ot = Module::Asm;
         else if (!strcmp(argv[i], "--emit-llvm"))
@@ -1025,6 +1026,10 @@ int main(int Argc, char *Argv[]) {
         Warning(SourcePos(), "Both -M and -MMM specified on the command line. "
                              "-MMM takes precedence.");
         flags &= Module::GenerateMakeRuleForDeps;
+    }
+
+    if (g->onlyCPP && outFileName == nullptr) {
+        outFileName = "-"; // Assume stdout by default (-E mode)
     }
 
     if (outFileName == NULL && headerFileName == NULL &&

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -135,7 +135,7 @@ static void lPrintVersion() {
     printf("    [--host-stub <filename>]\t\tEmit host-side offload stub functions to file\n");
     printf("    [-h <name>/--header-outfile=<name>]\tOutput filename for header\n");
     printf("    [-I <path>]\t\t\t\tAdd <path> to #include file search path\n");
-    printf("    [--ignore-preprocessor-errors]\t\t\tSuppress errors from the preprocessor\n");
+    printf("    [--ignore-preprocessor-errors]\tSuppress errors from the preprocessor\n");
     printf("    [--instrument]\t\t\tEmit instrumentation to gather performance data\n");
     printf("    [--math-lib=<option>]\t\tSelect math library\n");
     printf("        default\t\t\t\tUse ispc's built-in math functions\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,13 +94,11 @@ static void lPrintVersion() {
 #endif
 }
 
-
 // Command line argument constants
 static constexpr std::string_view ARG_NAME_ONLY_PREPROCESSOR{"--onlycpp"};
 static constexpr std::string_view ARG_DESC_ONLY_PREPROCESSOR{"Run only the preprocessor (if enabled)"};
 static constexpr std::string_view ARG_NAME_ONLY_PREPROCESSOR_SHORT{"-E"};
 static constexpr std::string_view ARG_DESC_ONLY_PREPROCESSOR_SHORT{"An alias for [--onlycpp]"};
-
 
 [[noreturn]] static void usage(int ret) {
     lPrintVersion();
@@ -715,7 +713,8 @@ int main(int Argc, char *Argv[]) {
 #endif
         else if (!strcmp(argv[i], "--enable-llvm-intrinsics")) {
             g->enableLLVMIntrinsics = true;
-        } else if (!strncmp(argv[i], ARG_NAME_ONLY_PREPROCESSOR_SHORT.data(), ARG_NAME_ONLY_PREPROCESSOR_SHORT.size())) { // -E
+        } else if (!strncmp(argv[i], ARG_NAME_ONLY_PREPROCESSOR_SHORT.data(),
+                            ARG_NAME_ONLY_PREPROCESSOR_SHORT.size())) { // -E
             g->onlyCPP = true;
         } else if (!strcmp(argv[i], "-I")) {
             if (++i != argc) {
@@ -771,7 +770,8 @@ int main(int Argc, char *Argv[]) {
             else {
                 errorHandler.AddError("Unknown --math-lib= option \"%s\".", lib);
             }
-        } else if (!strncmp(argv[i], ARG_NAME_ONLY_PREPROCESSOR.data(), ARG_NAME_ONLY_PREPROCESSOR.size())) { // --only-preprocessor
+        } else if (!strncmp(argv[i], ARG_NAME_ONLY_PREPROCESSOR.data(),
+                            ARG_NAME_ONLY_PREPROCESSOR.size())) { // --only-preprocessor
             g->onlyCPP = true;
         } else if (!strncmp(argv[i], "--opt=", 6)) {
             const char *opt = argv[i] + 6;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,8 +62,6 @@
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/ToolOutputFile.h>
 
-#include <string_view>
-
 using namespace ispc;
 
 #ifdef ISPC_HOST_IS_WINDOWS
@@ -115,7 +113,7 @@ static void lPrintVersion() {
     printf("    [--dllexport]\t\t\tMake non-static functions DLL exported.  Windows target only\n");
     printf("    [--dwarf-version={2,3,4}]\t\tGenerate source-level debug information with given DWARF version "
            "(triggers -g).  Ignored for Windows target\n");
-    printf("    [-E]\t\t\t\tRun only the preprocessor (if enabled)\n");
+    printf("    [-E]\t\t\t\tRun only the preprocessor\n");
     printf("    [--emit-asm]\t\t\tGenerate assembly language file as output\n");
     printf("    [--emit-llvm]\t\t\tEmit LLVM bitcode file as output\n");
     printf("    [--emit-llvm-text]\t\t\tEmit LLVM bitcode file as output in textual form\n");
@@ -137,7 +135,7 @@ static void lPrintVersion() {
     printf("    [--host-stub <filename>]\t\tEmit host-side offload stub functions to file\n");
     printf("    [-h <name>/--header-outfile=<name>]\tOutput filename for header\n");
     printf("    [-I <path>]\t\t\t\tAdd <path> to #include file search path\n");
-    printf("    [--ignorecpp]\t\t\tSuppress errors from the preprocessor (if enabled)\n");
+    printf("    [--ignore-preprocessor-errors]\t\t\tSuppress errors from the preprocessor\n");
     printf("    [--instrument]\t\t\tEmit instrumentation to gather performance data\n");
     printf("    [--math-lib=<option>]\t\tSelect math library\n");
     printf("        default\t\t\t\tUse ispc's built-in math functions\n");
@@ -717,8 +715,8 @@ int main(int Argc, char *Argv[]) {
             }
         } else if (!strncmp(argv[i], "-I", 2)) {
             lParseInclude(argv[i] + 2);
-        } else if (!strcmp(argv[i], "--ignorecpp")) {
-            g->ignoreCPP = true;
+        } else if (!strcmp(argv[i], "--ignore-preprocessor-errors")) {
+            g->ignoreCPPErrors = true;
         } else if (!strcmp(argv[i], "--fuzz-test"))
             g->enableFuzzTest = true;
         else if (!strncmp(argv[i], "--fuzz-seed=", 12))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,8 @@
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/ToolOutputFile.h>
 
+#include <string_view>
+
 using namespace ispc;
 
 #ifdef ISPC_HOST_IS_WINDOWS
@@ -91,6 +93,14 @@ static void lPrintVersion() {
            "http://ispc.github.io/downloads.html");
 #endif
 }
+
+
+// Command line argument constants
+static constexpr std::string_view ARG_NAME_ONLY_PREPROCESSOR{"--onlycpp"};
+static constexpr std::string_view ARG_DESC_ONLY_PREPROCESSOR{"Run only the preprocessor (if enabled)"};
+static constexpr std::string_view ARG_NAME_ONLY_PREPROCESSOR_SHORT{"-E"};
+static constexpr std::string_view ARG_DESC_ONLY_PREPROCESSOR_SHORT{"An alias for [--onlycpp]"};
+
 
 [[noreturn]] static void usage(int ret) {
     lPrintVersion();
@@ -127,6 +137,7 @@ static void lPrintVersion() {
     printf("    [--enable-llvm-intrinsics]\t\tEnable experimental feature to call LLVM intrinsics from ISPC "
            "source code\n");
     printf("    [--error-limit=<value>]\t\tLimit maximum number of errors emitting by ISPC to <value>\n");
+    printf("    [%s]\t\t\t\t%s\n", ARG_NAME_ONLY_PREPROCESSOR_SHORT.data(), ARG_DESC_ONLY_PREPROCESSOR_SHORT.data());
     printf("    [--force-alignment=<value>]\t\tForce alignment in memory allocations routine to be <value>\n");
     printf("    [-g]\t\t\t\tGenerate source-level debug information\n");
     printf("    [--help]\t\t\t\tPrint help\n");
@@ -155,6 +166,7 @@ static void lPrintVersion() {
     printf("        -O0\t\t\t\tOptimizations disabled.\n");
     printf("        -O1\t\t\t\tOptimization for size.\n");
     printf("        -O2/O3\t\t\t\tOptimization for speed.\n");
+    printf("    [%s]\t\t%s\n", ARG_NAME_ONLY_PREPROCESSOR.data(), ARG_DESC_ONLY_PREPROCESSOR.data());
     printf("    [--opt=<option>]\t\t\tSet optimization option\n");
     printf("        disable-assertions\t\tRemove assertion statements from final code.\n");
     printf("        disable-fma\t\t\tDisable 'fused multiply-add' instructions (on targets that support them)\n");
@@ -703,6 +715,8 @@ int main(int Argc, char *Argv[]) {
 #endif
         else if (!strcmp(argv[i], "--enable-llvm-intrinsics")) {
             g->enableLLVMIntrinsics = true;
+        } else if (!strncmp(argv[i], ARG_NAME_ONLY_PREPROCESSOR_SHORT.data(), ARG_NAME_ONLY_PREPROCESSOR_SHORT.size())) { // -E
+            g->onlyCPP = true;
         } else if (!strcmp(argv[i], "-I")) {
             if (++i != argc) {
                 lParseInclude(argv[i]);
@@ -757,6 +771,8 @@ int main(int Argc, char *Argv[]) {
             else {
                 errorHandler.AddError("Unknown --math-lib= option \"%s\".", lib);
             }
+        } else if (!strncmp(argv[i], ARG_NAME_ONLY_PREPROCESSOR.data(), ARG_NAME_ONLY_PREPROCESSOR.size())) { // --only-preprocessor
+            g->onlyCPP = true;
         } else if (!strncmp(argv[i], "--opt=", 6)) {
             const char *opt = argv[i] + 6;
             if (!strcmp(opt, "fast-math"))

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1951,7 +1951,6 @@ bool Module::writeCPPStub(Module *module, const char *outFileName) {
         fd = 1;
     } else {
 #ifdef ISPC_HOST_IS_WINDOWS
-        flags |= O_BINARY;
         fd = _open(outFileName, flags, 0644);
 #else
         fd = open(outFileName, flags, 0644);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3098,12 +3098,14 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
 
             case Bitcode:
             case BitcodeText:
-                writeBitcode(dispatchModule, outFileName, outputType);
+                if (!writeBitcode(dispatchModule, outFileName, outputType))
+                    return 1;
                 break;
 
             case Asm:
             case Object:
-                writeObjectFileOrAssembly(firstTargetMachine, dispatchModule, outputType, outFileName);
+                if (!writeObjectFileOrAssembly(firstTargetMachine, dispatchModule, outputType, outFileName))
+                    return 1;
                 break;
 
             default:

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1039,7 +1039,7 @@ bool Module::writeOutput(OutputType outputType, OutputFlags flags, const char *o
 
     // SIC! (verifyModule() == TRUE) means "failed", see llvm-link code.
     if ((outputType != Header) && (outputType != Deps) && (outputType != HostStub) && (outputType != DevStub) &&
-        llvm::verifyModule(*module)) {
+        (outputType != CPPStub) && llvm::verifyModule(*module)) {
         FATAL("Resulting module verification failed!");
     }
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3094,6 +3094,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
         if (outFileName != NULL) {
             switch (outputType) {
             case CPPStub:
+                // No preprocessor output for dispatch module.
                 break;
 
             case Bitcode:

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3088,7 +3088,6 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
                 break;
 
             case CPPStub:
-                fprintf(stderr, "Entering CPPStub function\n");
                 assert(m && "ISPC module `m` should exist");
                 writeCPPStub(m, outFileName);
                 break;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3107,7 +3107,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
                 break;
 
             default:
-                Assert(false && "Unexpected `outputType`");
+                FATAL("Unexpected `outputType`");
             }
         }
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1971,7 +1971,7 @@ bool Module::writeCPPStub(Module *module, const char *outFileName) {
     }
 
     // The CPP stream should have been initialized: print and clean it up.
-    assert(module->bufferCPP && "`bufferCPP` should not be null");
+    Assert(module->bufferCPP && "`bufferCPP` should not be null");
     llvm::raw_fd_ostream fos(fd, (fd != 1), false);
     fos << module->bufferCPP->str;
     module->bufferCPP.reset();
@@ -3093,22 +3093,18 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
 
         if (outFileName != NULL) {
             switch (outputType) {
-            case Bitcode:
-            case BitcodeText:
-                errorCount += static_cast<int>(writeBitcode(dispatchModule, outFileName, outputType));
+            case CPPStub:
                 break;
 
-            case CPPStub:
-                assert(m && "ISPC module `m` should exist");
-                errorCount += static_cast<int>(writeCPPStub(m, outFileName));
+            case Bitcode:
+            case BitcodeText:
+                writeBitcode(dispatchModule, outFileName, outputType);
                 break;
 
             default:
-                assert((outputType == Module::Object || outputType == Module::Asm) && "Unexpected `outputType`");
-                errorCount += static_cast<int>(
-                    writeObjectFileOrAssembly(firstTargetMachine, dispatchModule, outputType, outFileName));
+                Assert((outputType == Module::Object || outputType == Module::Asm) && "Unexpected `outputType`");
+                writeObjectFileOrAssembly(firstTargetMachine, dispatchModule, outputType, outFileName);
             }
-            m->clearCPPBuffer();
         }
 
         if (depsFileName != NULL || (outputFlags & Module::OutputDepsToStdout)) {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3101,9 +3101,13 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
                 writeBitcode(dispatchModule, outFileName, outputType);
                 break;
 
-            default:
-                Assert((outputType == Module::Object || outputType == Module::Asm) && "Unexpected `outputType`");
+            case Asm:
+            case Object:
                 writeObjectFileOrAssembly(firstTargetMachine, dispatchModule, outputType, outFileName);
+                break;
+
+            default:
+                Assert(false && "Unexpected `outputType`");
             }
         }
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -275,7 +275,7 @@ int Module::CompileFile() {
         std::string buffer;
         llvm::raw_string_ostream os(buffer);
         const int numErrors = execPreprocessor(!IsStdin(filename) ? filename : "-", &os);
-        errorCount += (g->ignoreCPP) ? 0 : numErrors;
+        errorCount += (g->ignoreCPPErrors) ? 0 : numErrors;
         YY_BUFFER_STATE strbuf = yy_scan_string(os.str().c_str());
         yyparse();
         yy_delete_buffer(strbuf);
@@ -2290,7 +2290,7 @@ int Module::execPreprocessor(const char *infilename, llvm::raw_string_ostream *o
 
     llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs> diagIDs(new clang::DiagnosticIDs);
     clang::DiagnosticsEngine *diagEngine = new clang::DiagnosticsEngine(diagIDs, diagOptions, diagPrinter);
-    diagEngine->setSuppressAllDiagnostics(g->ignoreCPP);
+    diagEngine->setSuppressAllDiagnostics(g->ignoreCPPErrors);
 
     inst.setDiagnostics(diagEngine);
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2421,7 +2421,7 @@ int Module::execPreprocessor(const char *infilename, llvm::raw_string_ostream *o
     diagPrinter->EndSourceFile();
 
     // Return preprocessor diagnostic errors after processing
-    return diagEngine->getNumErrors();
+    return static_cast<int>(diagEngine->hasErrorOccurred());
 }
 
 // Given an output filename of the form "foo.obj", and an ISA name like

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2888,7 +2888,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             }
 #endif
             if (outFileName != NULL)
-                if (!m->writeOutput(outputType, outputFlags, outFileName))
+                if (!m->writeOutputPPWrap(outputType, outputFlags, outFileName))
                     return 1;
             if (headerFileName != NULL)
                 if (!m->writeOutput(Module::Header, outputFlags, headerFileName))
@@ -3022,7 +3022,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
                     std::string targetOutFileName;
                     const char *isaName = g->target->GetISAString();
                     targetOutFileName = lGetTargetFileName(outFileName, isaName);
-                    if (!m->writeOutput(outputType, outputFlags, targetOutFileName.c_str())) {
+                    if (!m->writeOutputPPWrap(outputType, outputFlags, targetOutFileName.c_str())) {
                         return 1;
                     }
                 }
@@ -3111,6 +3111,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
                 assert((outputType == Module::Object || outputType == Module::Asm) && "Unexpected `outputType`");
                 writeObjectFileOrAssembly(firstTargetMachine, dispatchModule, outputType, outFileName);
             }
+            m->clearCPPBuffer();
         }
 
         if (depsFileName != NULL || (outputFlags & Module::OutputDepsToStdout)) {
@@ -3135,4 +3136,16 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
         g->target = NULL;
         return errorCount > 0;
     }
+}
+
+void Module::clearCPPBuffer() {
+    if (bufferCPP)
+        bufferCPP.reset();
+}
+
+bool Module::writeOutputPPWrap(OutputType ot, OutputFlags flags, const char *filename, const char *depTargetFileName,
+                               const char *sourceFileName, DispatchHeaderInfo *DHI) {
+    const bool result = writeOutput(ot, flags, filename, depTargetFileName, sourceFileName, DHI);
+    clearCPPBuffer();
+    return result;
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -291,6 +291,7 @@ int Module::CompileFile() {
         YY_BUFFER_STATE strbuf = yy_scan_string(bufferCPP->str.c_str());
         yyparse();
         yy_delete_buffer(strbuf);
+        clearCPPBuffer();
     } else {
         llvm::TimeTraceScope TimeScope("Frontend parser");
         // No preprocessor, just open up the file if it's not stdin..
@@ -1950,7 +1951,6 @@ bool Module::writeCPPStub(Module *module, const char *outFileName) {
     // Get a file descriptor corresponding to where we want the output to
     // go.  If we open it, it'll be closed by the llvm::raw_fd_ostream
     // destructor.
-    //
     int fd;
     int flags = O_CREAT | O_WRONLY | O_TRUNC;
 
@@ -2888,7 +2888,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             }
 #endif
             if (outFileName != NULL)
-                if (!m->writeOutputPPWrap(outputType, outputFlags, outFileName))
+                if (!m->writeOutput(outputType, outputFlags, outFileName))
                     return 1;
             if (headerFileName != NULL)
                 if (!m->writeOutput(Module::Header, outputFlags, headerFileName))
@@ -3022,7 +3022,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
                     std::string targetOutFileName;
                     const char *isaName = g->target->GetISAString();
                     targetOutFileName = lGetTargetFileName(outFileName, isaName);
-                    if (!m->writeOutputPPWrap(outputType, outputFlags, targetOutFileName.c_str())) {
+                    if (!m->writeOutput(outputType, outputFlags, targetOutFileName.c_str())) {
                         return 1;
                     }
                 }
@@ -3141,11 +3141,4 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
 void Module::clearCPPBuffer() {
     if (bufferCPP)
         bufferCPP.reset();
-}
-
-bool Module::writeOutputPPWrap(OutputType ot, OutputFlags flags, const char *filename, const char *depTargetFileName,
-                               const char *sourceFileName, DispatchHeaderInfo *DHI) {
-    const bool result = writeOutput(ot, flags, filename, depTargetFileName, sourceFileName, DHI);
-    clearCPPBuffer();
-    return result;
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -274,7 +274,8 @@ int Module::CompileFile() {
 
         std::string buffer;
         llvm::raw_string_ostream os(buffer);
-        errorCount += execPreprocessor(!IsStdin(filename) ? filename : "-", &os);
+        const int numErrors = execPreprocessor(!IsStdin(filename) ? filename : "-", &os);
+        errorCount += (g->ignoreCPP) ? 0 : numErrors;
         YY_BUFFER_STATE strbuf = yy_scan_string(os.str().c_str());
         yyparse();
         yy_delete_buffer(strbuf);
@@ -2289,6 +2290,7 @@ int Module::execPreprocessor(const char *infilename, llvm::raw_string_ostream *o
 
     llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs> diagIDs(new clang::DiagnosticIDs);
     clang::DiagnosticsEngine *diagEngine = new clang::DiagnosticsEngine(diagIDs, diagOptions, diagPrinter);
+    diagEngine->setSuppressAllDiagnostics(g->ignoreCPP);
 
     inst.setDiagnostics(diagEngine);
 

--- a/src/module.h
+++ b/src/module.h
@@ -198,8 +198,16 @@ class Module {
     const char *filename;
     AST *ast;
 
-    std::string CPPBuffer;
-    llvm::raw_string_ostream CPPStream;
+    // Definition and member object capturing preprocessing stream during Module lifetime.
+    struct CPPBuffer {
+        CPPBuffer() : str{}, os{std::make_unique<llvm::raw_string_ostream>(str)} {}
+        CPPBuffer(CPPBuffer &&o) : str{std::move(o.str)}, os{std::move(o.os)} {}
+        ~CPPBuffer() = default;
+        std::string str;
+        std::unique_ptr<llvm::raw_string_ostream> os;
+    };
+
+    std::unique_ptr<CPPBuffer> bufferCPP;
 
     std::vector<std::pair<const Type *, SourcePos>> exportedTypes;
 

--- a/src/module.h
+++ b/src/module.h
@@ -241,10 +241,6 @@ class Module {
 
     /** Helper function to clean internal CPP buffer. **/
     void clearCPPBuffer();
-
-    /** Wrapper aronud `writeOutput` to manage `CPPBuffer` lifetime. **/
-    bool writeOutputPPWrap(OutputType ot, OutputFlags flags, const char *filename, const char *depTargetFileName = NULL,
-                           const char *sourceFileName = NULL, DispatchHeaderInfo *DHI = 0);
 };
 
 inline Module::OutputFlags &operator|=(Module::OutputFlags &lhs, const __underlying_type(Module::OutputFlags) rhs) {

--- a/src/module.h
+++ b/src/module.h
@@ -221,7 +221,7 @@ class Module {
     static bool writeZEBin(llvm::Module *module, const char *outFileName);
 #endif
 
-    /** Run the preprocessor on the given file, writing to the output stream. 
+    /** Run the preprocessor on the given file, writing to the output stream.
         Returns the number of diagnostic errors encountered. */
     int execPreprocessor(const char *infilename, llvm::raw_string_ostream *ostream) const;
 };

--- a/src/module.h
+++ b/src/module.h
@@ -201,7 +201,6 @@ class Module {
     // Definition and member object capturing preprocessing stream during Module lifetime.
     struct CPPBuffer {
         CPPBuffer() : str{}, os{std::make_unique<llvm::raw_string_ostream>(str)} {}
-        CPPBuffer(CPPBuffer &&o) : str{std::move(o.str)}, os{std::move(o.os)} {}
         ~CPPBuffer() = default;
         std::string str;
         std::unique_ptr<llvm::raw_string_ostream> os;

--- a/src/module.h
+++ b/src/module.h
@@ -238,6 +238,13 @@ class Module {
     /** Run the preprocessor on the given file, writing to the output stream.
         Returns the number of diagnostic errors encountered. */
     int execPreprocessor(const char *infilename, llvm::raw_string_ostream *ostream) const;
+
+    /** Helper function to clean internal CPP buffer. **/
+    void clearCPPBuffer();
+
+    /** Wrapper aronud `writeOutput` to manage `CPPBuffer` lifetime. **/
+    bool writeOutputPPWrap(OutputType ot, OutputFlags flags, const char *filename, const char *depTargetFileName = NULL,
+                           const char *sourceFileName = NULL, DispatchHeaderInfo *DHI = 0);
 };
 
 inline Module::OutputFlags &operator|=(Module::OutputFlags &lhs, const __underlying_type(Module::OutputFlags) rhs) {

--- a/src/module.h
+++ b/src/module.h
@@ -123,6 +123,7 @@ class Module {
         Deps,        /** generate dependencies */
         DevStub,     /** generate device-side offload stubs */
         HostStub,    /** generate host-side offload stubs */
+        CPPStub,     /** generate preprocessed stubs (-E mode) */
 #ifdef ISPC_XE_ENABLED
         ZEBIN, /** generate L0 binary file */
         SPIRV, /** generate spir-v file */
@@ -197,6 +198,9 @@ class Module {
     const char *filename;
     AST *ast;
 
+    std::string CPPBuffer;
+    llvm::raw_string_ostream CPPStream;
+
     std::vector<std::pair<const Type *, SourcePos>> exportedTypes;
 
     /** Write the corresponding output type to the given file.  Returns
@@ -211,7 +215,9 @@ class Module {
                    const char *srcFilename = NULL);
     bool writeDevStub(const char *filename);
     bool writeHostStub(const char *filename);
+    bool writeCPPStub(const char *outFileName);
     bool writeObjectFileOrAssembly(OutputType outputType, const char *filename);
+    static bool writeCPPStub(Module *module, const char *outFileName);
     static bool writeObjectFileOrAssembly(llvm::TargetMachine *targetMachine, llvm::Module *module,
                                           OutputType outputType, const char *outFileName);
     static bool writeBitcode(llvm::Module *module, const char *outFileName, OutputType outputType);

--- a/src/module.h
+++ b/src/module.h
@@ -220,7 +220,10 @@ class Module {
     static bool writeSPIRV(llvm::Module *module, const char *outFileName);
     static bool writeZEBin(llvm::Module *module, const char *outFileName);
 #endif
-    void execPreprocessor(const char *infilename, llvm::raw_string_ostream *ostream) const;
+
+    /** Run the preprocessor on the given file, writing to the output stream. 
+        Returns the number of diagnostic errors encountered. */
+    int execPreprocessor(const char *infilename, llvm::raw_string_ostream *ostream) const;
 };
 
 inline Module::OutputFlags &operator|=(Module::OutputFlags &lhs, const __underlying_type(Module::OutputFlags) rhs) {

--- a/tests/lit-tests/2280.ispc
+++ b/tests/lit-tests/2280.ispc
@@ -1,30 +1,33 @@
-// RUN:     %{ispc} --target=host --nowrap --nostdlib -g -O0 -o %t.o %s -E
-// RUN:     %{ispc} --target=host --nowrap --nostdlib -g -O0 -o %t.o %s --onlycpp
+// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text -E                       -o -
+// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text                          -o - | FileCheck %s -check-prefix=CHECK_PASS_0
+// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text                          -o - | FileCheck %s -check-prefix=CHECK_PASS_2
+// RUN: not %{ispc} %s --target=host --nostdlib                                 -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR
+// RUN: not %{ispc} %s --target=host --nostdlib                  -E             -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR
 
-// RUN: not %{ispc} --target=host --nowrap --nostdlib -g -O0         %s                     2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_0
-// RUN: not %{ispc} --target=host --nowrap --nostdlib -g -O0         %s                     2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_0
-
-// RUN: not %{ispc} --target=host --nowrap --nostdlib -g -O0         %s           -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_1
-// RUN: not %{ispc} --target=host --nowrap --nostdlib -g -O0         %s           -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_1
-
-// RUN: not %{ispc} --target=host --nowrap --nostdlib -g -O0         %s -E        -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_1
-// RUN: not %{ispc} --target=host --nowrap --nostdlib -g -O0         %s --onlycpp -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_1
-
-// REQUIRES: X86_ENABLED
+// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text -E --ignorecpp           -o -
+// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text    --ignorecpp           -o - | FileCheck %s -check-prefix=CHECK_PASS_0
+// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text    --ignorecpp           -o - | FileCheck %s -check-prefix=CHECK_PASS_2
+// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text    --ignorecpp -DDO_ELSE -o - | FileCheck %s -check-prefix=CHECK_PASS_1
+// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text    --ignorecpp -DDO_ELSE -o - | FileCheck %s -check-prefix=CHECK_PASS_2
+// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text -E --ignorecpp -DDO_ELSE -o -
 
 
-// CHECK_ERROR_0: Error:
+// CHECK_PASS_0: ret i32 1337
+// CHECK_PASS_1: ret i32 7331
+// CHECK_PASS_2: ret i32 314159
 
-// CHECK_ERROR_1: DO_ELSE: Preprocessor #error
+// CHECK_ERROR:  DO_ELSE: Preprocessor #error
 
+
+#define TESTVALUE_0 1337
+#define TESTVALUE_1 7331
+#define TESTVALUE_2 314159
 
 #ifndef DO_ELSE
-void foo();
+uniform int foo() { return TESTVALUE_0; }
 #else
-int i;
-void bar();
+uniform int bar() { return TESTVALUE_1; }
 #error "DO_ELSE: Preprocessor #error"
 #endif // DO_ELSE
 
-// Should not compile
-void baz() { return 0; }
+uniform int baz() { return TESTVALUE_2; }

--- a/tests/lit-tests/2280.ispc
+++ b/tests/lit-tests/2280.ispc
@@ -1,0 +1,30 @@
+// RUN:     %{ispc} --target=host --nowrap --nostdlib -g -O0 -o %t.o %s -E
+// RUN:     %{ispc} --target=host --nowrap --nostdlib -g -O0 -o %t.o %s --onlycpp
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib -g -O0         %s                     2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_0
+// RUN: not %{ispc} --target=host --nowrap --nostdlib -g -O0         %s                     2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_0
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib -g -O0         %s           -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_1
+// RUN: not %{ispc} --target=host --nowrap --nostdlib -g -O0         %s           -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_1
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib -g -O0         %s -E        -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_1
+// RUN: not %{ispc} --target=host --nowrap --nostdlib -g -O0         %s --onlycpp -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_1
+
+// REQUIRES: X86_ENABLED
+
+
+// CHECK_ERROR_0: Error:
+
+// CHECK_ERROR_1: DO_ELSE: Preprocessor #error
+
+
+#ifndef DO_ELSE
+void foo();
+#else
+int i;
+void bar();
+#error "DO_ELSE: Preprocessor #error"
+#endif // DO_ELSE
+
+// Should not compile
+void baz() { return 0; }

--- a/tests/lit-tests/2280.ispc
+++ b/tests/lit-tests/2280.ispc
@@ -1,12 +1,12 @@
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E                                             | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_0
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text                                                                    | FileCheck %s -check-prefix=CHECK_PASS_1
-// RUN: not %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E                              -DDO_ELSE 2>&1 | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_ERROR
-// RUN: not %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text                                 -DDO_ELSE 2>&1                     | FileCheck %s -check-prefix=CHECK_ERROR
+// RUN:     %{ispc} %s      --target=host --nostdlib -E                                                              | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_0
+// RUN:     %{ispc} %s -o - --target=host --nostdlib    --emit-llvm-text                                                                 | FileCheck %s -check-prefix=CHECK_PASS_1
+// RUN: not %{ispc} %s      --target=host --nostdlib -E                                               -DDO_ELSE 2>&1 | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_ERROR
+// RUN: not %{ispc} %s -o - --target=host --nostdlib    --emit-llvm-text                              -DDO_ELSE 2>&1                     | FileCheck %s -check-prefix=CHECK_ERROR
 
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E --ignore-preprocessor-errors                | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_0
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text    --ignore-preprocessor-errors                                    | FileCheck %s -check-prefix=CHECK_PASS_1
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E --ignore-preprocessor-errors -DDO_ELSE      | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_2
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text    --ignore-preprocessor-errors -DDO_ELSE                          | FileCheck %s -check-prefix=CHECK_PASS_3
+// RUN:     %{ispc} %s      --target=host --nostdlib -E                  --ignore-preprocessor-errors                | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_0
+// RUN:     %{ispc} %s -o - --target=host --nostdlib    --emit-llvm-text --ignore-preprocessor-errors                                    | FileCheck %s -check-prefix=CHECK_PASS_1
+// RUN:     %{ispc} %s      --target=host --nostdlib -E                  --ignore-preprocessor-errors -DDO_ELSE      | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_2
+// RUN:     %{ispc} %s -o - --target=host --nostdlib    --emit-llvm-text --ignore-preprocessor-errors -DDO_ELSE                          | FileCheck %s -check-prefix=CHECK_PASS_3
 
 
 // CHECK_PASS_0: return 1337;

--- a/tests/lit-tests/2280.ispc
+++ b/tests/lit-tests/2280.ispc
@@ -8,6 +8,14 @@
 // RUN:     %{ispc} %s      --target=host --nostdlib -E                  --ignore-preprocessor-errors -DDO_ELSE      | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_2
 // RUN:     %{ispc} %s -o - --target=host --nostdlib    --emit-llvm-text --ignore-preprocessor-errors -DDO_ELSE                          | FileCheck %s -check-prefix=CHECK_PASS_3
 
+// RUN:     %{ispc} %s -o %t.i    --target=host --nostdlib -E 
+// RUN:     cat %t.i    | grep -v -e '^// '                        | FileCheck %s -check-prefix=CHECK_PASS_0
+// RUN:     %{ispc} %s -o %t.ispi --target=host --nostdlib -E
+// RUN:     cat %t.ispi | grep -v -e '^// '                        | FileCheck %s -check-prefix=CHECK_PASS_0
+
+// RUN:     %{ispc} %s -o %t.j    --target=host --nostdlib -E 2>&1 | FileCheck %s -check-prefix=CHECK_WARN
+// RUN:     %{ispc} %s -o %t.ispj --target=host --nostdlib -E 2>&1 | FileCheck %s -check-prefix=CHECK_WARN
+
 
 // CHECK_PASS_0: return 1337;
 // CHECK_PASS_0: return 314159;
@@ -22,6 +30,8 @@
 // CHECK_PASS_3: ret i32 314159
 
 // CHECK_ERROR:  DO_ELSE: Preprocessor #error
+
+// CHECK_WARN:   Emitting preprocessed stub file
 
 
 #define TESTVALUE_0 1337

--- a/tests/lit-tests/2280.ispc
+++ b/tests/lit-tests/2280.ispc
@@ -1,19 +1,25 @@
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text                                                | FileCheck %s -check-prefix=CHECK_PASS_0
-// RUN: not %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text                                 -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E                                             | FileCheck %s -check-prefix=CHECK_PASS_0
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text                                                | FileCheck %s -check-prefix=CHECK_PASS_1
 // RUN: not %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E                              -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR
+// RUN: not %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text                                 -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR
 
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E --ignore-preprocessor-errors
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text    --ignore-preprocessor-errors                | FileCheck %s -check-prefix=CHECK_PASS_0
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text    --ignore-preprocessor-errors -DDO_ELSE      | FileCheck %s -check-prefix=CHECK_PASS_1
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E --ignore-preprocessor-errors -DDO_ELSE
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E --ignore-preprocessor-errors                | FileCheck %s -check-prefix=CHECK_PASS_0
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text    --ignore-preprocessor-errors                | FileCheck %s -check-prefix=CHECK_PASS_1
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E --ignore-preprocessor-errors -DDO_ELSE      | FileCheck %s -check-prefix=CHECK_PASS_2
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text    --ignore-preprocessor-errors -DDO_ELSE      | FileCheck %s -check-prefix=CHECK_PASS_3
 
 
-// CHECK_PASS_0: ret i32 1337
-// CHECK_PASS_0: ret i32 314159
+// CHECK_PASS_0: return 1337;
+// CHECK_PASS_0: return 314159;
 
-// CHECK_PASS_1: ret i32 7331
+// CHECK_PASS_1: ret i32 1337
 // CHECK_PASS_1: ret i32 314159
+
+// CHECK_PASS_2: return 7331;
+// CHECK_PASS_2: return 314159;
+
+// CHECK_PASS_3: ret i32 7331
+// CHECK_PASS_3: ret i32 314159
 
 // CHECK_ERROR:  DO_ELSE: Preprocessor #error
 

--- a/tests/lit-tests/2280.ispc
+++ b/tests/lit-tests/2280.ispc
@@ -1,20 +1,19 @@
-// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text -E                       -o -
-// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text                          -o - | FileCheck %s -check-prefix=CHECK_PASS_0
-// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text                          -o - | FileCheck %s -check-prefix=CHECK_PASS_2
-// RUN: not %{ispc} %s --target=host --nostdlib                                 -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR
-// RUN: not %{ispc} %s --target=host --nostdlib                  -E             -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text                                                | FileCheck %s -check-prefix=CHECK_PASS_0
+// RUN: not %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text                                 -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR
+// RUN: not %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E                              -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR
 
-// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text -E --ignorecpp           -o -
-// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text    --ignorecpp           -o - | FileCheck %s -check-prefix=CHECK_PASS_0
-// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text    --ignorecpp           -o - | FileCheck %s -check-prefix=CHECK_PASS_2
-// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text    --ignorecpp -DDO_ELSE -o - | FileCheck %s -check-prefix=CHECK_PASS_1
-// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text    --ignorecpp -DDO_ELSE -o - | FileCheck %s -check-prefix=CHECK_PASS_2
-// RUN:     %{ispc} %s --target=host --nostdlib --emit-llvm-text -E --ignorecpp -DDO_ELSE -o -
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E --ignore-preprocessor-errors
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text    --ignore-preprocessor-errors                | FileCheck %s -check-prefix=CHECK_PASS_0
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text    --ignore-preprocessor-errors -DDO_ELSE      | FileCheck %s -check-prefix=CHECK_PASS_1
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E --ignore-preprocessor-errors -DDO_ELSE
 
 
 // CHECK_PASS_0: ret i32 1337
+// CHECK_PASS_0: ret i32 314159
+
 // CHECK_PASS_1: ret i32 7331
-// CHECK_PASS_2: ret i32 314159
+// CHECK_PASS_1: ret i32 314159
 
 // CHECK_ERROR:  DO_ELSE: Preprocessor #error
 

--- a/tests/lit-tests/2280.ispc
+++ b/tests/lit-tests/2280.ispc
@@ -1,12 +1,12 @@
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E                                             | FileCheck %s -check-prefix=CHECK_PASS_0
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text                                                | FileCheck %s -check-prefix=CHECK_PASS_1
-// RUN: not %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E                              -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR
-// RUN: not %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text                                 -DDO_ELSE 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E                                             | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_0
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text                                                                    | FileCheck %s -check-prefix=CHECK_PASS_1
+// RUN: not %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E                              -DDO_ELSE 2>&1 | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_ERROR
+// RUN: not %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text                                 -DDO_ELSE 2>&1                     | FileCheck %s -check-prefix=CHECK_ERROR
 
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E --ignore-preprocessor-errors                | FileCheck %s -check-prefix=CHECK_PASS_0
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text    --ignore-preprocessor-errors                | FileCheck %s -check-prefix=CHECK_PASS_1
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E --ignore-preprocessor-errors -DDO_ELSE      | FileCheck %s -check-prefix=CHECK_PASS_2
-// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text    --ignore-preprocessor-errors -DDO_ELSE      | FileCheck %s -check-prefix=CHECK_PASS_3
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E --ignore-preprocessor-errors                | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_0
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text    --ignore-preprocessor-errors                                    | FileCheck %s -check-prefix=CHECK_PASS_1
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text -E --ignore-preprocessor-errors -DDO_ELSE      | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_2
+// RUN:     %{ispc} %s -o - --target=host --nostdlib --emit-llvm-text    --ignore-preprocessor-errors -DDO_ELSE                          | FileCheck %s -check-prefix=CHECK_PASS_3
 
 
 // CHECK_PASS_0: return 1337;

--- a/tests/lit-tests/preprocessor-target=multi.ispc
+++ b/tests/lit-tests/preprocessor-target=multi.ispc
@@ -1,9 +1,9 @@
-// RUN: %{ispc} %s --nostdlib --target=sse4-i32x4            -E | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x4
-// RUN: %{ispc} %s --nostdlib --target=avx2-i32x8            -E | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x8
+// RUN: %{ispc} %s -E --nostdlib --target=sse4-i32x4 | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x4
+// RUN: %{ispc} %s -E --nostdlib --target=avx2-i32x8 | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x8
 
-// RUN: %{ispc} %s --nostdlib --target=sse4-i32x4,avx2-i32x8 -E -o %t.i
-// RUN: cat %t_sse4.i                                           | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x4
-// RUN: cat %t_avx2.i                                           | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x8
+// RUN: %{ispc} %s -E --nostdlib --target=sse4-i32x4,avx2-i32x8 -o %t.i
+// RUN: cat %t_sse4.i                                | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x4
+// RUN: cat %t_avx2.i                                | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x8
 
 // CHECK_PASS_i32x4: return 4; /*target_width*/
 // CHECK_PASS_i32x4: return 4; /*target_element_width*/

--- a/tests/lit-tests/preprocessor-target=multi.ispc
+++ b/tests/lit-tests/preprocessor-target=multi.ispc
@@ -2,8 +2,8 @@
 // RUN: %{ispc} %s --nostdlib --target=avx2-i32x8            -E | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x8
 
 // RUN: %{ispc} %s --nostdlib --target=sse4-i32x4,avx2-i32x8 -E -o %t.i
-// RUN: cat %t_sse4.i | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x4
-// RUN: cat %t_avx2.i | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x8
+// RUN: cat %t_sse4.i                                           | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x4
+// RUN: cat %t_avx2.i                                           | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x8
 
 // CHECK_PASS_i32x4: return 4; /*target_width*/
 // CHECK_PASS_i32x4: return 4; /*target_element_width*/

--- a/tests/lit-tests/preprocessor-target=multi.ispc
+++ b/tests/lit-tests/preprocessor-target=multi.ispc
@@ -1,0 +1,19 @@
+// RUN: %{ispc} %s --nostdlib --target=sse4-i32x4            -E | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x4
+// RUN: %{ispc} %s --nostdlib --target=avx2-i32x8            -E | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x8
+
+// RUN: %{ispc} %s --nostdlib --target=sse4-i32x4,avx2-i32x8 -E -o %t.i
+// RUN: cat %t_sse4.i | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x4
+// RUN: cat %t_avx2.i | grep -v -e '^// ' | FileCheck %s -check-prefix=CHECK_PASS_i32x8
+
+// CHECK_PASS_i32x4: return 4; /*target_width*/
+// CHECK_PASS_i32x4: return 4; /*target_element_width*/
+
+// CHECK_PASS_i32x8: return 8; /*target_width*/
+// CHECK_PASS_i32x8: return 4; /*target_element_width*/
+
+// REQUIRES: X86_ENABLED
+
+
+uniform int foo() { return TARGET_WIDTH; /*target_width*/ }
+
+uniform int bar() { return TARGET_ELEMENT_WIDTH; /*target_element_width*/ }


### PR DESCRIPTION
Closes #2257, #1212, and #800.

Changes:
* Adds `-E` and `--ignore-preprocessor-errors` flags to CLI.
* Updates `execPreprocessor` to return a status code.

Updated: 03/18/2022.