### PR TITLE
Editorial and test fixes

### DIFF
--- a/.github/workflows/rebuild-llvm15.yml
+++ b/.github/workflows/rebuild-llvm15.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/reusable.rebuild.yml
     with:
       version: '15.0'
-      full_version: '15.0.4'
+      full_version: '15.0.5'
       ubuntu: '18.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'

--- a/alloy.py
+++ b/alloy.py
@@ -121,7 +121,7 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     if  version_LLVM == "trunk":
         GIT_TAG="main"
     elif  version_LLVM == "15_0":
-        GIT_TAG="llvmorg-15.0.4"
+        GIT_TAG="llvmorg-15.0.5"
     elif  version_LLVM == "14_0":
         GIT_TAG="llvmorg-14.0.6"
     elif  version_LLVM == "13_0":

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -622,6 +622,8 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
         child->InitFromType(functionType, ds);
         type = child->type;
         name = child->name;
+    } else {
+        UNREACHABLE();
     }
 }
 

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -5493,7 +5493,7 @@ ConstExpr::ConstExpr(const Type *t, bool *b, SourcePos p) : Expr(p, ConstExprID)
         boolVal[j] = b[j];
 }
 
-ConstExpr::ConstExpr(ConstExpr *old, SourcePos p) : Expr(p, ConstExprID) {
+ConstExpr::ConstExpr(const ConstExpr *old, SourcePos p) : Expr(p, ConstExprID) {
     type = old->type;
 
     AtomicType::BasicType basicType = getBasicType();

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -7856,11 +7856,8 @@ void SymbolExpr::Print(Indent &indent) const {
 // FunctionSymbolExpr
 
 FunctionSymbolExpr::FunctionSymbolExpr(const char *n, const std::vector<Symbol *> &candidates, SourcePos p)
-    : Expr(p, FunctionSymbolExprID) {
-    name = n;
-    candidateFunctions = candidates;
-    matchingFunc = (candidates.size() == 1) ? candidates[0] : NULL;
-    triedToResolve = false;
+    : Expr(p, FunctionSymbolExprID), name(n), candidateFunctions(candidates), triedToResolve(false) {
+    matchingFunc = (candidates.size() == 1) ? candidates[0] : nullptr;
 }
 
 const Type *FunctionSymbolExpr::GetType() const {
@@ -7987,21 +7984,24 @@ static bool lIsMatchWithTypeWidening(const Type *callType, const Type *funcArgTy
  */
 std::vector<Symbol *> FunctionSymbolExpr::getCandidateFunctions(int argCount) const {
     std::vector<Symbol *> ret;
-    for (int i = 0; i < (int)candidateFunctions.size(); ++i) {
-        const FunctionType *ft = CastType<FunctionType>(candidateFunctions[i]->type);
+    for (Symbol *sym : candidateFunctions) {
+        AssertPos(pos, sym != nullptr);
+        const FunctionType *ft = CastType<FunctionType>(sym->type);
         AssertPos(pos, ft != NULL);
 
         // There's no way to match if the caller is passing more arguments
         // than this function instance takes.
-        if (argCount > ft->GetNumParameters())
+        if (argCount > ft->GetNumParameters()) {
             continue;
+        }
 
         // Not enough arguments, and no default argument value to save us
-        if (argCount < ft->GetNumParameters() && ft->GetParameterDefault(argCount) == NULL)
+        if (argCount < ft->GetNumParameters() && ft->GetParameterDefault(argCount) == nullptr) {
             continue;
+        }
 
         // Success
-        ret.push_back(candidateFunctions[i]);
+        ret.push_back(sym);
     }
     return ret;
 }

--- a/src/expr.h
+++ b/src/expr.h
@@ -428,7 +428,7 @@ class ConstExpr : public Expr {
 
     /** Create ConstExpr with the same type and values as the given one,
         but at the given position. */
-    ConstExpr(ConstExpr *old, SourcePos pos);
+    ConstExpr(const ConstExpr *old, SourcePos pos);
 
     static inline bool classof(ConstExpr const *) { return true; }
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ConstExprID; }

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -2237,10 +2237,8 @@ int ForeachActiveStmt::EstimateCost() const { return COST_VARYING_LOOP; }
 // ForeachUniqueStmt
 
 ForeachUniqueStmt::ForeachUniqueStmt(const char *iterName, Expr *e, Stmt *s, SourcePos pos)
-    : Stmt(pos, ForeachUniqueStmtID) {
+    : Stmt(pos, ForeachUniqueStmtID), expr(e), stmts(s) {
     sym = m->symbolTable->LookupVariable(iterName);
-    expr = e;
-    stmts = s;
 }
 
 void ForeachUniqueStmt::EmitCode(FunctionEmitContext *ctx) const {

--- a/tests/lit-tests/ftz_daz_flags_aarch64.ispc
+++ b/tests/lit-tests/ftz_daz_flags_aarch64.ispc
@@ -1,0 +1,18 @@
+// Tests checks that correct registries are used to set/restore FTZ/DAZ flags on ARM
+
+// RUN: %{ispc} %s --arch=aarch64 --target=neon-i32x8 --nostdlib --emit-asm --opt=reset-ftz-daz -o - | FileCheck --check-prefixes=CHECK_AARCH64 %s
+
+// CHECK_AARCH64: mrs
+// CHECK_AARCH64: FPCR
+
+// ARM must be enabled in order to test it.
+// REQUIRES: ARM_ENABLED
+// Not every ISPC build on macOS supports ARM targets.
+// They are supported only if macOS SDK supports them.
+// REQUIRES: !MACOS_HOST || MACOS_ARM_ENABLED
+
+export uniform float export_test_ftz_daz(){
+    uniform float x = 0x1p-149;
+    uniform float y = 0x0.fffffep-126f;
+    return y - x;
+}

--- a/tests/lit-tests/ftz_daz_flags_arm.ispc
+++ b/tests/lit-tests/ftz_daz_flags_arm.ispc
@@ -1,22 +1,13 @@
 // Tests checks that correct registries are used to set/restore FTZ/DAZ flags on ARM
 
-// RUN: %{ispc} %s --arch=arm --target=neon-i32x8 --emit-asm --opt=reset-ftz-daz -o - | FileCheck --check-prefixes=CHECK_ARM %s
-// RUN: %{ispc} %s --arch=aarch64 --target=neon-i32x8 --emit-asm --opt=reset-ftz-daz -o - | FileCheck --check-prefixes=CHECK_AARCH64 %s
+// RUN: %{ispc} %s --arch=arm --target=neon-i32x8 --nostdlib --emit-asm --opt=reset-ftz-daz -o - | FileCheck --check-prefixes=CHECK_ARM %s
 
 // CHECK_ARM: vmrs
 // CHECK_ARM: fpscr
 
-// CHECK_AARCH64: mrs
-// CHECK_AARCH64: FPCR
-
 // ARM must be enabled in order to test it.
-// REQUIRES: ARM_ENABLED
-// There are a few exceptions though.
-// We do not support ARM targets on Windows.
-// REQUIRES: !WINDOWS_HOST
-// Not every ISPC build on macOS supports ARM targets.
-// They are supported only if macOS SDK supports them.
-// REQUIRES: !MACOS_HOST || MACOS_ARM_ENABLED
+// Windows and Mac do not support 32 bit ARM. so test on Linux only (Android assumed to be the same)
+// REQUIRES: ARM_ENABLED && LINUX_HOST
 
 export uniform float export_test_ftz_daz(){
     uniform float x = 0x1p-149;

--- a/tests/lit-tests/ftz_daz_flags_x86.ispc
+++ b/tests/lit-tests/ftz_daz_flags_x86.ispc
@@ -1,0 +1,52 @@
+// Tests checks that stmxcsr/ldmxcsr intrinsics set/restore FTZ/DAZ flags when --opt=reset-ftz-daz is passed.
+// --opt=reset-ftz-daz affects external ISPC functions only.
+
+// RUN: %{ispc} %s --target=avx2 --arch=x86 --nostdlib --emit-llvm-text --opt=reset-ftz-daz -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx2 --arch=x86 --nostdlib --emit-llvm-text -o - | FileCheck --check-prefixes=CHECK_NO_FTZ_DAZ %s
+
+// CHECK: define float @test_ftz_daz___
+// CHECK-NOT: stmxcsr
+// CHECK-NOT: ldmxcsr
+// CHECK: define float @export_test_ftz_daz___
+// CHECK-NOT: stmxcsr
+// CHECK-NOT: ldmxcsr
+// CHECK: define void @export_void_test_ftz_daz___
+// CHECK-NOT: stmxcsr
+// CHECK-NOT: ldmxcsr
+// CHECK: define float @externC_test_ftz_daz()
+// CHECK: stmxcsr
+// CHECK-COUNT-2: ldmxcsr
+// CHECK: define float @export_test_ftz_daz(
+// CHECK: stmxcsr
+// CHECK-COUNT-2: ldmxcsr
+
+// CHECK_NO_FTZ_DAZ-NOT: stmxcsr
+// CHECK_NO_FTZ_DAZ-NOT: ldmxcsr
+
+// macOS doesn't support 32 bit x86.
+// REQUIRES: X86_ENABLED && !MACOS_HOST
+uniform float test_ftz_daz(){
+    uniform float x = 0x1p-149;
+    uniform float y = 0x0.fffffep-126f;
+    return y - x;
+}
+
+export uniform float export_test_ftz_daz(){
+    uniform float x = 0x1p-149;
+    uniform float y = 0x0.fffffep-126f;
+    return y - x;
+}
+
+export void export_void_test_ftz_daz(uniform float res[]){
+    uniform float x = 0x1p-149;
+    uniform float y = 0x0.fffffep-126f;
+    res[0] = y - x;
+}
+
+extern "C" uniform float externC_test_ftz_daz(){
+    uniform float x = 0x1p-149;
+    uniform float y = 0x0.fffffep-126f;
+    if (programIndex % 2)
+        return y + x;
+    return y - x;
+}

--- a/tests/lit-tests/ftz_daz_flags_x86_64.ispc
+++ b/tests/lit-tests/ftz_daz_flags_x86_64.ispc
@@ -1,9 +1,8 @@
 // Tests checks that stmxcsr/ldmxcsr intrinsics set/restore FTZ/DAZ flags when --opt=reset-ftz-daz is passed.
 // --opt=reset-ftz-daz affects external ISPC functions only.
 
-// RUN: %{ispc} %s --target=avx2 --arch=x86 --emit-llvm-text --opt=reset-ftz-daz -o - | FileCheck %s
-// RUN: %{ispc} %s --target=avx2 --arch=x86-64 --emit-llvm-text --opt=reset-ftz-daz -o - | FileCheck %s
-// RUN: %{ispc} %s --target=avx2 --emit-llvm-text -o - | FileCheck --check-prefixes=CHECK_NO_FTZ_DAZ %s
+// RUN: %{ispc} %s --target=avx2 --arch=x86-64 --nostdlib --emit-llvm-text --opt=reset-ftz-daz -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx2 --arch=x86-64 --nostdlib --emit-llvm-text -o - | FileCheck --check-prefixes=CHECK_NO_FTZ_DAZ %s
 
 // CHECK: define float @test_ftz_daz___
 // CHECK-NOT: stmxcsr

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -36,17 +36,11 @@ if llvm_version >= LooseVersion("12.0.0"):
 else:
     print("LLVM_12_0+: NO")
 
-if llvm_version >= LooseVersion("14.0.0"):
-    print("LLVM_14_0+: YES")
-    config.available_features.add("LLVM_14_0+")
+if llvm_version >= LooseVersion("13.0.0"):
+    print("LLVM_13_0+: YES")
+    config.available_features.add("LLVM_13_0+")
 else:
-    print("LLVM_14_0+: NO")
-
-if llvm_version >= LooseVersion("15.0.0"):
-    print("LLVM_15_0+: YES")
-    config.available_features.add("LLVM_15_0+")
-else:
-    print("LLVM_15_0+: NO")
+    print("LLVM_13_0+: NO")
 
 # Windows target OS is enabled
 windows_enabled = lit_config.params.get('windows_enabled')


### PR DESCRIPTION
- Fix FTZ/DAZ test on macOS (which doesn't support 32 bit version of x86 and arm).
- Removed unused LLVM14/15 macros in lit testing, as LLVM13, which is used by one of the tests.
- Move LLVM15 build (not use in CI) to `15.0.5`
- Clean up in FunctionSymbolExpr::ResolveOverloads() - this changes error message for builtins, but the logic is not changed. This logic supposed to be different for builtins, but it's not true for very long time.
- Several editorial changes, which were split from Templates PR.