### PR TITLE
Fix name visibility issues for LLVM 14 build

### DIFF
--- a/src/xe/GlobalsLocalization.cpp
+++ b/src/xe/GlobalsLocalization.cpp
@@ -36,7 +36,6 @@
 */
 
 #ifdef ISPC_XE_ENABLED
-#define DEBUG_TYPE "localize_globals"
 
 #include "GlobalsLocalization.h"
 
@@ -70,6 +69,8 @@
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Scalar.h>
+
+#define DEBUG_TYPE "localize_globals"
 
 using namespace llvm;
 


### PR DESCRIPTION
Ensure that `DEBUG_TYPE` is defined properly whenever `LLVM_DEBUG` is used.
It must be declared after all LLVM headers have been included (`llvm/Support/Debug.h` among these).

Without this, it results in:
```
/build/ispc/src/ispc-1.18.0/src/xe/GlobalsLocalization.cpp:470:9: error: use of undeclared identifier 'DEBUG_TYPE'
        LLVM_DEBUG(dbgs() << "Localizing global: " << *GV);
        ^
/usr/include/llvm/Support/Debug.h:101:39: note: expanded from macro 'LLVM_DEBUG'
#define LLVM_DEBUG(X) DEBUG_WITH_TYPE(DEBUG_TYPE, X)
                                      ^
```
```
/build/ispc/src/ispc-1.18.0/src/xe/GlobalsLocalization.cpp:633:9: error: use of undeclared identifier 'DEBUG_TYPE'
        LLVM_DEBUG(dbgs() << "Visiting " << Fn->getName());
        ^
/usr/include/llvm/Support/Debug.h:101:39: note: expanded from macro 'LLVM_DEBUG'
#define LLVM_DEBUG(X) DEBUG_WITH_TYPE(DEBUG_TYPE, X)
                                      ^
```