### PR TITLE
--ast-dump switch

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -66,7 +66,8 @@ void Indent::pushList(int i) {
 
 void Indent::setNextLabel(std::string s) { label = s; }
 
-void Indent::Print() {
+// Print indent and an optional string
+void Indent::Print(const char *title) {
     printCalls++;
     Assert(!stack.empty());
     int &top = stack.back();
@@ -91,22 +92,24 @@ void Indent::Print() {
         printf("(%s) ", label.c_str());
         label.clear();
     }
-}
 
-void Indent::Print(const char *title) {
-    Print();
+    // An optional string
     if (title != nullptr) {
         printf("%s", title);
     }
 }
 
 void Indent::Print(const char *title, const SourcePos &pos) {
+    // Same as previous version
     Print(title);
+    // Plus source position info
     pos.Print();
 }
 
 void Indent::PrintLn(const char *title, const SourcePos &pos) {
+    // Same as previous version
     Print(title, pos);
+    // Plus end of line
     printf("\n");
 }
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -147,6 +147,36 @@ void AST::GenerateIR() {
         functions[i]->GenerateIR();
 }
 
+void AST::Print(Globals::ASTDumpKind printKind) const {
+    if (printKind == Globals::ASTDumpKind::None) {
+        return;
+    }
+
+    printf("AST\n");
+    Indent indent;
+
+    int funcsToPrint = 0;
+    if (printKind == Globals::ASTDumpKind::All) {
+        funcsToPrint = functions.size();
+    } else if (printKind == Globals::ASTDumpKind::User) {
+        for (unsigned int i = 0; i < functions.size(); ++i) {
+            if (!functions[i]->IsStdlibSymbol()) {
+                funcsToPrint++;
+            }
+        }
+    }
+
+    indent.pushList(funcsToPrint);
+    for (unsigned int i = 0; i < functions.size(); ++i) {
+        if (printKind == Globals::ASTDumpKind::All ||
+            (printKind == Globals::ASTDumpKind::User && !functions[i]->IsStdlibSymbol())) {
+            functions[i]->Print(indent);
+        }
+    }
+
+    fflush(stdout);
+}
+
 ///////////////////////////////////////////////////////////////////////////
 
 ASTNode *ispc::WalkAST(ASTNode *node, ASTPreCallBackFunc preFunc, ASTPostCallBackFunc postFunc, void *data) {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -125,6 +125,13 @@ void Indent::Done() {
 
 ASTNode::~ASTNode() {}
 
+void ASTNode::Print() const {
+    Indent indent;
+    indent.pushSingle();
+    Print(indent);
+    fflush(stdout);
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // AST
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2021, Intel Corporation
+  Copyright (c) 2011-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -38,9 +38,58 @@
 #pragma once
 
 #include "ispc.h"
+#include <string>
 #include <vector>
 
 namespace ispc {
+
+/** @brief Helper class for printing AST.
+
+    This class keeps track of indentation when printing AST.
+    Before anything is printed, pushSingle() or pushList(int) methods need to be
+    invoked to declare how the following node(s) are going to be printed - as
+    a single nested node or a list of nested items. For example:
+
+    Parent Node
+    `-Single Nested Node
+
+    Parent Node
+    |-List Node #1
+    |-List Node #2
+    `-List Node #3
+
+    If the nested node needs to be annotated, setNextLabel(string) should be called
+    before recusing to the nested node.
+
+    Parent Node
+    |-(annotation 1) List Node #1
+    |-(annotation 2) List Node #2
+    `-(annotation 3) List Node #3
+
+    The call to any of Print()/PrintLn() methods does the indentation. Every such
+    call must be paired by Done() call when the node is printed.
+ */
+class Indent {
+    std::string label;
+    std::vector<int> stack;
+    int printCalls = 0;
+    int doneCalls = 0;
+
+  public:
+    Indent() {}
+    ~Indent();
+
+    void pushSingle();
+    void pushList(int i);
+
+    void setNextLabel(std::string s);
+
+    void Print();
+    void Print(const char *title);
+    void Print(const char *title, const SourcePos &pos);
+    void PrintLn(const char *title, const SourcePos &pos);
+    void Done();
+};
 
 /** @brief Abstract base class for nodes in the abstract syntax tree (AST).
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -59,7 +59,7 @@ namespace ispc {
     `-List Node #3
 
     If the nested node needs to be annotated, setNextLabel(string) should be called
-    before recusing to the nested node.
+    before recursing to the nested node.
 
     Parent Node
     |-(annotation 1) List Node #1

--- a/src/ast.h
+++ b/src/ast.h
@@ -83,15 +83,25 @@ class Indent {
     Indent() {}
     ~Indent();
 
+    /** Declare that the next level of nesting will contain a single node. */
     void pushSingle();
+    /** Declare that the next level of nesting will contain a list of nodes,
+        where i is the number of expected nodes. If i is 0, then no nested nodes
+        are expected (nothing is pushed on the stack).*/
     void pushList(int i);
 
+    /** Annotate the next nested node with a label. */
     void setNextLabel(std::string s);
 
+    /** Print indentation. */
     void Print();
+    /** Print indentation followed by the string. */
     void Print(const char *title);
+    /** Print indentation followed by the string and source position. */
     void Print(const char *title, const SourcePos &pos);
+    /** Print indentation followed by the string, source position and a new line character. */
     void PrintLn(const char *title, const SourcePos &pos);
+    /** Declare that current node printing is done. */
     void Done();
 };
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -184,6 +184,12 @@ class ASTNode {
         other purpose, as the values may change as ISPC evolves */
     unsigned getValueID() const { return SubclassID; }
 
+    /** A function for interactive debugging */
+    void Print() const;
+
+    /** A function that should be used for hierarchical AST dump. */
+    virtual void Print(Indent &indent) const = 0;
+
     static inline bool classof(ASTNode const *) { return true; }
 };
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -93,10 +93,8 @@ class Indent {
     /** Annotate the next nested node with a label. */
     void setNextLabel(std::string s);
 
-    /** Print indentation. */
-    void Print();
-    /** Print indentation followed by the string. */
-    void Print(const char *title);
+    /** Print indentation followed by an optional string string. */
+    void Print(const char *title = nullptr);
     /** Print indentation followed by the string and source position. */
     void Print(const char *title, const SourcePos &pos);
     /** Print indentation followed by the string, source position and a new line character. */

--- a/src/ast.h
+++ b/src/ast.h
@@ -203,6 +203,8 @@ class AST {
         module. */
     void GenerateIR();
 
+    void Print(Globals::ASTDumpKind printKind = Globals::ASTDumpKind::User) const;
+
   private:
     std::vector<Function *> functions;
 };

--- a/src/ast.h
+++ b/src/ast.h
@@ -68,6 +68,10 @@ namespace ispc {
 
     The call to any of Print()/PrintLn() methods does the indentation. Every such
     call must be paired by Done() call when the node is printed.
+
+    Note that this class is not assumed to encapsulate all printing functionality -
+    Print() member function is responsible for printing indented beginning of the
+    string, but the rest of the string needs to be printed with printf().
  */
 class Indent {
     std::string label;

--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -1170,10 +1170,11 @@ void ispc::DefineStdlib(SymbolTable *symbolTable, llvm::LLVMContext *ctx, llvm::
     // Define __math_lib stuff.  This is used by stdlib.ispc, for example, to
     // figure out which math routines to end up calling...
     lDefineConstantInt("__math_lib", (int)g->mathLib, module, symbolTable, debug_symbols);
-    lDefineConstantInt("__math_lib_ispc", (int)Globals::Math_ISPC, module, symbolTable, debug_symbols);
-    lDefineConstantInt("__math_lib_ispc_fast", (int)Globals::Math_ISPCFast, module, symbolTable, debug_symbols);
-    lDefineConstantInt("__math_lib_svml", (int)Globals::Math_SVML, module, symbolTable, debug_symbols);
-    lDefineConstantInt("__math_lib_system", (int)Globals::Math_System, module, symbolTable, debug_symbols);
+    lDefineConstantInt("__math_lib_ispc", (int)Globals::MathLib::Math_ISPC, module, symbolTable, debug_symbols);
+    lDefineConstantInt("__math_lib_ispc_fast", (int)Globals::MathLib::Math_ISPCFast, module, symbolTable,
+                       debug_symbols);
+    lDefineConstantInt("__math_lib_svml", (int)Globals::MathLib::Math_SVML, module, symbolTable, debug_symbols);
+    lDefineConstantInt("__math_lib_system", (int)Globals::MathLib::Math_System, module, symbolTable, debug_symbols);
     lDefineConstantIntFunc("__fast_masked_vload", (int)g->opt.fastMaskedVload, module, symbolTable, debug_symbols);
 
     lDefineConstantInt("__have_native_half", g->target->hasHalf(), module, symbolTable, debug_symbols);

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -326,8 +326,9 @@ void Declarator::Print(Indent &indent) const {
 
     if (functionParams.size() > 0) {
         for (unsigned int i = 0; i < functionParams.size(); ++i) {
-            char buffer[20];
-            snprintf(buffer, 20, "func param %d", i);
+            static constexpr std::size_t BUFSIZE{20};
+            char buffer[BUFSIZE];
+            snprintf(buffer, BUFSIZE, "func param %d", i);
             indent.setNextLabel(buffer);
             functionParams[i]->Print(indent);
         }

--- a/src/decl.h
+++ b/src/decl.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -53,6 +53,7 @@
 
 #pragma once
 
+#include "ast.h"
 #include "ispc.h"
 
 #include <llvm/ADT/SmallVector.h>
@@ -136,7 +137,8 @@ class Declarator {
 
     void InitFromType(const Type *base, DeclSpecs *ds);
 
-    void Print(int indent) const;
+    void Print() const;
+    void Print(Indent &indent) const;
 
     /** Position of the declarator in the source program. */
     const SourcePos pos;
@@ -184,7 +186,8 @@ class Declaration {
     Declaration(DeclSpecs *ds, std::vector<Declarator *> *dlist = NULL);
     Declaration(DeclSpecs *ds, Declarator *d);
 
-    void Print(int indent) const;
+    void Print() const;
+    void Print(Indent &indent) const;
 
     /** This method walks through all of the Declarators in a declaration
         and returns a fully-initialized Symbol and (possibly) and

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -5917,9 +5917,16 @@ void ConstExpr::Print(Indent &indent) const {
         case AtomicType::TYPE_UINT64:
             printf("%" PRIu64, uint64Val[i]);
             break;
-        case AtomicType::TYPE_FLOAT16:
-            printf("%f", fpVal[i].convertToFloat());
+        case AtomicType::TYPE_FLOAT16: {
+            llvm::APFloat V(fpVal[i]);
+#if ISPC_LLVM_VERSION < ISPC_LLVM_13_0
+            // Starting from LLVM 13, this is done by convertToFloat() implicitly.
+            bool ignored;
+            V.convert(llvm::APFloat::IEEEsingle(), llvm::APFloat::rmNearestTiesToEven, &ignored);
+#endif
+            printf("%f", V.convertToFloat());
             break;
+        }
         case AtomicType::TYPE_FLOAT:
             printf("%f", fpVal[i].convertToFloat());
             break;

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1336,7 +1336,7 @@ void UnaryExpr::Print(Indent &indent) const {
         printf("postfix '++'");
         break;
     case PostDec: ///< Post-decrement
-        printf("postfix '++'");
+        printf("postfix '--'");
         break;
     case Negate: ///< Negation
         printf("prefix '-'");

--- a/src/expr.h
+++ b/src/expr.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -105,9 +105,6 @@ class Expr : public ASTNode {
         encountered, NULL should be returned. */
     virtual Expr *TypeCheck() = 0;
 
-    /** Prints the expression to standard output (used for debugging). */
-    virtual void Print() const = 0;
-
     virtual bool HasAmbiguousVariability(std::vector<const Expr *> &warn) const;
 };
 
@@ -131,7 +128,7 @@ class UnaryExpr : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
-    void Print() const;
+    void Print(Indent &indent) const;
     Expr *Optimize();
     Expr *TypeCheck();
     int EstimateCost() const;
@@ -176,7 +173,7 @@ class BinaryExpr : public Expr {
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
     const Type *GetLValueType() const;
-    void Print() const;
+    void Print(Indent &indent) const;
 
     Expr *Optimize();
     Expr *TypeCheck();
@@ -213,7 +210,7 @@ class AssignExpr : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
-    void Print() const;
+    void Print(Indent &indent) const;
 
     Expr *Optimize();
     Expr *TypeCheck();
@@ -236,7 +233,7 @@ class SelectExpr : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
-    void Print() const;
+    void Print(Indent &indent) const;
 
     Expr *Optimize();
     Expr *TypeCheck();
@@ -262,7 +259,7 @@ class ExprList : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
-    void Print() const;
+    void Print(Indent &indent) const;
     std::pair<llvm::Constant *, bool> GetStorageConstant(const Type *type) const;
     std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
     ExprList *Optimize();
@@ -286,7 +283,7 @@ class FunctionCallExpr : public Expr {
     llvm::Value *GetLValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
     const Type *GetLValueType() const;
-    void Print() const;
+    void Print(Indent &indent) const;
 
     Expr *Optimize();
     Expr *TypeCheck();
@@ -315,7 +312,7 @@ class IndexExpr : public Expr {
     const Type *GetType() const;
     const Type *GetLValueType() const;
     Symbol *GetBaseSymbol() const;
-    void Print() const;
+    void Print(Indent &indent) const;
 
     Expr *Optimize();
     Expr *TypeCheck();
@@ -346,7 +343,7 @@ class MemberExpr : public Expr {
     llvm::Value *GetLValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
     Symbol *GetBaseSymbol() const;
-    void Print() const;
+    void Print(Indent &indent) const;
     Expr *Optimize();
     Expr *TypeCheck();
     int EstimateCost() const;
@@ -435,7 +432,7 @@ class ConstExpr : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
-    void Print() const;
+    void Print(Indent &indent) const;
     std::pair<llvm::Constant *, bool> GetStorageConstant(const Type *type) const;
     std::pair<llvm::Constant *, bool> GetConstant(const Type *constType) const;
 
@@ -496,7 +493,7 @@ class TypeCastExpr : public Expr {
     llvm::Value *GetLValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
     const Type *GetLValueType() const;
-    void Print() const;
+    void Print(Indent &indent) const;
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
@@ -522,7 +519,7 @@ class ReferenceExpr : public Expr {
     const Type *GetType() const;
     const Type *GetLValueType() const;
     Symbol *GetBaseSymbol() const;
-    void Print() const;
+    void Print(Indent &indent) const;
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
@@ -561,7 +558,7 @@ class PtrDerefExpr : public DerefExpr {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == PtrDerefExprID; }
 
     const Type *GetType() const;
-    void Print() const;
+    void Print(Indent &indent) const;
     Expr *TypeCheck();
     int EstimateCost() const;
 };
@@ -576,7 +573,7 @@ class RefDerefExpr : public DerefExpr {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == RefDerefExprID; }
 
     const Type *GetType() const;
-    void Print() const;
+    void Print(Indent &indent) const;
     Expr *TypeCheck();
     int EstimateCost() const;
 };
@@ -593,7 +590,7 @@ class AddressOfExpr : public Expr {
     const Type *GetType() const;
     const Type *GetLValueType() const;
     Symbol *GetBaseSymbol() const;
-    void Print() const;
+    void Print(Indent &indent) const;
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
@@ -614,7 +611,7 @@ class SizeOfExpr : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
-    void Print() const;
+    void Print(Indent &indent) const;
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
@@ -637,7 +634,7 @@ class AllocaExpr : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
-    void Print() const;
+    void Print(Indent &indent) const;
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
@@ -662,7 +659,7 @@ class SymbolExpr : public Expr {
     Symbol *GetBaseSymbol() const;
     Expr *TypeCheck();
     Expr *Optimize();
-    void Print() const;
+    void Print(Indent &indent) const;
     int EstimateCost() const;
 
   private:
@@ -684,7 +681,7 @@ class FunctionSymbolExpr : public Expr {
     Symbol *GetBaseSymbol() const;
     Expr *TypeCheck();
     Expr *Optimize();
-    void Print() const;
+    void Print(Indent &indent) const;
     int EstimateCost() const;
     std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
@@ -738,7 +735,7 @@ class SyncExpr : public Expr {
     const Type *GetType() const;
     Expr *TypeCheck();
     Expr *Optimize();
-    void Print() const;
+    void Print(Indent &indent) const;
     int EstimateCost() const;
 };
 
@@ -755,7 +752,7 @@ class NullPointerExpr : public Expr {
     Expr *TypeCheck();
     Expr *Optimize();
     std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
-    void Print() const;
+    void Print(Indent &indent) const;
     int EstimateCost() const;
 };
 
@@ -773,7 +770,7 @@ class NewExpr : public Expr {
     const Type *GetType() const;
     Expr *TypeCheck();
     Expr *Optimize();
-    void Print() const;
+    void Print(Indent &indent) const;
     int EstimateCost() const;
 
     /** Type of object to allocate storage for. */

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -71,6 +71,90 @@
 
 using namespace ispc;
 
+bool Function::IsStdlibSymbol() const {
+    if (sym == nullptr) {
+        return false;
+    }
+
+    if (sym->pos.name != nullptr && !strcmp(sym->pos.name, "stdlib.ispc")) {
+        return true;
+    }
+    return false;
+}
+
+void Function::debugPrintHelper(DebugPrintPoint dumpPoint) {
+    if (code == nullptr || sym == nullptr) {
+        return;
+    }
+
+    if (!g->debugPrint) {
+        return;
+    }
+
+    // With debug prints enabled we will dump AST on several stages, so need annotation.
+    if (g->debugPrint) {
+        switch (dumpPoint) {
+        case DebugPrintPoint::Initial:
+            printf("Initial AST\n");
+            break;
+        case DebugPrintPoint::AfterTypeChecking:
+            printf("AST after after typechecking\n");
+            break;
+        case DebugPrintPoint::AfterOptimization:
+            printf("AST after optimization\n");
+            break;
+        }
+    }
+
+    Print();
+    printf("\n");
+}
+
+void Function::Print() const {
+    Indent indent;
+    indent.pushSingle();
+    Print(indent);
+    fflush(stdout);
+}
+
+void Function::Print(Indent &indent) const {
+    indent.Print("Function");
+    if (sym) {
+        sym->pos.Print();
+        printf(" \"%s\"\n", sym->name.c_str());
+    } else {
+        printf("<NULL>");
+    }
+
+    indent.pushList(args.size() + 1);
+    if (args.size() > 0) {
+        for (int i = 0; i < args.size(); i++) {
+            char buffer[15];
+            snprintf(buffer, 15, "param %d", i);
+            indent.setNextLabel(buffer);
+            if (args[i]) {
+                indent.Print();
+                if (args[i]->type != nullptr) {
+                    printf("[%s] ", args[i]->type->GetString().c_str());
+                }
+                printf("%s\n", args[i]->name.c_str());
+                indent.Done();
+            } else {
+                indent.Print("<NULL>");
+                indent.Done();
+            }
+        }
+    }
+
+    indent.setNextLabel("body");
+    if (code != nullptr) {
+        code->Print(indent);
+    } else {
+        printf("<CODE is missing>\n");
+    }
+    indent.Done();
+}
+
 Function::Function(Symbol *s, Stmt *c) {
     sym = s;
     code = c;
@@ -79,30 +163,17 @@ Function::Function(Symbol *s, Stmt *c) {
     Assert(maskSymbol != NULL);
 
     if (code != NULL) {
+        debugPrintHelper(DebugPrintPoint::Initial);
+
         code = TypeCheck(code);
 
-        if (code != NULL && g->debugPrint) {
-            printf("After typechecking function \"%s\":\n", sym->name.c_str());
-            code->Print(0);
-            printf("---------------------\n");
-        }
+        debugPrintHelper(DebugPrintPoint::AfterTypeChecking);
 
         if (code != NULL) {
             code = Optimize(code);
-            if (g->debugPrint) {
-                printf("After optimizing function \"%s\":\n", sym->name.c_str());
-                code->Print(0);
-                printf("---------------------\n");
-            }
-        }
-    }
 
-    if (g->debugPrint) {
-        printf("Add Function %s\n", sym->name.c_str());
-        if (code != NULL) {
-            code->Print(0);
+            debugPrintHelper(DebugPrintPoint::AfterOptimization);
         }
-        printf("\n\n\n");
     }
 
     const FunctionType *type = CastType<FunctionType>(sym->type);

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -129,8 +129,9 @@ void Function::Print(Indent &indent) const {
     indent.pushList(args.size() + 1);
     if (args.size() > 0) {
         for (int i = 0; i < args.size(); i++) {
-            char buffer[15];
-            snprintf(buffer, 15, "param %d", i);
+            static constexpr std::size_t BUFSIZE{15};
+            char buffer[BUFSIZE];
+            snprintf(buffer, BUFSIZE, "param %d", i);
             indent.setNextLabel(buffer);
             if (args[i]) {
                 indent.Print();

--- a/src/func.h
+++ b/src/func.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2021, Intel Corporation
+  Copyright (c) 2011-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include "ast.h"
 #include "ispc.h"
 
 #include <vector>
@@ -53,7 +54,14 @@ class Function {
     /** Generate LLVM IR for the function into the current module. */
     void GenerateIR();
 
+    void Print() const;
+    void Print(Indent &indent) const;
+    bool IsStdlibSymbol() const;
+
   private:
+    enum class DebugPrintPoint { Initial, AfterTypeChecking, AfterOptimization };
+    void debugPrintHelper(DebugPrintPoint dumpPoint);
+
     void emitCode(FunctionEmitContext *ctx, llvm::Function *function, SourcePos firstStmtPos);
 
     Symbol *sym;

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1962,6 +1962,7 @@ Globals::Globals() {
     onlyCPP = false;
     ignoreCPPErrors = false;
     debugPrint = false;
+    astDump = Globals::ASTDumpKind::None;
     dumpFile = false;
     printTarget = false;
     NoOmitFramePointer = false;

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -806,7 +806,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
 #endif
 
     // Check math library
-    if (g->mathLib == Globals::Math_SVML && !ISPCTargetIsX86(m_ispc_target)) {
+    if (g->mathLib == Globals::MathLib::Math_SVML && !ISPCTargetIsX86(m_ispc_target)) {
         Error(SourcePos(), "SVML math library is supported for x86 targets only.");
         return;
     }
@@ -1954,8 +1954,8 @@ Opt::Opt() {
 Globals::Globals() {
     target_registry = TargetLibRegistry::getTargetLibRegistry();
 
-    mathLib = Globals::Math_ISPC;
-    codegenOptLevel = Globals::Aggressive;
+    mathLib = Globals::MathLib::Math_ISPC;
+    codegenOptLevel = Globals::CodegenOptLevel::Aggressive;
 
     includeStdlib = true;
     runCPP = true;

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2043,7 +2043,7 @@ llvm::DINamespace *SourcePos::GetDINamespace() const {
 }
 
 void SourcePos::Print() const {
-    printf(" @ [%s:%d.%d - %d.%d] ", name, first_line, first_column, last_line, last_column);
+    printf(" <%s:%d.%d - %d.%d> ", name, first_line, first_column, last_line, last_column);
 }
 
 bool SourcePos::operator==(const SourcePos &p2) const {

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -599,11 +599,11 @@ struct Globals {
 
     /** There are a number of math libraries that can be used for
         transcendentals and the like during program compilation. */
-    enum MathLib { Math_ISPC, Math_ISPCFast, Math_SVML, Math_System };
+    enum class MathLib { Math_ISPC, Math_ISPCFast, Math_SVML, Math_System };
     MathLib mathLib;
 
     /** Optimization level to be specified while creating TargetMachine. */
-    enum CodegenOptLevel { None, Aggressive };
+    enum class CodegenOptLevel { None, Aggressive };
     CodegenOptLevel codegenOptLevel;
 
     /** Records whether the ispc standard library should be made available

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -625,6 +625,14 @@ struct Globals {
         ispc's execution. */
     bool debugPrint;
 
+    /** When \c true, dump AST.
+        None - don't dump AST
+        User - dump AST only for user code, but not for stdlib functions
+        All - dump AST for all the code
+    */
+    enum class ASTDumpKind { None, User, All };
+    ASTDumpKind astDump;
+
     /** When \c true, target ISA will be printed during ispc's execution. */
     bool printTarget;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -754,13 +754,13 @@ int main(int Argc, char *Argv[]) {
         } else if (!strncmp(argv[i], "--math-lib=", 11)) {
             const char *lib = argv[i] + 11;
             if (!strcmp(lib, "default"))
-                g->mathLib = Globals::Math_ISPC;
+                g->mathLib = Globals::MathLib::Math_ISPC;
             else if (!strcmp(lib, "fast"))
-                g->mathLib = Globals::Math_ISPCFast;
+                g->mathLib = Globals::MathLib::Math_ISPCFast;
             else if (!strcmp(lib, "svml"))
-                g->mathLib = Globals::Math_SVML;
+                g->mathLib = Globals::MathLib::Math_SVML;
             else if (!strcmp(lib, "system"))
-                g->mathLib = Globals::Math_System;
+                g->mathLib = Globals::MathLib::Math_System;
             else {
                 errorHandler.AddError("Unknown --math-lib= option \"%s\".", lib);
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -210,6 +210,8 @@ static void lPrintVersion() {
 [[noreturn]] static void devUsage(int ret) {
     lPrintVersion();
     printf("\nusage (developer options): ispc\n");
+    printf("    [--ast-dump=user|all]\t\tDump AST for user code or all the code including stdlib. If no argument is "
+           "given, dump AST for user code only\n");
     printf("    [--debug]\t\t\t\tPrint information useful for debugging ispc\n");
     printf("    [--debug-llvm]\t\t\tEnable LLVM debugging information (dumps to stderr)\n");
 #ifndef ISPC_NO_DUMPS
@@ -641,6 +643,17 @@ int main(int Argc, char *Argv[]) {
                 std::string arch_str = ArchToString(arch);
                 errorHandler.AddWarning("Overwriting --arch=%s with --arch=%s", prev_arch_str.c_str(),
                                         arch_str.c_str());
+            }
+        } else if (!strcmp(argv[i], "--ast-dump")) {
+            g->astDump = Globals::ASTDumpKind::User;
+        } else if (!strncmp(argv[i], "--ast-dump=", 11)) {
+            const char *ast = argv[i] + 11;
+            if (!strcmp(ast, "user"))
+                g->astDump = Globals::ASTDumpKind::User;
+            else if (!strcmp(ast, "all"))
+                g->astDump = Globals::ASTDumpKind::All;
+            else {
+                errorHandler.AddError("Unknown --ast-dump= value \"%s\".", ast);
             }
         } else if (!strncmp(argv[i], "--x86-asm-syntax=", 17)) {
             intelAsmSyntax = argv[i] + 17;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -311,6 +311,8 @@ int Module::CompileFile() {
         fclose(f);
     }
 
+    ast->Print(g->astDump);
+
     if (g->NoOmitFramePointer)
         for (llvm::Function &f : *module)
             f.addFnAttr("no-frame-pointer-elim", "true");

--- a/src/stmt.h
+++ b/src/stmt.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -59,10 +59,6 @@ class Stmt : public ASTNode {
      */
     virtual void EmitCode(FunctionEmitContext *ctx) const = 0;
 
-    /** Print a representation of the statement (and any children AST
-        nodes) to standard output.  This method is used for debuggins. */
-    virtual void Print(int indent) const = 0;
-
     // Redeclare these methods with Stmt * return values, rather than
     // ASTNode *s, as in the original ASTNode declarations of them.  We'll
     // also provide a default implementation of Optimize(), since most
@@ -82,7 +78,7 @@ class ExprStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ExprStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;
@@ -109,7 +105,7 @@ class DeclStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == DeclStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *Optimize();
     Stmt *TypeCheck();
@@ -128,7 +124,7 @@ class IfStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == IfStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;
@@ -167,7 +163,7 @@ class DoStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == DoStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
 
@@ -193,7 +189,7 @@ class ForStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ForStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
 
@@ -225,7 +221,7 @@ class BreakStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == BreakStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;
@@ -241,7 +237,7 @@ class ContinueStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ContinueStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;
@@ -261,7 +257,7 @@ class ForeachStmt : public Stmt {
     void EmitCodeForXe(FunctionEmitContext *ctx) const;
 #endif
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     std::pair<Globals::pragmaUnrollType, int> loopAttribute =
@@ -286,7 +282,7 @@ class ForeachActiveStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ForeachActiveStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     std::pair<Globals::pragmaUnrollType, int> loopAttribute =
@@ -309,7 +305,7 @@ class ForeachUniqueStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ForeachUniqueStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     std::pair<Globals::pragmaUnrollType, int> loopAttribute =
@@ -332,7 +328,7 @@ class UnmaskedStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == UnmaskedStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;
@@ -350,7 +346,7 @@ class ReturnStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ReturnStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;
@@ -369,7 +365,7 @@ class CaseStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == CaseStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;
@@ -389,7 +385,7 @@ class DefaultStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == DefaultStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;
@@ -406,7 +402,7 @@ class SwitchStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == SwitchStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;
@@ -426,7 +422,7 @@ class GotoStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == GotoStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *Optimize();
     Stmt *TypeCheck();
@@ -447,7 +443,7 @@ class LabeledStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == LabeledStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *Optimize();
     Stmt *TypeCheck();
@@ -469,7 +465,7 @@ class StmtList : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == StmtListID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;
@@ -499,7 +495,7 @@ class PrintStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == PrintStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;
@@ -547,7 +543,7 @@ class AssertStmt : public Stmt {
     void EmitAssertCode(FunctionEmitContext *ctx, const Type *type) const;
     void EmitAssumeCode(FunctionEmitContext *ctx, const Type *type) const;
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;
@@ -568,7 +564,7 @@ class DeleteStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == DeleteStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
-    void Print(int indent) const;
+    void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
     int EstimateCost() const;

--- a/tests/lit-tests/ast_dump.ispc
+++ b/tests/lit-tests/ast_dump.ispc
@@ -1,0 +1,14 @@
+// RUN: %{ispc} %s --target=host -O0 --ast-dump | FileCheck %s -check-prefix=CHECK_USER
+// RUN: %{ispc} %s --target=host -O0 --ast-dump=user | FileCheck %s -check-prefix=CHECK_USER
+// RUN: %{ispc} %s --target=host -O0 --ast-dump=all | FileCheck %s -check-prefix=CHECK_ALL
+
+// "all" is stdlib function.
+
+// CHECK_USER-NOT: Function {{.*}} "all"
+// CHECK_USER: Function {{.*}} "foo"
+
+// CHECK_ALL: Function {{.*}} "all"
+// CHECK_ALL: Function {{.*}} "foo"
+int foo(int a, int b) {
+  return a+b;
+}

--- a/tests/lit-tests/ast_expr.ispc
+++ b/tests/lit-tests/ast_expr.ispc
@@ -1,0 +1,118 @@
+// RUN: %{ispc} %s --ast-dump --wno-perf --target=host
+
+// This test doesn't check anything specific about format of --ast-dump, but
+// it covers most of --ast-dump functionality with respect to Expr and verifies
+// that the options doesn't crash the compiler.
+
+void unary(int i) {
+    i++;
+    i--;
+    ++i;
+    --i;
+    !i;
+    ~i;
+    -i;
+}
+
+int binary(int a, int b) {
+    int i = (((a + b) - (b * a)) / b) % a;
+    a, b;
+    int j = ((a << b) >> b) & (a ^ b) | b;
+    bool k = (a < b) || (a <= b) && (a == b) || (a >= b) && (a == b) || (a != b);
+    return i + j + (int)k;
+}
+
+void assign(int a, int b) {
+    a = b;
+    b *= a;
+    b /= a;
+    a %= b;
+    a += b;
+    a -= b;
+    a <<= b;
+    a >>= b;
+    a &= b;
+    a ^= b;
+    a |= b;
+}
+
+int select(int a, int b, int c, int d) { return (a > b) ? a + b : a - b; }
+
+int call_expr_list(int a, int b) { return select(a, b, a + b, a - b); }
+
+int index(int a[], int b) { return a[b]; }
+
+struct S {
+    int fieldA;
+    int fieldB;
+} s;
+
+int member() { return s.fieldA + s.fieldB; }
+
+void const_expr() {
+    bool b1 = true;
+    bool b2 = programIndex % 2 == 0 ? true : false;
+    int8 i1 = 1;
+    uint8 i2 = 1;
+    int16 i3 = 1;
+    uint16 i4 = 1;
+    int32 i5 = 1;
+    uint32 i6 = 1;
+    int64 i7 = 1;
+    uint64 i8 = 1;
+    float16 f1 = 1.f16;
+    float f2 = 1.;
+    double f3 = 1.d;
+#if TARGET_WIDTH == 4
+    int i = {1, 8, 1, 9};
+#elif TARGET_WIDTH == 8
+    int i = {1, 8, 1, 9, 1, 1, 1, 1};
+#elif TARGET_WIDTH == 16
+    int i = {1, 8, 1, 9, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+#elif TARGET_WIDTH == 32
+    int i = {1, 8, 1, 9, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+#elif TARGET_WIDTH == 64
+    int i = {1, 8, 1, 9, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+#endif
+    int folding = programIndex % 3 == 0 ? ((1 + 2) * 3 - 1) : 9 / 2;
+    ;
+}
+
+void type_cast(int8 b, int i, float f, double d) {
+    int ii = (int)b;
+    int8 bb = (int8)i;
+    int iii = ((int)f) + ((int)d);
+    float ff = ((float)d) + ((float)i);
+}
+
+int ref(uniform int i, uniform int *uniform p, uniform int &r) {
+    // ReferenceExpr
+    uniform int &x = (uniform int &)i;
+    // RefDerefExpr
+    uniform int y = r;
+    // PtrDerefExpr
+    uniform int z = *p;
+    // AddressOfExpr
+    uniform int *pp = &y;
+}
+
+int size(float *p) { return sizeof(int) + sizeof(p); }
+
+int allocaaa(uniform int i) {
+    void *p = alloca(10);
+    void *p2 = alloca(i);
+}
+
+task void my_task_foo() {}
+
+void others(int vi, uniform int ui) {
+    sync;
+    launch[5] my_task_foo();
+    NULL;
+    new uniform int;
+    new uniform float[ui];
+    new uniform float[vi];
+    int *ptr = new int[100];
+    delete[] ptr;
+}

--- a/tests/lit-tests/ast_stmt.ispc
+++ b/tests/lit-tests/ast_stmt.ispc
@@ -1,0 +1,94 @@
+// RUN: %{ispc} %s --ast-dump --wno-perf --target=host
+
+// This test doesn't check anything specific about format of --ast-dump, but
+// it covers most of --ast-dump functionality with respect to Stmt and verifies
+// that the options doesn't crash the compiler.
+
+int foo(int a, int b) {
+    // DeclStmt
+    int result = a + b, result2, result3 = a;
+    // IfStmt
+    if (a > 2) {
+        a = 1;
+    } else {
+        return 3;
+    }
+
+    do {
+        a++;
+    } while (a > b);
+    // ForStmt
+    // BreakStmt
+    // ContinueStmt
+    for (uniform int ui = 0; ui < 16; ui++) {
+        int t = a;
+        a = b;
+        if (t == 5)
+            continue;
+        if (t == 6)
+            break;
+        b = t;
+    }
+    // ExprStmt
+    result++;
+    // Return
+    return result;
+}
+
+float bar(uniform int n1, uniform int n2, uniform int n3, float f[]) {
+    float r = 0;
+    // ForeachStmt
+    foreach (i1 = 0...n1, i2 = 0...16) {
+        f[i1] += 1;
+        r = i1 + i2;
+    }
+    // ForeachActiveStmt
+    foreach_active(i) { r += 5; }
+
+    int count;
+    // ForeachUniqueStmt
+    foreach_unique(ua in r) { ++count; }
+
+    // UnmaskedStmt
+    unmasked { count--; }
+
+    // SwitchStmt
+    // BreakStmt
+    // CaseStmt
+    // DefaultStmt
+    switch (n1) {
+    case 1:
+    case 2:
+        count--;
+        break;
+    case 3:
+    case 4:
+        count++;
+        break;
+    default:
+        count++;
+    }
+
+    return r;
+}
+
+int baz(uniform int i) {
+// LabeledStmt
+A:
+    if (i > 5) {
+        i--;
+        // GotoStmt
+        goto A;
+    } else {
+        i++;
+    }
+    // PrintStmt
+    print("asd %, %\n", i, i);
+    print("123");
+    // AssertStmt
+    assert(i < 5);
+    float *uniform buf = uniform new float[programCount];
+    // DeleteStmt
+    delete buf;
+    return i;
+}

--- a/tests_errors/soa-11.ispc
+++ b/tests_errors/soa-11.ispc
@@ -1,4 +1,4 @@
-// Type conversion from "const uniform int[0-9]*" to "soa<4> struct Foo" for assignment operator is not possible
+// Type conversion from "const uniform int[0-9]*" to "soa<4> struct Foo" for = is not possible
 
 struct Pt { float x, y, z; };
 


### PR DESCRIPTION
This PR adds `--ast-dump` switch, which is similar to clang's one. May be used in the following form:
- `--ast-dump=user` or `--ast-dump` to print AST for user code.
- `--ast-dump=all` to print all the code including stdlib.

The format of AST dump is intentionally made similar to format of clang AST, so it would look familiar for those who has experience with clang.

Other changes worth to note:
- `ASTNode` (and hence `Stmt` and `Expr`) class, and `Function` got member function `void Print()`, which works in the debugger. The one that was there previously didn't work in the debugger out of the box, as didn't do flashing, so nothing was printed unless `fflush()` was invoked manually.
- Most of functionality for `Print()` functions were kept the same, in some cases it was extended. But the key focus was new format. So there are things to improve in terms of what is being printed.
- `MathLib` and `CodegenOptLevel` `enum`s were changed to be `enum class` for code style uniformity.