### PR TITLE
Added __cast_mask_to_i32/i64 to internal functions

### DIFF
--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -469,6 +469,8 @@ static void lSetInternalFunctions(llvm::Module *module) {
         "__cast_mask_to_i1",
         "__cast_mask_to_i8",
         "__cast_mask_to_i16",
+        "__cast_mask_to_i32",
+        "__cast_mask_to_i64",
         "__ceil_uniform_double",
         "__ceil_uniform_float",
         "__ceil_uniform_half",

--- a/tests/lit-tests/2128.ispc
+++ b/tests/lit-tests/2128.ispc
@@ -1,0 +1,10 @@
+// This test checks that __cast_mask_to_i32/__cast_mask_to_i64 were inlined
+// and removed from final module.
+
+// RUN: %{ispc} --target avx512skx-x32 --emit-llvm-text %s -o - | FileCheck %s
+// RUN: %{ispc} --target avx512skx-x64 --emit-llvm-text %s -o - | FileCheck %s
+// REQUIRES: X86_ENABLED
+
+// CHECK-NOT: @__cast_mask_to_i32
+// CHECK-NOT: @__cast_mask_to_i64
+export void A() {}


### PR DESCRIPTION
Fix for https://github.com/ispc/ispc/issues/2128