### PR TITLE
Added print and check of ispcrt version

### DIFF
--- a/ispcrt/CMakeLists.txt
+++ b/ispcrt/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright 2020-2021 Intel Corporation
+## Copyright 2020-2022 Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.1)
@@ -166,6 +166,7 @@ write_basic_package_version_file(
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
   cmake/Findlevel_zero.cmake
   cmake/Finddpcpp_compiler.cmake
   cmake/ispc.cmake

--- a/ispcrt/cmake/ispc.cmake
+++ b/ispcrt/cmake/ispc.cmake
@@ -33,7 +33,12 @@ find_program(ISPC_EXECUTABLE ispc HINTS ${ISPC_DIR_HINT} DOC "Path to the ISPC e
 if (NOT ISPC_EXECUTABLE)
   message(FATAL_ERROR "Could not find ISPC. Exiting.")
 else()
-  message(STATUS "Found Intel(r) Implicit SPMD Compiler (Intel(r) ISPC): ${ISPC_EXECUTABLE}")
+  # Execute "ispc --version" and parse the version
+  execute_process(COMMAND ${ISPC_EXECUTABLE} "--version"
+                  OUTPUT_VARIABLE ISPC_INFO)
+  string(REGEX MATCH "(.*), ([0-9]*\.[0-9]*\.[0-9]*[a-z]*) (.*)" _ ${ISPC_INFO})
+  set(ISPC_VERSION ${CMAKE_MATCH_2})
+  message(STATUS "Found ISPC v${ISPC_VERSION}: ${ISPC_EXECUTABLE}")
 endif()
 
 ## ISPC config options ##

--- a/ispcrt/cmake/ispcrtConfig.cmake.in
+++ b/ispcrt/cmake/ispcrtConfig.cmake.in
@@ -1,4 +1,4 @@
-## Copyright 2020 Intel Corporation
+## Copyright 2020-2022 Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 
 @PACKAGE_INIT@
@@ -29,6 +29,9 @@ if(@ISPCRT_BUILD_GPU@)
   unset(OLD_CMAKE_MODULE_PATH)
 endif()
 
-## Standard signal that the package was found ##
+## Print info about found ISPCRT version
+include(FindPackageMessage)
+find_package_MESSAGE(@PROJECT_NAME@ "Found ispcrt: ${ISPCRT_DIR}" "[${ISPCRT_DIR}]")
 
+## Standard signal that the package was found ##
 set(ISPCRT_FOUND TRUE)


### PR DESCRIPTION
This change improves detection of ispcrt version:
1. prints found ispcrt path and version when find_package(ispcrt) is used:
`-- Found ispcrt: /home/users/ispc/build/install/lib/cmake/ispcrt-1.18.0`
2. detects when requested ispcrt version is not found:
`find_package(ispcrt 1.19.0 REQUIRED)`
```
Could not find a configuration file for package "ispcrt" that is compatible with requested version "1.19.0".
The following configuration files were considered but not accepted:

    /home/users/ispc/build/install/lib/cmake/ispcrt-1.18.0/ispcrtConfig.cmake, version: 1.18.0
    /home/users/ispc/build/ispcrt/ispcrtConfig.cmake, version: 1.18.0
```
3. prints version of found ISPC compiler:
`--Found ISPC v1.18.0: /home/users/ispc/build/bin/ispc`