### PR TITLE
Fix CI and move to LLVM 15.0.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,7 +58,7 @@ for:
         if "%LLVM_VERSION%"=="latest" (set WASM=ON)
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vspath="C:\Program Files (x86)\Microsoft Visual Studio\2019"))
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2022" ( (set generator="Visual Studio 17") & (set vspath="C:\Program Files\Microsoft Visual Studio\2022"))
-        set LLVM_TAR=llvm-15.0.3-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        set LLVM_TAR=llvm-15.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
         if "%LLVM_VERSION%"=="14.0" (set LLVM_TAR=llvm-14.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
         if "%LLVM_VERSION%"=="13.0" (set LLVM_TAR=llvm-13.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
         if "%LLVM_VERSION%"=="12.0" (set LLVM_TAR=llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
@@ -112,7 +112,7 @@ for:
         export LLVM_HOME=$APPVEYOR_BUILD_FOLDER/llvm
         export CROSS_TOOLS=/usr/local/src/cross
         export WASM=OFF
-        export LLVM_TAR=llvm-15.0.3-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+        export LLVM_TAR=llvm-15.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
   install:
     - sh: |-
         sudo apt-get update

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -69,7 +69,7 @@ jobs:
   linux-build-ispc-llvm11:
     needs: [define-flow]
     #if: ${{ needs.define-flow.outputs.flow_type == 'full' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       LLVM_VERSION: "11.1"
       LLVM_TAR: llvm-11.1.0-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
@@ -105,7 +105,7 @@ jobs:
 
   linux-build-ispc-llvm12:
     needs: [define-flow]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       LLVM_VERSION: "12.0"
       LLVM_TAR: llvm-12.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
@@ -318,7 +318,7 @@ jobs:
 
   linux-test-llvm11:
     needs: [define-flow, linux-build-ispc-llvm11]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -357,7 +357,7 @@ jobs:
 
   linux-test-llvm12:
     needs: [define-flow, linux-build-ispc-llvm12]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     continue-on-error: false
     strategy:
       fail-fast: false

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.3-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-15.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.3-ubuntu18.04-Release-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-15.0.6-ubuntu18.04-Release-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -290,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.3-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-15.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -767,7 +767,7 @@ jobs:
     runs-on: windows-2019
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.3-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_TAR: llvm-15.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -614,7 +614,7 @@ jobs:
         submodules: true
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1
 
     - name: Install dependencies
       run: |
@@ -655,7 +655,7 @@ jobs:
         submodules: true
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1
 
     - name: Install dependencies
       run: |
@@ -696,7 +696,7 @@ jobs:
         submodules: true
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1
 
     - name: Install dependencies
       run: |
@@ -737,7 +737,7 @@ jobs:
         submodules: true
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1
 
     - name: Install dependencies
       run: |
@@ -779,7 +779,7 @@ jobs:
         submodules: true
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -57,14 +57,14 @@ jobs:
       run: |
         # one and only one var should be set
         [[ $RUN_SMOKE == false && $RUN_FULL == true ]] || [[ $RUN_SMOKE == true && $RUN_FULL == false ]] || ( echo "One and only one env var must be set: RUN_SMOKE or RUN_FULL"; exit 1)
-        $RUN_SMOKE && echo "::set-output name=type::smoke" || true
-        $RUN_FULL &&  echo "::set-output name=type::full" || true
+        $RUN_SMOKE && echo "type=smoke" >> $GITHUB_OUTPUT || true
+        $RUN_FULL &&  echo "type=full" >> $GITHUB_OUTPUT || true
         # set tests matrix depends on flow
-        $RUN_SMOKE && echo "::set-output name=matrix::${TARGETS_SMOKE}" || true
-        $RUN_FULL &&  echo "::set-output name=matrix::${TARGETS_FULL}" || true
+        $RUN_SMOKE && echo "matrix=${TARGETS_SMOKE}" >> $GITHUB_OUTPUT || true
+        $RUN_FULL &&  echo "matrix=${TARGETS_FULL}" >> $GITHUB_OUTPUT || true
         # set tests optsets
-        $RUN_SMOKE && echo "::set-output name=optsets::${OPTSETS_SMOKE}" || true
-        $RUN_FULL &&  echo "::set-output name=optsets::${OPTSETS_FULL}" || true
+        $RUN_SMOKE && echo "optsets=${OPTSETS_SMOKE}" >> $GITHUB_OUTPUT || true
+        $RUN_FULL &&  echo "optsets=${OPTSETS_FULL}" >> $GITHUB_OUTPUT || true
 
   linux-build-ispc-llvm11:
     needs: [define-flow]

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -47,14 +47,14 @@ jobs:
       run: |
         # one and only one var should be set
         [[ $RUN_SMOKE == false && $RUN_FULL == true ]] || [[ $RUN_SMOKE == true && $RUN_FULL == false ]] || ( echo "One and only one env var must be set: RUN_SMOKE or RUN_FULL"; exit 1)
-        $RUN_SMOKE && echo "::set-output name=type::smoke" || true
-        $RUN_FULL &&  echo "::set-output name=type::full" || true
+        $RUN_SMOKE && echo "type=smoke" >> $GITHUB_OUTPUT || true
+        $RUN_FULL &&  echo "type=full" >> $GITHUB_OUTPUT || true
         # set tests matrix depends on flow
-        $RUN_SMOKE && echo "::set-output name=matrix::${TARGETS_SMOKE}" || true
-        $RUN_FULL &&  echo "::set-output name=matrix::${TARGETS_FULL}" || true
+        $RUN_SMOKE && echo "matrix=${TARGETS_SMOKE}" >> $GITHUB_OUTPUT || true
+        $RUN_FULL &&  echo "matrix=${TARGETS_FULL}" >> $GITHUB_OUTPUT || true
         # set tests optsets
-        $RUN_SMOKE && echo "::set-output name=optsets::${OPTSETS_SMOKE}" || true
-        $RUN_FULL &&  echo "::set-output name=optsets::${OPTSETS_FULL}" || true
+        $RUN_SMOKE && echo "optsets=${OPTSETS_SMOKE}" >> $GITHUB_OUTPUT || true
+        $RUN_FULL &&  echo "optsets=${OPTSETS_FULL}" >> $GITHUB_OUTPUT || true
 
   linux-build-ispc-llvm13:
     needs: [define-flow]

--- a/.github/workflows/nightly-15.yml
+++ b/.github/workflows/nightly-15.yml
@@ -241,7 +241,7 @@ jobs:
         path: ${{env.LLVM_HOME}}
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/nightly-15.yml
+++ b/.github/workflows/nightly-15.yml
@@ -78,20 +78,20 @@ jobs:
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-15.0 .
         # Note using gzip here, instead of xz - trading of space for speed, as it's just for passing to another stage.
-        tar czvf llvm-15.0.3-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-15.0
+        tar czvf llvm-15.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-15.0
 
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
         name: llvm_15_linux
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-15.0.3-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-15.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
   linux-build-ispc-llvm-15:
     needs: [linux-build-llvm-15-2]
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.3-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+      LLVM_TAR: llvm-15.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
     steps:
     - uses: actions/checkout@v3
@@ -208,7 +208,7 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-15.0.3-win.vs2019-Release+Asserts-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-15.0.6-win.vs2019-Release+Asserts-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-15.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -216,7 +216,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: llvm_15_win
-        path: llvm/llvm-15.0.3-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        path: llvm/llvm-15.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
 
   win-build-ispc-llvm-15:
@@ -224,7 +224,7 @@ jobs:
     runs-on: windows-2022
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.3-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_TAR: llvm-15.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"

--- a/.github/workflows/rebuild-llvm15.yml
+++ b/.github/workflows/rebuild-llvm15.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/reusable.rebuild.yml
     with:
       version: '15.0'
-      full_version: '15.0.5'
+      full_version: '15.0.6'
       ubuntu: '18.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'

--- a/.github/workflows/scripts/install-build-deps.sh
+++ b/.github/workflows/scripts/install-build-deps.sh
@@ -5,7 +5,7 @@ echo "APT::Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-retries
 for i in {1..5}
 do
   sudo apt-get update | tee log${i}.txt
-  sudo apt-get install bison flex libc6-dev-i386 g++-multilib lib32stdc++6 ncurses-dev | tee -a log${i}.txt
+  sudo apt-get install bison flex libc6-dev-i386 g++-multilib lib32stdc++6 ncurses-dev libtinfo5 | tee -a log${i}.txt
   if [[ ! `grep "^Err: " log${i}.txt` && ! `grep "^E: " log${i}.txt` ]]; then
     echo "APT packages installation was successful"
     break

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
       dist: bionic
       env:
         - LLVM_VERSION=15.0 OS=Ubuntu18.04aarch64
-        - LLVM_TAR=llvm-15.0.3-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_TAR=llvm-15.0.6-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
         - LLVM_REPO=https://github.com/ispc/llvm-project
         - ISPC_HOME=$TRAVIS_BUILD_DIR
       before_install:

--- a/alloy.py
+++ b/alloy.py
@@ -261,7 +261,7 @@ def build_LLVM(version_LLVM, folder, debug, selfbuild, extra, from_validation, f
                 try_do_LLVM("patch LLVM with patch " + patch + " ", "git apply " + patch, from_validation, verbose)
         os.chdir("../")
 
-    targets_and_common_options = "  -DLLVM_ENABLE_ZLIB=OFF -DLLVM_TARGETS_TO_BUILD=AArch64\;ARM\;X86 -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly"
+    targets_and_common_options = "  -DLLVM_ENABLE_ZLIB=OFF -DLLVM_ENABLE_ZSTD=OFF -DLLVM_TARGETS_TO_BUILD=AArch64\;ARM\;X86 -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly"
 
     # configuring llvm and build for first phase of selfbuild
     cmakelists_path = LLVM_SRC + "/llvm"

--- a/alloy.py
+++ b/alloy.py
@@ -121,7 +121,7 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     if  version_LLVM == "trunk":
         GIT_TAG="main"
     elif  version_LLVM == "15_0":
-        GIT_TAG="llvmorg-15.0.5"
+        GIT_TAG="llvmorg-15.0.6"
     elif  version_LLVM == "14_0":
         GIT_TAG="llvmorg-14.0.6"
     elif  version_LLVM == "13_0":

--- a/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
@@ -16,7 +16,7 @@ RUN uname -a
 
 # Packages required to build ISPC and Clang.
 RUN apt-get -y update && apt-get --no-install-recommends install -y wget=1.19.4-1ubuntu2.2 build-essential=12.4ubuntu1 gcc=4:7.4.0-1ubuntu2.3 \
-    g++=4:7.4.0-1ubuntu2.3 git=1:2.17.1-1ubuntu0.12 python3-dev=3.6.7-1~18.04 libncurses5-dev=6.1-1ubuntu1.18.04 libtinfo-dev=6.1-1ubuntu1.18.04 ca-certificates=20211016~18.04.1 && \    
+    g++=4:7.4.0-1ubuntu2.3 git=1:2.17.1-1ubuntu0.13 python3-dev=3.6.7-1~18.04 libncurses5-dev=6.1-1ubuntu1.18.04 libtinfo-dev=6.1-1ubuntu1.18.04 ca-certificates=20211016~18.04.1 && \
     rm -rf /var/lib/apt/lists/*
 
 # Download and install required version of cmake (3.14 for x86, 3.20 for aarch64, as earlier versions are not available as binary distribution) for ISPC build


### PR DESCRIPTION
- Build LLVM `15.0.6` with `alloy.py`
- Use LLVM `15.0.6` in CI (instead of `15.0.3`)
- Build LLVM with explicitly turned off ZSTD compression. This should not matter on Linux and Windows, but ZSTD shows up on macOS. We don't use compression anyway.
- Fix git version in Ubuntu 18.04 Dockerfile.
- Explicitly install `libtinfo5` for ISPC build, as it's not available by default in `ubuntu-22.04` image from Github.
- Use `ubuntu-20.04` image for testing with LLVM 11 & 12, as new version of library GLIBCXX has deprecation attributes for some of the stuff used by LLVM 11 & 12 and it causes build errors (with `-Werror` that we have enabled in CI)
- Fix Github Actions warnings: avoid using `set-output` and update `microsoft/setup-msbuild` action by switching to `v1` tag.