### PR TITLE
[opaque pointers 6] Final fixes

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -3083,8 +3083,13 @@ void FunctionEmitContext::MemcpyInst(llvm::Value *dest, llvm::Value *src, llvm::
     if (align == NULL)
         align = LLVMInt32(1);
     llvm::FunctionCallee mcFuncCallee =
+#ifdef ISPC_OPAQUE_PTR_MODE
+        m->module->getOrInsertFunction("llvm.memcpy.p0.p0.i64", LLVMTypes::VoidType, LLVMTypes::VoidPointerType,
+                                       LLVMTypes::VoidPointerType, LLVMTypes::Int64Type, LLVMTypes::BoolType);
+#else
         m->module->getOrInsertFunction("llvm.memcpy.p0i8.p0i8.i64", LLVMTypes::VoidType, LLVMTypes::VoidPointerType,
                                        LLVMTypes::VoidPointerType, LLVMTypes::Int64Type, LLVMTypes::BoolType);
+#endif
     llvm::Constant *mcFunc = llvm::cast<llvm::Constant>(mcFuncCallee.getCallee());
     AssertPos(currentPos, mcFunc != NULL);
     AssertPos(currentPos, llvm::isa<llvm::Function>(mcFunc));

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -67,6 +67,9 @@ class AddressInfo {
     // Return the type of the values stored in this address.
     llvm::Type *getElementType() const { return elementType; }
 
+    // Return the ISPC type. May be NULL.
+    const Type *getISPCType() const { return ispcType; }
+
     // Return the address space that this address resides in.
     unsigned getAddressSpace() const { return getType()->getAddressSpace(); }
 
@@ -449,7 +452,8 @@ class FunctionEmitContext {
         and an integer offset to a slice within that type. */
     llvm::Value *MakeSlicePointer(llvm::Value *ptr, llvm::Value *offset);
 
-    /* Regularize to a standard pointer type. */
+    /* Regularize to a standard pointer type.
+       May return NULL if type is not PointerType or ReferenceType */
     const PointerType *RegularizePointer(const Type *ptrRefType);
 
     /** These GEP methods are generalizations of the standard ones in LLVM;
@@ -467,11 +471,9 @@ class FunctionEmitContext {
     /** This method returns a new pointer that represents offsetting the
         given base pointer to point at the given element number of the
         structure type that the base pointer points to.  (The provided
-        pointer must be a pointer to a structure type.  The ptrType gives
-        the type of the pointer, though it may be NULL if the base pointer
-        is uniform. */
-    llvm::Value *AddElementOffset(llvm::Value *basePtr, int elementNum, const Type *ptrType,
-                                  const llvm::Twine &name = "", const PointerType **resultPtrType = NULL);
+        pointer in AddressInfo must be a pointer to a structure type.) */
+    llvm::Value *AddElementOffset(AddressInfo *basePtrInfo, int elementNum, const llvm::Twine &name = "",
+                                  const PointerType **resultPtrType = NULL);
 
     /** Bool is stored as i8 and <WIDTH x i8> but represented in IR as i1 and
      * <WIDTH x MASK>. This is a helper function to match bool size at storage

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -70,6 +70,9 @@ class AddressInfo {
     // Return the address space that this address resides in.
     unsigned getAddressSpace() const { return getType()->getAddressSpace(); }
 
+    // Get LLVM pointer element type from ISPC PointerType.
+    static llvm::Type *GetPointeeLLVMType(const PointerType *pt);
+
   private:
     llvm::Value *pointer;
     llvm::Type *elementType;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,7 +55,8 @@ list(APPEND LIT_ARGS "-Dwindows_enabled=$<IF:$<BOOL:${ISPC_WINDOWS_TARGET}>,ON,O
 list(APPEND LIT_ARGS "-Dmacos_arm_enabled=$<IF:$<BOOL:${ISPC_MACOS_ARM_TARGET}>,ON,OFF>")
 # Dumps enabled/disbaled
 list(APPEND LIT_ARGS "-Ddumps_enabled=$<IF:$<BOOL:${ISPC_NO_DUMPS}>,OFF,ON>")
-
+# ISPC opaque pointers
+list(APPEND LIT_ARGS "-Dopaque_mode=$<IF:$<BOOL:${ISPC_OPAQUE_PTR_MODE}>,ON,OFF>")
 add_custom_target(check-all DEPENDS ispc
     COMMAND ${LIT_COMMAND} ${LIT_ARGS}
     COMMENT "Running lit tests"

--- a/tests/lit-tests/1323_1.ispc
+++ b/tests/lit-tests/1323_1.ispc
@@ -1,0 +1,50 @@
+// RUN: %{ispc} %s --target=sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16 -h %t.h --emit-llvm -o %t.bc
+// RUN: llvm-dis %t.bc -o - | FileCheck %s -check-prefix=CHECK_TYPES
+// REQUIRES: X86_ENABLED
+// The test doesn't make sense in opaque mode, all types will be opaque.
+// UNSUPPORTED: OPAQUE_PTRS_ENABLED
+
+// CHECK_TYPES: type { <4 x float> }
+// CHECK_TYPES-NEXT: type { <8 x i32> }
+// CHECK_TYPES-NEXT: type { <4 x i8> }
+// CHECK_TYPES-NEXT: type { <16 x i64> }
+// CHECK_TYPES-NEXT: type { <4 x i8> }
+
+typedef float<3> float3;
+struct A {
+    uniform float3 value;
+};
+
+export void check_A(uniform const A * uniform x){
+}
+
+typedef int<5> int5;
+struct B {
+    uniform int5 value;
+};
+
+export void check_B(uniform const B * uniform x){
+}
+typedef int8<4> int8_4;
+struct C {
+    uniform int8_4 value;
+};
+
+export void check_C(uniform const C * uniform x){
+}
+
+typedef int64<9> int64_9;
+struct D {
+    uniform int64_9 value;
+};
+
+export void check_D(uniform const D * uniform x){
+}
+
+typedef bool<2> bool2;
+struct E {
+    uniform bool2 value;
+};
+
+export void check_E(uniform const E * uniform x){
+}

--- a/tests/lit-tests/1323_2.ispc
+++ b/tests/lit-tests/1323_2.ispc
@@ -1,13 +1,6 @@
 // RUN: %{ispc} %s --target=sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16 -h %t.h --emit-llvm -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s -check-prefix=CHECK_TYPES
 // RUN: FileCheck --input-file=%t.h %s -check-prefix=CHECK_ALIGN
 // REQUIRES: X86_ENABLED
-
-// CHECK_TYPES: type { <4 x float> }
-// CHECK_TYPES-NEXT: type { <8 x i32> }
-// CHECK_TYPES-NEXT: type { <4 x i8> }
-// CHECK_TYPES-NEXT: type { <16 x i64> }
-// CHECK_TYPES-NEXT: type { <4 x i8> }
 
 typedef float<3> float3;
 // CHECK_ALIGN: #ifdef _MSC_VER

--- a/tests/lit-tests/1763.ispc
+++ b/tests/lit-tests/1763.ispc
@@ -1,6 +1,6 @@
 // RUN: %{ispc} %s --target=avx2-i64x4 --nowrap --opt=disable-handle-pseudo-memory-ops --emit-llvm-text -o - | FileCheck %s
 // REQUIRES: X86_ENABLED
-// CHECK: declare void @__pseudo_scatter_factored_base_offsets64_i8(i8* nocapture, <4 x i64>, i32, <4 x i64>, <4 x i8>, <4 x i64>)
+// CHECK: declare void @__pseudo_scatter_factored_base_offsets64_i8({{.*}} nocapture, <4 x i64>, i32, <4 x i64>, <4 x i8>, <4 x i64>)
 extern uniform unsigned int64 var_1;
 extern uniform bool var_11;
 extern uniform unsigned int64 arr_253[2];

--- a/tests/lit-tests/2376.ispc
+++ b/tests/lit-tests/2376.ispc
@@ -1,0 +1,14 @@
+// This test checks that compiler is not crashing and producing
+// error when varying index is used with short vectors
+// Currently fails (https://github.com/ispc/ispc/issues/2376).
+
+// RUN: not %{ispc} %s --target=host --nostdlib 2>&1 | FileCheck %s
+// CHECK-NOT: FATAL ERROR
+// XFAIL: *
+typedef int<3> int3;
+
+export void test(uniform float ret[], uniform float b) {
+    int3 v0 = { b, 2*b, 3*b };
+    int3 v1 = { b, b/2, b/3 };
+    ret[programIndex] = (v0+v1)[programIndex];
+}

--- a/tests/lit-tests/float16_uniform.ispc
+++ b/tests/lit-tests/float16_uniform.ispc
@@ -9,8 +9,8 @@ uniform float16 foo0(uniform float16 arg0) {
 }
 
 // Tests float16 constant parsing in *.*F16 form.
-//; CHECK: define void @foo1___REFunhun_3C_unh_3E_(half* noalias %arg0, half* noalias %arg1
-//; CHECK: store half 0xH4252, half*
+//; CHECK: define void @foo1___REFunhun_3C_unh_3E_
+//; CHECK: store half 0xH4252,
 //; CHECK: fmul half %arg
 void foo1(uniform float16 &arg0, uniform float16 *uniform arg1) {
     arg0 = 3.16F16;

--- a/tests/lit-tests/float16_varying.ispc
+++ b/tests/lit-tests/float16_varying.ispc
@@ -9,7 +9,7 @@ varying float16 foo0(varying float16 arg0) {
 }
 
 // Tests float16 constant parsing in *.*f16 form.
-//; CHECK: define void @foo1___REFvyhvy_3C_vyh_3E_(<{{[0-9]*}} x half>* noalias %arg0, <{{[0-9]*}} x i64> %arg1
+//; CHECK: define void @foo1___REFvyhvy_3C_vyh_3E_({{.*}} noalias %arg0, <{{[0-9]*}} x i64> %arg1
 //; CHECK: fmul <{{[0-9]*}} x half>
 void foo1(varying float16 &arg0, varying float16 *varying arg1) {
     arg0 = 3.16f16;

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -132,3 +132,14 @@ elif dumps_enabled == "OFF":
     print("DUMPS_ENABLED: NO")
 else:
     sys.exit("Cannot parse dumps_enabled: " + dumps_enabled)
+
+# Opaque pointers enabled
+opaque_mode = lit_config.params.get('opaque_mode', '0')
+if opaque_mode == "ON":
+    print("OPAQUE_PTRS_ENABLED: YES")
+    config.available_features.add("OPAQUE_PTRS_ENABLED")
+elif opaque_mode == "OFF":
+    print("OPAQUE_PTRS_ENABLED: NO")
+else:
+    sys.exit("Cannot parse opaque_mode: " + opaque_mode)
+

--- a/tests/lit-tests/load_unaligned.ispc
+++ b/tests/lit-tests/load_unaligned.ispc
@@ -1,0 +1,9 @@
+// This test checks reduced alignment for varying atomic types
+// RUN: %{ispc} %s --nostdlib --emit-llvm-text -o - | FileCheck %s
+typedef float<3> float3;
+// CHECK-COUNT-3: load <{{[0-9]+}} x float>, <{{[0-9]+}} x float>* %{{.*}}, align 1
+
+extern float3 TestLoadUnaligned(float3 &b) {
+    float3 xyz = b.xyz;
+    return xyz;
+}

--- a/tests/lit-tests/print_bool.ispc
+++ b/tests/lit-tests/print_bool.ispc
@@ -1,5 +1,9 @@
+// The test checks correct IR generation for print of bool types.
+// It doesn't make much sense with opaque pointers since the most of the instructions will be optimized.
 // RUN: %{ispc} %s --target=avx2-i32x4 --nowrap -O0 --emit-llvm-text -o - | FileCheck %s
 // REQUIRES: X86_ENABLED
+
+// UNSUPPORTED: OPAQUE_PTRS_ENABLED
 // CHECK: [[PRTARG_PTR_BITCAST:%[a-zA-Z0-9_.]+]] = bitcast [1 x i8*]*  [[PRTARG_PTR:%[a-zA-Z0-9_.]+]] to i8**
 // CHECK: [[PRTARG_BITCAST:%[a-zA-Z0-9_.]+]] = bitcast <4 x i32>* {{%[a-zA-Z0-9_.]+}} to i8*
 // CHECK: [[SCT_OFF:%[a-zA-Z0-9_.]+]] = getelementptr [1 x i8*], [1 x i8*]* [[PRTARG_PTR]], i32 0, i32 0


### PR DESCRIPTION
The last piece of changes related to opaque pointers.
1. Eliminated remaining usages of getPointerElementType
2. Fixed signature of `llvm.memcpy` intrinsic in opaque mode
3. Fixed lit tests