### PR TITLE
Set of minor fixes

### DIFF
--- a/.github/workflows/rebuild-llvm15.yml
+++ b/.github/workflows/rebuild-llvm15.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/reusable.rebuild.yml
     with:
       version: '15.0'
-      full_version: '15.0.3'
+      full_version: '15.0.4'
       ubuntu: '18.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'

--- a/alloy.py
+++ b/alloy.py
@@ -121,7 +121,7 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     if  version_LLVM == "trunk":
         GIT_TAG="main"
     elif  version_LLVM == "15_0":
-        GIT_TAG="llvmorg-15.0.3"
+        GIT_TAG="llvmorg-15.0.4"
     elif  version_LLVM == "14_0":
         GIT_TAG="llvmorg-14.0.6"
     elif  version_LLVM == "13_0":

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -164,8 +164,6 @@ Function::Function(Symbol *s, Stmt *c) : sym(s), code(c) {
     maskSymbol = m->symbolTable->LookupVariable("__mask");
     Assert(maskSymbol != NULL);
 
-    typeCheckAndOptimize();
-
     const FunctionType *type = CastType<FunctionType>(sym->type);
     Assert(type != NULL);
 
@@ -209,6 +207,8 @@ Function::Function(Symbol *s, Stmt *c) : sym(s), code(c) {
         taskIndexSym0 = taskIndexSym1 = taskIndexSym2 = NULL;
         taskCountSym0 = taskCountSym1 = taskCountSym2 = NULL;
     }
+
+    typeCheckAndOptimize();
 }
 
 void Function::typeCheckAndOptimize() {

--- a/src/func.h
+++ b/src/func.h
@@ -61,6 +61,7 @@ class Function {
   private:
     enum class DebugPrintPoint { Initial, AfterTypeChecking, AfterOptimization };
     void debugPrintHelper(DebugPrintPoint dumpPoint);
+    void typeCheckAndOptimize();
 
     void emitCode(FunctionEmitContext *ctx, llvm::Function *function, SourcePos firstStmtPos);
 

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -85,13 +85,13 @@ struct PragmaAttributes {
 
 %{
 
-#include "ispc.h"
-#include "type.h"
-#include "module.h"
 #include "decl.h"
 #include "expr.h"
-#include "sym.h"
+#include "ispc.h"
+#include "module.h"
 #include "stmt.h"
+#include "sym.h"
+#include "type.h"
 #include "util.h"
 
 #include <stdio.h>

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -48,15 +48,9 @@ using namespace ispc;
 ///////////////////////////////////////////////////////////////////////////
 // Symbol
 
-Symbol::Symbol(const std::string &n, SourcePos p, const Type *t, StorageClass sc) : pos(p), name(n) {
-    storageInfo = NULL;
-    function = exportedFunction = NULL;
-    type = t;
-    constValue = NULL;
-    storageClass = sc;
-    varyingCFDepth = 0;
-    parentFunction = NULL;
-}
+Symbol::Symbol(const std::string &n, SourcePos p, const Type *t, StorageClass sc)
+    : pos(p), name(n), storageInfo(NULL), function(NULL), exportedFunction(NULL), type(t), constValue(NULL),
+      storageClass(sc), varyingCFDepth(0), parentFunction(NULL) {}
 
 ///////////////////////////////////////////////////////////////////////////
 // SymbolTable


### PR DESCRIPTION
Most of the changes are editorial, except these two:
- `Function` class constructor to run `TypeCheck()` and `Optimize()` after all the symbols are saved. This should not affect compiler behavior, but it's done, as it's more consistent.
- LLVM 15 to build in `alloy.py` is `15.0.4` instead of `15.0.3`. CI still uses `15.0.3`

Editorial changes:
- Reorder includes in `parse.yy` in alphabetical order.
- Add documentation for `Function` class constructor and outline typechecking & optimization calls.
- `Symbol` constructor to use initialization list.