### PR TITLE
GH Actions: fix Windows & enable macOS build

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -598,6 +598,50 @@ jobs:
         name: fail_db.llvm15.debug.txt
         path: fail_db.txt
 
+  macos-build-ispc-llvm15:
+    needs: [define-flow]
+    runs-on: macos-11
+    env:
+      LLVM_VERSION: "15.0"
+      LLVM_TAR: llvm-15.0.6-macos11-Release+Asserts-x86.arm.wasm.tar.xz
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Install dependencies
+      run: |
+        ls -al /Library/Developer/CommandLineTools/SDKs/
+        xcrun --show-sdk-path
+        [ -n "$LLVM_REPO" ] && wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 --no-verbose $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
+        tar xf $LLVM_TAR
+        echo "${GITHUB_WORKSPACE}/bin-$LLVM_VERSION/bin" >> $GITHUB_PATH
+        brew install bison flex
+        echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
+        echo "/usr/local/opt/flex/bin" >> $GITHUB_PATH
+
+    - name: Check environment
+      run: |
+        ./check_env.py
+        which -a clang
+        llvm-config --system-libs
+        sysctl -n machdep.cpu.brand_string
+
+    - name: Build package
+      run: |
+        .github/workflows/scripts/build-ispc.sh -DBENCHMARKS_ISPC_TARGETS=avx1-i32x4
+
+    - name: Sanity testing (make check-all, make test)
+      run: |
+        .github/workflows/scripts/check-ispc.sh
+
+    - name: Upload package
+      uses: actions/upload-artifact@v3
+      with:
+        name: ispc_llvm15_macos
+        path: build/ispc-trunk-macos.tar.gz
+
   win-build-ispc-llvm11:
     needs: [define-flow]
     runs-on: windows-2019

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   linux-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3
@@ -104,7 +104,7 @@ jobs:
   calcite:
     continue-on-error: true
     needs: benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CALCITE_CLI: '@siliceum/calcite-cli@0.7.2'
     steps:

--- a/.github/workflows/scripts/build-ispc.sh
+++ b/.github/workflows/scripts/build-ispc.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -e
 echo PATH=$PATH
 
-cmake -B build -DISPC_PREPARE_PACKAGE=ON -DISPC_INCLUDE_BENCHMARKS=ON -DCMAKE_CXX_FLAGS="-Werror" -DISPC_PACKAGE_NAME=ispc-trunk-linux -DISPC_OPAQUE_PTR_MODE=${ISPC_OPAQUE_PTR_MODE} $@
+if [[ $OSTYPE == 'darwin'* ]]; then
+  # macOS is treated differently because we don't build benchmarks and package name is different.
+  # Benchmarks are not built, because Github Action macOS shared runners run on too old hardware -
+  # IvyBridge, i.e. AVX1, while our benchmark setup assumes at least AVX2.
+  cmake -B build -DISPC_PREPARE_PACKAGE=ON -DCMAKE_CXX_FLAGS="-Werror" -DISPC_PACKAGE_NAME=ispc-trunk-macos -DISPC_OPAQUE_PTR_MODE=${ISPC_OPAQUE_PTR_MODE} $@
+else
+  cmake -B build -DISPC_PREPARE_PACKAGE=ON -DISPC_INCLUDE_BENCHMARKS=ON -DCMAKE_CXX_FLAGS="-Werror" -DISPC_PACKAGE_NAME=ispc-trunk-linux -DISPC_OPAQUE_PTR_MODE=${ISPC_OPAQUE_PTR_MODE} $@
+fi
 cmake --build build --target package -j4

--- a/.github/workflows/scripts/check-ispc.sh
+++ b/.github/workflows/scripts/check-ispc.sh
@@ -2,4 +2,8 @@
 cd build
 bin/check_isa
 bin/ispc --support-matrix
-cmake --build . --target check-all ispc_benchmarks test
+if [[ $OSTYPE == 'darwin'* ]]; then
+  cmake --build . --target check-all
+else
+  cmake --build . --target check-all ispc_benchmarks test
+fi

--- a/.github/workflows/scripts/install-build-deps.ps1
+++ b/.github/workflows/scripts/install-build-deps.ps1
@@ -20,5 +20,7 @@ echo "${env:LLVM_HOME}\bin-${env:LLVM_VERSION}\bin" | Out-File -FilePath $env:GI
 # Download and unpack gnuwin32
 mkdir ${env:CROSS_TOOLS_GNUWIN32}
 cd ${env:CROSS_TOOLS_GNUWIN32}
-wget --retry-connrefused --waitretry=10 --read-timeout=20 --timeout=15 -t 5 -O libgw32c-0.4-lib.zip https://sourceforge.net/projects/gnuwin32/files/libgw32c/0.4/libgw32c-0.4-lib.zip/download
+# The following line is needed to enable all TLS versions. The server appears to require different TLS version depending on the specific redirect.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls, [Net.SecurityProtocolType]::Tls11, [Net.SecurityProtocolType]::Tls12
+wget --retry-connrefused --waitretry=10 --read-timeout=20 --timeout=15 -t 5 -O libgw32c-0.4-lib.zip 'https://downloads.sourceforge.net/project/gnuwin32/libgw32c/0.4/libgw32c-0.4-lib.zip'
 7z.exe x libgw32c-0.4-lib.zip

--- a/alloy.py
+++ b/alloy.py
@@ -385,6 +385,8 @@ def check_targets():
                  ["SSE2", "SSE4"], "-wsm", False]),
       ("AVX",    [["avx1-i32x4",  "avx1-i32x8",  "avx1-i32x16",  "avx1-i64x4"],
                  ["SSE2", "SSE4", "AVX"], "-snb", False]),
+      ("AVX1.1", [["avx1-i32x4",  "avx1-i32x8",  "avx1-i32x16",  "avx1-i64x4"],
+                 ["SSE2", "SSE4", "AVX"], "-snb", False]),
       ("AVX2",   [["avx2-i32x4", "avx2-i32x8",  "avx2-i32x16",  "avx2-i64x4", "avx2-i8x32", "avx2-i16x16"],
                  ["SSE2", "SSE4", "AVX", "AVX2"], "-hsw", False]),
       ("KNL",    [["avx512knl-x16"],


### PR DESCRIPTION
- one of dependencies downloads on Windows we randomly failing - the reason redirect routes to the server with new TLS version requirement. Fix by enabling TLS of all versions.
- add macOS build. macOS testing is not added yet, as `alloy.py` in testing mode fails on macOS in a strange way (this still needs debugging).