### PR TITLE
CI to test with LLVM 14.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@
 configuration: Release
 
 environment:
-  LLVM_LATEST: 13.0
+  LLVM_LATEST: 14.0
   DOCKER_PATH: "ispc/test_repo"
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
@@ -40,7 +40,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       LLVM_VERSION: latest
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      LLVM_VERSION: 12.0
+      LLVM_VERSION: 13.0
 
 for:
 -
@@ -58,7 +58,8 @@ for:
         if "%LLVM_VERSION%"=="latest" (set WASM=ON)
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vspath="C:\Program Files (x86)\Microsoft Visual Studio\2019"))
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2022" ( (set generator="Visual Studio 17") & (set vspath="C:\Program Files\Microsoft Visual Studio\2022"))
-        set LLVM_TAR=llvm-13.0.1-win.vs2022-Release+Asserts-x86.arm.wasm.tar.7z
+        set LLVM_TAR=llvm-14.0.1-win.vs2022-Release+Asserts-x86.arm.wasm.tar.7z
+        if "%LLVM_VERSION%"=="13.0" (set LLVM_TAR=llvm-13.0.1-win.vs2022-Release+Asserts-x86.arm.wasm.tar.7z)
         if "%LLVM_VERSION%"=="12.0" (set LLVM_TAR=llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
         if "%LLVM_VERSION%"=="11.1" (set LLVM_TAR=llvm-11.1.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
   install:
@@ -110,7 +111,7 @@ for:
         export LLVM_HOME=$APPVEYOR_BUILD_FOLDER/llvm
         export CROSS_TOOLS=/usr/local/src/cross
         export WASM=OFF
-        export LLVM_TAR=llvm-13.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+        export LLVM_TAR=llvm-14.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
   install:
     - sh: |-
         sudo apt-get update

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -169,6 +169,42 @@ jobs:
         name: ispc_llvm13_linux
         path: build/ispc-trunk-linux.tar.gz
 
+  linux-build-ispc-llvm14:
+    needs: [define-flow]
+    runs-on: ubuntu-latest
+    env:
+      LLVM_VERSION: "14.0"
+      LLVM_TAR: llvm-14.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Install dependencies
+      run: |
+        .github/workflows/scripts/install-build-deps.sh
+
+    - name: Check environment
+      run: |
+        ./check_env.py
+        which -a clang
+        cat /proc/cpuinfo
+
+    - name: Build package
+      run: |
+        .github/workflows/scripts/build-ispc.sh
+
+    - name: Sanity testing (make check-all, make test)
+      run: |
+        .github/workflows/scripts/check-ispc.sh
+
+    - name: Upload package
+      uses: actions/upload-artifact@v2
+      with:
+        name: ispc_llvm14_linux
+        path: build/ispc-trunk-linux.tar.gz
+
   linux-test-llvm11:
     needs: [define-flow, linux-build-ispc-llvm11]
     runs-on: ubuntu-latest
@@ -234,7 +270,8 @@ jobs:
     - name: Running tests
       run: |
         echo PATH=$PATH
-        ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+        # Just sanity check for 12.0
+        ./alloy.py -r --only="stability current -O2" --only-targets="avx2-i32x8" --time --update-errors=FP
 
     - name: Check
       run: |
@@ -286,6 +323,46 @@ jobs:
       if: failure()
       with:
         name: fail_db.llvm13.${{matrix.target}}.txt
+        path: fail_db.txt
+
+  linux-test-llvm14:
+    needs: [define-flow, linux-build-ispc-llvm14]
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: ispc_llvm14_linux
+
+    - name: Install dependencies and unpack artifacts
+      run: |
+        .github/workflows/scripts/install-test-deps.sh
+
+    - name: Check environment
+      run: |
+        cat /proc/cpuinfo
+
+    - name: Running tests
+      run: |
+        echo PATH=$PATH
+        ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
+    - name: Upload fail_db.txt
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: fail_db.llvm14.${{matrix.target}}.txt
         path: fail_db.txt
 
   # Debug run is experimental with the purpose to see if it's capable to catch anything.
@@ -453,6 +530,47 @@ jobs:
         name: ispc_llvm13_win
         path: build/ispc-trunk-windows.msi
 
+  win-build-ispc-llvm14:
+    needs: [define-flow]
+    runs-on: windows-2022
+    env:
+      LLVM_VERSION: "14.0"
+      LLVM_TAR: llvm-14.0.1-win.vs2022-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_HOME: "C:\\projects\\llvm"
+      CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
+      BUILD_TYPE: "Release"
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Install dependencies
+      run: |
+        .github/workflows/scripts/install-build-deps.ps1
+
+    - name: Check environment
+      shell: cmd
+      run: |
+        wmic cpu get caption, deviceid, name, numberofcores, maxclockspeed, status
+
+    - name: Build package
+      run: |
+        .github/workflows/scripts/build-ispc.ps1
+
+    - name: Sanity testing (make check-all, make test)
+      run: |
+        .github/workflows/scripts/check-ispc.ps1
+
+    - name: Upload package
+      uses: actions/upload-artifact@v2
+      with:
+        name: ispc_llvm14_win
+        path: build/ispc-trunk-windows.msi
+
   win-test-llvm11:
     needs: [define-flow, win-build-ispc-llvm11]
     runs-on: windows-2022
@@ -532,7 +650,8 @@ jobs:
       run: |
         $env:ISPC_HOME = "$pwd"
         .github/workflows/scripts/load-vs-env.ps1 "${{ matrix.arch }}"
-        python .\alloy.py -r --only="stability ${{ matrix.arch }} current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+        # Just sanity check for 12.0
+        python .\alloy.py -r --only="stability ${{ matrix.arch }} current -O2" --only-targets="avx2-i32x8" --time --update-errors=FP
 
     - name: Check
       run: |
@@ -590,5 +709,51 @@ jobs:
       if: failure()
       with:
         name: fail_db.llvm13.${{matrix.arch}}.${{matrix.target}}.txt
+        path: fail_db.txt
+
+  win-test-llvm14:
+    needs: [define-flow, win-build-ispc-llvm14]
+    env:
+      LLVM_HOME: "C:\\projects\\llvm"
+    runs-on: windows-2022
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86, x86-64]
+        target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: ispc_llvm14_win
+
+    - name: Install dependencies
+      run: |
+        .github/workflows/scripts/install-test-deps.ps1
+
+    - name: Check environment
+      shell: cmd
+      run: |
+        wmic cpu get caption, deviceid, name, numberofcores, maxclockspeed, status
+
+    - name: Running tests
+      run: |
+        $env:ISPC_HOME = "$pwd"
+        .github/workflows/scripts/load-vs-env.ps1 "${{ matrix.arch }}"
+        python .\alloy.py -r --only="stability ${{ matrix.arch }} current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
+    - name: Upload fail_db.txt
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: fail_db.llvm14.${{matrix.arch}}.${{matrix.target}}.txt
         path: fail_db.txt
 

--- a/.github/workflows/nightly-15.yml
+++ b/.github/workflows/nightly-15.yml
@@ -1,10 +1,10 @@
 # Nightly Linux run.
 
 ####################################################################
-# Currently disabled. To be reenabled for 14.0 when it's branched. #
+# Currently disabled. To be reenabled for 15.0 when it's branched. #
 ####################################################################
 
-name: Nightly tests / LLVM 14.0
+name: Nightly tests / LLVM 15.0
 
 # Run daily - test sse2-avx512 targets @ -O0/-O1/-O2
 on:
@@ -22,7 +22,7 @@ jobs:
   # makes the resulting build not usable on other Ubuntu 18.04 images.
   # Doing Linux build in two stages, as self-build is required, but Github Action runners are not always capable
   # to finish the full job in less than 6 hours.
-  linux-build-llvm-14-1:
+  linux-build-llvm-15-1:
     runs-on: ubuntu-latest
 
     steps:
@@ -38,16 +38,16 @@ jobs:
       run: |
         cd docker/ubuntu/18.04/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu18.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=13.0 .
+        docker buildx build --tag ispc/ubuntu18.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=15.0 .
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: llvm14_linux_stage1_cache
+        name: llvm15_linux_stage1_cache
         path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
-  linux-build-llvm-14-2:
-    needs: [linux-build-llvm-14-1]
+  linux-build-llvm-15-2:
+    needs: [linux-build-llvm-15-1]
     runs-on: ubuntu-latest
 
     steps:
@@ -62,7 +62,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: llvm14_linux_stage1_cache
+        name: llvm15_linux_stage1_cache
         path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
 
     - name: Build LLVM
@@ -70,28 +70,28 @@ jobs:
         cd docker/ubuntu/18.04/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=14.0 --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=15.0 --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
         cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
-        mv usr/local/src/llvm/bin-14.0 .
+        mv usr/local/src/llvm/bin-15.0 .
         # Note using gzip here, instead of xz - trading of space for speed, as it's just for passing to another stage.
-        tar czvf llvm-14.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-14.0
+        tar czvf llvm-15.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-15.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: llvm_14_linux
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+        name: llvm_15_linux
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-15.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
-  linux-build-ispc-llvm-14:
-    needs: [linux-build-llvm-14-2]
+  linux-build-ispc-llvm-15:
+    needs: [linux-build-llvm-15-2]
     runs-on: ubuntu-latest
     env:
-      LLVM_VERSION: "14.0"
-      LLVM_TAR: llvm-14.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+      LLVM_VERSION: "15.0"
+      LLVM_TAR: llvm-15.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
     steps:
     - uses: actions/checkout@v2
@@ -101,7 +101,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: llvm_14_linux
+        name: llvm_15_linux
 
     - name: Install dependencies
       run: |
@@ -124,11 +124,11 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: ispc_llvm_14_linux
+        name: ispc_llvm_15_linux
         path: build/ispc-trunk-linux.tar.gz
 
-  linux-test-llvm-14:
-    needs: [linux-build-ispc-llvm-14]
+  linux-test-llvm-15:
+    needs: [linux-build-ispc-llvm-15]
     runs-on: ubuntu-latest
     continue-on-error: false
     strategy:
@@ -145,7 +145,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: ispc_llvm_14_linux
+        name: ispc_llvm_15_linux
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -175,7 +175,7 @@ jobs:
         [ -z "`git diff`" ]
 
 
-  win-build-llvm-14:
+  win-build-llvm-15:
     runs-on: windows-2022
 
     steps:
@@ -201,30 +201,30 @@ jobs:
     - name: Build LLVM
       shell: cmd
       run: |
-        python ./alloy.py -b --version=14.0 --verbose
+        python ./alloy.py -b --version=15.0 --verbose
         cd alloy_results* && type alloy_build.log
 
     - name: Pack LLVM
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-14.0.0-win.vs2019-Release+Asserts-x86.arm.wasm
-        7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-14.0
+        set TAR_BASE_NAME=llvm-15.0.0-win.vs2019-Release+Asserts-x86.arm.wasm
+        7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-15.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: llvm_14_win
-        path: llvm/llvm-14.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        name: llvm_15_win
+        path: llvm/llvm-15.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
 
-  win-build-ispc-llvm-14:
-    needs: [win-build-llvm-14]
+  win-build-ispc-llvm-15:
+    needs: [win-build-llvm-15]
     runs-on: windows-2022
     env:
-      LLVM_VERSION: "14.0"
-      LLVM_TAR: llvm-14.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_VERSION: "15.0"
+      LLVM_TAR: llvm-15.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"
@@ -237,7 +237,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: llvm_14_win
+        name: llvm_15_win
         path: ${{env.LLVM_HOME}}
 
     - name: Add msbuild to PATH
@@ -263,12 +263,12 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: ispc_llvm14_win
+        name: ispc_llvm15_win
         path: build/ispc-trunk-windows.msi
 
 
-  win-test-llvm14:
-    needs: [win-build-ispc-llvm-14]
+  win-test-llvm15:
+    needs: [win-build-ispc-llvm-15]
     env:
       LLVM_HOME: "C:\\projects\\llvm"
     runs-on: windows-2022
@@ -289,7 +289,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: ispc_llvm14_win
+        name: ispc_llvm15_win
 
     - name: Install dependencies
       run: |
@@ -315,6 +315,6 @@ jobs:
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: fail_db.llvm14.${{matrix.arch}}.${{matrix.target}}.txt
+        name: fail_db.llvm15.${{matrix.arch}}.${{matrix.target}}.txt
         path: fail_db.txt
 

--- a/.github/workflows/rebuild-llvm14.yml
+++ b/.github/workflows/rebuild-llvm14.yml
@@ -175,6 +175,7 @@ jobs:
       shell: cmd
       run: |
         cd llvm
+        rmdir /s /q build-14.0
         set TAR_BASE_NAME=llvm-14.0.1-win.vs2022-Release+Asserts-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-14.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
@@ -218,6 +219,7 @@ jobs:
       shell: cmd
       run: |
         cd llvm
+        rmdir /s /q build-14.0
         set TAR_BASE_NAME=llvm-14.0.1-win.vs2022-Release-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-14.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar

--- a/.github/workflows/rebuild-llvm14.yml
+++ b/.github/workflows/rebuild-llvm14.yml
@@ -71,13 +71,13 @@ jobs:
         cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-14.0 .
-        tar cJvf llvm-14.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz bin-14.0
+        tar cJvf llvm-14.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz bin-14.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm14_linux
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
   linux-build-release-1:
     runs-on: ubuntu-latest
@@ -134,13 +134,13 @@ jobs:
         cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-14.0 .
-        tar cJvf llvm-14.0.0-ubuntu18.04-Release-x86.arm.wasm.tar.xz bin-14.0
+        tar cJvf llvm-14.0.1-ubuntu18.04-Release-x86.arm.wasm.tar.xz bin-14.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm14rel_linux
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.0-ubuntu18.04-Release-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.1-ubuntu18.04-Release-x86.arm.wasm.tar.xz
 
   win-build:
     runs-on: windows-2022
@@ -175,7 +175,7 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-14.0.0-win.vs2022-Release+Asserts-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-14.0.1-win.vs2022-Release+Asserts-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-14.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -183,7 +183,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: llvm14_win
-        path: llvm/llvm-14.0.0-win.vs2022-Release+Asserts-x86.arm.wasm.tar.7z
+        path: llvm/llvm-14.0.1-win.vs2022-Release+Asserts-x86.arm.wasm.tar.7z
 
   win-build-release:
     runs-on: windows-2022
@@ -218,7 +218,7 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-14.0.0-win.vs2022-Release-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-14.0.1-win.vs2022-Release-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-14.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -226,7 +226,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: llvm14rel_win
-        path: llvm/llvm-14.0.0-win.vs2022-Release-x86.arm.wasm.tar.7z
+        path: llvm/llvm-14.0.1-win.vs2022-Release-x86.arm.wasm.tar.7z
 
   mac-build:
     runs-on: macos-10.15
@@ -263,13 +263,13 @@ jobs:
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-14.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz bin-14.0
+        tar cJvf llvm-14.0.1-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz bin-14.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm14_macos
-        path: llvm/llvm-14.0.0-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
+        path: llvm/llvm-14.0.1-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
 
   mac-build-release:
     runs-on: macos-10.15
@@ -306,11 +306,11 @@ jobs:
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-14.0.0-macos10.15-Release-x86.arm.wasm.tar.xz bin-14.0
+        tar cJvf llvm-14.0.1-macos10.15-Release-x86.arm.wasm.tar.xz bin-14.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm14rel_macos
-        path: llvm/llvm-14.0.0-macos10.15-Release-x86.arm.wasm.tar.xz
+        path: llvm/llvm-14.0.1-macos10.15-Release-x86.arm.wasm.tar.xz
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ sudo: required
 jobs:
   include:
     # ARM build
-    # LLVM 13.0 + Ubuntu 18.04:
+    # LLVM 14.0 + Ubuntu 18.04:
     #   - ARM only (default): build, lit tests, examples (build)
     #   - ARM + x86: build, lit tests, examples (build), tests (aarch64)
     - stage: test
@@ -50,8 +50,8 @@ jobs:
       arch: arm64
       dist: bionic
       env:
-        - LLVM_VERSION=13.0 OS=Ubuntu18.04aarch64
-        - LLVM_TAR=llvm-13.0.1-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_VERSION=14.0 OS=Ubuntu18.04aarch64
+        - LLVM_TAR=llvm-14.0.1-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
         - LLVM_REPO=https://github.com/ispc/llvm-project
         - ISPC_HOME=$TRAVIS_BUILD_DIR
       before_install:

--- a/alloy.py
+++ b/alloy.py
@@ -121,7 +121,7 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     if  version_LLVM == "trunk":
         GIT_TAG="main"
     elif  version_LLVM == "14_0":
-        GIT_TAG="llvmorg-14.0.0"
+        GIT_TAG="llvmorg-14.0.1"
     elif  version_LLVM == "13_0":
         GIT_TAG="llvmorg-13.0.1"
     elif  version_LLVM == "12_0":


### PR DESCRIPTION
- `alloy.py` to build 14.0.1 when building `14.0`
- Rebuild14 pipeline to build files named 14.0.1
- `nightly-14` pipeline renames to `nightly-15` and changed accordingly. It supposed to be enabled when 15.0 is branched
- Remove build directories on Windows before packing LLVM 14, as the worker may run out of space
- GitHub Actions to testing to run LLVM 14 jobs: LLVM 13.0 & 14.0 - full testing, LLVM 11.1 & 12.0 sanity. Was LLVM 13.0 & 12.0 full, LLVM 11.1 - sanity
- Appveyor to test LLVM 13.0 and 14.0, instead of 12.0 and 13.0
- Travis to test 14.0, instead of 13.0.