### PR TITLE
[opaque pointers 4] Use AddressInfo in StoreInst

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -3637,7 +3637,10 @@ llvm::Value *FunctionEmitContext::LaunchInst(llvm::Value *callee, std::vector<ll
     llvm::PointerType *pt = llvm::dyn_cast<llvm::PointerType>(argType);
     AssertPos(currentPos, pt);
     AssertPos(currentPos, llvm::StructType::classof(pt->PTR_ELT_TYPE()));
-    llvm::StructType *argStructType = static_cast<llvm::StructType *>(pt->PTR_ELT_TYPE());
+
+    std::vector<llvm::Type *> llvmArgTypes = funcType->LLVMFunctionArgTypes(g->ctx);
+    llvm::StructType *argStructType = llvm::StructType::get(*g->ctx, llvmArgTypes);
+    AssertPos(currentPos, argStructType != NULL);
 
     llvm::Function *falloc = m->module->getFunction("ISPCAlloc");
     AssertPos(currentPos, falloc != NULL);

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -524,7 +524,8 @@ class FunctionEmitContext {
     /** Standard store instruction; for this variant, the lvalue must be a
         single pointer, not a varying lvalue.
         'ptrType' needs to be provided when storage type is different from IR type. For example,
-     * 'unform bool' is 'i1' in IR but stored as 'i8'. */
+        'unform bool' is 'i1' in IR but stored as 'i8'. */
+    /*  TODO: keep all info about type in ptrInfo so we can eliminate usage of ptrType optional arg */
     void StoreInst(llvm::Value *value, AddressInfo *ptrInfo, const Type *ptrType = NULL);
 
     /** In this variant of StoreInst(), the lvalue may be varying.  If so,

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -525,7 +525,7 @@ class FunctionEmitContext {
         single pointer, not a varying lvalue.
         'ptrType' needs to be provided when storage type is different from IR type. For example,
      * 'unform bool' is 'i1' in IR but stored as 'i8'. */
-    void StoreInst(llvm::Value *value, llvm::Value *ptr, const Type *ptrType = NULL, bool isUniformData = false);
+    void StoreInst(llvm::Value *value, AddressInfo *ptrInfo, const Type *ptrType = NULL, bool isUniformData = false);
 
     /** In this variant of StoreInst(), the lvalue may be varying.  If so,
         this corresponds to a scatter.  Whether the lvalue is uniform of

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -525,7 +525,7 @@ class FunctionEmitContext {
         single pointer, not a varying lvalue.
         'ptrType' needs to be provided when storage type is different from IR type. For example,
      * 'unform bool' is 'i1' in IR but stored as 'i8'. */
-    void StoreInst(llvm::Value *value, AddressInfo *ptrInfo, const Type *ptrType = NULL, bool isUniformData = false);
+    void StoreInst(llvm::Value *value, AddressInfo *ptrInfo, const Type *ptrType = NULL);
 
     /** In this variant of StoreInst(), the lvalue may be varying.  If so,
         this corresponds to a scatter.  Whether the lvalue is uniform of

--- a/src/expr.h
+++ b/src/expr.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include "ast.h"
+#include "ctx.h"
 #include "ispc.h"
 #include "type.h"
 
@@ -820,7 +821,7 @@ Expr *MakeBinaryExpr(BinaryExpr::Op o, Expr *a, Expr *b, SourcePos p);
     @param ctx       FunctionEmitContext to use for generating instructions
     @param pos       Source file position of the variable being initialized
 */
-void InitSymbol(llvm::Value *lvalue, const Type *symType, Expr *initExpr, FunctionEmitContext *ctx, SourcePos pos);
+void InitSymbol(AddressInfo *lvalue, const Type *symType, Expr *initExpr, FunctionEmitContext *ctx, SourcePos pos);
 
 bool PossiblyResolveFunctionOverloads(Expr *expr, const Type *type);
 } // namespace ispc

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -265,7 +265,7 @@ static void lCopyInTaskParameter(int i, AddressInfo *structArgPtrInfo, const std
     // and copy the value from the struct and into the local alloca'ed
     // memory
     llvm::Value *ptrval = ctx->LoadInst(ptr, sym->type, sym->name.c_str());
-    ctx->StoreInst(ptrval, sym->storageInfo, sym->type, sym->type->IsUniformType());
+    ctx->StoreInst(ptrval, sym->storageInfo, sym->type);
     ctx->EmitFunctionParameterDebugInfo(sym, i);
 }
 

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -265,7 +265,7 @@ static void lCopyInTaskParameter(int i, AddressInfo *structArgPtrInfo, const std
     // and copy the value from the struct and into the local alloca'ed
     // memory
     llvm::Value *ptrval = ctx->LoadInst(ptr, sym->type, sym->name.c_str());
-    ctx->StoreInst(ptrval, sym->storageInfo->getPointer(), sym->type, sym->type->IsUniformType());
+    ctx->StoreInst(ptrval, sym->storageInfo, sym->type, sym->type->IsUniformType());
     ctx->EmitFunctionParameterDebugInfo(sym, i);
 }
 
@@ -334,32 +334,32 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
         // Copy threadIndex and threadCount into stack-allocated storage so
         // that their symbols point to something reasonable.
         threadIndexSym->storageInfo = ctx->AllocaInst(LLVMTypes::Int32Type, "threadIndex");
-        ctx->StoreInst(threadIndex, threadIndexSym->storageInfo->getPointer());
+        ctx->StoreInst(threadIndex, threadIndexSym->storageInfo);
 
         threadCountSym->storageInfo = ctx->AllocaInst(LLVMTypes::Int32Type, "threadCount");
-        ctx->StoreInst(threadCount, threadCountSym->storageInfo->getPointer());
+        ctx->StoreInst(threadCount, threadCountSym->storageInfo);
 
         // Copy taskIndex and taskCount into stack-allocated storage so
         // that their symbols point to something reasonable.
         taskIndexSym->storageInfo = ctx->AllocaInst(LLVMTypes::Int32Type, "taskIndex");
-        ctx->StoreInst(taskIndex, taskIndexSym->storageInfo->getPointer());
+        ctx->StoreInst(taskIndex, taskIndexSym->storageInfo);
 
         taskCountSym->storageInfo = ctx->AllocaInst(LLVMTypes::Int32Type, "taskCount");
-        ctx->StoreInst(taskCount, taskCountSym->storageInfo->getPointer());
+        ctx->StoreInst(taskCount, taskCountSym->storageInfo);
 
         taskIndexSym0->storageInfo = ctx->AllocaInst(LLVMTypes::Int32Type, "taskIndex0");
-        ctx->StoreInst(taskIndex0, taskIndexSym0->storageInfo->getPointer());
+        ctx->StoreInst(taskIndex0, taskIndexSym0->storageInfo);
         taskIndexSym1->storageInfo = ctx->AllocaInst(LLVMTypes::Int32Type, "taskIndex1");
-        ctx->StoreInst(taskIndex1, taskIndexSym1->storageInfo->getPointer());
+        ctx->StoreInst(taskIndex1, taskIndexSym1->storageInfo);
         taskIndexSym2->storageInfo = ctx->AllocaInst(LLVMTypes::Int32Type, "taskIndex2");
-        ctx->StoreInst(taskIndex2, taskIndexSym2->storageInfo->getPointer());
+        ctx->StoreInst(taskIndex2, taskIndexSym2->storageInfo);
 
         taskCountSym0->storageInfo = ctx->AllocaInst(LLVMTypes::Int32Type, "taskCount0");
-        ctx->StoreInst(taskCount0, taskCountSym0->storageInfo->getPointer());
+        ctx->StoreInst(taskCount0, taskCountSym0->storageInfo);
         taskCountSym1->storageInfo = ctx->AllocaInst(LLVMTypes::Int32Type, "taskCount1");
-        ctx->StoreInst(taskCount1, taskCountSym1->storageInfo->getPointer());
+        ctx->StoreInst(taskCount1, taskCountSym1->storageInfo);
         taskCountSym2->storageInfo = ctx->AllocaInst(LLVMTypes::Int32Type, "taskCount2");
-        ctx->StoreInst(taskCount2, taskCountSym2->storageInfo->getPointer());
+        ctx->StoreInst(taskCount2, taskCountSym2->storageInfo);
     } else {
         // Regular, non-task function or GPU task
         llvm::Function::arg_iterator argIter = function->arg_begin();
@@ -388,7 +388,7 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
             }
 #endif
 
-            ctx->StoreInst(addrCasted, argSym->storageInfo->getPointer(), argSym->type);
+            ctx->StoreInst(addrCasted, argSym->storageInfo, argSym->type);
 
             ctx->EmitFunctionParameterDebugInfo(argSym, i);
         }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -2518,17 +2518,13 @@ FunctionType::FunctionMangledName FunctionType::GetFunctionMangledName(bool appF
     return mangle;
 }
 
-llvm::FunctionType *FunctionType::LLVMFunctionType(llvm::LLVMContext *ctx, bool removeMask) const {
-    if (!g->target->isXeTarget() && isTask == true) {
-        Assert(removeMask == false);
-    }
-
+std::vector<llvm::Type *> FunctionType::LLVMFunctionArgTypes(llvm::LLVMContext *ctx, bool removeMask) const {
     // Get the LLVM Type *s for the function arguments
     std::vector<llvm::Type *> llvmArgTypes;
     for (unsigned int i = 0; i < paramTypes.size(); ++i) {
         if (paramTypes[i] == NULL) {
             Assert(m->errorCount > 0);
-            return NULL;
+            return llvmArgTypes;
         }
         Assert(paramTypes[i]->IsVoidType() == false);
 
@@ -2559,7 +2555,7 @@ llvm::FunctionType *FunctionType::LLVMFunctionType(llvm::LLVMContext *ctx, bool 
 
         if (castedArgType == NULL) {
             Assert(m->errorCount > 0);
-            return NULL;
+            return llvmArgTypes;
         }
         llvmArgTypes.push_back(castedArgType);
     }
@@ -2568,6 +2564,15 @@ llvm::FunctionType *FunctionType::LLVMFunctionType(llvm::LLVMContext *ctx, bool 
     if (!(removeMask || isUnmasked || IsISPCKernel())) {
         llvmArgTypes.push_back(LLVMTypes::MaskType);
     }
+    return llvmArgTypes;
+}
+
+llvm::FunctionType *FunctionType::LLVMFunctionType(llvm::LLVMContext *ctx, bool removeMask) const {
+    if (!g->target->isXeTarget() && isTask == true) {
+        Assert(removeMask == false);
+    }
+
+    std::vector<llvm::Type *> llvmArgTypes = LLVMFunctionArgTypes(ctx, removeMask);
 
     std::vector<llvm::Type *> callTypes;
     if (isTask && (!g->target->isXeTarget())) {

--- a/src/type.h
+++ b/src/type.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -887,6 +887,11 @@ class FunctionType : public Type {
         The \c appFunction parameter indicates whether the function is generated for
         internal ISPC call or for external call from application.*/
     FunctionMangledName GetFunctionMangledName(bool appFunction) const;
+
+    /** This method returns std::vector of LLVM types of function arguments.
+        The \c disableMask parameter indicates whether the mask parameter should be
+        included to the list of arguments types. */
+    std::vector<llvm::Type *> LLVMFunctionArgTypes(llvm::LLVMContext *ctx, bool disableMask = false) const;
 
     /** This method returns the LLVM FunctionType that corresponds to this
         function type.  The \c disableMask parameter indicates whether the

--- a/tests/lit-tests/bool_swizzle.ispc
+++ b/tests/lit-tests/bool_swizzle.ispc
@@ -1,0 +1,10 @@
+// This test checks that compiler is not crashing on bool swizzle.
+// Currently fails (https://github.com/ispc/ispc/issues/2367).
+
+// RUN: %{ispc} %s --target=host --nostdlib
+// XFAIL: *
+export void test(uniform float out[]) {
+    uniform bool<3> a = {1,0,1};
+    uniform bool<3> b = a.zxy;
+    out[programIndex] = b.x;
+}


### PR DESCRIPTION
Depends on https://github.com/ispc/ispc/pull/2363.
This PR introduces more usages of `AddressInfo` class in particular in `StoreInst` and `InitSymbol`.
It also introduces a method to get LLVM types of function arguments `LLVMFunctionArgTypes` and simplifies `StoreInst` - we don't need to pass info about uniform data anymore.

During the testing, I also discovered the problem with bool swizzles: https://github.com/ispc/ispc/issues/2367.


