### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Check environment
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,10 @@ name: Docs check
 
 on:
   push:
-    path:
+    paths:
       - "docs/**"
   pull_request:
-    path:
+    paths:
       - "docs/**"
   workflow_dispatch:
 

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -15,9 +15,9 @@ jobs:
       run: |
         echo "APT::Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-retries
         sudo apt-get update
-        sudo apt-get install -y clang-format-10 clang-10
-        sudo ln -sf /usr/bin/clang-10 /usr/bin/clang
-        sudo ln -sf /usr/bin/clang-format-10 /usr/bin/clang-format
+        sudo apt-get install -y clang-format-12 clang-12
+        sudo ln -sf /usr/bin/clang-12 /usr/bin/clang
+        sudo ln -sf /usr/bin/clang-format-12 /usr/bin/clang-format
 
     - name: Check format
       run: |

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -10,7 +10,12 @@ on:
       flow_type:
         description: 'Workflow flow type (full or smoke)'
         required: true
-        default: 'full'
+        default: 'smoke'
+        type: choice
+        options:
+        - 'full'
+        - 'smoke'
+
 env:
   SDE_MIRROR_ID: 684899
   SDE_TAR_NAME: sde-external-9.0.0-2021-11-07

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -74,7 +74,7 @@ jobs:
       LLVM_TAR: llvm-11.1.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -110,7 +110,7 @@ jobs:
       LLVM_TAR: llvm-12.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -146,7 +146,7 @@ jobs:
       LLVM_TAR: llvm-13.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -182,7 +182,7 @@ jobs:
       LLVM_TAR: llvm-14.0.3-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -218,7 +218,7 @@ jobs:
       LLVM_TAR: llvm-14.0.3-ubuntu18.04-Release-x86.arm.wasm.tar.xz
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -254,7 +254,7 @@ jobs:
       LLVM_TAR: llvm-14.0.3-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -283,7 +283,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:
@@ -324,7 +324,7 @@ jobs:
       matrix:
         target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:
@@ -365,7 +365,7 @@ jobs:
       matrix:
         target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:
@@ -405,7 +405,7 @@ jobs:
       matrix:
         target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:
@@ -444,7 +444,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:
@@ -486,7 +486,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:
@@ -528,7 +528,7 @@ jobs:
       BUILD_TYPE: "Release"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -569,7 +569,7 @@ jobs:
       BUILD_TYPE: "Release"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -610,7 +610,7 @@ jobs:
       BUILD_TYPE: "Release"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -651,7 +651,7 @@ jobs:
       BUILD_TYPE: "Release"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -694,7 +694,7 @@ jobs:
         arch: [x86, x86-64]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:
@@ -743,7 +743,7 @@ jobs:
         target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:
@@ -791,7 +791,7 @@ jobs:
         target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:
@@ -837,7 +837,7 @@ jobs:
         target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -64,7 +64,7 @@ jobs:
       LLVM_TAR: llvm-13.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -102,7 +102,7 @@ jobs:
       matrix:
         target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -108,7 +108,7 @@ jobs:
     env:
       CALCITE_CLI: '@siliceum/calcite-cli@0.7.2'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download benchmarks results
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -92,7 +92,7 @@ jobs:
       LLVM_TAR: llvm-trunk-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -139,7 +139,7 @@ jobs:
                  avx512knl-x16,
                  avx512skx-x4, avx512skx-x8, avx512skx-x16, avx512skx-x64, avx512skx-x32]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/nightly-15.yml
+++ b/.github/workflows/nightly-15.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -94,7 +94,7 @@ jobs:
       LLVM_TAR: llvm-15.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -141,7 +141,7 @@ jobs:
                  avx512knl-x16,
                  avx512skx-x4, avx512skx-x8, avx512skx-x16, avx512skx-x64, avx512skx-x32]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:
@@ -179,7 +179,7 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -230,7 +230,7 @@ jobs:
       BUILD_TYPE: "Release"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -285,7 +285,7 @@ jobs:
                  avx512skx-x4, avx512skx-x8, avx512skx-x16, avx512skx-x64, avx512skx-x32]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download package
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/rebuild-llvm11.yml
+++ b/.github/workflows/rebuild-llvm11.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -145,7 +145,7 @@ jobs:
   linux-arm-build:
     runs-on: [self-hosted, linux, ARM64]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -177,7 +177,7 @@ jobs:
   linux-arm-build-release:
     runs-on: [self-hosted, linux, ARM64]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -210,7 +210,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -253,7 +253,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -296,7 +296,7 @@ jobs:
     runs-on: macos-10.15
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -339,7 +339,7 @@ jobs:
     runs-on: macos-10.15
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 

--- a/.github/workflows/rebuild-llvm12.yml
+++ b/.github/workflows/rebuild-llvm12.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -145,7 +145,7 @@ jobs:
   linux-arm-build:
     runs-on: [self-hosted, linux, ARM64]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -177,7 +177,7 @@ jobs:
   linux-arm-build-release:
     runs-on: [self-hosted, linux, ARM64]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -210,7 +210,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -253,7 +253,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -296,7 +296,7 @@ jobs:
     runs-on: macos-10.15
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -339,7 +339,7 @@ jobs:
     runs-on: macos-10.15
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 

--- a/.github/workflows/rebuild-llvm13.yml
+++ b/.github/workflows/rebuild-llvm13.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -145,7 +145,7 @@ jobs:
   linux-arm-build:
     runs-on: [self-hosted, linux, ARM64]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -177,7 +177,7 @@ jobs:
   linux-arm-build-release:
     runs-on: [self-hosted, linux, ARM64]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -210,7 +210,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -253,7 +253,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -296,7 +296,7 @@ jobs:
     runs-on: macos-10.15
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -339,7 +339,7 @@ jobs:
     runs-on: macos-10.15
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 

--- a/.github/workflows/rebuild-llvm14.yml
+++ b/.github/workflows/rebuild-llvm14.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -145,7 +145,7 @@ jobs:
   linux-arm-build:
     runs-on: [self-hosted, linux, ARM64]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -177,7 +177,7 @@ jobs:
   linux-arm-build-release:
     runs-on: [self-hosted, linux, ARM64]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -210,7 +210,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -254,7 +254,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -298,7 +298,7 @@ jobs:
     runs-on: macos-10.15
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -341,7 +341,7 @@ jobs:
     runs-on: macos-10.15
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 

--- a/.github/workflows/rebuild-llvm14.yml
+++ b/.github/workflows/rebuild-llvm14.yml
@@ -71,13 +71,13 @@ jobs:
         cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-14.0 .
-        tar cJvf llvm-14.0.3-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz bin-14.0
+        tar cJvf llvm-14.0.5-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz bin-14.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm14_linux_x86
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.3-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.5-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
   linux-build-release-1:
     runs-on: ubuntu-latest
@@ -134,13 +134,13 @@ jobs:
         cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-14.0 .
-        tar cJvf llvm-14.0.3-ubuntu18.04-Release-x86.arm.wasm.tar.xz bin-14.0
+        tar cJvf llvm-14.0.5-ubuntu18.04-Release-x86.arm.wasm.tar.xz bin-14.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm14rel_linux_x86
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.3-ubuntu18.04-Release-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.5-ubuntu18.04-Release-x86.arm.wasm.tar.xz
 
   linux-arm-build:
     runs-on: [self-hosted, linux, ARM64]
@@ -165,14 +165,14 @@ jobs:
         cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-14.0 .
-        tar cJvf llvm-14.0.3-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz bin-14.0
+        tar cJvf llvm-14.0.5-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz bin-14.0
         rm -rf result.tar usr bin-14.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm14_linux_aarch64
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.3-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.5-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
 
   linux-arm-build-release:
     runs-on: [self-hosted, linux, ARM64]
@@ -197,14 +197,14 @@ jobs:
         cd docker/ubuntu/18.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-14.0 .
-        tar cJvf llvm-14.0.3-ubuntu18.04aarch64-Release-x86.arm.wasm.tar.xz bin-14.0
+        tar cJvf llvm-14.0.5-ubuntu18.04aarch64-Release-x86.arm.wasm.tar.xz bin-14.0
         rm -rf result.tar usr bin-14.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm14rel_linux_aarch64
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.3-ubuntu18.04aarch64-Release-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-14.0.5-ubuntu18.04aarch64-Release-x86.arm.wasm.tar.xz
 
   win-build:
     runs-on: windows-2019
@@ -240,7 +240,7 @@ jobs:
       run: |
         cd llvm
         rmdir /s /q build-14.0
-        set TAR_BASE_NAME=llvm-14.0.3-win.vs2019-Release+Asserts-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-14.0.5-win.vs2019-Release+Asserts-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-14.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -248,7 +248,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: llvm14_win_x86
-        path: llvm/llvm-14.0.3-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        path: llvm/llvm-14.0.5-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
   win-build-release:
     runs-on: windows-2019
@@ -284,7 +284,7 @@ jobs:
       run: |
         cd llvm
         rmdir /s /q build-14.0
-        set TAR_BASE_NAME=llvm-14.0.3-win.vs2019-Release-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-14.0.5-win.vs2019-Release-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-14.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -292,7 +292,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: llvm14rel_win_x86
-        path: llvm/llvm-14.0.3-win.vs2019-Release-x86.arm.wasm.tar.7z
+        path: llvm/llvm-14.0.5-win.vs2019-Release-x86.arm.wasm.tar.7z
 
   mac-build:
     runs-on: macos-10.15
@@ -329,13 +329,13 @@ jobs:
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-14.0.3-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz bin-14.0
+        tar cJvf llvm-14.0.5-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz bin-14.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm14_macos_x86
-        path: llvm/llvm-14.0.3-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
+        path: llvm/llvm-14.0.5-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
 
   mac-build-release:
     runs-on: macos-10.15
@@ -372,11 +372,11 @@ jobs:
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-14.0.3-macos10.15-Release-x86.arm.wasm.tar.xz bin-14.0
+        tar cJvf llvm-14.0.5-macos10.15-Release-x86.arm.wasm.tar.xz bin-14.0
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm14rel_macos_x86
-        path: llvm/llvm-14.0.3-macos10.15-Release-x86.arm.wasm.tar.xz
+        path: llvm/llvm-14.0.5-macos10.15-Release-x86.arm.wasm.tar.xz
 

--- a/alloy.py
+++ b/alloy.py
@@ -121,7 +121,7 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     if  version_LLVM == "trunk":
         GIT_TAG="main"
     elif  version_LLVM == "14_0":
-        GIT_TAG="llvmorg-14.0.3"
+        GIT_TAG="llvmorg-14.0.5"
     elif  version_LLVM == "13_0":
         GIT_TAG="llvmorg-13.0.1"
     elif  version_LLVM == "12_0":

--- a/check_format.sh
+++ b/check_format.sh
@@ -34,13 +34,13 @@ EXIT_CODE=0
 echo "\
 ############################################################################
 Checking formatting of modified files. It is expected that the files were
-formatted with clang-format 10.0.0. It is also expected that clang-format
-version 10.0.0 is used for the check. Otherwise the result can ne unexpected.
+formatted with clang-format 12.0.0. It is also expected that clang-format
+version 12.0.0 is used for the check. Otherwise the result can ne unexpected.
 ############################################################################"
 
 CLANG_FORMAT="clang-format"
 [[ ! -z $1 ]] && CLANG_FORMAT=$1
-REQUIRED_VERSION="10.0.0"
+REQUIRED_VERSION="12.0.0"
 VERSION_STRING="clang-format version $REQUIRED_VERSION.*"
 CURRENT_VERSION="$($CLANG_FORMAT --version)"
 if ! [[ $CURRENT_VERSION =~ $VERSION_STRING ]] ; then


### PR DESCRIPTION
- ISPC CI to use options selections for manual dispatch instead of sting input (`full` / `smoke`)
- `clang-format` to be used for format checking to be 12.0. More recent ones are still not available in the latest Ubuntu distributions
- `actions/checkout@v3` to be used instead of `v2`. No reason to stay on `v2`.
- Docs check pipeline to trigger only for docs changes (fixing typo in existing rules)
- LLVM to build `14.0.3` => `14.0.5`