### PR TITLE
Fixes to enable ISPC build with LLVM15

### DIFF
--- a/.github/workflows/rebuild-llvm15.yml
+++ b/.github/workflows/rebuild-llvm15.yml
@@ -1,0 +1,25 @@
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Rebuild LLVM 15.0
+
+on:
+  push:
+    branches:
+      - main
+      - '**rebuild_llvm**'
+    paths:
+      - "llvm_patches/*15_0*"
+      - "alloy.py"
+      - ".github/workflows/rebuild-llvm15.yml"
+  workflow_dispatch:
+
+jobs:
+  llvm15:
+    uses: ./.github/workflows/reusable.rebuild.yml
+    with:
+      version: '15.0'
+      full_version: '15.0.0rc2'
+      ubuntu: '18.04'
+      vs_generator: 'Visual Studio 16 2019'
+      vs_version_str: 'vs2019'

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -1,7 +1,0 @@
-variables:
-  RUN_ON_MAIN: "1"
-
-include:
-  - project: 'ispc/ispc'
-    ref: gen 
-    file: '.gitlab/.gitlab-ci.yml'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,8 @@ option(ISPC_INCLUDE_UTILS "Generate build targets for the utils." ON)
 option(ISPC_PREPARE_PACKAGE "Generate build targets for ispc package" OFF)
 option(ISPC_NO_DUMPS "Turn off functionality, which requires LLVM dump() functions" OFF)
 
+option(ISPC_OPAQUE_PTR_MODE "Build ISPC with usage of opaque pointers" OFF)
+
 option(ISPC_CROSS "Build ISPC with cross compilation support" OFF)
 # Default settings for cross compilation
 if (ISPC_CROSS)
@@ -288,6 +290,9 @@ if (WASM_ENABLED)
 endif()
 
 set(CLANG_LIBRARY_LIST clangFrontend clangDriver clangSerialization clangParse clangSema clangAnalysis clangAST clangBasic clangEdit clangLex)
+if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "15.0.0")
+    list(APPEND CLANG_LIBRARY_LIST clangSupport)
+endif()
 set(LLVM_COMPONENTS engine ipo bitreader bitwriter instrumentation linker option frontendopenmp)
 
 if (X86_ENABLED)
@@ -311,6 +316,25 @@ if (XE_ENABLED)
 
     list(APPEND XE_LIBRARY_LIST LLVMGenXIntrinsics LLVMSPIRVLib)
 endif()
+
+# Set the flag responsible for generation of opaque pointers in builtins
+set(ISPC_OPAQUE_FLAGS)
+if (ISPC_OPAQUE_PTR_MODE)
+    if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "15.0.0")
+    # Do nothing, opaque pointers mode is default
+    elseif (${LLVM_VERSION_NUMBER} VERSION_EQUAL "14.0.0")
+    # Explicitly enable opaque pointers for LLVM 14.0
+        set(ISPC_OPAQUE_FLAGS "-Xclang" "-opaque-pointers")
+    else()
+        message(FATAL_ERROR "ISPC opaque pointers mode is not supported with LLVM " ${LLVM_VERSION_NUMBER})
+    endif()
+else()
+    # Explicitly disable opaque pointers starting LLVM 15.0
+    if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "15.0.0")
+        set(ISPC_OPAQUE_FLAGS "-Xclang" "-no-opaque-pointers")
+    endif()
+endif()
+message(STATUS "ISPC opaque pointers mode is " ${ISPC_OPAQUE_PTR_MODE})
 
 get_llvm_libfiles(LLVM_LIBRARY_LIST ${LLVM_COMPONENTS})
 get_llvm_cppflags(LLVM_CPP_FLAGS)
@@ -395,6 +419,7 @@ endif()
 if (ARM_ENABLED)
     target_compile_definitions(${PROJECT_NAME} PRIVATE ISPC_ARM_ENABLED)
 endif()
+
 if (XE_ENABLED)
     target_compile_definitions(${PROJECT_NAME} PRIVATE ISPC_XE_ENABLED)
 endif()
@@ -428,6 +453,11 @@ if (NOT ISPC_ANDROID_TARGET)
 endif()
 if (NOT ISPC_PS_TARGET)
     target_compile_definitions(${PROJECT_NAME} PRIVATE ISPC_PS_TARGET_OFF)
+endif()
+
+# Compile definition for opaque pointers mode
+if (ISPC_OPAQUE_PTR_MODE)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ISPC_OPAQUE_PTR_MODE)
 endif()
 
 # Include directories

--- a/alloy.py
+++ b/alloy.py
@@ -120,6 +120,8 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     # git: "origin/release/9.x"
     if  version_LLVM == "trunk":
         GIT_TAG="main"
+    elif  version_LLVM == "15_0":
+        GIT_TAG="llvmorg-15.0.0-rc2"
     elif  version_LLVM == "14_0":
         GIT_TAG="llvmorg-14.0.6"
     elif  version_LLVM == "13_0":
@@ -610,7 +612,7 @@ def validation_run(only, only_targets, reference_branch, number, update, speed_n
             archs.append("x86-64")
         if "native" in only:
             sde_targets_t = []
-        for i in ["6.0", "7.0", "8.0", "9.0", "10.0", "11.0", "12.0", "13.0", "14.0", "trunk"]:
+        for i in ["6.0", "7.0", "8.0", "9.0", "10.0", "11.0", "12.0", "13.0", "14.0", "15.0", "trunk"]:
             if i in only:
                 LLVM.append(i)
         if "current" in only:
@@ -816,7 +818,7 @@ def Main():
     if os.environ.get("ISPC_HOME") == None:
         alloy_error("you have no ISPC_HOME", 1)
     if options.only != "":
-        test_only_r = " 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0 14.0 trunk current build stability performance x86 x86-64 x86_64 -O0 -O1 -O2 native debug nodebug "
+        test_only_r = " 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0 14.0 15.0 trunk current build stability performance x86 x86-64 x86_64 -O0 -O1 -O2 native debug nodebug "
         test_only = options.only.split(" ")
         for iterator in test_only:
             if not (" " + iterator + " " in test_only_r):

--- a/cmake/GenerateBuiltins.cmake
+++ b/cmake/GenerateBuiltins.cmake
@@ -293,7 +293,7 @@ function(builtin_to_cpp bit os_name arch supported_archs supported_oses resultFi
     else()
         add_custom_command(
             OUTPUT ${output}
-            COMMAND ${CLANGPP_EXECUTABLE} ${target_flags} -I${CMAKE_SOURCE_DIR} -m${bit} -emit-llvm --std=gnu++17 -c ${inputFilePath} -o - | (\"${LLVM_DIS_EXECUTABLE}\" - || echo "builtins-c-*.cpp compile error")
+            COMMAND ${CLANGPP_EXECUTABLE} ${target_flags} -I${CMAKE_SOURCE_DIR} -m${bit} -emit-llvm ${ISPC_OPAQUE_FLAGS} --std=gnu++17 -c ${inputFilePath} -o - | (\"${LLVM_DIS_EXECUTABLE}\" - || echo "builtins-c-*.cpp compile error")
                 | \"${Python3_EXECUTABLE}\" bitcode2cpp.py c --type=builtins-c --runtime=${bit} --os=${os_name} --arch=${target_arch} --llvm_as ${LLVM_AS_EXECUTABLE}
                 > ${output}
             DEPENDS ${inputFilePath} bitcode2cpp.py

--- a/run_tests.py
+++ b/run_tests.py
@@ -490,6 +490,11 @@ def run_test(testname, host, target):
                 cc_cmd = "%s -O2 -I. %s test_static.cpp -DTEST_SIG=%d -DTEST_WIDTH=%d %s -o %s" % \
                     (options.compiler_exe, gcc_arch, match, width, obj_name, exe_name)
 
+                # Produce position independent code for both c++ and ispc compilations.
+                # The motivation for this is that Clang 15 changed default
+                # from "-mrelocation-model static" to "-mrelocation-model pic", so
+                # we enable PIC compilation to have it consistently regardless compiler version.
+                cc_cmd += ' -fPIE'
                 if should_fail:
                     cc_cmd += " -DEXPECT_FAILURE"
 
@@ -501,8 +506,7 @@ def run_test(testname, host, target):
                              match, width, exe_name)
                     exe_name = "./" + exe_name
                     cc_cmd += " -DTEST_ZEBIN" if options.ispc_output == "ze" else " -DTEST_SPV"
-
-            ispc_cmd = ispc_exe_rel + " --woff %s -o %s --arch=%s --target=%s -DTEST_SIG=%d" % \
+            ispc_cmd = ispc_exe_rel + " --pic --woff %s -o %s --arch=%s --target=%s -DTEST_SIG=%d" % \
                         (filename, obj_name, options.arch, xe_target if target.is_xe() else options.target, match)
 
             if target.is_xe():

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1995,6 +1995,25 @@ Globals::Globals() {
     timeTraceGranularity = 500;
     target = NULL;
     ctx = new llvm::LLVMContext;
+
+// Opaque pointers mode is supported starting from LLVM 14,
+// became default in LLVM 15
+#ifdef ISPC_OPAQUE_PTR_MODE
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_15_0
+// Do nothing, opaque pointers mode is default
+#elif ISPC_LLVM_VERSION == ISPC_LLVM_14_0
+    // Explicitly enable opaque pointers mode for LLVM 14.0
+    ctx->setOpaquePointers(true);
+#else
+    FATAL("Opaque pointers mode is not supported with this LLVM version!");
+#endif
+#else
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_15_0
+    // Explicitly disable opaque pointers starting LLVM 15.0
+    ctx->setOpaquePointers(false);
+#endif
+#endif
+
 #ifdef ISPC_XE_ENABLED
     stackMemSize = 0;
 #endif

--- a/src/ispc_version.h
+++ b/src/ispc_version.h
@@ -49,9 +49,10 @@
 #define ISPC_LLVM_13_0 130000
 #define ISPC_LLVM_14_0 140000
 #define ISPC_LLVM_15_0 150000
+#define ISPC_LLVM_16_0 160000
 
 #define OLDEST_SUPPORTED_LLVM ISPC_LLVM_10_0
-#define LATEST_SUPPORTED_LLVM ISPC_LLVM_15_0
+#define LATEST_SUPPORTED_LLVM ISPC_LLVM_16_0
 
 #ifdef __ispc__xstr
 #undef __ispc__xstr
@@ -63,7 +64,7 @@
     __ispc__xstr(LLVM_VERSION_MAJOR) "." __ispc__xstr(LLVM_VERSION_MINOR) "." __ispc__xstr(LLVM_VERSION_PATCH)
 
 #if ISPC_LLVM_VERSION < OLDEST_SUPPORTED_LLVM || ISPC_LLVM_VERSION > LATEST_SUPPORTED_LLVM
-#error "Only LLVM 11.0 - 14.0 and 15.0 development branch are supported"
+#error "Only LLVM 11.0 - 15.0 and 16.0 development branch are supported"
 #endif
 
 #define ISPC_VERSION_STRING                                                                                            \


### PR DESCRIPTION
- `alloy.py` changes to build LLVM15 rc2
- workflow to build LLVM 15
- changes to support LLVM 16 / trunk
- unused GitLab files are removed
- CMake `ISPC_OPAQUE_PTR_MODE` flag to govern if opaque pointers are enabled (off by default)
- disabling `llvm::createArgumentPromotionPass()` for LLVM15+, as it's not supported by old pass manager. To be reenabled when we migrate to the new pass manager.
- Tests to build with `--pic`.