### PR TITLE
WIP: Function templates support

### DIFF
--- a/contrib/ispc.vim
+++ b/contrib/ispc.vim
@@ -2,7 +2,7 @@
 " Language:		ISPC
 " Maintainer:		Dmitry Babokin <dmitry.y.babokin@intel.com>
 " Previous Maintainer:	Andreas Wendleder <andreas.wendleder@gmail.com>
-" Last Change:		May 19, 2022
+" Last Change:		February 27, 2023
 
 " Quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -21,6 +21,7 @@ syn keyword	ispcBuiltin		programCount programIndex taskCount taskCount0 taskCoun
 syn keyword	ispcType		export uniform varying int8 int16 int32 int64 uint8 uint16 uint32 uint64 float16
 syn keyword	ispcOperator		operator in
 syn keyword	ispcStorageClass	noinline __vectorcall __regcall
+syn keyword	ispcTemplates		template typename
 syn keyword	ispcDefine		ISPC ISPC_POINTER_SIZE ISPC_MAJOR_VERSION ISPC_MINOR_VERSION TARGET_WIDTH PI
 					\ TARGET_ELEMENT_WIDTH ISPC_UINT_IS_DEFINED ISPC_FP16_SUPPORTED ISPC_FP64_SUPPORTED ISPC_LLVM_INTRINSICS_ENABLED
 					\ ISPC_TARGET_NEON ISPC_TARGET_SSE2 ISPC_TARGET_SSE4 ISPC_TARGET_AVX ISPC_TARGET_AVX2 ISPC_TARGET_AVX512KNL ISPC_TARGET_AVX512SKX
@@ -54,6 +55,7 @@ HiLink ispcConditional	Conditional
 HiLink ispcRepeat	Repeat
 HiLink ispcBuiltin	Statement
 HiLink ispcType		Type
+HiLink ispcTemplates	Type
 HiLink ispcOperator	Operator
 HiLink ispcDefine	Define
 HiLink ispcStorageClass	StorageClass

--- a/docs/design/templates.rst
+++ b/docs/design/templates.rst
@@ -1,0 +1,168 @@
+=================
+Templates support
+=================
+
+Language design
+---------------
+
+Please refer to ``Function Template`` section of ``User Guide``.
+
+Implementation design
+---------------------
+
+An AST node for template function is `FunctionTemplate`, which is similar to `Function`, but stores type parameters
+(represented by `TemplateTypeParmType``).  The body of `FunctionTemplate` contains `TemplateTypeParmType`, which implies
+that some of type checking may not be done until after the function is instantiated.  This requires redesigning type
+checking, which needs to be decoupled from AST creation.
+
+Implementation details
+----------------------
+
+Type checking is generally not done for function templates, it's only done the instantiations. Nevertheless type
+checking might be invoked for selected expressions, as it might be required to implement GetType() and GetValue()
+functions. More disciplined approach would do type checking on function templates, but bail in case type dependent
+expressions. The reason to do type checking in this manner is to report those errors that are possible to report without
+resolving dependent types.
+
+Template argument deduction mechanism. It's implemented as part of FunctionSymbolExpr logic. When function call is
+parsed, it's not known if the call is to a function or a function template, so template argument deduction is part of
+general overload resolution process.
+
+Possible variants of template argument deduction rules
+------------------------------------------------------
+
+While the rules generally follow C++ rules, the existence of `uniform`, `varying`, and `unbound` types, creates a
+certain variability in design space for the language. They basically boil down to tree questions that have binary
+answers:
+
+1. whether resolved type parameters might be `unbound` or not;
+2. whether variability of type parameter `T` might be overwritten by `uniform` or `varying` specifier or not;
+3. whether strict matching is required for template type arguments variability with template parameters variability
+   or not.
+
+For the (1) there's a temptation to allow `unbound` types, as this is generally how ISPC type system works. I.e. the
+types themselves are either `uniform`, `varying`, or `unbound`, while variables might have only `uniform` or `varying`
+types. If the variable is declared with `unbound` type (for example `int i`), the default kicks in that treats `unbound`
+as `varying`.
+
+The major drawback of allowing `unbound` types as resolved template type parameters is that it creates the possibility
+for the user to unconsciously create two function instances instead of one. Consider the following example:
+
+.. code-block:: cpp
+    template <typename T> T foo(T t);
+
+    // Two instances should be created, which is very likely not the intended by the user.
+    foo<int>(1);
+    foo<varying int>(2);
+
+Another drawback is that existence of `unbound` type pushed towards prioritization of `unbound` version of the type
+during template type deduction, while it is preferable to prioritize `uniform` as better performing version (if such
+possibility exists).
+
+So the decision is to require template type parameters to resolve only to `uniform` and `varying`, but not `unbound`
+types.
+
+For the (2), the decision is to allow overwriting of variability of template type parameter `T` with keywords `uniform`
+and `varying` to allow better flexibility and expressiveness of the code. For example:
+
+.. code-block:: cpp
+    template <typename T> void foo() {
+        uniform T ut; // it's always legal to have "uniform T"
+        varying T vt; // and "varying T", regardless of T variability.
+    };
+
+Nevertheless, the type deduction rules might be different with respect to `uniform` and `varying` keywords, i.e.
+consider the following:
+
+.. code-block:: cpp
+    template <typename T> void foo1(T t);
+    template <typename T> void foo2(uniform T t);
+    template <typename T> void foo3(varying T t);
+
+    uniform int ui;
+    varying int vi;
+    foo1(ui); // T is uniform
+    foo1(vi); // T is varying
+    foo2(ui); // not clear if "uniform" key word should "cancel" uniform variability of type T
+    foo2(vi); // error: varying type cannot be passed to uniform parameter
+    foo3(ui); // not clear...
+    foo3(vi); // not clear if "varying" key word should "cancel" varying variability of type T
+
+There might be multiple justifications and considerations on "not clear" cases. The proposal is to treat `uniform` and
+`varying` keywords as assumption that T has an opposite variability, so the keywords are specified on purpose. i.e.:
+
+    argument |     T t     | uniform T t | varying T t
+    --------------------------------------------------
+    uniform  | T = uniform | T = varying | T = uniform
+    varying  | T = varying | error       | T = uniform
+
+For the (3), C++ philosophy requires strict type matching, i.e. in C++:
+
+.. code-block:: cpp
+    template <typename T> void foo(T t1, T t2);
+
+    int i;
+    unsigned int ui;
+    foo(i, ui); // error: conflict between resolution to T = int and T = unsigned int
+
+But in ISPC it's frequent case when uniform argument is passed to varying parameter assuming default conversion rules
+that cause value broadcast.  Disallowing this case for function templates would cause major inconvenience and would be a
+blocker for using function templates in libraries that assumed to be drop-in replacement for versions implemented using
+function overloads.
+
+.. code-block:: cpp
+    template <typename T> T fma(T t1, T t2, T t3);
+
+    varying float v1, v2;
+    varying float fma(v1, v2, 2f); // this should be allowed.
+
+So this the decision is to:
+1. allow only `uniform` and `varying` as resolved template type parameters values, but not `unbound`;
+2. variability of template type parameter `T` might be overwritten by `uniform` and `varying` keywords: `uniform T` and
+   `varying T` are always valid;
+3. strict matching of template type parameters and template argument variability is not required, `uniform` argument
+   might be passed to `varying` parameter.
+
+Open design issues
+------------------
+
+AST is implemented as a collection of `Functions`, which means:
+- Any manipulation with AST on module level need to be changed synchronously - i.e. covering `FunctionTemplate` in
+  addition to `Functions`.  A better design would be to have a single AST root node (`Module`?) that would contain all
+  the functions, global variable declarations, typedefs, and templates;
+- Symbol table exists as a separate entity and variable declarations on module level do not have AST node.
+
+Also there are some other issues, which require refactoring and redesign:
+- Symbols in symbol table do not have explicit information about their definition scope - if they are global or local.
+  This needs to be fixed, as it's required to implement correct template instantiation - global symbols should not be
+  duplicated.
+- `Symbol` and `TemplateSymbol` need to be unified. The `Symbol` class itself is overloaded and needs redesign to
+  clearly distinguish between different types of symbols and their properties.
+- Error reporting needs to be dramatically improved for templates, this includes better error messages with detailed
+  reasons for rejecting specific template function overloads in the process of template argument deduction and
+  information about current template instantiation during instantiation process.
+- SFINAE-like mechanism for template instantiations. Some of template instantiations may fail to instantiate and this
+  should be ok, as other overloads may be valid.
+- Template function declarations should be fully supported. Right now they are parsed, but do not work as a valid
+  function templates for the purpose of template argument deduction.
+- A function symbol may refer to both functions and function templates, right now the candidate list is built from
+  either of them, but not both, this needs to be fixed.
+
+C++ template argument deduction algorithm
+-----------------------------------------
+
+The template argument deduction algorithm is described in [temp.deduct], [temp.deduct.call], and [temp.deduct.type]
+sections of C++ standard. It's useful to read these sections, but no sane human being can convert it to working
+algorithm correctly without extra knowledge. The recommended way to learn more is to read and debug clang's function
+`DeduceTemplateArgumentsFromCallArgument()`.
+
+Notable not obvious points:
+- In C++, the type of an expression is always adjusted so that it will not have reference type (C++ [expr]p6). I.e. the
+  standard describes stripping cv-qualifiers from argument type, but not reference, because it's assumed to be already
+  stripped before starting the process.
+- `const T &` is a reference type, but not a constant type. Stripping cv-qualifiers from this type has no effect, but
+  stripping reference type yields `cosnt T`.
+
+Also it might be useful to check [temp.dep.type] and [temp.dep.expr] sections of C++ standard to get better context of
+dependent types and expressions.
+

--- a/src/ast.h
+++ b/src/ast.h
@@ -213,6 +213,8 @@ class AST {
         information and source code. */
     void AddFunction(Symbol *sym, Stmt *code);
 
+    void AddFunctionTemplate(TemplateSymbol *templ, Stmt *code);
+
     /** Generate LLVM IR for all of the functions into the current
         module. */
     void GenerateIR();
@@ -221,6 +223,7 @@ class AST {
 
   private:
     std::vector<Function *> functions;
+    std::vector<FunctionTemplate *> functionTemplates;
 };
 
 /** Callback function type for preorder traversial visiting function for

--- a/src/ast.h
+++ b/src/ast.h
@@ -134,6 +134,8 @@ class ASTNode : public Traceable {
         enumerant values defined in ispc.h. */
     virtual int EstimateCost() const = 0;
 
+    virtual ASTNode *Instantiate(TemplateInstantiation &templInst) const = 0;
+
     /** All AST nodes must track the file position where they are
         defined. */
     SourcePos pos;

--- a/src/ast.h
+++ b/src/ast.h
@@ -158,6 +158,7 @@ class ASTNode : public Traceable {
         IndexExprID,
         StructMemberExprID,
         VectorMemberExprID,
+        DependentMemberExprID,
         NewExprID,
         NullPointerExprID,
         ReferenceExprID,

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2022, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -472,7 +472,9 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
                 snprintf(buf, sizeof(buf), "__anon_parameter_%d", i);
                 decl->name = buf;
             }
-            decl->type = decl->type->ResolveUnboundVariability(Variability::Varying);
+            if (!decl->type->IsDependentType()) {
+                decl->type = decl->type->ResolveUnboundVariability(Variability::Varying);
+            }
 
             if (d->declSpecs->storageClass != SC_NONE)
                 Error(decl->pos,
@@ -553,7 +555,9 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
             return;
         }
 
-        returnType = returnType->ResolveUnboundVariability(Variability::Varying);
+        if (!returnType->IsDependentType()) {
+            returnType = returnType->ResolveUnboundVariability(Variability::Varying);
+        }
 
         bool isExternC = ds && (ds->storageClass == SC_EXTERN_C);
         bool isExternSYCL = ds && (ds->storageClass == SC_EXTERN_SYCL);
@@ -662,7 +666,9 @@ std::vector<VariableDeclaration> Declaration::GetVariableDeclarations() const {
         if (decl->type->IsVoidType())
             Error(decl->pos, "\"void\" type variable illegal in declaration.");
         else if (CastType<FunctionType>(decl->type) == NULL) {
-            decl->type = decl->type->ResolveUnboundVariability(Variability::Varying);
+            if (!decl->type->IsDependentType()) {
+                decl->type = decl->type->ResolveUnboundVariability(Variability::Varying);
+            }
             Symbol *sym = new Symbol(decl->name, decl->pos, decl->type, decl->storageClass);
             m->symbolTable->AddVariable(sym);
             vars.push_back(VariableDeclaration(sym, decl->initExpr));

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -8439,7 +8439,16 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
                     paramType = paramType->GetAsNonConstType();
 
                     // If P is not a reference:
-                    // TODO: - if A is an array type, apply array-to-pointer conversion.
+                    // - if A is an array type, apply array-to-pointer conversion.
+                    const ArrayType *at = CastType<ArrayType>(argType);
+                    if (at) {
+                        const Type *targetType = at->GetElementType();
+                        if (targetType == NULL) {
+                            deductionFailed = true;
+                            break;
+                        }
+                        argType = PointerType::GetUniform(targetType, at->IsSOAType());
+                    }
                     // TODO: - if A is a function type, apply function-to-pointer conversion.
                     // - if A is a cv-qualified type, remove the top level cv-qualifiers from A.
                     argType = argType->GetAsNonConstType();

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -38,6 +38,7 @@
 #include "expr.h"
 #include "ast.h"
 #include "ctx.h"
+#include "func.h"
 #include "llvmutil.h"
 #include "module.h"
 #include "sym.h"
@@ -1316,6 +1317,11 @@ int UnaryExpr::EstimateCost() const {
         return 0;
 
     return COST_SIMPLE_ARITH_LOGIC_OP;
+}
+
+UnaryExpr *UnaryExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Expr *instExpr = expr ? expr->Instantiate(templInst) : nullptr;
+    return new UnaryExpr(op, instExpr, pos);
 }
 
 void UnaryExpr::Print(Indent &indent) const {
@@ -2824,6 +2830,12 @@ int BinaryExpr::EstimateCost() const {
     return (op == Div || op == Mod) ? COST_COMPLEX_ARITH_OP : COST_SIMPLE_ARITH_LOGIC_OP;
 }
 
+Expr *BinaryExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Expr *instArg0 = arg0 ? arg0->Instantiate(templInst) : nullptr;
+    Expr *instArg1 = arg1 ? arg1->Instantiate(templInst) : nullptr;
+    return MakeBinaryExpr(op, instArg0, instArg1, pos);
+}
+
 void BinaryExpr::Print(Indent &indent) const {
     if (!arg0 || !arg1 || !GetType()) {
         indent.Print("BinaryExpr: <NULL EXPR>\n");
@@ -3244,6 +3256,12 @@ int AssignExpr::EstimateCost() const {
         return COST_ASSIGN + COST_SIMPLE_ARITH_LOGIC_OP;
 }
 
+AssignExpr *AssignExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Expr *instLValue = lvalue ? lvalue->Instantiate(templInst) : nullptr;
+    Expr *instRValue = rvalue ? rvalue->Instantiate(templInst) : nullptr;
+    return new AssignExpr(op, instLValue, instRValue, pos);
+}
+
 void AssignExpr::Print(Indent &indent) const {
     if (!lvalue || !rvalue || !GetType()) {
         indent.Print("AssignExpr: <NULL EXPR>\n");
@@ -3628,6 +3646,13 @@ Expr *SelectExpr::TypeCheck() {
 }
 
 int SelectExpr::EstimateCost() const { return COST_SELECT; }
+
+SelectExpr *SelectExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Expr *instTest = test ? test->Instantiate(templInst) : nullptr;
+    Expr *instExpr1 = expr1 ? expr1->Instantiate(templInst) : nullptr;
+    Expr *instExpr2 = expr2 ? expr2->Instantiate(templInst) : nullptr;
+    return new SelectExpr(instTest, instExpr1, instExpr2, pos);
+}
 
 void SelectExpr::Print(Indent &indent) const {
     if (!test || !expr1 || !expr2 || !GetType()) {
@@ -4017,13 +4042,22 @@ int FunctionCallExpr::EstimateCost() const {
         return COST_FUNCALL;
 }
 
+FunctionCallExpr *FunctionCallExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Expr *instFunc = func ? func->Instantiate(templInst) : nullptr;
+    ExprList *instantiatedArgs = args ? args->Instantiate(templInst) : nullptr;
+    FunctionCallExpr *inst = new FunctionCallExpr(instFunc, instantiatedArgs, pos, isLaunch);
+    inst->launchCountExpr[0] = launchCountExpr[0] ? launchCountExpr[0]->Instantiate(templInst) : nullptr;
+    inst->launchCountExpr[1] = launchCountExpr[1] ? launchCountExpr[1]->Instantiate(templInst) : nullptr;
+    inst->launchCountExpr[2] = launchCountExpr[2] ? launchCountExpr[2]->Instantiate(templInst) : nullptr;
+    return inst;
+}
+
 void FunctionCallExpr::Print(Indent &indent) const {
     if (!func || !args || !GetType()) {
         indent.Print("FunctionCallExpr: <NULL EXPR>\n");
         indent.Done();
         return;
     }
-
     indent.Print("FunctionCallExpr", pos);
 
     printf("[%s] %s %s\n", GetType()->GetString().c_str(), isLaunch ? "launch" : "", isInvoke ? "invoke_sycl" : "");
@@ -4218,6 +4252,14 @@ std::pair<llvm::Constant *, bool> ExprList::GetConstant(const Type *type) const 
 }
 
 int ExprList::EstimateCost() const { return 0; }
+
+ExprList *ExprList::Instantiate(TemplateInstantiation &templInst) const {
+    ExprList *inst = new ExprList(pos);
+    for (auto e : exprs) {
+        inst->exprs.push_back(e->Instantiate(templInst));
+    }
+    return inst;
+}
 
 void ExprList::Print(Indent &indent) const {
     indent.PrintLn("ExprList", pos);
@@ -4727,6 +4769,12 @@ int IndexExpr::EstimateCost() const {
         return COST_GATHER;
     else
         return COST_LOAD;
+}
+
+IndexExpr *IndexExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Expr *instBaseExpr = baseExpr ? baseExpr->Instantiate(templInst) : nullptr;
+    Expr *instIndex = index ? index->Instantiate(templInst) : nullptr;
+    return new IndexExpr(instBaseExpr, instIndex, pos);
 }
 
 void IndexExpr::Print(Indent &indent) const {
@@ -5243,6 +5291,11 @@ int MemberExpr::EstimateCost() const {
         return COST_GATHER + COST_SIMPLE_ARITH_LOGIC_OP;
     else
         return COST_SIMPLE_ARITH_LOGIC_OP;
+}
+
+MemberExpr *MemberExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Expr *instExpr = expr ? expr->Instantiate(templInst) : nullptr;
+    return MemberExpr::create(instExpr, identifier.c_str(), pos, identifierPos, dereferenceExpr);
 }
 
 void MemberExpr::Print(Indent &indent) const {
@@ -5886,6 +5939,8 @@ Expr *ConstExpr::Optimize() { return this; }
 Expr *ConstExpr::TypeCheck() { return this; }
 
 int ConstExpr::EstimateCost() const { return 0; }
+
+ConstExpr *ConstExpr::Instantiate(TemplateInstantiation &templInst) const { return new ConstExpr(this, pos); }
 
 void ConstExpr::Print(Indent &indent) const {
     indent.Print("ConstExpr", pos);
@@ -7152,6 +7207,12 @@ int TypeCastExpr::EstimateCost() const {
     return COST_TYPECAST_SIMPLE;
 }
 
+TypeCastExpr *TypeCastExpr::Instantiate(TemplateInstantiation &templInst) const {
+    const Type *instType = type ? type->ResolveDependence(templInst) : nullptr;
+    Expr *instExpr = expr ? expr->Instantiate(templInst) : nullptr;
+    return new TypeCastExpr(instType, instExpr, pos);
+}
+
 void TypeCastExpr::Print(Indent &indent) const {
     indent.Print("TypeCastExpr", pos);
     printf("[%s]\n", GetType()->GetString().c_str());
@@ -7298,6 +7359,11 @@ Expr *ReferenceExpr::TypeCheck() {
 
 int ReferenceExpr::EstimateCost() const { return 0; }
 
+ReferenceExpr *ReferenceExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Expr *instExpr = expr ? expr->Instantiate(templInst) : nullptr;
+    return new ReferenceExpr(instExpr, pos);
+}
+
 void ReferenceExpr::Print(Indent &indent) const {
     if (expr == NULL || GetType() == NULL) {
         indent.Print("ReferenceExpr: <NULL EXPR>\n");
@@ -7416,6 +7482,11 @@ int PtrDerefExpr::EstimateCost() const {
         return COST_DEREF;
 }
 
+PtrDerefExpr *PtrDerefExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Expr *instExpr = expr ? expr->Instantiate(templInst) : nullptr;
+    return new PtrDerefExpr(instExpr, pos);
+}
+
 void PtrDerefExpr::Print(Indent &indent) const {
     if (expr == NULL || GetType() == NULL) {
         indent.Print("PtrDerefExpr: <NULL EXPR>\n");
@@ -7468,6 +7539,11 @@ int RefDerefExpr::EstimateCost() const {
         return 0;
 
     return COST_DEREF;
+}
+
+RefDerefExpr *RefDerefExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Expr *instExpr = expr ? expr->Instantiate(templInst) : nullptr;
+    return new RefDerefExpr(instExpr, pos);
 }
 
 void RefDerefExpr::Print(Indent &indent) const {
@@ -7573,6 +7649,11 @@ Expr *AddressOfExpr::TypeCheck() {
 Expr *AddressOfExpr::Optimize() { return this; }
 
 int AddressOfExpr::EstimateCost() const { return 0; }
+
+AddressOfExpr *AddressOfExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Expr *instExpr = expr ? expr->Instantiate(templInst) : nullptr;
+    return new AddressOfExpr(instExpr, pos);
+}
 
 std::pair<llvm::Constant *, bool> AddressOfExpr::GetConstant(const Type *type) const {
     if (expr == NULL || expr->GetType() == NULL) {
@@ -7689,6 +7770,14 @@ Expr *SizeOfExpr::Optimize() { return this; }
 
 int SizeOfExpr::EstimateCost() const { return 0; }
 
+SizeOfExpr *SizeOfExpr::Instantiate(TemplateInstantiation &templInst) const {
+    if (expr != nullptr) {
+        return new SizeOfExpr(expr->Instantiate(templInst), pos);
+    }
+    Assert(type != nullptr);
+    return new SizeOfExpr(type->ResolveDependence(templInst), pos);
+}
+
 std::pair<llvm::Constant *, bool> SizeOfExpr::GetConstant(const Type *rtype) const {
     const Type *t = expr ? expr->GetType() : type;
     if (t == NULL)
@@ -7766,6 +7855,11 @@ Expr *AllocaExpr::Optimize() { return this; }
 
 int AllocaExpr::EstimateCost() const { return 0; }
 
+AllocaExpr *AllocaExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Expr *instExpr = expr ? expr->Instantiate(templInst) : nullptr;
+    return new AllocaExpr(instExpr, pos);
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // SymbolExpr
 
@@ -7827,6 +7921,11 @@ int SymbolExpr::EstimateCost() const {
     return 0;
 }
 
+SymbolExpr *SymbolExpr::Instantiate(TemplateInstantiation &templInst) const {
+    Symbol *resolvedSymbol = templInst.InstantiateSymbol(symbol);
+    return new SymbolExpr(resolvedSymbol, pos);
+}
+
 void SymbolExpr::Print(Indent &indent) const {
     if (symbol == NULL || GetType() == NULL) {
         indent.Print("SymbolExpr: <NULL EXPR>\n");
@@ -7869,6 +7968,10 @@ Expr *FunctionSymbolExpr::TypeCheck() { return this; }
 Expr *FunctionSymbolExpr::Optimize() { return this; }
 
 int FunctionSymbolExpr::EstimateCost() const { return 0; }
+
+FunctionSymbolExpr *FunctionSymbolExpr::Instantiate(TemplateInstantiation &templInst) const {
+    return new FunctionSymbolExpr(name.c_str(), candidateFunctions, pos);
+}
 
 void FunctionSymbolExpr::Print(Indent &indent) const {
     if (!matchingFunc || !GetType()) {
@@ -8235,6 +8338,8 @@ llvm::Value *SyncExpr::GetValue(FunctionEmitContext *ctx) const {
 
 int SyncExpr::EstimateCost() const { return COST_SYNC; }
 
+SyncExpr *SyncExpr::Instantiate(TemplateInstantiation &templInst) const { return new SyncExpr(pos); }
+
 void SyncExpr::Print(Indent &indent) const {
     indent.PrintLn("SyncExpr", pos);
     indent.Done();
@@ -8278,6 +8383,10 @@ void NullPointerExpr::Print(Indent &indent) const {
 
 int NullPointerExpr::EstimateCost() const { return 0; }
 
+NullPointerExpr *NullPointerExpr::Instantiate(TemplateInstantiation &templInst) const {
+    return new NullPointerExpr(pos);
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // NewExpr
 
@@ -8306,6 +8415,10 @@ NewExpr::NewExpr(int typeQual, const Type *t, Expr *init, Expr *count, SourcePos
     if (allocType != NULL)
         allocType = allocType->ResolveUnboundVariability(Variability::Uniform);
 }
+
+// Private constructor for cloning.
+NewExpr::NewExpr(const Type *type, Expr *count, Expr *init, bool isV, SourcePos p)
+    : Expr(p, NewExprID), allocType(type), countExpr(count), initExpr(init), isVarying(isV) {}
 
 llvm::Value *NewExpr::GetValue(FunctionEmitContext *ctx) const {
     bool do32Bit = (g->target->is32Bit() || g->opt.force32BitAddressing);
@@ -8513,3 +8626,10 @@ void NewExpr::Print(Indent &indent) const {
 }
 
 int NewExpr::EstimateCost() const { return COST_NEW; }
+
+NewExpr *NewExpr::Instantiate(TemplateInstantiation &templInst) const {
+    const Type *instType = allocType ? allocType->ResolveDependence(templInst) : nullptr;
+    Expr *instInit = initExpr ? initExpr->Instantiate(templInst) : nullptr;
+    Expr *instCount = countExpr ? countExpr->Instantiate(templInst) : nullptr;
+    return new NewExpr(instType, instCount, instInit, isVarying, pos);
+}

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -5192,6 +5192,21 @@ int VectorMemberExpr::getElementNumber() const {
 
 const Type *VectorMemberExpr::getElementType() const { return memberType; }
 
+//////////////////////////////////////////////////
+// DependentMemberExpr
+
+DependentMemberExpr::DependentMemberExpr(Expr *e, const char *id, SourcePos p, SourcePos idpos, bool derefLValue)
+    : MemberExpr(e, id, p, idpos, derefLValue, DependentMemberExprID) {
+    Assert(e != NULL);
+    Assert(id != NULL);
+}
+
+int DependentMemberExpr::getElementNumber() const { UNREACHABLE(); };
+const Type *DependentMemberExpr::getElementType() const { UNREACHABLE(); };
+
+//////////////////////////////////////////////////
+// MemberExpr
+
 MemberExpr *MemberExpr::create(Expr *e, const char *id, SourcePos p, SourcePos idpos, bool derefLValue) {
     // FIXME: we need to call TypeCheck() here so that we can call
     // e->GetType() in the following.  But really we just shouldn't try to
@@ -5202,6 +5217,10 @@ MemberExpr *MemberExpr::create(Expr *e, const char *id, SourcePos p, SourcePos i
     const Type *exprType;
     if (e == NULL || (exprType = e->GetType()) == NULL)
         return NULL;
+
+    if (exprType->IsDependentType()) {
+        return new DependentMemberExpr(e, id, p, idpos, derefLValue);
+    }
 
     const ReferenceType *referenceType = CastType<ReferenceType>(exprType);
     if (referenceType != NULL) {
@@ -5374,6 +5393,8 @@ void MemberExpr::Print(Indent &indent) const {
         indent.Print("StructMemberExpr", pos);
     } else if (getValueID() == VectorMemberExprID) {
         indent.Print("VectorMemberExpr", pos);
+    } else if (getValueID() == DependentMemberExprID) {
+        indent.Print("DependentMemberExpr", pos);
     } else {
         indent.Print("MemberExpr", pos);
     }

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -8078,7 +8078,17 @@ Expr *FunctionSymbolExpr::Optimize() { return this; }
 int FunctionSymbolExpr::EstimateCost() const { return 0; }
 
 FunctionSymbolExpr *FunctionSymbolExpr::Instantiate(TemplateInstantiation &templInst) const {
-    return new FunctionSymbolExpr(name.c_str(), candidateFunctions, pos);
+    // TODO: interfaces for regular function call and template function call should be unified.
+    // Bonus: it is possbile that a call can possbily refer to both.
+    if (candidateFunctions.size() != 0) {
+        Assert(candidateTemplateFunctions.size() == 0);
+        return new FunctionSymbolExpr(name.c_str(), candidateFunctions, pos);
+    }
+    std::vector<std::pair<const Type *, SourcePos>> instTemplateArgs;
+    for (auto arg : templateArgs) {
+        instTemplateArgs.push_back(std::make_pair(arg.first->ResolveDependence(templInst), arg.second));
+    }
+    return new FunctionSymbolExpr(name.c_str(), candidateTemplateFunctions, instTemplateArgs, pos);
 }
 
 void FunctionSymbolExpr::Print(Indent &indent) const {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -8085,7 +8085,7 @@ FunctionSymbolExpr *FunctionSymbolExpr::Instantiate(TemplateInstantiation &templ
         return new FunctionSymbolExpr(name.c_str(), candidateFunctions, pos);
     }
     std::vector<std::pair<const Type *, SourcePos>> instTemplateArgs;
-    for (auto arg : templateArgs) {
+    for (auto &arg : templateArgs) {
         instTemplateArgs.push_back(std::make_pair(arg.first->ResolveDependence(templInst), arg.second));
     }
     return new FunctionSymbolExpr(name.c_str(), candidateTemplateFunctions, instTemplateArgs, pos);

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -7272,7 +7272,7 @@ int TypeCastExpr::EstimateCost() const {
 }
 
 TypeCastExpr *TypeCastExpr::Instantiate(TemplateInstantiation &templInst) const {
-    const Type *instType = type ? type->ResolveDependence(templInst) : nullptr;
+    const Type *instType = type ? type->ResolveDependenceForTopType(templInst) : nullptr;
     Expr *instExpr = expr ? expr->Instantiate(templInst) : nullptr;
     return new TypeCastExpr(instType, instExpr, pos);
 }
@@ -8086,7 +8086,7 @@ FunctionSymbolExpr *FunctionSymbolExpr::Instantiate(TemplateInstantiation &templ
     }
     std::vector<std::pair<const Type *, SourcePos>> instTemplateArgs;
     for (auto &arg : templateArgs) {
-        instTemplateArgs.push_back(std::make_pair(arg.first->ResolveDependence(templInst), arg.second));
+        instTemplateArgs.push_back(std::make_pair(arg.first->ResolveDependenceForTopType(templInst), arg.second));
     }
     return new FunctionSymbolExpr(name.c_str(), candidateTemplateFunctions, instTemplateArgs, pos);
 }
@@ -8805,7 +8805,7 @@ void NewExpr::Print(Indent &indent) const {
 int NewExpr::EstimateCost() const { return COST_NEW; }
 
 NewExpr *NewExpr::Instantiate(TemplateInstantiation &templInst) const {
-    const Type *instType = allocType ? allocType->ResolveDependence(templInst) : nullptr;
+    const Type *instType = allocType ? allocType->ResolveDependenceForTopType(templInst) : nullptr;
     Expr *instInit = initExpr ? initExpr->Instantiate(templInst) : nullptr;
     Expr *instCount = countExpr ? countExpr->Instantiate(templInst) : nullptr;
     return new NewExpr(instType, instCount, instInit, isVarying, pos);

--- a/src/expr.h
+++ b/src/expr.h
@@ -743,7 +743,7 @@ class FunctionSymbolExpr : public Expr {
   public:
     FunctionSymbolExpr(const char *name, const std::vector<Symbol *> &candFuncs, SourcePos pos);
     FunctionSymbolExpr(const char *name, const std::vector<TemplateSymbol *> &candFuncs,
-                       std::vector<std::pair<const Type *, SourcePos>> &types, SourcePos pos);
+                       const std::vector<std::pair<const Type *, SourcePos>> &types, SourcePos pos);
 
     static inline bool classof(FunctionSymbolExpr const *) { return true; }
     static inline bool classof(ASTNode const *N) { return N->getValueID() == FunctionSymbolExprID; }

--- a/src/expr.h
+++ b/src/expr.h
@@ -106,6 +106,8 @@ class Expr : public ASTNode {
         encountered, NULL should be returned. */
     virtual Expr *TypeCheck() = 0;
 
+    virtual Expr *Instantiate(TemplateInstantiation &templInst) const = 0;
+
     virtual bool HasAmbiguousVariability(std::vector<const Expr *> &warn) const;
 };
 
@@ -133,6 +135,7 @@ class UnaryExpr : public Expr {
     Expr *Optimize();
     Expr *TypeCheck();
     int EstimateCost() const;
+    UnaryExpr *Instantiate(TemplateInstantiation &templInst) const;
 
     const Op op;
     Expr *expr;
@@ -179,6 +182,7 @@ class BinaryExpr : public Expr {
     Expr *Optimize();
     Expr *TypeCheck();
     int EstimateCost() const;
+    Expr *Instantiate(TemplateInstantiation &templInst) const;
     std::pair<llvm::Constant *, bool> GetStorageConstant(const Type *type) const;
     std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
     bool HasAmbiguousVariability(std::vector<const Expr *> &warn) const;
@@ -216,6 +220,7 @@ class AssignExpr : public Expr {
     Expr *Optimize();
     Expr *TypeCheck();
     int EstimateCost() const;
+    AssignExpr *Instantiate(TemplateInstantiation &templInst) const;
 
     const Op op;
     Expr *lvalue, *rvalue;
@@ -239,6 +244,7 @@ class SelectExpr : public Expr {
     Expr *Optimize();
     Expr *TypeCheck();
     int EstimateCost() const;
+    SelectExpr *Instantiate(TemplateInstantiation &templInst) const;
     bool HasAmbiguousVariability(std::vector<const Expr *> &warn) const;
 
     Expr *test, *expr1, *expr2;
@@ -266,6 +272,7 @@ class ExprList : public Expr {
     ExprList *Optimize();
     ExprList *TypeCheck();
     int EstimateCost() const;
+    ExprList *Instantiate(TemplateInstantiation &templInst) const;
     bool HasAmbiguousVariability(std::vector<const Expr *> &warn) const;
 
     std::vector<Expr *> exprs;
@@ -290,6 +297,7 @@ class FunctionCallExpr : public Expr {
     Expr *Optimize();
     Expr *TypeCheck();
     int EstimateCost() const;
+    FunctionCallExpr *Instantiate(TemplateInstantiation &templInst) const;
 
     Expr *func;
     ExprList *args;
@@ -320,6 +328,7 @@ class IndexExpr : public Expr {
     Expr *Optimize();
     Expr *TypeCheck();
     int EstimateCost() const;
+    IndexExpr *Instantiate(TemplateInstantiation &templInst) const;
 
     Expr *baseExpr, *index;
 
@@ -350,6 +359,7 @@ class MemberExpr : public Expr {
     Expr *Optimize();
     Expr *TypeCheck();
     int EstimateCost() const;
+    MemberExpr *Instantiate(TemplateInstantiation &templInst) const;
 
     virtual int getElementNumber() const = 0;
     virtual const Type *getElementType() const = 0;
@@ -478,6 +488,7 @@ class ConstExpr : public Expr {
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
+    ConstExpr *Instantiate(TemplateInstantiation &templInst) const;
 
     /** Return the ConstExpr's values as the given pointer type, doing type
         conversion from the actual type if needed.  If forceVarying is
@@ -536,6 +547,7 @@ class TypeCastExpr : public Expr {
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
+    TypeCastExpr *Instantiate(TemplateInstantiation &templInst) const;
     Symbol *GetBaseSymbol() const;
     std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
     bool HasAmbiguousVariability(std::vector<const Expr *> &warn) const;
@@ -562,6 +574,7 @@ class ReferenceExpr : public Expr {
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
+    ReferenceExpr *Instantiate(TemplateInstantiation &templInst) const;
 
     Expr *expr;
 };
@@ -600,6 +613,7 @@ class PtrDerefExpr : public DerefExpr {
     void Print(Indent &indent) const;
     Expr *TypeCheck();
     int EstimateCost() const;
+    PtrDerefExpr *Instantiate(TemplateInstantiation &templInst) const;
 };
 
 /** @brief Expression that represents dereferencing a reference to get its
@@ -615,6 +629,7 @@ class RefDerefExpr : public DerefExpr {
     void Print(Indent &indent) const;
     Expr *TypeCheck();
     int EstimateCost() const;
+    RefDerefExpr *Instantiate(TemplateInstantiation &templInst) const;
 };
 
 /** Expression that represents taking the address of an expression. */
@@ -633,6 +648,7 @@ class AddressOfExpr : public Expr {
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
+    AddressOfExpr *Instantiate(TemplateInstantiation &templInst) const;
     std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
     Expr *expr;
@@ -654,6 +670,7 @@ class SizeOfExpr : public Expr {
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
+    SizeOfExpr *Instantiate(TemplateInstantiation &templInst) const;
     std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
     /* One of expr or type should be non-NULL (but not both of them).  The
@@ -677,6 +694,7 @@ class AllocaExpr : public Expr {
     Expr *TypeCheck();
     Expr *Optimize();
     int EstimateCost() const;
+    AllocaExpr *Instantiate(TemplateInstantiation &templInst) const;
 
     // The expr should have size_t type and should evaluate to size
     // of stack memory to be allocated.
@@ -700,6 +718,7 @@ class SymbolExpr : public Expr {
     Expr *Optimize();
     void Print(Indent &indent) const;
     int EstimateCost() const;
+    SymbolExpr *Instantiate(TemplateInstantiation &templInst) const;
 
   private:
     Symbol *symbol;
@@ -722,6 +741,7 @@ class FunctionSymbolExpr : public Expr {
     Expr *Optimize();
     void Print(Indent &indent) const;
     int EstimateCost() const;
+    FunctionSymbolExpr *Instantiate(TemplateInstantiation &templInst) const;
     std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
     /** Given the types of the function arguments, in the presence of
@@ -775,6 +795,7 @@ class SyncExpr : public Expr {
     Expr *Optimize();
     void Print(Indent &indent) const;
     int EstimateCost() const;
+    SyncExpr *Instantiate(TemplateInstantiation &templInst) const;
 };
 
 /** @brief An expression that represents a NULL pointer. */
@@ -792,6 +813,7 @@ class NullPointerExpr : public Expr {
     std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
     void Print(Indent &indent) const;
     int EstimateCost() const;
+    NullPointerExpr *Instantiate(TemplateInstantiation &templInst) const;
 };
 
 /** An expression representing a "new" expression, used for dynamically
@@ -810,6 +832,7 @@ class NewExpr : public Expr {
     Expr *Optimize();
     void Print(Indent &indent) const;
     int EstimateCost() const;
+    NewExpr *Instantiate(TemplateInstantiation &templInst) const;
 
     /** Type of object to allocate storage for. */
     const Type *allocType;
@@ -825,6 +848,9 @@ class NewExpr : public Expr {
         instance, or whether a single allocation is performed for the
         entire gang of program instances.) */
     bool isVarying;
+
+  private:
+    NewExpr(const Type *type, Expr *count, Expr *init, bool isV, SourcePos p);
 };
 
 /** This function indicates whether it's legal to convert from fromType to

--- a/src/expr.h
+++ b/src/expr.h
@@ -730,6 +730,8 @@ class SymbolExpr : public Expr {
 class FunctionSymbolExpr : public Expr {
   public:
     FunctionSymbolExpr(const char *name, const std::vector<Symbol *> &candFuncs, SourcePos pos);
+    FunctionSymbolExpr(const char *name, const std::vector<TemplateSymbol *> &candFuncs,
+                       std::vector<std::pair<const Type *, SourcePos>> &types, SourcePos pos);
 
     static inline bool classof(FunctionSymbolExpr const *) { return true; }
     static inline bool classof(ASTNode const *N) { return N->getValueID() == FunctionSymbolExprID; }
@@ -762,6 +764,7 @@ class FunctionSymbolExpr : public Expr {
 
   private:
     std::vector<Symbol *> getCandidateFunctions(int argCount) const;
+    std::vector<Symbol *> getCandidateTemplateFunctions(const std::vector<const Type *> &argTypes) const;
     static int computeOverloadCost(const FunctionType *ftype, const std::vector<const Type *> &argTypes,
                                    const std::vector<bool> *argCouldBeNULL, const std::vector<bool> *argIsConstant,
                                    int *cost);
@@ -773,6 +776,8 @@ class FunctionSymbolExpr : public Expr {
         there may be more then one, in which case we need to resolve which
         overload is the best match. */
     std::vector<Symbol *> candidateFunctions;
+    std::vector<TemplateSymbol *> candidateTemplateFunctions;
+    std::vector<std::pair<const Type *, SourcePos>> templateArgs;
 
     /** The actual matching function found after overload resolution. */
     Symbol *matchingFunc;

--- a/src/expr.h
+++ b/src/expr.h
@@ -783,6 +783,7 @@ class FunctionSymbolExpr : public Expr {
     Symbol *matchingFunc;
 
     bool triedToResolve;
+    bool unresolvedButDependent;
 };
 
 /** @brief A sync statement in the program (waits for all launched tasks before

--- a/src/expr.h
+++ b/src/expr.h
@@ -348,7 +348,8 @@ class MemberExpr : public Expr {
 
     static inline bool classof(MemberExpr const *) { return true; }
     static inline bool classof(ASTNode const *N) {
-        return ((N->getValueID() == StructMemberExprID) || (N->getValueID() == VectorMemberExprID));
+        return ((N->getValueID() == StructMemberExprID) || (N->getValueID() == VectorMemberExprID) ||
+                (N->getValueID() == DependentMemberExprID));
     }
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
@@ -415,6 +416,17 @@ class VectorMemberExpr : public MemberExpr {
   private:
     const VectorType *exprVectorType;
     const VectorType *memberType;
+};
+
+class DependentMemberExpr : public MemberExpr {
+  public:
+    DependentMemberExpr(Expr *e, const char *id, SourcePos p, SourcePos idpos, bool derefLValue);
+
+    static inline bool classof(DependentMemberExpr const *) { return true; }
+    static inline bool classof(ASTNode const *N) { return N->getValueID() == DependentMemberExprID; }
+
+    int getElementNumber() const;
+    const Type *getElementType() const;
 };
 
 /** @brief Expression representing a compile-time constant value.

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -1028,7 +1028,7 @@ Symbol *TemplateInstantiation::InstantiateSymbol(Symbol *sym) {
         return t->second;
     }
 
-    const Type *instType = sym->type->ResolveDependence(*this);
+    const Type *instType = sym->type->ResolveDependenceForTopType(*this);
     Symbol *instSym = new Symbol(sym->name, sym->pos, instType, sym->storageClass);
     instSym->constValue = sym->constValue ? sym->constValue->Instantiate(*this) : nullptr;
     instSym->varyingCFDepth = sym->varyingCFDepth;
@@ -1045,7 +1045,7 @@ Symbol *TemplateInstantiation::InstantiateTemplateSymbol(TemplateSymbol *sym) {
     Assert(sym && functionSym == nullptr);
 
     // Instantiate the function type
-    const Type *instType = sym->type->ResolveDependence(*this);
+    const Type *instType = sym->type->ResolveDependenceForTopType(*this);
 
     // Create a function symbol
     Symbol *instSym = new Symbol(sym->name, sym->pos, instType, SC_STATIC);

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -807,3 +807,20 @@ bool TemplateParms::IsEqual(const TemplateParms *p) const {
 
     return true;
 }
+
+///////////////////////////////////////////////////////////////////////////
+// TemplateArgs
+
+TemplateArgs::TemplateArgs(const std::vector<std::pair<const Type *, SourcePos>> &a) : args(a) {}
+
+bool TemplateArgs::IsEqual(TemplateArgs &otherArgs) const {
+    if (args.size() != otherArgs.args.size()) {
+        return false;
+    }
+    for (int i = 0; i < args.size(); i++) {
+        if (!Type::Equal(args[i].first, otherArgs.args[i].first)) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -996,6 +996,7 @@ TemplateInstantiation::TemplateInstantiation(const TemplateParms &typeParms,
         std::string name = typeParms[i]->GetName();
         const Type *type = typeArgs[i].first;
         args[name] = type;
+        templateArgs.push_back(typeArgs[i].first);
     }
 }
 
@@ -1081,7 +1082,7 @@ llvm::Function *TemplateInstantiation::createLLVMFunction(Symbol *functionSym, b
     }
 
     // Mangling
-    auto [name_pref, name_suf] = functionType->GetFunctionMangledName(false);
+    auto [name_pref, name_suf] = functionType->GetFunctionMangledName(false, &templateArgs);
     std::string functionName = name_pref + functionSym->name + name_suf;
 
     // And create the llvm::Function

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -778,3 +778,32 @@ void Function::GenerateIR() {
         }
     }
 }
+
+///////////////////////////////////////////////////////////////////////////
+// TemplateParms
+
+TemplateParms::TemplateParms() {}
+
+void TemplateParms::Add(const TemplateTypeParmType *p) { parms.push_back(p); }
+
+size_t TemplateParms::GetCount() const { return parms.size(); }
+
+const TemplateTypeParmType *TemplateParms::operator[](size_t i) const { return parms[i]; }
+
+bool TemplateParms::IsEqual(const TemplateParms *p) const {
+    if (p == nullptr) {
+        return false;
+    }
+
+    if (GetCount() != p->GetCount()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < GetCount(); i++) {
+        if (!Type::Equal((*this)[i], (*p)[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -991,18 +991,24 @@ Symbol *FunctionTemplate::AddInstantiation(const std::vector<std::pair<const Typ
 TemplateInstantiation::TemplateInstantiation(const TemplateParms &typeParms,
                                              const std::vector<std::pair<const Type *, SourcePos>> &typeArgs)
     : functionSym(nullptr) {
-    Assert(typeArgs.size() == typeParms.GetCount());
+    Assert(typeArgs.size() <= typeParms.GetCount());
+    // Create a mapping from the template parameters to the arguments.
+    // Note we do that for all specified templates arguments, which number may be less than a number of template
+    // parameters. In this case the rest of template parameters will be deduced later during template argumnet
+    // deduction.
     for (int i = 0; i < typeArgs.size(); i++) {
         std::string name = typeParms[i]->GetName();
         const Type *type = typeArgs[i].first;
-        args[name] = type;
+        argsMap[name] = type;
         templateArgs.push_back(typeArgs[i].first);
     }
 }
 
+void TemplateInstantiation::AddArgument(std::string paramName, const Type *argType) { argsMap[paramName] = argType; }
+
 const Type *TemplateInstantiation::InstantiateType(const std::string &name) {
-    auto t = args.find(name);
-    if (t == args.end()) {
+    auto t = argsMap.find(name);
+    if (t == argsMap.end()) {
         return nullptr;
     }
 

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -878,6 +878,24 @@ Symbol *TemplateInstantiation::InstantiateSymbol(Symbol *sym) {
     return instSym;
 }
 
+Symbol *TemplateInstantiation::InstantiateTemplateSymbol(TemplateSymbol *sym) {
+    // The function is assumed to be called once per instantiation and
+    // only for the tempalte that is being instantiated.
+    Assert(sym && functionSym == nullptr);
+
+    // Instantiate the function type
+    const Type *instType = sym->type->ResolveDependence(*this);
+
+    // Create a function symbol
+    Symbol *instSym = new Symbol(sym->name, sym->pos, instType, SC_STATIC);
+    functionSym = instSym;
+
+    // Create llvm::Function and attach to the symbol, so the symbol is complete and ready for use.
+    llvm::Function *llvmFunc = createLLVMFunction(instSym, sym->isInline, sym->isNoInline);
+    instSym->function = llvmFunc;
+    return instSym;
+}
+
 // After the instance of the template function is created, the symbols should point to the parent function.
 void TemplateInstantiation::SetFunction(Function *func) {
     for (auto &symPair : symMap) {
@@ -885,4 +903,9 @@ void TemplateInstantiation::SetFunction(Function *func) {
         sym->parentFunction = func;
     }
     functionSym->parentFunction = func;
+}
+
+llvm::Function *TemplateInstantiation::createLLVMFunction(Symbol *functionSym, bool isInline, bool isNoInline) {
+    // TODO: implement
+    return nullptr;
 }

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -824,3 +824,48 @@ bool TemplateArgs::IsEqual(TemplateArgs &otherArgs) const {
     }
     return true;
 }
+
+///////////////////////////////////////////////////////////////////////////
+// TemplateInstantiation
+
+TemplateInstantiation::TemplateInstantiation(const TemplateParms &typeParms,
+                                             const std::vector<std::pair<const Type *, SourcePos>> &typeArgs)
+    : functionSym(nullptr) {
+    Assert(typeArgs.size() == typeParms.GetCount());
+    for (int i = 0; i < typeArgs.size(); i++) {
+        std::string name = typeParms[i]->GetName();
+        const Type *type = typeArgs[i].first;
+        args[name] = type;
+    }
+}
+
+const Type *TemplateInstantiation::InstantiateType(const std::string &name) {
+    auto t = args.find(name);
+    if (t == args.end()) {
+        return nullptr;
+    }
+
+    return t->second;
+}
+
+Symbol *TemplateInstantiation::InstantiateSymbol(Symbol *sym) {
+    if (sym == nullptr) {
+        return nullptr;
+    }
+    auto t = symMap.find(sym);
+    if (t != symMap.end()) {
+        return t->second;
+    }
+
+    // TODO: implement symbol instantiation.
+    return sym;
+}
+
+// After the instance of the template function is created, the symbols should point to the parent function.
+void TemplateInstantiation::SetFunction(Function *func) {
+    for (auto &symPair : symMap) {
+        Symbol *sym = symPair.second;
+        sym->parentFunction = func;
+    }
+    functionSym->parentFunction = func;
+}

--- a/src/func.h
+++ b/src/func.h
@@ -49,6 +49,7 @@ namespace ispc {
 class Function {
   public:
     Function(Symbol *sym, Stmt *code);
+    Function(Symbol *sym, Stmt *code, Symbol *maskSymbol, std::vector<Symbol *> &args);
 
     const Type *GetReturnType() const;
     const FunctionType *GetType() const;
@@ -97,6 +98,32 @@ class TemplateArgs {
     bool IsEqual(TemplateArgs &otherArgs) const;
 
     std::vector<std::pair<const Type *, SourcePos>> args;
+};
+
+class FunctionTemplate {
+  public:
+    FunctionTemplate(TemplateSymbol *sym, Stmt *code);
+    std::string GetName() const;
+    const TemplateParms *GetTemplateParms() const;
+    const FunctionType *GetFunctionType() const;
+
+    Symbol *LookupInstantiation(const std::vector<std::pair<const Type *, SourcePos>> &types);
+    Symbol *AddInstantiation(const std::vector<std::pair<const Type *, SourcePos>> &types);
+
+    // Generate code for instantiations
+    void GenerateIR() const;
+
+    void Print() const;
+    void Print(Indent &indent) const;
+    bool IsStdlibSymbol() const;
+
+  private:
+    TemplateSymbol *sym;
+    std::vector<Symbol *> args;
+    Stmt *code;
+    Symbol *maskSymbol;
+
+    std::vector<std::pair<TemplateArgs *, Symbol *>> instantiations;
 };
 
 // A helper class to drive function instantiation, it provides the following:

--- a/src/func.h
+++ b/src/func.h
@@ -108,6 +108,7 @@ class TemplateInstantiation {
                           const std::vector<std::pair<const Type *, SourcePos>> &typeArgs);
     const Type *InstantiateType(const std::string &name);
     Symbol *InstantiateSymbol(Symbol *sym);
+    Symbol *InstantiateTemplateSymbol(TemplateSymbol *sym);
     void SetFunction(Function *func);
 
   private:
@@ -117,6 +118,8 @@ class TemplateInstantiation {
     std::unordered_map<Symbol *, Symbol *> symMap;
     // Mapping of template parameter names to the types in the instantiation.
     std::unordered_map<std::string, const Type *> args;
+
+    llvm::Function *createLLVMFunction(Symbol *functionSym, bool isInline, bool isNoInline);
 };
 
 } // namespace ispc

--- a/src/func.h
+++ b/src/func.h
@@ -41,6 +41,7 @@
 #include "ispc.h"
 #include "type.h"
 
+#include <unordered_map>
 #include <vector>
 
 namespace ispc {
@@ -96,6 +97,26 @@ class TemplateArgs {
     bool IsEqual(TemplateArgs &otherArgs) const;
 
     std::vector<std::pair<const Type *, SourcePos>> args;
+};
+
+// A helper class to drive function instantiation, it provides the following:
+// - mapping of the symbols in the template to the symbols in the instantiation
+// - type instantiation
+class TemplateInstantiation {
+  public:
+    TemplateInstantiation(const TemplateParms &typeParms,
+                          const std::vector<std::pair<const Type *, SourcePos>> &typeArgs);
+    const Type *InstantiateType(const std::string &name);
+    Symbol *InstantiateSymbol(Symbol *sym);
+    void SetFunction(Function *func);
+
+  private:
+    // Function Symbol of the instantiation.
+    Symbol *functionSym;
+    // Mapping of the symbols in the template to correspoding symbols in the instantiation.
+    std::unordered_map<Symbol *, Symbol *> symMap;
+    // Mapping of template parameter names to the types in the instantiation.
+    std::unordered_map<std::string, const Type *> args;
 };
 
 } // namespace ispc

--- a/src/func.h
+++ b/src/func.h
@@ -90,4 +90,12 @@ class TemplateParms {
     std::vector<const TemplateTypeParmType *> parms;
 };
 
+class TemplateArgs {
+  public:
+    TemplateArgs(const std::vector<std::pair<const Type *, SourcePos>> &args);
+    bool IsEqual(TemplateArgs &otherArgs) const;
+
+    std::vector<std::pair<const Type *, SourcePos>> args;
+};
+
 } // namespace ispc

--- a/src/func.h
+++ b/src/func.h
@@ -138,13 +138,15 @@ class TemplateInstantiation {
     Symbol *InstantiateTemplateSymbol(TemplateSymbol *sym);
     void SetFunction(Function *func);
 
+    void AddArgument(std::string paramName, const Type *argType);
+
   private:
     // Function Symbol of the instantiation.
     Symbol *functionSym;
     // Mapping of the symbols in the template to correspoding symbols in the instantiation.
     std::unordered_map<Symbol *, Symbol *> symMap;
     // Mapping of template parameter names to the types in the instantiation.
-    std::unordered_map<std::string, const Type *> args;
+    std::unordered_map<std::string, const Type *> argsMap;
     // Template arguments in the order of the template parameters.
     std::vector<const Type *> templateArgs;
 

--- a/src/func.h
+++ b/src/func.h
@@ -145,6 +145,8 @@ class TemplateInstantiation {
     std::unordered_map<Symbol *, Symbol *> symMap;
     // Mapping of template parameter names to the types in the instantiation.
     std::unordered_map<std::string, const Type *> args;
+    // Template arguments in the order of the template parameters.
+    std::vector<const Type *> templateArgs;
 
     llvm::Function *createLLVMFunction(Symbol *functionSym, bool isInline, bool isNoInline);
 };

--- a/src/func.h
+++ b/src/func.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2022, Intel Corporation
+  Copyright (c) 2011-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,7 @@
 
 #include "ast.h"
 #include "ispc.h"
+#include "type.h"
 
 #include <vector>
 
@@ -75,4 +76,18 @@ class Function {
     Symbol *taskIndexSym1, *taskCountSym1;
     Symbol *taskIndexSym2, *taskCountSym2;
 };
+
+// A helper class to manage template parameters list.
+class TemplateParms {
+  public:
+    TemplateParms();
+    void Add(const TemplateTypeParmType *);
+    size_t GetCount() const;
+    const TemplateTypeParmType *operator[](size_t i) const;
+    bool IsEqual(const TemplateParms *p) const;
+
+  private:
+    std::vector<const TemplateTypeParmType *> parms;
+};
+
 } // namespace ispc

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -106,6 +106,7 @@ class FunctionEmitContext;
 class Expr;
 class ExprList;
 class Function;
+class FunctionTemplate;
 class FunctionType;
 class Module;
 class PointerType;
@@ -113,6 +114,8 @@ class Stmt;
 class Symbol;
 class SymbolTable;
 class TemplateInstantiation;
+class TemplateParms;
+class TemplateSymbol;
 class Type;
 struct VariableDeclaration;
 

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -112,6 +112,7 @@ class PointerType;
 class Stmt;
 class Symbol;
 class SymbolTable;
+class TemplateInstantiation;
 class Type;
 struct VariableDeclaration;
 

--- a/src/lex.ll
+++ b/src/lex.ll
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -81,8 +81,8 @@ static int allTokens[] = {
   TOKEN_UINT, TOKEN_UINT8, TOKEN_UINT16, TOKEN_UINT64,
   TOKEN_NEW, TOKEN_NULL, TOKEN_PRINT, TOKEN_RETURN, TOKEN_SOA, TOKEN_SIGNED,
   TOKEN_SIZEOF, TOKEN_ALLOCA, TOKEN_STATIC, TOKEN_STRUCT, TOKEN_SWITCH, TOKEN_SYNC,
-  TOKEN_TASK, TOKEN_TRUE, TOKEN_TYPEDEF, TOKEN_UNIFORM, TOKEN_UNMASKED,
-  TOKEN_UNSIGNED, TOKEN_VARYING, TOKEN_VOID, TOKEN_WHILE,
+  TOKEN_TASK, TOKEN_TEMPLATE, TOKEN_TRUE, TOKEN_TYPEDEF, TOKEN_TYPENAME,
+  TOKEN_UNIFORM, TOKEN_UNMASKED, TOKEN_UNSIGNED, TOKEN_VARYING, TOKEN_VOID, TOKEN_WHILE,
   TOKEN_STRING_C_LITERAL, TOKEN_STRING_SYCL_LITERAL, TOKEN_DOTDOTDOT,
   TOKEN_FLOAT_CONSTANT, TOKEN_FLOAT16_CONSTANT, TOKEN_DOUBLE_CONSTANT,
   TOKEN_INT8_CONSTANT, TOKEN_UINT8_CONSTANT,
@@ -160,8 +160,10 @@ void ParserInit() {
     tokenToName[TOKEN_SWITCH] = "switch";
     tokenToName[TOKEN_SYNC] = "sync";
     tokenToName[TOKEN_TASK] = "task";
+    tokenToName[TOKEN_TEMPLATE] = "template";
     tokenToName[TOKEN_TRUE] = "true";
     tokenToName[TOKEN_TYPEDEF] = "typedef";
+    tokenToName[TOKEN_TYPENAME] = "typename";
     tokenToName[TOKEN_UNIFORM] = "uniform";
     tokenToName[TOKEN_UNMASKED] = "unmasked";
     tokenToName[TOKEN_UNSIGNED] = "unsigned";
@@ -287,8 +289,10 @@ void ParserInit() {
     tokenNameRemap["TOKEN_SWITCH"] = "\'switch\'";
     tokenNameRemap["TOKEN_SYNC"] = "\'sync\'";
     tokenNameRemap["TOKEN_TASK"] = "\'task\'";
+    tokenNameRemap["TOKEN_TEMPLATE"] = "\'template\'";
     tokenNameRemap["TOKEN_TRUE"] = "\'true\'";
     tokenNameRemap["TOKEN_TYPEDEF"] = "\'typedef\'";
+    tokenNameRemap["TOKEN_TYPENAME"] = "\'typename\'";
     tokenNameRemap["TOKEN_UNIFORM"] = "\'uniform\'";
     tokenNameRemap["TOKEN_UNMASKED"] = "\'unmasked\'";
     tokenNameRemap["TOKEN_UNSIGNED"] = "\'unsigned\'";
@@ -462,8 +466,10 @@ struct { RT; return TOKEN_STRUCT; }
 switch { RT; return TOKEN_SWITCH; }
 sync { RT; return TOKEN_SYNC; }
 task { RT; return TOKEN_TASK; }
+template { RT; return TOKEN_TEMPLATE; }
 true { RT; return TOKEN_TRUE; }
 typedef { RT; return TOKEN_TYPEDEF; }
+typename { RT; return TOKEN_TYPENAME; }
 uniform { RT; return TOKEN_UNIFORM; }
 unmasked { RT; return TOKEN_UNMASKED; }
 unsigned { RT; return TOKEN_UNSIGNED; }
@@ -491,6 +497,8 @@ L?\"(\\.|[^\\"])*\" { lStringConst(&yylval, &yylloc); return TOKEN_STRING_LITERA
     yylval.stringVal = new std::string(yytext);
     if (m->symbolTable->LookupType(yytext) != NULL)
         return TOKEN_TYPE_NAME;
+    else if (m->symbolTable->LookupFunctionTemplate(yytext))
+        return TOKEN_TEMPLATE_NAME;
     else
         return TOKEN_IDENTIFIER;
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -449,6 +449,11 @@ void Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *
         return;
     }
 
+    if (symbolTable->LookupFunctionTemplate(name.c_str())) {
+        Error(pos, "Global variable \"%s\" shadows previously-declared function template.", name.c_str());
+        return;
+    }
+
     if (storageClass == SC_EXTERN_C) {
         Error(pos, "extern \"C\" qualifier can only be used for functions.");
         return;
@@ -967,8 +972,14 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
             function->addAttribute(i+1, llvm::Attribute::constructAlignmentFromInt(align));
 #endif
         }
+
         if (symbolTable->LookupFunction(argName.c_str())) {
             Warning(argPos, "Function parameter \"%s\" shadows a function declared in global scope.", argName.c_str());
+        }
+
+        if (symbolTable->LookupFunctionTemplate(argName.c_str())) {
+            Warning(argPos, "Function parameter \"%s\" shadows a function template declared in global scope.",
+                    argName.c_str());
         }
 
         if (defaultValue != NULL)

--- a/src/module.h
+++ b/src/module.h
@@ -96,6 +96,21 @@ class Module {
         provided statements to the module. */
     void AddFunctionDefinition(const std::string &name, const FunctionType *ftype, Stmt *code);
 
+    /** Add a declaration of the function template defined by the given function
+        symbol to the module. */
+    void AddFunctionTemplateDeclaration(const TemplateParms *templateParmList, const std::string &name,
+                                        const FunctionType *ftype, StorageClass sc, bool isInline, bool isNoInline,
+                                        bool isVectorCall, SourcePos pos);
+
+    /** Add the function described by the declaration information and the
+        provided statements to the module. */
+    void AddFunctionTemplateDefinition(const TemplateParms *templateParmList, const std::string &name,
+                                       const FunctionType *ftype, Stmt *code);
+
+    void AddFunctionTemplateInstantiation(const std::string &name,
+                                          const std::vector<std::pair<const Type *, SourcePos>> &types,
+                                          const FunctionType *ftype, SourcePos pos);
+
     /** Adds the given type to the set of types that have their definitions
         included in automatically generated header files. */
     void AddExportedTypes(const std::vector<std::pair<const Type *, SourcePos>> &types);

--- a/src/stmt.h
+++ b/src/stmt.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2022, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -65,6 +65,7 @@ class Stmt : public ASTNode {
     // Stmts don't have anything to do here.
     virtual Stmt *Optimize();
     virtual Stmt *TypeCheck() = 0;
+    virtual Stmt *Instantiate(TemplateInstantiation &templInst) const = 0;
 
     virtual void SetLoopAttribute(std::pair<Globals::pragmaUnrollType, int>);
 };
@@ -82,6 +83,7 @@ class ExprStmt : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    ExprStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     Expr *expr;
 };
@@ -110,6 +112,7 @@ class DeclStmt : public Stmt {
     Stmt *Optimize();
     Stmt *TypeCheck();
     int EstimateCost() const;
+    DeclStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     std::vector<VariableDeclaration> vars;
 };
@@ -128,6 +131,7 @@ class IfStmt : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    IfStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     // @todo these are only public for lHasVaryingBreakOrContinue(); would
     // be nice to clean that up...
@@ -171,6 +175,7 @@ class DoStmt : public Stmt {
         std::pair<Globals::pragmaUnrollType, int>(Globals::pragmaUnrollType::none, -1);
     void SetLoopAttribute(std::pair<Globals::pragmaUnrollType, int>);
     int EstimateCost() const;
+    DoStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     Expr *testExpr;
     Stmt *bodyStmts;
@@ -197,6 +202,7 @@ class ForStmt : public Stmt {
         std::pair<Globals::pragmaUnrollType, int>(Globals::pragmaUnrollType::none, -1);
     void SetLoopAttribute(std::pair<Globals::pragmaUnrollType, int>);
     int EstimateCost() const;
+    ForStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     /** 'for' statment initializer; may be NULL, indicating no intitializer */
     Stmt *init;
@@ -225,6 +231,7 @@ class BreakStmt : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    BreakStmt *Instantiate(TemplateInstantiation &templInst) const;
 };
 
 /** @brief Statement implementation for a continue statement in the
@@ -241,6 +248,7 @@ class ContinueStmt : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    ContinueStmt *Instantiate(TemplateInstantiation &templInst) const;
 };
 
 /** @brief Statement implementation for parallel 'foreach' loops.
@@ -264,6 +272,7 @@ class ForeachStmt : public Stmt {
         std::pair<Globals::pragmaUnrollType, int>(Globals::pragmaUnrollType::none, -1);
     void SetLoopAttribute(std::pair<Globals::pragmaUnrollType, int>);
     int EstimateCost() const;
+    ForeachStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     std::vector<Symbol *> dimVariables;
     std::vector<Expr *> startExprs;
@@ -289,6 +298,7 @@ class ForeachActiveStmt : public Stmt {
         std::pair<Globals::pragmaUnrollType, int>(Globals::pragmaUnrollType::none, -1);
     void SetLoopAttribute(std::pair<Globals::pragmaUnrollType, int>);
     int EstimateCost() const;
+    ForeachActiveStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     Symbol *sym;
     Stmt *stmts;
@@ -300,6 +310,7 @@ class ForeachActiveStmt : public Stmt {
 class ForeachUniqueStmt : public Stmt {
   public:
     ForeachUniqueStmt(const char *iterName, Expr *expr, Stmt *stmts, SourcePos pos);
+    ForeachUniqueStmt(Symbol *sym, Expr *expr, Stmt *stmts, SourcePos pos);
 
     static inline bool classof(ForeachUniqueStmt const *) { return true; }
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ForeachUniqueStmtID; }
@@ -312,6 +323,7 @@ class ForeachUniqueStmt : public Stmt {
         std::pair<Globals::pragmaUnrollType, int>(Globals::pragmaUnrollType::none, -1);
     void SetLoopAttribute(std::pair<Globals::pragmaUnrollType, int>);
     int EstimateCost() const;
+    ForeachUniqueStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     Symbol *sym;
     Expr *expr;
@@ -332,6 +344,7 @@ class UnmaskedStmt : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    UnmaskedStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     Stmt *stmts;
 };
@@ -350,6 +363,7 @@ class ReturnStmt : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    ReturnStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     Expr *expr;
 };
@@ -369,6 +383,7 @@ class CaseStmt : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    CaseStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     /** Integer value after the "case" statement */
     const int value;
@@ -389,6 +404,7 @@ class DefaultStmt : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    DefaultStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     Stmt *stmts;
 };
@@ -406,6 +422,7 @@ class SwitchStmt : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    SwitchStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     /** Expression that is used to determine which label to jump to. */
     Expr *expr;
@@ -427,6 +444,7 @@ class GotoStmt : public Stmt {
     Stmt *Optimize();
     Stmt *TypeCheck();
     int EstimateCost() const;
+    GotoStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     /** Name of the label to jump to when the goto is executed. */
     std::string label;
@@ -448,6 +466,7 @@ class LabeledStmt : public Stmt {
     Stmt *Optimize();
     Stmt *TypeCheck();
     int EstimateCost() const;
+    LabeledStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     /** Name of the label. */
     std::string name;
@@ -469,6 +488,7 @@ class StmtList : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    StmtList *Instantiate(TemplateInstantiation &templInst) const;
 
     void Add(Stmt *s) {
         if (s)
@@ -499,6 +519,7 @@ class PrintStmt : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    PrintStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     std::vector<llvm::Value *> getDoPrintArgs(FunctionEmitContext *ctx) const;
     std::vector<llvm::Value *> getPrintImplArgs(FunctionEmitContext *ctx) const;
@@ -547,6 +568,7 @@ class AssertStmt : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    AssertStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     /** Message to print if the assertion fails. */
     const std::string message;
@@ -568,6 +590,7 @@ class DeleteStmt : public Stmt {
 
     Stmt *TypeCheck();
     int EstimateCost() const;
+    DeleteStmt *Instantiate(TemplateInstantiation &templInst) const;
 
     /** Expression that gives the pointer value to be deleted. */
     Expr *expr;

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -55,6 +55,13 @@ Symbol::Symbol(const std::string &n, SourcePos p, const Type *t, StorageClass sc
       storageClass(sc), varyingCFDepth(0), parentFunction(NULL) {}
 
 ///////////////////////////////////////////////////////////////////////////
+// TemplateSymbol
+
+TemplateSymbol::TemplateSymbol(const TemplateParms *parms, const std::string &n, const FunctionType *t,
+                               const SourcePos p, bool inl, bool noinl)
+    : pos(p), name(n), type(t), templateParms(parms), functionTemplate(nullptr), isInline(inl), isNoInline(noinl) {}
+
+///////////////////////////////////////////////////////////////////////////
 // SymbolTable
 
 SymbolTable::SymbolTable() { PushScope(); }

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -36,8 +36,10 @@
 */
 
 #include "sym.h"
+#include "expr.h"
 #include "type.h"
 #include "util.h"
+
 #include <algorithm>
 #include <array>
 #include <iterator>

--- a/src/sym.h
+++ b/src/sym.h
@@ -42,6 +42,7 @@
 #include "ctx.h"
 #include "decl.h"
 #include "ispc.h"
+
 #include <map>
 
 namespace ispc {
@@ -213,6 +214,29 @@ class SymbolTable {
         @return pointer to matching Symbol; NULL if none is found. */
     Symbol *LookupFunction(const char *name, const FunctionType *type);
 
+    /** Adds the given function template to the symbol table.
+        @param templ The function template to be added.
+
+        @return true if the template has been added.  False if another
+        function template with the same name and function signature is
+        already present in the symbol table. */
+    bool AddFunctionTemplate(TemplateSymbol *templ);
+
+    /** Looks for the function or functions with the given name in the
+        symbol name.  If a function has been overloaded and multiple
+        definitions are present for a given function name, all of them will
+        be returned in the provided vector and it's up the the caller to
+        resolve which one (if any) to use.  Returns true if any matches
+        were found. */
+    bool LookupFunctionTemplate(const std::string &name, std::vector<TemplateSymbol *> *matches = nullptr);
+
+    /** Looks for a function template with the given name and type
+        in the symbol table.
+
+        @return pointer to matching FunctionTemplate; NULL if none is found. */
+    TemplateSymbol *LookupFunctionTemplate(const TemplateParms *templateParmList, const std::string &name,
+                                           const FunctionType *type);
+
     /** Returns all of the functions in the symbol table that match the given
         predicate.
 
@@ -322,6 +346,13 @@ class SymbolTable {
      */
     typedef std::map<llvm::Function *, Symbol *> IntrinsicMapType;
     IntrinsicMapType intrinsics;
+
+    /** Function template declarations, as well as function declaration, are
+        *not* scoped.  A STL \c vector is used to store the function templates
+        for a given name since, due to function overloading, a name can
+        have multiple function templates associated with it. */
+    typedef std::map<std::string, std::vector<TemplateSymbol *>> FunctionTemplateMapType;
+    FunctionTemplateMapType functionTemplates;
 
     /** Scoped types.
      */

--- a/src/sym.h
+++ b/src/sym.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2022, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -106,6 +106,33 @@ class Symbol {
     /*!< For symbols that are parameters to functions or are
          variables declared inside functions, this gives the
          function they're in. */
+};
+
+/**
+   @brief Represents function template.
+
+   TODO: The only reason that it's separate from Symbol is that we trying not to introduce additional
+   overhead. Symbol class needs to be refactored to be either a class hierarchy or be implemented as
+   a union of different types of symbols.
+ */
+class TemplateSymbol {
+  public:
+    TemplateSymbol(const TemplateParms *parms, const std::string &n, const FunctionType *t, const SourcePos p,
+                   bool isInline, bool inNoInline);
+
+    SourcePos pos;
+    const std::string name;
+    const FunctionType *type;
+    const TemplateParms *templateParms;
+    FunctionTemplate *functionTemplate;
+
+    // Inline / noinline attributes.
+    // TODO: it's bad idea to store them here, this need to be redesigned.
+    // The reason to keep them here for now is that for regular functions it's not stored anywhere in AST,
+    // but attached as attrubutes to llvm::Function when it's created. For templates we need to store this
+    // information in here and use later when the template is instantiated.
+    bool isInline;
+    bool isNoInline;
 };
 
 /** @brief Symbol table that holds all known symbols during parsing and compilation.

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -128,6 +128,12 @@ std::string Variability::MangleString() const {
 ///////////////////////////////////////////////////////////////////////////
 // Type
 llvm::Type *Type::LLVMStorageType(llvm::LLVMContext *ctx) const { return LLVMType(ctx); }
+
+const Type *Type::ResolveDependenceForTopType(TemplateInstantiation &templInst) const {
+    const Type *temp = ResolveDependence(templInst);
+    const Type *result = temp->ResolveUnboundVariability(Variability::Varying);
+    return result;
+}
 ///////////////////////////////////////////////////////////////////////////
 // AtomicType
 
@@ -1105,7 +1111,6 @@ const PointerType *PointerType::ResolveDependence(TemplateInstantiation &templIn
     }
 
     const PointerType *pType = new PointerType(resType, variability, isConst, isSlice, isFrozen);
-    pType = pType->ResolveUnboundVariability(Variability::Varying);
     return pType;
 }
 
@@ -2618,7 +2623,7 @@ const FunctionType *FunctionType::ResolveDependence(TemplateInstantiation &templ
         Assert(m->errorCount > 0);
         return NULL;
     }
-    const Type *rt = returnType->ResolveDependence(templInst);
+    const Type *rt = returnType->ResolveDependenceForTopType(templInst);
 
     llvm::SmallVector<const Type *, 8> pt;
     for (unsigned int i = 0; i < paramTypes.size(); ++i) {
@@ -2626,7 +2631,7 @@ const FunctionType *FunctionType::ResolveDependence(TemplateInstantiation &templ
             Assert(m->errorCount > 0);
             return NULL;
         }
-        const Type *argt = paramTypes[i]->ResolveDependence(templInst);
+        const Type *argt = paramTypes[i]->ResolveDependenceForTopType(templInst);
         pt.push_back(argt);
     }
 

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -3217,6 +3217,20 @@ static bool lCheckTypeEquality(const Type *a, const Type *b, bool ignoreConst) {
         return true;
     }
 
+    const TemplateTypeParmType *ttpa = CastType<TemplateTypeParmType>(a);
+    const TemplateTypeParmType *ttpb = CastType<TemplateTypeParmType>(b);
+    if (ttpa != NULL && ttpb != NULL) {
+        // Template type parameter types must have the same name to match.
+        if (ttpa->GetName() != ttpb->GetName()) {
+            return false;
+        }
+        // Variability should match, otherwise they are not equal.
+        if (ttpa->GetVariability() != ttpb->GetVariability()) {
+            return false;
+        }
+        return true;
+    }
+
     return false;
 }
 

--- a/src/type.h
+++ b/src/type.h
@@ -952,7 +952,8 @@ class FunctionType : public Type {
     /** This method returns the FunctionMangledName depending on Function type.
         The \c appFunction parameter indicates whether the function is generated for
         internal ISPC call or for external call from application.*/
-    FunctionMangledName GetFunctionMangledName(bool appFunction) const;
+    FunctionMangledName GetFunctionMangledName(bool appFunction,
+                                               std::vector<const Type *> *templateArgs = nullptr) const;
 
     /** This method returns std::vector of LLVM types of function arguments.
         The \c disableMask parameter indicates whether the mask parameter should be
@@ -1013,6 +1014,8 @@ class FunctionType : public Type {
     int costOverride;
 
   private:
+    std::string mangleTemplateArgs(std::vector<const Type *> *templateArgs) const;
+
     const Type *const returnType;
 
     // The following four vectors should all have the same length (which is

--- a/src/type.h
+++ b/src/type.h
@@ -154,8 +154,15 @@ class Type : public Traceable {
         unbound. */
     bool HasUnboundVariability() const { return GetVariability() == Variability::Unbound; }
 
-    /** Resolves dependent type with mapping of template types to concrete type passed as argeument */
+    /** Resolves dependent type with mapping of template types to concrete type passed as argeument.
+        Do not handle variability resolution, which need to be done as a separate step.
+     */
     virtual const Type *ResolveDependence(TemplateInstantiation &templInst) const = 0;
+
+    /** Resolves dependent type with mapping of template types to concrete type passed as argeument.
+        Resolve variability of the type as well.
+     */
+    const Type *ResolveDependenceForTopType(TemplateInstantiation &templInst) const;
 
     /* Returns a type wherein any elements of the original type and
        contained types that have unbound variability have their variability

--- a/src/type.h
+++ b/src/type.h
@@ -151,6 +151,9 @@ class Type : public Traceable {
         unbound. */
     bool HasUnboundVariability() const { return GetVariability() == Variability::Unbound; }
 
+    /** Resolves dependent type with mapping of template types to concrete type passed as argeument */
+    virtual const Type *ResolveDependence(TemplateInstantiation &templInst) const = 0;
+
     /* Returns a type wherein any elements of the original type and
        contained types that have unbound variability have their variability
        set to the given variability. */
@@ -288,6 +291,7 @@ class AtomicType : public Type {
     const AtomicType *GetAsUnboundVariabilityType() const;
     const AtomicType *GetAsSOAType(int width) const;
 
+    const AtomicType *ResolveDependence(TemplateInstantiation &templInst) const;
     const AtomicType *ResolveUnboundVariability(Variability v) const;
     const AtomicType *GetAsUnsignedType() const;
     const AtomicType *GetAsConstType() const;
@@ -366,6 +370,7 @@ class TemplateTypeParmType : public Type {
     const Type *GetAsUniformType() const;
     const Type *GetAsUnboundVariabilityType() const;
     const Type *GetAsSOAType(int width) const;
+    const Type *ResolveDependence(TemplateInstantiation &templInst) const;
     const Type *ResolveUnboundVariability(Variability v) const;
 
     const Type *GetAsConstType() const;
@@ -414,6 +419,7 @@ class EnumType : public Type {
     const EnumType *GetAsUnboundVariabilityType() const;
     const EnumType *GetAsSOAType(int width) const;
 
+    const EnumType *ResolveDependence(TemplateInstantiation &templInst) const;
     const EnumType *ResolveUnboundVariability(Variability v) const;
     const EnumType *GetAsConstType() const;
     const EnumType *GetAsNonConstType() const;
@@ -499,6 +505,7 @@ class PointerType : public Type {
     const PointerType *GetAsUnboundVariabilityType() const;
     const PointerType *GetAsSOAType(int width) const;
 
+    const PointerType *ResolveDependence(TemplateInstantiation &templInst) const;
     const PointerType *ResolveUnboundVariability(Variability v) const;
     const PointerType *GetAsConstType() const;
     const PointerType *GetAsNonConstType() const;
@@ -600,6 +607,7 @@ class ArrayType : public SequentialType {
     const ArrayType *GetAsUniformType() const;
     const ArrayType *GetAsUnboundVariabilityType() const;
     const ArrayType *GetAsSOAType(int width) const;
+    const ArrayType *ResolveDependence(TemplateInstantiation &templInst) const;
     const ArrayType *ResolveUnboundVariability(Variability v) const;
 
     const ArrayType *GetAsUnsignedType() const;
@@ -667,6 +675,7 @@ class VectorType : public SequentialType {
     const VectorType *GetAsUniformType() const;
     const VectorType *GetAsUnboundVariabilityType() const;
     const VectorType *GetAsSOAType(int width) const;
+    const VectorType *ResolveDependence(TemplateInstantiation &templInst) const;
     const VectorType *ResolveUnboundVariability(Variability v) const;
 
     const VectorType *GetAsUnsignedType() const;
@@ -720,6 +729,7 @@ class StructType : public CollectionType {
     const StructType *GetAsUniformType() const;
     const StructType *GetAsUnboundVariabilityType() const;
     const StructType *GetAsSOAType(int width) const;
+    const StructType *ResolveDependence(TemplateInstantiation &templInst) const;
     const StructType *ResolveUnboundVariability(Variability v) const;
 
     const StructType *GetAsConstType() const;
@@ -808,6 +818,7 @@ class UndefinedStructType : public Type {
     const UndefinedStructType *GetAsUniformType() const;
     const UndefinedStructType *GetAsUnboundVariabilityType() const;
     const UndefinedStructType *GetAsSOAType(int width) const;
+    const UndefinedStructType *ResolveDependence(TemplateInstantiation &templInst) const;
     const UndefinedStructType *ResolveUnboundVariability(Variability v) const;
 
     const UndefinedStructType *GetAsConstType() const;
@@ -851,6 +862,7 @@ class ReferenceType : public Type {
     const ReferenceType *GetAsUniformType() const;
     const ReferenceType *GetAsUnboundVariabilityType() const;
     const Type *GetAsSOAType(int width) const;
+    const ReferenceType *ResolveDependence(TemplateInstantiation &templInst) const;
     const ReferenceType *ResolveUnboundVariability(Variability v) const;
 
     const ReferenceType *GetAsConstType() const;
@@ -910,6 +922,7 @@ class FunctionType : public Type {
     const Type *GetAsUniformType() const;
     const Type *GetAsUnboundVariabilityType() const;
     const Type *GetAsSOAType(int width) const;
+    const FunctionType *ResolveDependence(TemplateInstantiation &templInst) const;
     const FunctionType *ResolveUnboundVariability(Variability v) const;
 
     const Type *GetAsConstType() const;

--- a/src/type.h
+++ b/src/type.h
@@ -130,6 +130,9 @@ class Type : public Traceable {
     /** Returns true if the underlying type is a float or integer type. */
     bool IsNumericType() const { return IsFloatType() || IsIntType(); }
 
+    /** Returns true if the type is any kind of dependent type. */
+    bool IsDependentType() const;
+
     /** Returns the variability of the type. */
     virtual Variability GetVariability() const = 0;
 
@@ -322,6 +325,7 @@ class AtomicType : public Type {
         TYPE_INT64,
         TYPE_UINT64,
         TYPE_DOUBLE,
+        TYPE_DEPENDENT,
         NUM_BASIC_TYPES
     };
 
@@ -339,6 +343,7 @@ class AtomicType : public Type {
     static const AtomicType *UniformInt64, *VaryingInt64;
     static const AtomicType *UniformUInt64, *VaryingUInt64;
     static const AtomicType *UniformDouble, *VaryingDouble;
+    static const AtomicType *Dependent;
     static const AtomicType *Void;
 
   private:
@@ -750,6 +755,9 @@ class StructType : public CollectionType {
     /** Returns the type of the i'th structure element.  The value of \c i must
         be between 0 and NumElements()-1. */
     const Type *GetElementType(int i) const;
+
+    /** Return the raw element type without "finilizing" varibility and constness of the element. */
+    const Type *GetRawElementType(int i) const;
 
     /** Returns which structure element number (starting from zero) that
         has the given name.  If there is no such element, return -1. */

--- a/tests/lit-tests/func_template_1.ispc
+++ b/tests/lit-tests/func_template_1.ispc
@@ -1,0 +1,41 @@
+// Basic test to instantiate template with different atomic types as well as
+// variability. Also checks case where an already instantiated instance is
+// called.
+
+// RUN: %{ispc}  %s --emit-llvm-text --target=host -o - | FileCheck %s
+
+// CHECK-LABEL: define <{{[0-9]*}} x float> @foo0
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___ubfubi___vyfuni(<{{[0-9]*}} x float>
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___ubiubi___vyiuni(<{{[0-9]*}} x i32>
+
+// CHECK-LABEL: define <{{[0-9]*}} x float> @foo1___uniuni
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___ubiubi___vyiuni(<{{[0-9]*}} x i32>
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___uniubi___uniuni(i32
+
+// CHECK-LABEL: define <{{[0-9]*}} x float> @foo2___uniuni
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___ubiubi___vyiuni(<{{[0-9]*}} x i32>
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___ubfubi___vyfuni(<{{[0-9]*}} x float>
+
+template <typename T, typename C> noinline int goo(T argGooOne, uniform int argGooTwo) {
+    C val = argGooTwo;
+    int i_val = argGooOne;
+    return val + i_val;
+}
+
+noinline float foo0(uniform int argFoo0, uniform int argFoo1) {
+    int a = goo<float, int>(argFoo0, argFoo1);
+    int b = goo<int, int>(argFoo0, argFoo1);
+    return a + b;
+}
+
+float foo1(uniform int argFoo0, uniform int argFoo1) {
+    int a = goo<int, int>(argFoo0, argFoo1);
+    int b = goo<uniform int, int>(argFoo0, argFoo1);
+    return a + b;
+}
+
+float foo2(uniform int argFoo0, uniform int argFoo1) {
+    int a = goo<int, int>(argFoo0, argFoo1);
+    int b = goo<float, int>(argFoo0, argFoo1);
+    return a + b;
+}

--- a/tests/lit-tests/func_template_1.ispc
+++ b/tests/lit-tests/func_template_1.ispc
@@ -2,19 +2,19 @@
 // variability. Also checks case where an already instantiated instance is
 // called.
 
-// RUN: %{ispc}  %s --emit-llvm-text --target=host -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
 
 // CHECK-LABEL: define <{{[0-9]*}} x float> @foo0
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___ubfubi___vyfuni(<{{[0-9]*}} x float>
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___ubiubi___vyiuni(<{{[0-9]*}} x i32>
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyfvyi___vyfuni(<{{[0-9]*}} x float>
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyiuni(<{{[0-9]*}} x i32>
 
 // CHECK-LABEL: define <{{[0-9]*}} x float> @foo1___uniuni
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___ubiubi___vyiuni(<{{[0-9]*}} x i32>
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___uniubi___uniuni(i32
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyiuni(<{{[0-9]*}} x i32>
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___univyi___uniuni(i32
 
 // CHECK-LABEL: define <{{[0-9]*}} x float> @foo2___uniuni
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___ubiubi___vyiuni(<{{[0-9]*}} x i32>
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___ubfubi___vyfuni(<{{[0-9]*}} x float>
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyiuni(<{{[0-9]*}} x i32>
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyfvyi___vyfuni(<{{[0-9]*}} x float>
 
 template <typename T, typename C> noinline int goo(T argGooOne, uniform int argGooTwo) {
     C val = argGooTwo;

--- a/tests/lit-tests/func_template_10.ispc
+++ b/tests/lit-tests/func_template_10.ispc
@@ -1,0 +1,21 @@
+// Check how pointer types are instantiated with [T = uniform int] and [T = varying int]
+// RUN: %{ispc} %s --target=host --nostdlib --ast-dump -o %t.o | FileCheck %s
+
+// CHECK: (instantiation <varying int32>) Function {{.*}} [ void(varying int32 * varying p1, varying int32 * uniform * varying p2, varying int32 * uniform * uniform * varying p3)] "foo"
+// CHECK: (instantiation <uniform int32>) Function {{.*}} [ void(uniform int32 * varying p1, uniform int32 * uniform * varying p2, uniform int32 * uniform * uniform * varying p3)] "foo"
+template <typename T> void foo(T *p1, T **p2, T ***p3) { }
+
+void bar(uniform int *up1, uniform int **up2, uniform int ***up3,
+         varying int *vp1, varying int **vp2, varying int ***vp3) {
+  // CHECK: FunctionSymbolExpr {{.*}} [ void(varying int32 * varying p1, varying int32 * uniform * varying p2, varying int32 * uniform * uniform * varying p3)] function name: foo
+  foo<int>(vp1, vp2, vp3);
+  // CHECK: FunctionSymbolExpr {{.*}} [ void(varying int32 * varying p1, varying int32 * uniform * varying p2, varying int32 * uniform * uniform * varying p3)] function name: foo
+  foo<varying int>(vp1, vp2, vp3);
+  // CHECK: FunctionSymbolExpr {{.*}} [ void(uniform int32 * varying p1, uniform int32 * uniform * varying p2, uniform int32 * uniform * uniform * varying p3)] function name: foo
+  foo<uniform int>(up1, up2, up3);
+
+  // CHECK: FunctionSymbolExpr {{.*}} [ void(varying int32 * varying p1, varying int32 * uniform * varying p2, varying int32 * uniform * uniform * varying p3)] function name: foo
+  foo(vp1, vp2, vp3);
+  // CHECK: FunctionSymbolExpr {{.*}} [ void(uniform int32 * varying p1, uniform int32 * uniform * varying p2, uniform int32 * uniform * uniform * varying p3)] function name: foo
+  foo(up1, up2, up3);
+}

--- a/tests/lit-tests/func_template_2.ispc
+++ b/tests/lit-tests/func_template_2.ispc
@@ -4,8 +4,8 @@
 // RUN: %{ispc}  %s --emit-llvm-text --target=host -o - | FileCheck %s
 
 // CHECK: define void @foo
-// CHECK: call {{.*}} void @aos_to_soa2_ispc___ubiubi___un_3C_uni_3E_un_3C_vyi_3E_un_3C_vyi_3E_REFCvyi({{(i32*|ptr)}}
-// CHECK: call {{.*}} void @aos_to_soa2_ispc___ubfubi___un_3C_unf_3E_un_3C_vyf_3E_un_3C_vyf_3E_REFCvyi({{(float*|ptr)}}
+// CHECK: call {{.*}} void @aos_to_soa2_ispc___vyivyi___un_3C_uni_3E_un_3C_vyi_3E_un_3C_vyi_3E_REFCvyi({{(i32*|ptr)}}
+// CHECK: call {{.*}} void @aos_to_soa2_ispc___vyfvyi___un_3C_unf_3E_un_3C_vyf_3E_un_3C_vyf_3E_REFCvyi({{(float*|ptr)}}
 
 template <typename T, typename C>
 noinline void aos_to_soa2_ispc(uniform T src[], varying T *uniform v0, varying T *uniform v1, const C &ind) {

--- a/tests/lit-tests/func_template_2.ispc
+++ b/tests/lit-tests/func_template_2.ispc
@@ -1,0 +1,23 @@
+// Tests template instantiation involving pointers/arrays with variability
+// resolution.
+
+// RUN: %{ispc}  %s --emit-llvm-text --target=host -o - | FileCheck %s
+
+// CHECK: define void @foo
+// CHECK: call {{.*}} void @aos_to_soa2_ispc___ubiubi___un_3C_uni_3E_un_3C_vyi_3E_un_3C_vyi_3E_REFCvyi({{(i32*|ptr)}}
+// CHECK: call {{.*}} void @aos_to_soa2_ispc___ubfubi___un_3C_unf_3E_un_3C_vyf_3E_un_3C_vyf_3E_REFCvyi({{(float*|ptr)}}
+
+template <typename T, typename C>
+noinline void aos_to_soa2_ispc(uniform T src[], varying T *uniform v0, varying T *uniform v1, const C &ind) {
+    const varying T src0 = src[programIndex];
+    const varying T src1 = src[programCount + programIndex];
+
+    *v0 = shuffle(src0, src1, ind);
+    *v1 = shuffle(src0, src1, ind);
+}
+
+void foo(uniform float srcf[], varying float *uniform v0f, varying float *uniform v1f, uniform int srci[],
+         varying int *uniform v0i, varying int *uniform v1i, int ind) {
+    aos_to_soa2_ispc<int, int>(srci, v0i, v1i, ind);
+    aos_to_soa2_ispc<float, int>(srcf, v0f, v1f, ind);
+}

--- a/tests/lit-tests/func_template_3.ispc
+++ b/tests/lit-tests/func_template_3.ispc
@@ -1,0 +1,17 @@
+// Tests multiple instantiation of templates with same function type (no
+// typenames as parameters or return type)
+// This verifies temlate name mangling.
+
+// RUN: %{ispc}  %s --emit-llvm-text --target=host -o - | FileCheck %s
+
+// CHECK: define {{.*}} @addTemp___ubi___vyfvyf
+// CHECK: define {{.*}} @addTemp___ubI___vyfvyf
+template <typename T> noinline int addTemp(float targ0, float targ1) { return (int)((T)targ0 + (T)targ1); }
+
+bool foo(float arg0, float arg1) {
+    int v1 = addTemp<int>(arg0, arg1);
+    int v2 = addTemp<int64>(arg0, arg1);
+    if (v1 == v2)
+        return true;
+    return false;
+}

--- a/tests/lit-tests/func_template_3.ispc
+++ b/tests/lit-tests/func_template_3.ispc
@@ -1,11 +1,10 @@
-// Tests multiple instantiation of templates with same function type (no
-// typenames as parameters or return type)
+// Tests multiple instantiations of templates with same function type (no typenames as parameters or return type).
 // This verifies temlate name mangling.
 
-// RUN: %{ispc}  %s --emit-llvm-text --target=host -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
 
-// CHECK: define {{.*}} @addTemp___ubi___vyfvyf
-// CHECK: define {{.*}} @addTemp___ubI___vyfvyf
+// CHECK: define {{.*}} @addTemp___vyi___vyfvyf
+// CHECK: define {{.*}} @addTemp___vyI___vyfvyf
 template <typename T> noinline int addTemp(float targ0, float targ1) { return (int)((T)targ0 + (T)targ1); }
 
 bool foo(float arg0, float arg1) {

--- a/tests/lit-tests/func_template_4.ispc
+++ b/tests/lit-tests/func_template_4.ispc
@@ -1,0 +1,19 @@
+// Tests nested templates.
+
+// RUN: %{ispc}  %s --emit-llvm-text --target=host -O0 -o - | FileCheck %s
+
+template <typename T> noinline T add(T A, T B) { return A + B; }
+template <typename T> noinline T mul(T A, T B) { return A * B; }
+template <typename T> noinline T fma(T A, T B, T C) { return add<T>(mul<T>(A, B), C); }
+
+// CHECK: define <{{[0-9]*}} x float> @foo___vyfvyfvyf
+// CHECK: call {{.*}} @fma___vyf___vyfvyfvyf(<{{[0-9]*}} x float>
+
+// CHECK: define {{.*}} @fma___vyf___vyfvyfvyf
+// CHECK: call {{.*}} @mul___vyf___vyfvyf(<{{[0-9]*}} x float>
+// CHECK: call {{.*}} @add___vyf___vyfvyf(<{{[0-9]*}} x float>
+
+// CHECK: define {{.*}} @mul___vyf___vyfvyf
+
+// CHECK: define {{.*}} @add___vyf___vyfvyf
+float foo(float A, float B, float C) { return fma<varying float>(A, B, C); }

--- a/tests/lit-tests/func_template_5.ispc
+++ b/tests/lit-tests/func_template_5.ispc
@@ -1,0 +1,12 @@
+// Tests negative case for errors - incorrect typename types or number of parameters.
+
+// RUN: not %{ispc} %s -o %t.o --nowrap --target=host 2>&1 | FileCheck %s
+
+template <typename T> noinline T add(T A, T B) { return A + B; }
+
+// CHECK: 8:40: Error: Unable to find any matching overload for call to function "add".
+void foo0(float A, float B, float C) { add<varying float>(A, B, C); }
+
+// CHECK: 11:31: Error: Unable to find any matching overload for call to function "add".
+void foo1(float A, float B) { add<varying float, int>(A, B); }
+

--- a/tests/lit-tests/func_template_6.ispc
+++ b/tests/lit-tests/func_template_6.ispc
@@ -1,0 +1,21 @@
+// Tests template with no params/return type i.e., void.
+// Also test global symbol used in the template and print() expression.
+
+// RUN: %{ispc}  %s --emit-llvm-text --target=host -O0 -o - | FileCheck %s
+
+int gVal;
+
+template <typename T> noinline void goo() {
+    print("\n Global val = % \n", (T)gVal);
+}
+
+// CHECK: define void @foo___
+// CHECK: call void @goo___vyi___
+// CHECK: call void @goo___vys___
+
+// CHECK: define internal void @goo___vyi___
+// CHECK: define internal void @goo___vys___
+void foo() {
+    goo<int>();
+    goo<int16>();
+}

--- a/tests/lit-tests/func_template_7.ispc
+++ b/tests/lit-tests/func_template_7.ispc
@@ -1,0 +1,26 @@
+// Check that operator overloading kicks-in for template parameter arguments.
+// If it doesn't, the test will crash, because type check will alarm binary operation on non-atomic types.
+
+// RUN: %{ispc} %s --nostdlib --target=host -o %t.o
+
+struct S {
+    float<4> V;
+};
+
+inline uniform S operator+(const uniform S &A, const uniform S &B) {
+    varying float S0, S1, Result;
+    *((uniform S * uniform) & S0) = *((uniform S * uniform) & A);
+    *((uniform S * uniform) & S1) = *((uniform S * uniform) & B);
+
+    Result = S0 + S1;
+
+    return *((uniform S * uniform) & Result);
+}
+
+template <typename T> inline T VectorAdd(const T &A, const T &B) { return A + B; }
+
+export void Add(uniform float A[], uniform float B[], uniform float C[], uniform int i) {
+    const uniform S Vb = *((uniform S * uniform) & B[i]);
+    const uniform S Vc = *((uniform S * uniform) & C[i]);
+    *((uniform S * uniform) & A[i]) = VectorAdd(Vb, Vc);
+}

--- a/tests/lit-tests/func_template_8.ispc
+++ b/tests/lit-tests/func_template_8.ispc
@@ -1,0 +1,17 @@
+// Test member expressions with dependent types - they need to compile, not crash.
+// RUN: %{ispc} %s --target=host --nostdlib -o %t.o
+
+struct S {
+  float f1[4];
+  float<4> f2;
+};
+
+template <typename T> noinline float templ(const T& v1, const T* v2) {
+  float res = v1.f1[1]  + v1.f2[1]  + v1.f2.x +
+              v2->f1[1] + v2->f2[1] + v2->f2.x;
+  return res;
+}
+
+float foo (struct S s1, struct S s2) {
+  return templ(s1, &s1);
+}

--- a/tests/lit-tests/func_template_9.ispc
+++ b/tests/lit-tests/func_template_9.ispc
@@ -1,0 +1,19 @@
+// Check that explicit instantiation picks the right version of the template.
+
+// RUN: %{ispc} %s --nostdlib --target=host --ast-dump -o %t.o | FileCheck %s
+
+
+template <typename T> T foo(T a) { return a; }
+template <typename T> T foo(T a, T b) { return a+b; }
+template <typename T> T foo(T a, int b) { return a+b; }
+
+template <typename T> T goo(T a) { return a; }
+template <typename T> T goo(T a, T b) { return a+b; }
+template <typename T> T goo(T a, int b) { return a+b; }
+
+// CHECK: (instantiation <varying float>) Function {{.*}} [ varying float(varying float a, varying float b)] "foo"
+template float foo<float>(float, float);
+
+// CHECK: (instantiation <varying float>) Function {{.*}} [ varying float(varying float a, varying int32 b)] "goo"
+template float goo<float>(float, int);
+

--- a/tests/lit-tests/func_template_not_supported.ispc
+++ b/tests/lit-tests/func_template_not_supported.ispc
@@ -1,0 +1,16 @@
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap  2>&1 | FileCheck %s
+
+// CHECK-NOT: Please file a bug report
+
+// CHECK: Default values for template type parameters are not yet supported.
+// CHECK: Non-type template paramters are not yet supported.
+template <typename T = int, int I> T foo(T t) {
+  T tt = t + 1;
+  return tt;
+}
+
+// CHECK: Template function specialization not yet supported.
+template <> int foo(int t);
+
+// CHECK: Template function specialization not yet supported.
+template <> int foo(int t) { return 1; }

--- a/tests/lit-tests/template_argument_deduction2.ispc
+++ b/tests/lit-tests/template_argument_deduction2.ispc
@@ -1,0 +1,46 @@
+// The test check template argument deduction rules with different combination of const and &.
+// The test is designed to be a valid C++ program, and can be compiled by C++ compiler to observe C++ template deduction rules.
+// RUN: %{ispc} %s --nostdlib --target=host --emit-llvm-text -O0 -o - | FileCheck %s
+
+#ifdef ISPC
+#define NOINLINE noinline
+#define UNMASKED unmasked
+#else
+#define NOINLINE
+#define UNMASKED
+#endif
+
+template <typename T> NOINLINE T foo1(T t) { return t; }
+template <typename T> NOINLINE T foo2(T &t) { return t; }
+template <typename T> NOINLINE T foo3(const T t) { return t; }
+template <typename T> NOINLINE T foo4(const T &t) { return t; }
+
+UNMASKED void bar(int i, int& ri, const int ci, const int &cri) {
+  // CHECK-COUNT-4: call {{.*}} @foo1___vyi___vyi
+  foo1(i);   // int(int),               T = int. P = T, A = int.               T = int.
+  foo1(ri);  // int(int),               T = int. P = T, A = int&.              A ref dropped before deduction (A = int), adjusted A is int. T = int.
+  foo1(ci);  // int(int),               T = int. P = T, A = const int.         cv removal from A (P is not ref), adjusted A is int. T = int.
+  foo1(cri); // int(int),               T = int. P = T, A = const int&         A ref dropped before deduction (A = const int), cv removal (P is not ref), adjusted A is int. T = int.
+
+  // CHECK-COUNT-2: call {{.*}} @foo2___vyi___REFvyi
+  // CHECK-COUNT-2: call {{.*}} @foo2___Cvyi___REFCvyi
+  foo2(i);  // int (int &),             T = int.       P = T&. A = int.        P ref removal. Adjust P = T. T = int.
+  foo2(ri); // int (int &),             T = int.       P = T&. A = int&.       A ref dropped before deduction (A = int). P ref removal. Adjust P = T, A = int => T = int.
+  foo2(ci); // const int (const int &), T = const int. P = T&. A = const int.  P ref removal. Adjust P = T => T = const int.
+  foo2(cri);// const int (const int &), T = const int. P = T&. A = const int&. A ref dropped before deduction (A = const int). P ref removal. Adjust P = T, A = const int => T = const int.
+
+  // CHECK-COUNT-4: call {{.*}} @foo3___vyi___Cvyi
+  foo3(i);  // int (const int),         T = int. P = const T. A = int.         cv removal from P. P = int. A = int => T = int.
+  foo3(ri); // int (const int),         T = int. P = const T, A = int&.        A ref dropped before deduction. cv removal from P. P = int. A = int => T = int.
+  foo3(ci); // int (const int),         T = int. P = const T, A = const int.   cv removal from A (P is not ref), cv removal from P. P = int. A = int => T = int.
+  foo3(cri);// int (const int),         T = int. P = const T, A = const int&.  A ref dropped before deduction (A = const int). cv removal from A (P is not ref), cv removal from P. P = int. A = int => T = int.
+
+  // CHECK-COUNT-4: call {{.*}} @foo4___vyi___REFCvyi
+  foo4(i);  // int (const int &),       T = int. P = const T&. A = int.        P ref removal. P = const int. A = int. According to [temp.deduct.call]p4*, we can drop const from P => T = int.
+  foo4(ri); // int (const int &),       T = int. P = const T&. A = int&.       A ref dropped before deduction (A = int). P ref removal. P = const int. A = int. According to [temp.deduct.call]p4, we can drop const from P => T = int.
+  foo4(ci); // int (const int &),       T = int. P = const T&. A = const int.  P ref removal. P = const T. A = const int. Const canceled => T = int.
+  foo4(cri);// int (const int &),       T = int. P = const T&. A = const int&. A ref dropped before deduction (A = const int). P ref removal. P = const T. A = const int. Const canceled => T = int.
+            //
+            // * [temp.deduct.call]p4:
+            // If the original P is a reference type, the deduced A (i.e., the type referred to by the reference) can be more cv-qualified than the transformed A.
+}

--- a/tests/lit-tests/template_argument_deduction3.ispc
+++ b/tests/lit-tests/template_argument_deduction3.ispc
@@ -1,0 +1,51 @@
+// The test check template argument deduction rules with different combination of const and *.
+// The test is designed to be a valid C++ program, and can be compiled by C++ compiler to observe C++ template deduction rules.
+// RUN: %{ispc} %s --nostdlib --target=host --emit-llvm-text --wno-perf -O0 -o - | FileCheck %s
+
+#ifdef ISPC
+#define NOINLINE noinline
+#define UNMASKED unmasked
+#define VARYING varying
+#else
+#define NOINLINE
+#define UNMASKED
+#define VARYING
+#endif
+
+template <typename T> NOINLINE VARYING T foo1(T * t) { return *t; }
+template <typename T> NOINLINE VARYING T foo2(const T * t) { return *t; }
+template <typename T> NOINLINE VARYING T foo3(T * const t) { return *t; }
+template <typename T> NOINLINE VARYING T foo4(const T * const t) { return *t; }
+
+UNMASKED void bar(int *p, const int *cp, int * const pc, const int * const cpc) {
+    // CHECK: call {{.*}} @foo1___uni___vy_3C_uni_3E_
+    // CHECK: call {{.*}} @foo1___Cuni___vy_3C_Cuni_3E_
+    // CHECK: call {{.*}} @foo1___uni___vy_3C_uni_3E_
+    // CHECK: call {{.*}} @foo1___Cuni___vy_3C_Cuni_3E_
+    foo1(p);    // T = int
+    foo1(cp);   // T = const int
+    foo1(pc);   // T = int
+    foo1(cpc);  // T = const int
+
+    // CHECK-COUNT-4: call {{.*}} @foo2___uni___vy_3C_Cuni_3E_
+    foo2(p);    // T = int
+    foo2(cp);   // T = int
+    foo2(pc);   // T = int
+    foo2(cpc);  // T = int
+
+    // CHECK: call {{.*}} @foo3___uni___vy_3C_uni_3E_
+    // CHECK: call {{.*}} @foo3___Cuni___vy_3C_Cuni_3E_
+    // CHECK: call {{.*}} @foo3___uni___vy_3C_uni_3E_
+    // CHECK: call {{.*}} @foo3___Cuni___vy_3C_Cuni_3E_
+    foo3(p);    // T = int
+    foo3(cp);   // T = const int
+    foo3(pc);   // T = int
+    foo3(cpc);  // T = const int
+
+    // CHECK-COUNT-4: call {{.*}} @foo4___uni___vy_3C_Cuni_3E_
+    foo4(p);    // T = int
+    foo4(cp);   // T = int
+    foo4(pc);   // T = int
+    foo4(cpc);  // T = int
+}
+

--- a/tests/lit-tests/template_argument_deduction4.ispc
+++ b/tests/lit-tests/template_argument_deduction4.ispc
@@ -1,0 +1,16 @@
+// Check how pointer types are handled by template argument deduction.
+// RUN: %{ispc} %s --target=host --nostdlib --ast-dump -o %t.o | FileCheck %s
+
+template <typename T> noinline void foo1(T * uniform p1, T ** uniform p2, T *** uniform p3) { }
+template <typename T> noinline void foo2(T * p1, T ** p2, T *** p3) { }
+
+void bar(uniform int * uniform up1, uniform int ** uniform up2, uniform int *** uniform up3) {
+  // CHECK-COUNT-2: FunctionSymbolExpr {{.*}} [ void(uniform int32 * uniform p1, uniform int32 * uniform * uniform p2, uniform int32 * uniform * uniform * uniform p3)] function name: foo1
+  foo1<uniform int>(up1, up2, up3);
+  foo1(up1, up2, up3);
+
+  // foo2 assume uniform->varying convertion for arguments.
+  // CHECK-COUNT-2: FunctionSymbolExpr {{.*}} [ void(uniform int32 * varying p1, uniform int32 * uniform * varying p2, uniform int32 * uniform * uniform * varying p3)] function name: foo2
+  foo2<uniform int>(up1, up2, up3);
+  foo2(up1, up2, up3);
+}

--- a/tests/lit-tests/template_argument_deduction5.ispc
+++ b/tests/lit-tests/template_argument_deduction5.ispc
@@ -1,0 +1,35 @@
+// Check that correct version of the template was instantiated and called.
+// RUN: %{ispc} %s --target=host --emit-llvm-text -O0 -o - | FileCheck %s
+
+struct S {
+    float V[4];
+};
+
+template <typename T> noinline uniform T foo(const uniform T &V1, const uniform T &V2) {
+    uniform T Result;
+    foreach (i = 0 ... 4) {
+        Result.V[i] = max(V1.V[i], V2.V[i]);
+    }
+    return Result;
+}
+
+template <typename T> noinline varying T foo(const varying T &V1, const varying T &V2) {
+    varying T Result;
+    for (uniform int i = 0; i < 4; i++) {
+        Result.V[i] = max(V1.V[i], V2.V[i]);
+    }
+    return Result;
+}
+
+// CHECK-LABEL: define {{.*}} @bar1
+// CHECK: call {{.*}} @foo___s_5B_vyS_5D____REFs_5B__c_unS_5D_REFs_5B__c_unS_5D_
+unmasked const uniform S bar1(const uniform S Vb, const uniform S Vc) {
+    return foo(Vb, Vc);
+}
+
+// CHECK-LABEL: define {{.*}} @bar2
+// CHECK: call {{.*}} @foo___s_5B_unS_5D____REFs_5B__c_vyS_5D_REFs_5B__c_vyS_5D_
+unmasked const varying S bar2(const varying S Vb, const varying S Vc) {
+    return foo(Vb, Vc);
+}
+

--- a/tests/lit-tests/template_argument_deduction6.ispc
+++ b/tests/lit-tests/template_argument_deduction6.ispc
@@ -1,0 +1,24 @@
+// Check array to pointer decay in template argument deduction rules.
+// RUN: %{ispc} %s --nostdlib --target=host --ast-dump -o %t.o | FileCheck %s
+
+uniform int foo1(uniform int a[10], uniform int i) {
+  return a[i];
+}
+
+// CHECK: (instantiation <uniform int32>) Function {{.*}} [ uniform int32(uniform int32 * uniform a, uniform int32 i)] "foo2"
+// CHECK: (instantiation <uniform float>) Function {{.*}} [ uniform float(uniform float * uniform a, uniform int32 i)] "foo2"
+template <typename T> T foo2(T a[10], uniform int i) {
+  return a[i];
+}
+
+void bar() {
+  uniform int int_array[100];
+  uniform float float_array[10];
+
+  // CHECK: FunctionSymbolExpr {{.*}} [ uniform int32(uniform int32 * uniform a, uniform int32 i)] function name: foo1
+  foo1(int_array, 5);
+  // CHECK: FunctionSymbolExpr {{.*}} [ uniform int32(uniform int32 * uniform a, uniform int32 i)] function name: foo2
+  foo2(int_array, 5);
+  // CHECK: FunctionSymbolExpr {{.*}} [ uniform float(uniform float * uniform a, uniform int32 i)] function name: foo2
+  foo2(float_array, 5);
+}


### PR DESCRIPTION
This PR introduces function template support with syntax and semantic borrowed from C++. Specifically, keywords `template` and `typename` were added. They can be used to declare or define the function template:
```cpp
template <typename T> T foo(T t) { return t + 1; }
```

Template functions may be called through explicit type parameters specification syntax:
```cpp
void bar() {
    int i = foo<int>(1);
    uniform int ui = foo<uniform int>(1);
    float f = foo<float>(1.f);
}
```
While template argument deduction rules generally follow C++, there are some differences caused by existence of ``uniform``, ``varying`` and ``unbound`` types in ``ispc`` type system.  The template type parameter may resolve only to ``uniform`` and ``varying`` types, but not to ``unbound`` type. Consider the following example:
```cpp
template <typename T> T add(T a, T b) { return a + b; }

void foo() {
    // Note that these two lines call the same function:
    int i1 = add<int>(1, 2);                 // T = varying int
    varying int i2 = add<varying int>(1, 2); // T = varying int

    // And this call a uniform version:
    uniform int i3 = add<uniform int>(1, 2); // T = uniform int
}
```
The variability of template type parameter ``T`` may be overwritten by ``uniform`` and ``varying`` keywords, so ``uniform T`` and ``varying T``  are always valid types. But when ``uniform T`` and ``varying T`` are used to specify template function parameters it has an effect on template argument deduction process.  If variability keyword is specified and the type was successfully deduced, the default variability of type ``T`` is assumed to be the opposite of the variability keyword.  The logic behind it is that the keyword was specified "on purpose" to changed the variability of the type ``T``. Consider the following example:

```cpp
template <typename T> void foo1(T t);
template <typename T> void foo2(uniform T t);
template <typename T> void foo3(varying T t);

void bar() {
    uniform int ui;
    varying int vi;
    foo1(ui); // T is uniform int
    foo1(vi); // T is varying int
    foo2(ui); // T is varying int!
    foo2(vi); // error: varying type cannot be passed to uniform parameter
    foo3(ui); // T is uniform int!
    foo3(vi); // T is uniform int!
}
```
Template parameters type deduction is not yet implemented, but planned in this PR, i.e.:
```cpp
void bar() {
    int i = foo((varying int)1);
    uniform int ui = foo(1);
    float f = foo(programIndex + 1.f);
}
```

Also, this PR introduces the syntax for a set of function template features that are planned, but not yet implemented:
- default values for template type parameters
- non-type template type parameters (integer parameters)
- function specialization
The test demonstrating what is not supported is [here](https://github.com/dbabokin/ispc/blob/templates_new/tests/lit-tests/func_template_not_supported.ispc).

Here are the tests that demonstrate what is supported and working: [test1](https://github.com/dbabokin/ispc/blob/templates_new/tests/lit-tests/func_template_1.ispc), [test2](https://github.com/dbabokin/ispc/blob/templates_new/tests/lit-tests/func_template_2.ispc).

TODO for this PR:
- [x] type deduction support in the call expression to support `foo(arg1, arg2);` call syntax (partially completed)
- [x] support all types of expressions in template code (call expressions depended types are not supported yet)
- [x] user documentation update
- [x] design document
- [x] test coverage
- [ ] consider several refactorings and review memory allocations.

TODO for either this or follow up PRs:

- [ ] support for non-type template parameters - integer parameters.

**Feedback for this feature is very welcome.**
Linux and Windows builds of the latest version can be found in Appveyor artifacts. Current (as of writing this comment) Linux build is [here](https://ci.appveyor.com/api/buildjobs/j858ese3ok5ffrqa/artifacts/build%2Fispc-trunk-linux.tar.gz). Windows build is [here](https://ci.appveyor.com/api/buildjobs/s5qdooa3ps58aitt/artifacts/build%2Fispc-trunk-windows.zip).