### PR TITLE
CI updates: 15.0.2, macos-11, others

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,7 +58,7 @@ for:
         if "%LLVM_VERSION%"=="latest" (set WASM=ON)
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vspath="C:\Program Files (x86)\Microsoft Visual Studio\2019"))
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2022" ( (set generator="Visual Studio 17") & (set vspath="C:\Program Files\Microsoft Visual Studio\2022"))
-        set LLVM_TAR=llvm-15.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        set LLVM_TAR=llvm-15.0.2-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
         if "%LLVM_VERSION%"=="14.0" (set LLVM_TAR=llvm-14.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
         if "%LLVM_VERSION%"=="13.0" (set LLVM_TAR=llvm-13.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
         if "%LLVM_VERSION%"=="12.0" (set LLVM_TAR=llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
@@ -112,7 +112,7 @@ for:
         export LLVM_HOME=$APPVEYOR_BUILD_FOLDER/llvm
         export CROSS_TOOLS=/usr/local/src/cross
         export WASM=OFF
-        export LLVM_TAR=llvm-15.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+        export LLVM_TAR=llvm-15.0.2-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
   install:
     - sh: |-
         sudo apt-get update

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -98,7 +98,7 @@ jobs:
         .github/workflows/scripts/check-ispc.sh
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm11_linux
         path: build/ispc-trunk-linux.tar.gz
@@ -134,7 +134,7 @@ jobs:
         .github/workflows/scripts/check-ispc.sh
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm12_linux
         path: build/ispc-trunk-linux.tar.gz
@@ -170,7 +170,7 @@ jobs:
         .github/workflows/scripts/check-ispc.sh
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm13_linux
         path: build/ispc-trunk-linux.tar.gz
@@ -206,7 +206,7 @@ jobs:
         .github/workflows/scripts/check-ispc.sh
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm14_linux
         path: build/ispc-trunk-linux.tar.gz
@@ -243,7 +243,7 @@ jobs:
         .github/workflows/scripts/check-ispc.sh
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm15_linux
         path: build/ispc-trunk-linux.tar.gz
@@ -280,7 +280,7 @@ jobs:
         .github/workflows/scripts/check-ispc.sh
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm15rel_linux
         path: build/ispc-trunk-linux.tar.gz
@@ -325,7 +325,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm11_linux
 
@@ -349,7 +349,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm11.${{matrix.target}}.txt
@@ -366,7 +366,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm12_linux
 
@@ -390,7 +390,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm12.${{matrix.target}}.txt
@@ -407,7 +407,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm13_linux
 
@@ -430,7 +430,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm13.${{matrix.target}}.txt
@@ -447,7 +447,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm14_linux
 
@@ -471,7 +471,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm14.${{matrix.target}}.txt
@@ -488,7 +488,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm15_linux
 
@@ -511,7 +511,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm15.${{matrix.target}}.txt
@@ -527,7 +527,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm15rel_linux
 
@@ -550,7 +550,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm15rel.${{matrix.target}}.txt
@@ -569,7 +569,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm15_linux
 
@@ -592,7 +592,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm15.debug.txt
@@ -634,7 +634,7 @@ jobs:
         .github/workflows/scripts/check-ispc.ps1
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm11_win
         path: build/ispc-trunk-windows.msi
@@ -675,7 +675,7 @@ jobs:
         .github/workflows/scripts/check-ispc.ps1
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm12_win
         path: build/ispc-trunk-windows.msi
@@ -716,7 +716,7 @@ jobs:
         .github/workflows/scripts/check-ispc.ps1
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm13_win
         path: build/ispc-trunk-windows.msi
@@ -757,7 +757,7 @@ jobs:
         .github/workflows/scripts/check-ispc.ps1
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm14_win
         path: build/ispc-trunk-windows.msi
@@ -799,7 +799,7 @@ jobs:
         .github/workflows/scripts/check-ispc.ps1
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm15_win
         path: build/ispc-trunk-windows.msi
@@ -819,7 +819,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm11_win
 
@@ -845,7 +845,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm11.${{matrix.arch}}.${{matrix.target}}.txt
@@ -868,7 +868,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm12_win
 
@@ -894,7 +894,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm12.${{matrix.arch}}.${{matrix.target}}.txt
@@ -916,7 +916,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm13_win
 
@@ -941,7 +941,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm13.${{matrix.arch}}.${{matrix.target}}.txt
@@ -962,7 +962,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm14_win
 
@@ -988,7 +988,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm14.${{matrix.arch}}.${{matrix.target}}.txt
@@ -1009,7 +1009,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm15_win
 
@@ -1034,7 +1034,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm15.${{matrix.arch}}.${{matrix.target}}.txt

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-15.0.2-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.0-ubuntu18.04-Release-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-15.0.2-ubuntu18.04-Release-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -290,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-15.0.2-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -767,7 +767,7 @@ jobs:
     runs-on: windows-2019
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_TAR: llvm-15.0.2-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -87,7 +87,7 @@ jobs:
         .github/workflows/scripts/check-ispc.sh
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm13_linux
         path: build/ispc-trunk-linux.tar.gz
@@ -104,7 +104,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm13_linux
 
@@ -128,7 +128,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm13.${{matrix.target}}.txt

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -56,7 +56,7 @@ jobs:
         make ispc_benchmarks && make test
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm13_linux_bench
         path: build/ispc-trunk-linux.tar.gz
@@ -67,7 +67,7 @@ jobs:
     needs: linux-build
     steps:
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm13_linux_bench
     - name: Install dependencies and unpack artifacts
@@ -93,7 +93,7 @@ jobs:
       run: curl http://$StabilizerServer:7373/release
       if: always()
     - name: Upload results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm13_linux_bench_results
         path: ispc-trunk-linux/benchmarks/out/*.json
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download benchmarks results
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ispc_llvm13_linux_bench_results
       - name: Upload bench datasets to calcite

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -39,7 +39,7 @@ jobs:
         docker buildx build --tag ispc/ubuntu18.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=trunk .
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvm_trunk_linux_stage1_cache
         path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
@@ -58,7 +58,7 @@ jobs:
         cat /proc/cpuinfo
 
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: llvm_trunk_linux_stage1_cache
         path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
@@ -79,7 +79,7 @@ jobs:
         tar czvf llvm-trunk-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-trunk
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvm_trunk_linux
         path: docker/ubuntu/18.04/cpu_ispc_build/llvm-trunk-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
@@ -97,7 +97,7 @@ jobs:
         submodules: true
 
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: llvm_trunk_linux
 
@@ -120,7 +120,7 @@ jobs:
         .github/workflows/scripts/check-ispc.sh
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm_trunk_linux
         path: build/ispc-trunk-linux.tar.gz
@@ -141,7 +141,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm_trunk_linux
 
@@ -159,7 +159,7 @@ jobs:
         ./alloy.py -r --only="stability current -O0 -O1 -O2" --only-targets="${{ matrix.target }}" --time --update-errors=FP
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.${{matrix.target}}.txt

--- a/.github/workflows/nightly-15.yml
+++ b/.github/workflows/nightly-15.yml
@@ -78,20 +78,20 @@ jobs:
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-15.0 .
         # Note using gzip here, instead of xz - trading of space for speed, as it's just for passing to another stage.
-        tar czvf llvm-15.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-15.0
+        tar czvf llvm-15.0.2-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-15.0
 
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
         name: llvm_15_linux
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-15.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-15.0.2-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
   linux-build-ispc-llvm-15:
     needs: [linux-build-llvm-15-2]
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+      LLVM_TAR: llvm-15.0.2-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
     steps:
     - uses: actions/checkout@v3
@@ -208,7 +208,7 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-15.0.0-win.vs2019-Release+Asserts-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-15.0.2-win.vs2019-Release+Asserts-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-15.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -216,7 +216,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: llvm_15_win
-        path: llvm/llvm-15.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        path: llvm/llvm-15.0.2-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
 
   win-build-ispc-llvm-15:
@@ -224,7 +224,7 @@ jobs:
     runs-on: windows-2022
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_TAR: llvm-15.0.2-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"

--- a/.github/workflows/nightly-15.yml
+++ b/.github/workflows/nightly-15.yml
@@ -41,7 +41,7 @@ jobs:
         docker buildx build --tag ispc/ubuntu18.04:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=15.0 .
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvm15_linux_stage1_cache
         path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
@@ -60,7 +60,7 @@ jobs:
         cat /proc/cpuinfo
 
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: llvm15_linux_stage1_cache
         path: docker/ubuntu/18.04/cpu_ispc_build/cache.local
@@ -81,7 +81,7 @@ jobs:
         tar czvf llvm-15.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-15.0
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvm_15_linux
         path: docker/ubuntu/18.04/cpu_ispc_build/llvm-15.0.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
@@ -99,7 +99,7 @@ jobs:
         submodules: true
 
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: llvm_15_linux
 
@@ -122,7 +122,7 @@ jobs:
         .github/workflows/scripts/check-ispc.sh
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm_15_linux
         path: build/ispc-trunk-linux.tar.gz
@@ -143,7 +143,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm_15_linux
 
@@ -161,7 +161,7 @@ jobs:
         ./alloy.py -r --only="stability current -O0 -O1 -O2" --only-targets="${{ matrix.target }}" --time --update-errors=FP
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.${{matrix.target}}.txt
@@ -213,7 +213,7 @@ jobs:
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvm_15_win
         path: llvm/llvm-15.0.0-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
@@ -235,7 +235,7 @@ jobs:
         submodules: true
 
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: llvm_15_win
         path: ${{env.LLVM_HOME}}
@@ -261,7 +261,7 @@ jobs:
         .github/workflows/scripts/check-ispc.ps1
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ispc_llvm15_win
         path: build/ispc-trunk-windows.msi
@@ -287,7 +287,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ispc_llvm15_win
 
@@ -312,7 +312,7 @@ jobs:
         git diff --exit-code
 
     - name: Upload fail_db.txt
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: fail_db.llvm15.${{matrix.arch}}.${{matrix.target}}.txt

--- a/.github/workflows/rebuild-llvm15.yml
+++ b/.github/workflows/rebuild-llvm15.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/reusable.rebuild.yml
     with:
       version: '15.0'
-      full_version: '15.0.0'
+      full_version: '15.0.2'
       ubuntu: '18.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -314,7 +314,7 @@ jobs:
         name: llvmrel_win_x86
         path: llvm/llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release-x86.arm.wasm.tar.7z
 
-  mac-build:
+  mac-build-1:
     runs-on: macos-11
 
     steps:
@@ -324,17 +324,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        ls -ald /Applications/Xcode*
-        xcrun --show-sdk-path
-        # There are several Xcode versions installed.
-        # /Applications/Xcode.app is a symlink pointing to the one that needs to be used.
-        # But the one, which is currently "selected" doesn't use symlink.
-        # We need canonical location to make resulting clang build working on other machines.
-        sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
-        xcrun --show-sdk-path
-        mkdir llvm
-        echo "LLVM_HOME=${GITHUB_WORKSPACE}/llvm" >> $GITHUB_ENV
-        echo "ISPC_HOME=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
+        .github/workflows/scripts/install-llvm-deps-mac.sh
 
     - name: Check environment
       run: |
@@ -345,7 +335,55 @@ jobs:
 
     - name: Build LLVM
       run: |
-        ./alloy.py -b --version=${{ inputs.version }} --selfbuild --verbose
+        ./alloy.py -b --version=${{ inputs.version }} --selfbuild-phase1 --verbose
+
+    - name: Tar itermediate results
+      run: |
+        cd llvm
+        rm -rf llvm*/.git
+        tar cf llvm_stage1.tar bin* llvm*
+
+    - name: Upload package
+      uses: actions/upload-artifact@v2
+      with:
+        name: llvm_macos_x86_stage1
+        path: |
+          llvm/llvm_stage1.tar
+
+  mac-build-2:
+    needs: [mac-build-1]
+    runs-on: macos-11
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Install dependencies
+      run: |
+        .github/workflows/scripts/install-llvm-deps-mac.sh
+
+    - name: Check environment
+      run: |
+        ./check_env.py
+        which -a clang
+        sysctl -n machdep.cpu.brand_string
+        sysctl -n hw.ncpu
+
+    - name: Download package
+      uses: actions/download-artifact@v3
+      with:
+        name: llvm_macos_x86_stage1
+        path: llvm
+
+    - name: Extract intermediate results
+      run: |
+        cd llvm
+        tar xf llvm_stage1.tar
+
+    - name: Build LLVM
+      run: |
+        ./alloy.py -b --version=${{ inputs.version }} --selfbuild-phase2 --verbose
 
     - name: Pack LLVM
       run: |
@@ -358,7 +396,7 @@ jobs:
         name: llvm_macos_x86
         path: llvm/llvm-${{ inputs.full_version }}-macos11-Release+Asserts-x86.arm.wasm.tar.xz
 
-  mac-build-release:
+  mac-build-release-1:
     runs-on: macos-11
 
     steps:
@@ -368,17 +406,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        ls -ald /Applications/Xcode*
-        xcrun --show-sdk-path
-        # There are several Xcode versions installed.
-        # /Applications/Xcode.app is a symlink pointing to the one that needs to be used.
-        # But the one, which is currently "selected" doesn't use symlink.
-        # We need canonical location to make resulting clang build working on other machines.
-        sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
-        xcrun --show-sdk-path
-        mkdir llvm
-        echo "LLVM_HOME=${GITHUB_WORKSPACE}/llvm" >> $GITHUB_ENV
-        echo "ISPC_HOME=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
+        .github/workflows/scripts/install-llvm-deps-mac.sh
 
     - name: Check environment
       run: |
@@ -389,7 +417,55 @@ jobs:
 
     - name: Build LLVM
       run: |
-        ./alloy.py -b --version=${{ inputs.version }} --selfbuild --verbose --llvm-disable-assertions
+        ./alloy.py -b --version=${{ inputs.version }} --selfbuild-phase1 --verbose --llvm-disable-assertions
+
+    - name: Tar itermediate results
+      run: |
+        cd llvm
+        rm -rf llvm*/.git
+        tar cf llvm_stage1.tar bin* llvm*
+
+    - name: Upload package
+      uses: actions/upload-artifact@v2
+      with:
+        name: llvmrel_macos_x86_stage1
+        path: |
+          llvm/llvm_stage1.tar
+
+  mac-build-release-2:
+    needs: [mac-build-release-1]
+    runs-on: macos-11
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Install dependencies
+      run: |
+        .github/workflows/scripts/install-llvm-deps-mac.sh
+
+    - name: Check environment
+      run: |
+        ./check_env.py
+        which -a clang
+        sysctl -n machdep.cpu.brand_string
+        sysctl -n hw.ncpu
+
+    - name: Download package
+      uses: actions/download-artifact@v3
+      with:
+        name: llvmrel_macos_x86_stage1
+        path: llvm
+
+    - name: Extract intermediate results
+      run: |
+        cd llvm
+        tar xf llvm_stage1.tar
+
+    - name: Build LLVM
+      run: |
+        ./alloy.py -b --version=${{ inputs.version }} --selfbuild-phase2 --verbose --llvm-disable-assertions
 
     - name: Pack LLVM
       run: |
@@ -401,4 +477,3 @@ jobs:
       with:
         name: llvmrel_macos_x86
         path: llvm/llvm-${{ inputs.full_version }}-macos11-Release-x86.arm.wasm.tar.xz
-

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -315,7 +315,7 @@ jobs:
         path: llvm/llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release-x86.arm.wasm.tar.7z
 
   mac-build:
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v3
@@ -349,16 +349,16 @@ jobs:
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-${{ inputs.full_version }}-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
+        tar cJvf llvm-${{ inputs.full_version }}-macos11-Release+Asserts-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvm_macos_x86
-        path: llvm/llvm-${{ inputs.full_version }}-macos10.15-Release+Asserts-x86.arm.wasm.tar.xz
+        path: llvm/llvm-${{ inputs.full_version }}-macos11-Release+Asserts-x86.arm.wasm.tar.xz
 
   mac-build-release:
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v3
@@ -392,11 +392,11 @@ jobs:
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-${{ inputs.full_version }}-macos10.15-Release-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
+        tar cJvf llvm-${{ inputs.full_version }}-macos11-Release-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
         name: llvmrel_macos_x86
-        path: llvm/llvm-${{ inputs.full_version }}-macos10.15-Release-x86.arm.wasm.tar.xz
+        path: llvm/llvm-${{ inputs.full_version }}-macos11-Release-x86.arm.wasm.tar.xz
 

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -341,6 +341,7 @@ jobs:
         ./check_env.py
         which -a clang
         sysctl -n machdep.cpu.brand_string
+        sysctl -n hw.ncpu
 
     - name: Build LLVM
       run: |
@@ -384,6 +385,7 @@ jobs:
         ./check_env.py
         which -a clang
         sysctl -n machdep.cpu.brand_string
+        sysctl -n hw.ncpu
 
     - name: Build LLVM
       run: |

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -51,7 +51,7 @@ jobs:
         docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=${{ inputs.version }} .
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvm_linux_x86_stage1_cache
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
@@ -70,7 +70,7 @@ jobs:
         cat /proc/cpuinfo
 
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: llvm_linux_x86_stage1_cache
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
@@ -90,7 +90,7 @@ jobs:
         tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release+Asserts-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvm_linux_x86
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release+Asserts-x86.arm.wasm.tar.xz
@@ -114,7 +114,7 @@ jobs:
         docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg EXTRA_BUILD_ARG="--llvm-disable-assertions" .
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvmrel_linux_x86_stage1_cache
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
@@ -133,7 +133,7 @@ jobs:
         cat /proc/cpuinfo
 
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: llvmrel_linux_x86_stage1_cache
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
@@ -153,7 +153,7 @@ jobs:
         tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvmrel_linux_x86
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release-x86.arm.wasm.tar.xz
@@ -187,7 +187,7 @@ jobs:
         rm -rf result.tar usr bin-${{ inputs.version }}
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvm_linux_aarch64
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release+Asserts-x86.arm.wasm.tar.xz
@@ -221,7 +221,7 @@ jobs:
         rm -rf result.tar usr bin-${{ inputs.version }}
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvmrel_linux_aarch64
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release-x86.arm.wasm.tar.xz
@@ -265,7 +265,7 @@ jobs:
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvm_win_x86
         path: llvm/llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release+Asserts-x86.arm.wasm.tar.7z
@@ -309,7 +309,7 @@ jobs:
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvmrel_win_x86
         path: llvm/llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release-x86.arm.wasm.tar.7z
@@ -344,7 +344,7 @@ jobs:
         tar cf llvm_stage1.tar bin* llvm*
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvm_macos_x86_stage1
         path: |
@@ -391,7 +391,7 @@ jobs:
         tar cJvf llvm-${{ inputs.full_version }}-macos11-Release+Asserts-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvm_macos_x86
         path: llvm/llvm-${{ inputs.full_version }}-macos11-Release+Asserts-x86.arm.wasm.tar.xz
@@ -426,7 +426,7 @@ jobs:
         tar cf llvm_stage1.tar bin* llvm*
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvmrel_macos_x86_stage1
         path: |
@@ -473,7 +473,7 @@ jobs:
         tar cJvf llvm-${{ inputs.full_version }}-macos11-Release-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: llvmrel_macos_x86
         path: llvm/llvm-${{ inputs.full_version }}-macos11-Release-x86.arm.wasm.tar.xz

--- a/.github/workflows/scripts/install-llvm-deps-mac.sh
+++ b/.github/workflows/scripts/install-llvm-deps-mac.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+ls -ald /Applications/Xcode*
+xcrun --show-sdk-path
+# There are several Xcode versions installed on GHA runnner.
+# /Applications/Xcode.app is a symlink pointing to the one that needs to be used.
+# But the one, which is currently "selected" doesn't use symlink.
+# We need canonical location to make resulting clang build working on other machines.
+sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
+xcrun --show-sdk-path
+mkdir llvm
+echo "LLVM_HOME=${GITHUB_WORKSPACE}/llvm" >> $GITHUB_ENV
+echo "ISPC_HOME=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
       dist: bionic
       env:
         - LLVM_VERSION=15.0 OS=Ubuntu18.04aarch64
-        - LLVM_TAR=llvm-15.0.0-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_TAR=llvm-15.0.2-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
         - LLVM_REPO=https://github.com/ispc/llvm-project
         - ISPC_HOME=$TRAVIS_BUILD_DIR
       before_install:

--- a/alloy.py
+++ b/alloy.py
@@ -121,7 +121,7 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     if  version_LLVM == "trunk":
         GIT_TAG="main"
     elif  version_LLVM == "15_0":
-        GIT_TAG="llvmorg-15.0.0"
+        GIT_TAG="llvmorg-15.0.2"
     elif  version_LLVM == "14_0":
         GIT_TAG="llvmorg-14.0.6"
     elif  version_LLVM == "13_0":

--- a/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
@@ -15,7 +15,7 @@ ARG EXTRA_BUILD_ARG
 RUN uname -a
 
 # Packages required to build ISPC and Clang.
-RUN apt-get -y update && apt-get install -y wget build-essential gcc g++ git python3 ncurses-dev libtinfo-dev && \
+RUN apt-get -y update && apt-get install -y wget build-essential gcc g++ git python3-dev ncurses-dev libtinfo-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Download and install required version of cmake (3.14 for x86, 3.20 for aarch64, as earlier versions are not available as binary distribution) for ISPC build

--- a/docker/ubuntu/20.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/20.04/cpu_ispc_build/Dockerfile
@@ -15,7 +15,7 @@ ARG EXTRA_BUILD_ARG
 RUN uname -a
 
 # Packages
-RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y wget cmake build-essential gcc g++ git python3 ncurses-dev libtinfo-dev && \
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y wget cmake build-essential gcc g++ git python3-dev ncurses-dev libtinfo-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # If you are behind a proxy, you need to configure git.

--- a/docker/ubuntu/20.04/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/20.04/xpu_ispc_build/Dockerfile
@@ -16,7 +16,7 @@ ARG SPIRV_TRANSLATOR_COMMIT_SHA="d7a030447802718de76355c248b6bb292669683b"
 # otherwise LLVM build may fail, as it will use all the cores available to container.
 
 # Packages
-RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y clang-8 build-essential libnuma1 opencl-headers ocl-icd-libopencl1 clinfo vim gcc g++ git python3 imagemagick \
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y clang-8 build-essential libnuma1 opencl-headers ocl-icd-libopencl1 clinfo vim gcc g++ git python3-dev imagemagick \
     m4 bison flex zlib1g-dev libncurses-dev libtinfo-dev libc6-dev-i386 cpio lsb-core wget netcat-openbsd libtbb-dev libglfw3-dev pkgconf gdb gcc-multilib g++-multilib curl libomp-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/ubuntu/22.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/22.04/cpu_ispc_build/Dockerfile
@@ -15,7 +15,7 @@ ARG EXTRA_BUILD_ARG
 RUN uname -a
 
 # Packages
-RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y wget cmake build-essential gcc g++ git python3 ncurses-dev libtinfo-dev && \
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y wget cmake build-essential gcc g++ git python3-dev ncurses-dev libtinfo-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # If you are behind a proxy, you need to configure git.

--- a/docker/ubuntu/22.04/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/22.04/xpu_ispc_build/Dockerfile
@@ -16,7 +16,7 @@ ARG SPIRV_TRANSLATOR_COMMIT_SHA="5d69690864d8e7d5bf221284a37c57f016ce7d98"
 # otherwise LLVM build may fail, as it will use all the cores available to container.
 
 # Packages
-RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y clang-12 build-essential libnuma1 opencl-headers ocl-icd-libopencl1 clinfo vim gcc g++ git python3 imagemagick \
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y clang-12 build-essential libnuma1 opencl-headers ocl-icd-libopencl1 clinfo vim gcc g++ git python3-dev imagemagick \
     m4 bison flex zlib1g-dev libncurses-dev libtinfo-dev libc6-dev-i386 cpio lsb-core wget netcat-openbsd libtbb2-dev libglfw3-dev pkgconf gdb gcc-multilib g++-multilib curl libomp-12-dev && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- Install `python-dev` instead of `python` in Ubuntu images, otherwise LLVM trunk doesn't build.
- Use `macos-11` for LLVM builds.
- Build LLVM on macOS in two stages, as building in one now timeouts.
- Move LLVM 15 build from `15.0.0` to `15.0.2`, it contains critical fix for enabling macOS testing in CI (static link of ZSTD).
- Move CI testing to use `15.0.2`
- Use `v3` of download/upload actions.