### PR TITLE
[opaque pointers 5] Use AddressInfo in LoadInst

### DIFF
--- a/src/ctx.h
+++ b/src/ctx.h
@@ -486,7 +486,7 @@ class FunctionEmitContext {
      * 'type' needs to be provided when storage type is different from IR type. For example,
      * 'unform bool' is 'i1' in IR but stored as 'i8'.
      * Otherwise leave this as NULL. */
-    llvm::Value *LoadInst(llvm::Value *ptr, const Type *type = NULL, const llvm::Twine &name = "");
+    llvm::Value *LoadInst(AddressInfo *ptrInfo, const Type *type = NULL, const llvm::Twine &name = "");
 
     /** Emits addrspacecast instruction. Depending on atEntryBlock it is generated in
         alloca block or in the current block.

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -7728,7 +7728,7 @@ llvm::Value *AllocaExpr::GetValue(FunctionEmitContext *ctx) const {
     llvm::Value *llvmValue = expr->GetValue(ctx);
     if (llvmValue == NULL)
         return NULL;
-    llvm::Value *resultPtr = ctx->AllocaInst((LLVMTypes::VoidPointerType)->PTR_ELT_TYPE(), llvmValue, "allocaExpr", 16,
+    llvm::Value *resultPtr = ctx->AllocaInst(LLVMTypes::Int8Type, llvmValue, "allocaExpr", 16,
                                              false)
                                  ->getPointer(); // 16 byte stack alignment.
     return resultPtr;

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -264,7 +264,8 @@ static void lCopyInTaskParameter(int i, AddressInfo *structArgPtrInfo, const std
 
     // and copy the value from the struct and into the local alloca'ed
     // memory
-    llvm::Value *ptrval = ctx->LoadInst(ptr, sym->type, sym->name.c_str());
+    llvm::Value *ptrval =
+        ctx->LoadInst(new AddressInfo(ptr, sym->storageInfo->getElementType()), sym->type, sym->name.c_str());
     ctx->StoreInst(ptrval, sym->storageInfo, sym->type);
     ctx->EmitFunctionParameterDebugInfo(sym, i);
 }
@@ -327,7 +328,7 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
             int nArgs = (int)args.size();
             // The mask is the last parameter in the argument structure
             llvm::Value *ptr = ctx->AddElementOffset(structParamPtr, nArgs, NULL, "task_struct_mask");
-            llvm::Value *ptrval = ctx->LoadInst(ptr, NULL, "mask");
+            llvm::Value *ptrval = ctx->LoadInst(new AddressInfo(ptr, LLVMTypes::MaskType), NULL, "mask");
             ctx->SetFunctionMask(ptrval);
         }
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2647,10 +2647,7 @@ static void lCreateDispatchFunction(llvm::Module *module, llvm::Function *setISA
 
     // Now we can load the system's ISA enumerant
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_11_0
-    llvm::PointerType *ptr_type = llvm::dyn_cast<llvm::PointerType>(systemBestISAPtr->getType());
-    Assert(ptr_type);
-    llvm::Value *systemISA =
-        new llvm::LoadInst(ptr_type->getPointerElementType(), systemBestISAPtr, "system_isa", bblock);
+    llvm::Value *systemISA = new llvm::LoadInst(LLVMTypes::Int32Type, systemBestISAPtr, "system_isa", bblock);
 #else
     llvm::Value *systemISA = new llvm::LoadInst(systemBestISAPtr, "system_isa", bblock);
 #endif
@@ -2770,23 +2767,23 @@ static void lEmitDispatchModule(llvm::Module *module, std::map<std::string, Func
     optPM.run(*module);
 }
 
-// Determines if two types are compatible
+// Determines if two types are compatible.
+// Here we check layout compatibility. We don't care about pointer types.
 static bool lCompatibleTypes(llvm::Type *Ty1, llvm::Type *Ty2) {
     while (Ty1->getTypeID() == Ty2->getTypeID())
         switch (Ty1->getTypeID()) {
-        case llvm::ArrayType::ArrayTyID:
+        case llvm::Type::ArrayTyID:
             if (Ty1->getArrayNumElements() != Ty2->getArrayNumElements())
                 return false;
             Ty1 = Ty1->getArrayElementType();
             Ty2 = Ty2->getArrayElementType();
             break;
-
-        case llvm::ArrayType::PointerTyID:
-            Ty1 = Ty1->getPointerElementType();
-            Ty2 = Ty2->getPointerElementType();
-            break;
-
-        case llvm::ArrayType::StructTyID: {
+        case llvm::Type::PointerTyID:
+            // Uniform pointers are compatible.
+            // Varying pointers are represented as <N x i32>/<N x i64>, it'll
+            // be checked in default statement.
+            return true;
+        case llvm::Type::StructTyID: {
             llvm::StructType *STy1 = llvm::dyn_cast<llvm::StructType>(Ty1);
             llvm::StructType *STy2 = llvm::dyn_cast<llvm::StructType>(Ty2);
             return STy1 && STy2 && STy1->isLayoutIdentical(STy2);
@@ -2811,7 +2808,7 @@ static void lExtractOrCheckGlobals(llvm::Module *msrc, llvm::Module *mdst, bool 
         llvm::GlobalVariable *gv = &*iter;
         // Is it a global definition?
         if (gv->getLinkage() == llvm::GlobalValue::ExternalLinkage && gv->hasInitializer()) {
-            llvm::Type *type = gv->getType()->PTR_ELT_TYPE();
+            llvm::Type *type = gv->getValueType();
             Symbol *sym = m->symbolTable->LookupVariable(gv->getName().str().c_str());
             Assert(sym != NULL);
 
@@ -2823,7 +2820,7 @@ static void lExtractOrCheckGlobals(llvm::Module *msrc, llvm::Module *mdst, bool 
                 // It is possible that the types may not match: for
                 // example, this happens with varying globals if we
                 // compile to different vector widths
-                if (!lCompatibleTypes(exist->getType(), gv->getType())) {
+                if (!lCompatibleTypes(exist->getValueType(), gv->getValueType())) {
                     Warning(sym->pos,
                             "Mismatch in size/layout of global "
                             "variable \"%s\" with different targets. "


### PR DESCRIPTION
This PR switches `StoreInst` to use `AddressInfo` class.
Also eliminates usage of `getPointerElementType` in easy cases.