### PR TITLE
[opaque pointers 3] Introduce AddressInfo class to ISPC

### DIFF
--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -1087,7 +1087,7 @@ static void lDefineConstantInt(const char *name, int val, llvm::Module *module, 
     llvm::Constant *linit = LLVMInt32(val);
     auto GV = new llvm::GlobalVariable(*module, ltype, true, llvm::GlobalValue::InternalLinkage, linit, name);
     dbg_sym.push_back(GV);
-    sym->storagePtr = GV;
+    sym->storageInfo = new AddressInfo(GV, GV->getValueType());
     symbolTable->AddVariable(sym);
 
     if (m->diBuilder != NULL) {
@@ -1097,7 +1097,7 @@ static void lDefineConstantInt(const char *name, int val, llvm::Module *module, 
         // FIXME? DWARF says that this (and programIndex below) should
         // have the DW_AT_artifical attribute.  It's not clear if this
         // matters for anything though.
-        llvm::GlobalVariable *sym_GV_storagePtr = llvm::dyn_cast<llvm::GlobalVariable>(sym->storagePtr);
+        llvm::GlobalVariable *sym_GV_storagePtr = llvm::dyn_cast<llvm::GlobalVariable>(sym->storageInfo->getPointer());
         Assert(sym_GV_storagePtr);
         llvm::DIGlobalVariableExpression *var =
             m->diBuilder->createGlobalVariableExpression(cu, name, name, file, 0 /* line */, diType, true /* static */);
@@ -1142,14 +1142,14 @@ static void lDefineProgramIndex(llvm::Module *module, SymbolTable *symbolTable,
     auto GV =
         new llvm::GlobalVariable(*module, ltype, true, llvm::GlobalValue::InternalLinkage, linit, sym->name.c_str());
     dbg_sym.push_back(GV);
-    sym->storagePtr = GV;
+    sym->storageInfo = new AddressInfo(GV, GV->getValueType());
     symbolTable->AddVariable(sym);
 
     if (m->diBuilder != NULL) {
         llvm::DIFile *file = m->diCompileUnit->getFile();
         llvm::DICompileUnit *cu = m->diCompileUnit;
         llvm::DIType *diType = sym->type->GetDIType(file);
-        llvm::GlobalVariable *sym_GV_storagePtr = llvm::dyn_cast<llvm::GlobalVariable>(sym->storagePtr);
+        llvm::GlobalVariable *sym_GV_storagePtr = llvm::dyn_cast<llvm::GlobalVariable>(sym->storageInfo->getPointer());
         Assert(sym_GV_storagePtr);
         llvm::DIGlobalVariableExpression *var = m->diBuilder->createGlobalVariableExpression(
             cu, sym->name.c_str(), sym->name.c_str(), file, 0 /* line */, diType, false /* static */);

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -218,6 +218,28 @@ CFInfo *CFInfo::GetSwitch(bool isUniform, bool isUniformEmulated, llvm::BasicBlo
 
 ///////////////////////////////////////////////////////////////////////////
 
+AddressInfo::AddressInfo(llvm::Value *p, llvm::Type *t) : pointer(p), elementType(t), ispcType(nullptr) {
+    Assert(pointer != nullptr && "Pointer cannot be null");
+    Assert(elementType != nullptr && "Element type cannot be null");
+}
+AddressInfo::AddressInfo(llvm::Value *p, const Type *t) : pointer(p), ispcType(t) {
+    Assert(pointer != nullptr && "Pointer cannot be null");
+    Assert(ispcType != nullptr && "ISPC type cannot be null");
+    // Get LLVM pointer element type based on ISPC type.
+    // TODO: need more testing
+    if (CastType<ReferenceType>(t) != nullptr) {
+        PointerType *pType = PointerType::GetUniform(t->GetReferenceTarget());
+        elementType = pType->GetBaseType()->LLVMStorageType(g->ctx);
+    } else if (CastType<PointerType>(t) != nullptr) {
+        elementType = t->GetBaseType()->LLVMStorageType(g->ctx);
+    } else {
+        elementType = t->LLVMStorageType(g->ctx);
+    }
+    Assert(elementType != nullptr && "Element type cannot be null");
+}
+
+///////////////////////////////////////////////////////////////////////////
+
 FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::Function *lf, SourcePos firstStmtPos) {
     function = func;
     llvmFunction = lf;

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -126,9 +126,9 @@ class FunctionEmitContext {
         the function entry mask and the internal mask. */
     llvm::Value *GetFullMask();
 
-    /** Returns a pointer to storage in memory that stores the current full
+    /** Returns an AddressInfo with a pointer to storage in memory that stores the current full
         mask. */
-    llvm::Value *GetFullMaskPointer();
+    AddressInfo *GetFullMaskAddressInfo();
 
     /** Provides the value of the mask at function entry */
     void SetFunctionMask(llvm::Value *val);
@@ -499,7 +499,7 @@ class FunctionEmitContext {
         instruction is added at the start of the function in the entry
         basic block; if it should be added to the current basic block, then
         the atEntryBlock parameter should be false. */
-    llvm::Value *AllocaInst(llvm::Type *llvmType, llvm::Value *size, const llvm::Twine &name = "", int align = 0,
+    AddressInfo *AllocaInst(llvm::Type *llvmType, llvm::Value *size, const llvm::Twine &name = "", int align = 0,
                             bool atEntryBlock = true);
     /** Emits an alloca instruction to allocate stack storage for the given
         type.  If a non-zero alignment is specified, the object is also
@@ -507,7 +507,7 @@ class FunctionEmitContext {
         instruction is added at the start of the function in the entry
         basic block; if it should be added to the current basic block, then
         the atEntryBlock parameter should be false. */
-    llvm::Value *AllocaInst(llvm::Type *llvmType, const llvm::Twine &name = "", int align = 0,
+    AddressInfo *AllocaInst(llvm::Type *llvmType, const llvm::Twine &name = "", int align = 0,
                             bool atEntryBlock = true);
 
     /** Emits an alloca instruction to allocate stack storage for the given
@@ -519,7 +519,7 @@ class FunctionEmitContext {
         This implementation is preferred when possible. It is needed when
         storage type is different from IR type. For example,
         'unform bool' is 'i1' in IR but stored as 'i8'. */
-    llvm::Value *AllocaInst(const Type *ptrType, const llvm::Twine &name = "", int align = 0, bool atEntryBlock = true);
+    AddressInfo *AllocaInst(const Type *ptrType, const llvm::Twine &name = "", int align = 0, bool atEntryBlock = true);
 
     /** Standard store instruction; for this variant, the lvalue must be a
         single pointer, not a varying lvalue.
@@ -666,14 +666,14 @@ class FunctionEmitContext {
         instructions */
     llvm::BasicBlock *bblock;
 
-    /** Pointer to stack-allocated memory that stores the current value of
+    /** AddressInfo with pointer to stack-allocated memory that stores the current value of
         the full program mask. */
-    llvm::Value *fullMaskPointer;
+    AddressInfo *fullMaskAddressInfo;
 
-    /** Pointer to stack-allocated memory that stores the current value of
+    /** AddressInfo with pointer to stack-allocated memory that stores the current value of
         the program mask representing varying control flow within the
         function. */
-    llvm::Value *internalMaskPointer;
+    AddressInfo *internalMaskAddressInfo;
 
     /** Value of the program mask when the function starts execution.  */
     llvm::Value *functionMaskValue;
@@ -691,16 +691,16 @@ class FunctionEmitContext {
         mask at the start of it. */
     llvm::Value *blockEntryMask;
 
-    /** If currently in a loop body or switch statement, this is a pointer
+    /** If currently in a loop body or switch statement, this is an AddressInfo with pointer
         to memory to store a mask value that represents which of the lanes
         have executed a 'break' statement.  If we're not in a loop body or
         switch, this should be NULL. */
-    llvm::Value *breakLanesPtr;
+    AddressInfo *breakLanesAddressInfo;
 
-    /** Similar to breakLanesPtr, if we're inside a loop, this is a pointer
+    /** Similar to breakLanesAddressInfo, if we're inside a loop, this is an AddressInfo with a pointer
         to memory to record which of the program instances have executed a
         'continue' statement. */
-    llvm::Value *continueLanesPtr;
+    AddressInfo *continueLanesAddressInfo;
 
     /** If we're inside a loop or switch statement, this gives the basic
         block immediately after the current loop or switch, which we will
@@ -730,9 +730,9 @@ class FunctionEmitContext {
         statements after the switch to execute. */
     llvm::Value *switchExpr;
 
-    /** A pointer to memory that contains mask for lanes that should be
+    /** An AddressInfo with a pointer to memory that contains mask for lanes that should be
         active in the next block */
-    llvm::Value *switchFallThroughMaskPtr;
+    AddressInfo *switchFallThroughMaskAddressInfo;
 
     /** Map from case label numbers to the basic block that will hold code
         for that case. */
@@ -755,16 +755,16 @@ class FunctionEmitContext {
     bool switchConditionWasUniform;
     /** @} */
 
-    /** A pointer to memory that records which of the program instances
+    /** AddressInfo with a pointer to memory that records which of the program instances
         have executed a 'return' statement (and are thus really truly done
         running any more instructions in this functions. */
-    llvm::Value *returnedLanesPtr;
+    AddressInfo *returnedLanesAddressInfo;
 
-    /** A pointer to memory to store the return value for the function.
+    /** AddressInfo with a pointer to memory to store the return value for the function.
         Since difference program instances may execute 'return' statements
         at different times, we need to accumulate the return values as they
         come in until we return for real. */
-    llvm::Value *returnValuePtr;
+    AddressInfo *returnValueAddressInfo;
 
     /** The CFInfo structure records information about a nesting level of
         control flow.  This vector lets us see what control flow is going
@@ -790,10 +790,10 @@ class FunctionEmitContext {
     /** True if a 'launch' statement has been encountered in the function. */
     bool launchedTasks;
 
-    /** This is a pointer to a void * that is passed to the ISPCLaunch(),
+    /** This is an AddressInfo with a pointer to a void * that is passed to the ISPCLaunch(),
         ISPCAlloc(), and ISPCSync() routines as a handle to the group ot
         tasks launched from the current function. */
-    llvm::Value *launchGroupHandlePtr;
+    AddressInfo *launchGroupHandleAddressInfo;
 
     /** Nesting count of the number of times calling code has disabled (and
         not yet reenabled) gather/scatter performance warnings. */

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -50,6 +50,31 @@
 namespace ispc {
 
 struct CFInfo;
+
+///////////////////////////////////////////////////////////////////////////
+/** AddressInfo is a helper class to work with pointers.
+    It keeps llvm pointer, llvm element type, and ISPC type.
+*/
+class AddressInfo {
+  public:
+    AddressInfo(llvm::Value *p, llvm::Type *t);
+    AddressInfo(llvm::Value *p, const Type *t);
+    llvm::Value *getPointer() const { return pointer; }
+
+    // Return the type of the pointer value.
+    llvm::PointerType *getType() const { return llvm::cast<llvm::PointerType>(getPointer()->getType()); }
+
+    // Return the type of the values stored in this address.
+    llvm::Type *getElementType() const { return elementType; }
+
+    // Return the address space that this address resides in.
+    unsigned getAddressSpace() const { return getType()->getAddressSpace(); }
+
+  private:
+    llvm::Value *pointer;
+    llvm::Type *elementType;
+    const Type *ispcType;
+};
 
 /** FunctionEmitContext is one of the key classes in ispc; it is used to
     help with emitting the intermediate representation of a function during

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -446,6 +446,9 @@ class FunctionEmitContext {
         and an integer offset to a slice within that type. */
     llvm::Value *MakeSlicePointer(llvm::Value *ptr, llvm::Value *offset);
 
+    /* Regularize to a standard pointer type. */
+    const PointerType *RegularizePointer(const Type *ptrRefType);
+
     /** These GEP methods are generalizations of the standard ones in LLVM;
         they support both uniform and varying basePtr values as well as
         uniform and varying index values (arrays of indices).  Varying base

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -50,6 +50,7 @@ using namespace ispc;
 
 Symbol::Symbol(const std::string &n, SourcePos p, const Type *t, StorageClass sc) : pos(p), name(n) {
     storagePtr = NULL;
+    storageInfo = NULL;
     function = exportedFunction = NULL;
     type = t;
     constValue = NULL;

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -49,7 +49,6 @@ using namespace ispc;
 // Symbol
 
 Symbol::Symbol(const std::string &n, SourcePos p, const Type *t, StorageClass sc) : pos(p), name(n) {
-    storagePtr = NULL;
     storageInfo = NULL;
     function = exportedFunction = NULL;
     type = t;

--- a/src/sym.h
+++ b/src/sym.h
@@ -70,11 +70,6 @@ class Symbol {
 
     SourcePos pos;            /*!< Source file position where the symbol was defined */
     std::string name;         /*!< Symbol's name */
-    llvm::Value *storagePtr;  /*!< For symbols with storage associated with
-                                   them (i.e. variables but not functions),
-                                   this member stores a pointer to its
-                                   location in memory.)
-                                   DEPRECATED. Use storageInfo instead. */
     AddressInfo *storageInfo; /*!< For symbols with storage associated with
                                    them (i.e. variables but not functions),
                                    this member stores an address info: pointer to
@@ -96,7 +91,7 @@ class Symbol {
                                     example, the ConstExpr class can't currently represent
                                     struct types.  For cases like these, ConstExpr is NULL,
                                     though for all const symbols, the value pointed to by the
-                                    storagePtr member will be its constant value.  (This
+                                    storageInfo pointer member will be its constant value.  (This
                                     messiness is due to needing an ispc ConstExpr for the early
                                     constant folding optimizations). */
     StorageClass storageClass; /*!< Records the storage class (if any) provided with the

--- a/src/sym.h
+++ b/src/sym.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include "ctx.h"
 #include "decl.h"
 #include "ispc.h"
 #include <map>
@@ -72,7 +73,12 @@ class Symbol {
     llvm::Value *storagePtr;  /*!< For symbols with storage associated with
                                    them (i.e. variables but not functions),
                                    this member stores a pointer to its
-                                   location in memory.) */
+                                   location in memory.)
+                                   DEPRECATED. Use storageInfo instead. */
+    AddressInfo *storageInfo; /*!< For symbols with storage associated with
+                                   them (i.e. variables but not functions),
+                                   this member stores an address info: pointer to
+                                   its location in memory and its element type.) */
     llvm::Function *function; /*!< For symbols that represent functions,
                                    this stores the LLVM Function value for
                                    the symbol once it has been created. */


### PR DESCRIPTION
`AddressInfo` class is necessary to support opaque pointers. It contains the pointer itself, LLVM pointer element type and ISPC type (may be NULL).
This PR is the first set of changes switching ISPC to use `AddressInfo`:
1. `AllocaInst` starts returning `AddressInfo*` instead of `llvm::Value*`
2. `Symbol` class keeps `AddressInfo*` instead of simple `llvm::Value*`

Note: Many `getPointer()` calls will be removed in future PRs.