### PR TITLE
Updates for Xe targets (7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,7 +454,7 @@ else()
     # Security options
     target_compile_options(${PROJECT_NAME} PRIVATE -fstack-protector-strong
                            -fdata-sections -ffunction-sections -fno-delete-null-pointer-checks
-                           -Wformat -Wformat-security -fpie -fwrapv)
+                           -Wformat -Wformat-security -fPIE -fwrapv)
 endif()
 
 # Set C++ standard to C++17.
@@ -473,11 +473,15 @@ endif()
 # Link options
 if (WIN32)
     target_link_options(${PROJECT_NAME} PRIVATE /DYNAMICBASE)
+    # Control flow guard
+    target_link_options(${PROJECT_NAME} PRIVATE /GUARD:CF)
     if (MSVC AND NOT CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
         target_link_options(${PROJECT_NAME} PUBLIC /OPT:REF /OPT:ICF)
     endif()
 elseif (APPLE)
 else()
+    # Position independent code
+    target_link_options(${PROJECT_NAME} PRIVATE -pie)
     # Link options for security hardening.
     target_link_options(${PROJECT_NAME}
         PUBLIC "SHELL: -z noexecstack"

--- a/builtins/util-xe.m4
+++ b/builtins/util-xe.m4
@@ -1686,22 +1686,18 @@ declare void @llvm.prefetch(i8* nocapture %ptr, i32 %readwrite, i32 %locality,
                             i32 %cachetype) ; cachetype == 1 is dcache
 
 define void @__prefetch_read_uniform_1(i8 *) alwaysinline {
-  call void @llvm.prefetch(i8 * %0, i32 0, i32 3, i32 1)
   ret void
 }
 
 define void @__prefetch_read_uniform_2(i8 *) alwaysinline {
-  call void @llvm.prefetch(i8 * %0, i32 0, i32 2, i32 1)
   ret void
 }
 
 define void @__prefetch_read_uniform_3(i8 *) alwaysinline {
-  call void @llvm.prefetch(i8 * %0, i32 0, i32 1, i32 1)
   ret void
 }
 
 define void @__prefetch_read_uniform_nt(i8 *) alwaysinline {
-  call void @llvm.prefetch(i8 * %0, i32 0, i32 0, i32 1)
   ret void
 }
 
@@ -1718,45 +1714,25 @@ define void @__prefetch_write_uniform_3(i8 *) alwaysinline {
   ret void
 }
 
-define void @__prefetch_read_varying_1(<WIDTH x i64> %addr, <WIDTH x MASK> %mask) alwaysinline {
-  per_lane(WIDTH, <WIDTH x MASK> %mask, `
-  %iptr_LANE_ID = extractelement <WIDTH x i64> %addr, i32 LANE
-  %ptr_LANE_ID = inttoptr i64 %iptr_LANE_ID to i8*
-  call void @llvm.prefetch(i8 * %ptr_LANE_ID, i32 0, i32 3, i32 1)
-  ')
+define void @__prefetch_read_varying_1(<WIDTH x i64>, <WIDTH x MASK>) alwaysinline {
   ret void
 }
 
 declare void @__prefetch_read_varying_1_native(i8 * %base, i32 %scale, <WIDTH x i32> %offsets, <WIDTH x MASK> %mask) nounwind
 
-define void @__prefetch_read_varying_2(<WIDTH x i64> %addr, <WIDTH x MASK> %mask) alwaysinline {
-  per_lane(WIDTH, <WIDTH x MASK> %mask, `
-  %iptr_LANE_ID = extractelement <WIDTH x i64> %addr, i32 LANE
-  %ptr_LANE_ID = inttoptr i64 %iptr_LANE_ID to i8*
-  call void @llvm.prefetch(i8 * %ptr_LANE_ID, i32 0, i32 2, i32 1)
-  ')
+define void @__prefetch_read_varying_2(<WIDTH x i64>, <WIDTH x MASK>) alwaysinline {
   ret void
 }
 
 declare void @__prefetch_read_varying_2_native(i8 * %base, i32 %scale, <WIDTH x i32> %offsets, <WIDTH x MASK> %mask) nounwind
 
-define void @__prefetch_read_varying_3(<WIDTH x i64> %addr, <WIDTH x MASK> %mask) alwaysinline {
-  per_lane(WIDTH, <WIDTH x MASK> %mask, `
-  %iptr_LANE_ID = extractelement <WIDTH x i64> %addr, i32 LANE
-  %ptr_LANE_ID = inttoptr i64 %iptr_LANE_ID to i8*
-  call void @llvm.prefetch(i8 * %ptr_LANE_ID, i32 0, i32 1, i32 1)
-  ')
+define void @__prefetch_read_varying_3(<WIDTH x i64>, <WIDTH x MASK>) alwaysinline {
   ret void
 }
 
 declare void @__prefetch_read_varying_3_native(i8 * %base, i32 %scale, <WIDTH x i32> %offsets, <WIDTH x MASK> %mask) nounwind
 
-define void @__prefetch_read_varying_nt(<WIDTH x i64> %addr, <WIDTH x MASK> %mask) alwaysinline {
-  per_lane(WIDTH, <WIDTH x MASK> %mask, `
-  %iptr_LANE_ID = extractelement <WIDTH x i64> %addr, i32 LANE
-  %ptr_LANE_ID = inttoptr i64 %iptr_LANE_ID to i8*
-  call void @llvm.prefetch(i8 * %ptr_LANE_ID, i32 0, i32 0, i32 1)
-  ')
+define void @__prefetch_read_varying_nt(<WIDTH x i64>, <WIDTH x MASK>) alwaysinline {
   ret void
 }
 

--- a/builtins/util-xe.m4
+++ b/builtins/util-xe.m4
@@ -1705,18 +1705,16 @@ define void @__prefetch_read_uniform_nt(i8 *) alwaysinline {
   ret void
 }
 
+;; There is no write prefetch on Xe targets, so do nothing
 define void @__prefetch_write_uniform_1(i8 *) alwaysinline {
-  call void @llvm.prefetch(i8 * %0, i32 1, i32 3, i32 1)
   ret void
 }
 
 define void @__prefetch_write_uniform_2(i8 *) alwaysinline {
-  call void @llvm.prefetch(i8 * %0, i32 1, i32 2, i32 1)
   ret void
 }
 
 define void @__prefetch_write_uniform_3(i8 *) alwaysinline {
-  call void @llvm.prefetch(i8 * %0, i32 1, i32 1, i32 1)
   ret void
 }
 
@@ -1764,37 +1762,20 @@ define void @__prefetch_read_varying_nt(<WIDTH x i64> %addr, <WIDTH x MASK> %mas
 
 declare void @__prefetch_read_varying_nt_native(i8 * %base, i32 %scale, <WIDTH x i32> %offsets, <WIDTH x MASK> %mask) nounwind
 
+;; There is no write prefetch on Xe targets, so do nothing
 define void @__prefetch_write_varying_1(<WIDTH x i64> %addr, <WIDTH x MASK> %mask) alwaysinline {
-  per_lane(WIDTH, <WIDTH x MASK> %mask, `
-  %iptr_LANE_ID = extractelement <WIDTH x i64> %addr, i32 LANE
-  %ptr_LANE_ID = inttoptr i64 %iptr_LANE_ID to i8*
-  call void @llvm.prefetch(i8 * %ptr_LANE_ID, i32 1, i32 3, i32 1)
-  ')
   ret void
 }
 
 declare void @__prefetch_write_varying_1_native(i8 * %base, i32 %scale, <WIDTH x i32> %offsets, <WIDTH x MASK> %mask) nounwind
-
 define void @__prefetch_write_varying_2(<WIDTH x i64> %addr, <WIDTH x MASK> %mask) alwaysinline {
-  per_lane(WIDTH, <WIDTH x MASK> %mask, `
-  %iptr_LANE_ID = extractelement <WIDTH x i64> %addr, i32 LANE
-  %ptr_LANE_ID = inttoptr i64 %iptr_LANE_ID to i8*
-  call void @llvm.prefetch(i8 * %ptr_LANE_ID, i32 1, i32 3, i32 1)
-  ')
   ret void
 }
 
 declare void @__prefetch_write_varying_2_native(i8 * %base, i32 %scale, <WIDTH x i32> %offsets, <WIDTH x MASK> %mask) nounwind
-
 define void @__prefetch_write_varying_3(<WIDTH x i64> %addr, <WIDTH x MASK> %mask) alwaysinline {
-  per_lane(WIDTH, <WIDTH x MASK> %mask, `
-  %iptr_LANE_ID = extractelement <WIDTH x i64> %addr, i32 LANE
-  %ptr_LANE_ID = inttoptr i64 %iptr_LANE_ID to i8*
-  call void @llvm.prefetch(i8 * %ptr_LANE_ID, i32 1, i32 3, i32 1)
-  ')
   ret void
 }
-
 declare void @__prefetch_write_varying_3_native(i8 * %base, i32 %scale, <WIDTH x i32> %offsets, <WIDTH x MASK> %mask) nounwind
 ')
 

--- a/ispcrt/CMakeLists.txt
+++ b/ispcrt/CMakeLists.txt
@@ -135,8 +135,17 @@ macro(build_ispcrt SHARED_OR_STATIC TARGET_NAME)
   )
 
   # Security options
-  if (UNIX)
-    target_compile_options(${TARGET_NAME} PRIVATE -fstack-protector-strong)
+  if (MSVC)
+    # Stack canaries
+    target_compile_options(${TARGET_NAME} PRIVATE /GS)
+    # Control flow guard
+    target_link_options(${TARGET_NAME} PRIVATE /GUARD:CF)
+  elseif (APPLE)
+  else()
+    # Enable stack protector
+    # NOT to assume that null pointer deference does not exist
+    # Assume that signed overflow always wraps
+    target_compile_options(${TARGET_NAME} PRIVATE -fstack-protector-strong -fno-delete-null-pointer-checks -fwrapv)
   endif()
 
   ## Install targets + exports ##

--- a/ispcrt/detail/TaskQueue.h
+++ b/ispcrt/detail/TaskQueue.h
@@ -18,6 +18,7 @@ struct TaskQueue : public RefCounted {
 
     virtual void copyToHost(base::MemoryView &mv) = 0;
     virtual void copyToDevice(base::MemoryView &mv) = 0;
+    virtual void copyMemoryView(base::MemoryView &mv_dst, base::MemoryView &mv_src, const size_t size) = 0;
 
     virtual base::Future *launch(Kernel &k, base::MemoryView *params, size_t dim0, size_t dim1, size_t dim2) = 0;
 

--- a/ispcrt/detail/cpu/CPUDevice.cpp
+++ b/ispcrt/detail/cpu/CPUDevice.cpp
@@ -11,6 +11,7 @@
 // std
 #include <cassert>
 #include <chrono>
+#include <cstring>
 #include <exception>
 #include <string>
 
@@ -160,6 +161,12 @@ struct TaskQueue : public ispcrt::base::TaskQueue {
 
     void copyToDevice(ispcrt::base::MemoryView &) override {
         // no-op
+    }
+
+    void copyMemoryView(base::MemoryView &mv_dst, base::MemoryView &mv_src, const size_t size) override {
+        auto &view_dst = (cpu::MemoryView &)mv_dst;
+        auto &view_src = (cpu::MemoryView &)mv_src;
+        memcpy(view_dst.devicePtr(), view_src.devicePtr(), size);
     }
 
     ispcrt::base::Future *launch(ispcrt::base::Kernel &k, ispcrt::base::MemoryView *params, size_t dim0, size_t dim1,

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -1083,8 +1083,6 @@ ISPCRTAllocationType GPUDevice::getMemAllocType(void* appMemory) const {
             return ISPCRT_ALLOC_TYPE_DEVICE;
         case ZE_MEMORY_TYPE_SHARED:
             return ISPCRT_ALLOC_TYPE_SHARED;
-        case ZE_MEMORY_TYPE_FORCE_UINT32:
-            return ISPCRT_ALLOC_TYPE_FORCE_UINT32;
         default:
             return ISPCRT_ALLOC_TYPE_UNKNOWN;
     }

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -303,6 +303,20 @@ void ispcrtCopyToHost(ISPCRTTaskQueue q, ISPCRTMemoryView mv) ISPCRT_CATCH_BEGIN
 }
 ISPCRT_CATCH_END_NO_RETURN()
 
+void ispcrtCopyMemoryView(ISPCRTTaskQueue q, ISPCRTMemoryView mvDst, ISPCRTMemoryView mvSrc, const size_t size) ISPCRT_CATCH_BEGIN {
+    auto &queue = referenceFromHandle<ispcrt::base::TaskQueue>(q);
+    auto &viewDst = referenceFromHandle<ispcrt::base::MemoryView>(mvDst);
+    auto &viewSrc = referenceFromHandle<ispcrt::base::MemoryView>(mvSrc);
+    if (size > viewDst.numBytes()) {
+        throw std::runtime_error("Requested copy size is bigger than destination buffer size!");
+    }
+    if (size > viewSrc.numBytes()) {
+        throw std::runtime_error("Requested copy size is bigger than source buffer size!");
+    }
+    queue.copyMemoryView(viewDst, viewSrc, size);
+}
+ISPCRT_CATCH_END_NO_RETURN()
+
 ISPCRTFuture ispcrtLaunch1D(ISPCRTTaskQueue q, ISPCRTKernel k, ISPCRTMemoryView p, size_t dim0) ISPCRT_CATCH_BEGIN {
     return ispcrtLaunch3D(q, k, p, dim0, 1, 1);
 }

--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -129,6 +129,7 @@ void ispcrtDeviceBarrier(ISPCRTTaskQueue);
 
 void ispcrtCopyToDevice(ISPCRTTaskQueue, ISPCRTMemoryView);
 void ispcrtCopyToHost(ISPCRTTaskQueue, ISPCRTMemoryView);
+void ispcrtCopyMemoryView(ISPCRTTaskQueue, ISPCRTMemoryView, ISPCRTMemoryView, const size_t size);
 
 // NOTE: 'params' can be a NULL handle (NULL will get passed to the ISPC task as the function parameter)
 ISPCRTFuture ispcrtLaunch1D(ISPCRTTaskQueue, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0);

--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -95,7 +95,6 @@ typedef enum {
     // The following allocation types are not used for allocation of ISPCRuntime objects,
     // but required to match possible L0 allocation types.
     ISPCRT_ALLOC_TYPE_HOST,
-    ISPCRT_ALLOC_TYPE_FORCE_UINT32,
     ISPCRT_ALLOC_TYPE_UNKNOWN,
 } ISPCRTAllocationType;
 

--- a/ispcrt/ispcrt.hpp
+++ b/ispcrt/ispcrt.hpp
@@ -363,6 +363,7 @@ class TaskQueue : public GenericObject<ISPCRTTaskQueue> {
 
     template <typename T, AllocType AT> void copyToDevice(const Array<T,AT> &arr) const;
     template <typename T, AllocType AT> void copyToHost(const Array<T,AT> &arr) const;
+    template <typename T, AllocType AT> void copyArray(const Array<T,AT> &arrDst, const Array<T,AT> &arrSrc, const size_t size) const;
 
     Future launch(const Kernel &k, size_t dim0) const;
     Future launch(const Kernel &k, size_t dim0, size_t dim1) const;
@@ -395,6 +396,10 @@ template <typename T, AllocType AT> inline void TaskQueue::copyToDevice(const Ar
 
 template <typename T, AllocType AT> inline void TaskQueue::copyToHost(const Array<T,AT> &arr) const {
     ispcrtCopyToHost(handle(), arr.handle());
+}
+
+template <typename T, AllocType AT> inline void TaskQueue::copyArray(const Array<T,AT> &arrDst, const Array<T,AT> &arrSrc, const size_t size) const {
+    ispcrtCopyMemoryView(handle(), arrDst.handle(), arrSrc.handle(), size * sizeof(T));
 }
 
 inline Future TaskQueue::launch(const Kernel &k, size_t dim0) const {

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -6489,16 +6489,6 @@ bool CheckUnsupportedInsts::runOnBasicBlock(llvm::BasicBlock &bb) {
         llvm::Instruction *inst = &*I;
         SourcePos pos;
         lGetSourcePosFromMetadata(inst, &pos);
-        if (llvm::CallInst *ci = llvm::dyn_cast<llvm::CallInst>(inst)) {
-            llvm::Function *func = ci->getCalledFunction();
-
-            // Report error that prefetch is not supported on skl and tgllp
-            if (func && func->getName().contains("genx.lsc.prefetch.stateless")) {
-                if (!g->target->hasXePrefetch()) {
-                    Error(pos, "\'prefetch\' is not supported by %s\n", g->target->getCPU().c_str());
-                }
-            }
-        }
         // Report error if double type is not supported by the target
         if (!g->target->hasFp64Support()) {
             for (int i = 0; i < (int)inst->getNumOperands(); ++i) {

--- a/tests/lit-tests/xe_prefetchw.ispc
+++ b/tests/lit-tests/xe_prefetchw.ispc
@@ -1,0 +1,23 @@
+// Xe platforms do not support write prefetch.
+// Check that prefetch/prefetchw instructions are not generated.
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
+// RUN: %{ispc} %s --target=xelp-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
+// RUN: %{ispc} %s --target=xehpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
+
+// REQUIRES: GENX12_PLUS_ENABLED
+
+// CHECK_NO_PREFETCH-NOT: .prefetch
+// CHECK_NO_PREFETCH-NOT: .prefetchw
+
+task void test(uniform float input[], uniform float out[]) {
+    prefetchw_l1(input);
+    prefetchw_l2(input);
+    prefetchw_l3(input);
+
+    uniform int64 a[programCount];
+    int64 *ptr = &(a[programIndex]);
+
+    prefetchw_l1(ptr);
+    prefetchw_l2(ptr);
+    prefetchw_l3(ptr);
+}

--- a/tests/prefetch-varying.ispc
+++ b/tests/prefetch-varying.ispc
@@ -1,6 +1,5 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
-// rule: skip on arch=xe64
+
 int64 zero = 0;
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/prefetch.ispc
+++ b/tests/prefetch.ispc
@@ -1,6 +1,5 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
-// rule: skip on arch=xe64
+
 task void f_f(uniform float RET[], uniform float aFOO[]) {
     prefetch_l1(aFOO);
     prefetch_l2(aFOO);


### PR DESCRIPTION
This update for Xe targets includes:
1. New ISPC Runtime API to copy MemoryView on device
2. Support of "device-only" memory without corresponding "appMemory" on CPU in ISPC Runtime
3. Changed behavior of prefetch operation on the targets where it is not natively supported: no operation is performed instead of reporting error.