### PR TITLE
Make dispatch function dllexport if needed

### DIFF
--- a/src/func.cpp
+++ b/src/func.cpp
@@ -735,6 +735,11 @@ void Function::GenerateIR() {
                     appFunction->setDLLStorageClass(llvm::GlobalValue::DLLExportStorageClass);
                     appFunction->addFnAttr("CMGenxMain");
                 }
+            } else {
+                // Make application function callable from DLLs.
+                if ((g->target_os == TargetOS::windows) && (g->dllExport)) {
+                    appFunction->setDLLStorageClass(llvm::GlobalValue::DLLExportStorageClass);
+                }
             }
 
             if (function->getFunctionType()->getNumParams() > 0) {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2589,6 +2589,10 @@ static void lCreateDispatchFunction(llvm::Module *module, llvm::Function *setISA
         llvm::Function::Create(ftype, llvm::GlobalValue::ExternalLinkage, functionName.c_str(), module);
     dispatchFunc->setCallingConv(callingConv);
 
+    // Make dispatch function callable from DLLs.
+    if ((g->target_os == TargetOS::windows) && (g->dllExport)) {
+        dispatchFunc->setDLLStorageClass(llvm::GlobalValue::DLLExportStorageClass);
+    }
     llvm::BasicBlock *bblock = llvm::BasicBlock::Create(*g->ctx, "entry", dispatchFunc);
 
     // Start by calling out to the function that determines the system's

--- a/tests/lit-tests/windows_dllexport.ispc
+++ b/tests/lit-tests/windows_dllexport.ispc
@@ -1,0 +1,29 @@
+// This test checks that dispatch function (in case of multu-target compilation) and application function (in case of single target compilation) have
+// "dllexport" storage type when ISPC "--dllexport" switch is used.
+
+// RUN: %{ispc} %s  --dllexport --target=sse2 --emit-llvm-text -o - | FileCheck %s --check-prefixes=CHECK_DLLEXPORT,CHECK_DLLEXPORT_SINGLE_TARGET
+// RUN: %{ispc} %s  --dllexport --target=sse2 --emit-llvm-text -o - | FileCheck %s --check-prefix=CHECK_DLLEXPORT
+
+// RUN: %{ispc} %s  --target=sse2 --emit-llvm-text -o - | FileCheck %s --check-prefix=CHECK_NODLLEXPORT
+// RUN: %{ispc} %s  --target=sse2 --emit-llvm-text -o - | FileCheck %s --check-prefix=CHECK_NODLLEXPORT
+
+// REQUIRES: WINDOWS_ENABLED
+
+// CHECK_DLLEXPORT_SINGLE_TARGET: define dllexport float @foo_extern___
+// CHECK_DLLEXPORT_SINGLE_TARGET: define dllexport float @foo_export___
+
+// CHECK_DLLEXPORT: define dllexport float @foo_export
+
+// CHECK_NODLLEXPORT-NOT: define dllexport
+
+static uniform float foo_static(uniform float a, uniform float b) {
+    return a + b;
+}
+
+uniform float foo_extern(uniform float a, uniform float b) {
+    return a + b;
+}
+
+export uniform float foo_export(uniform float a, uniform float b) {
+    return a + b;
+}

--- a/tests/lit-tests/windows_dllexport.ispc
+++ b/tests/lit-tests/windows_dllexport.ispc
@@ -1,11 +1,11 @@
-// This test checks that dispatch function (in case of multu-target compilation) and application function (in case of single target compilation) have
+// This test checks that dispatch function (in case of multi-target compilation) and application function (in case of single target compilation) have
 // "dllexport" storage type when ISPC "--dllexport" switch is used.
 
-// RUN: %{ispc} %s  --dllexport --target=sse2 --emit-llvm-text -o - | FileCheck %s --check-prefixes=CHECK_DLLEXPORT,CHECK_DLLEXPORT_SINGLE_TARGET
-// RUN: %{ispc} %s  --dllexport --target=sse2 --emit-llvm-text -o - | FileCheck %s --check-prefix=CHECK_DLLEXPORT
+// RUN: %{ispc} %s  --dllexport --target=sse2 --target-os=windows --emit-llvm-text -o - | FileCheck %s --check-prefixes=CHECK_DLLEXPORT,CHECK_DLLEXPORT_SINGLE_TARGET
+// RUN: %{ispc} %s  --dllexport --target=sse2 --target-os=windows --emit-llvm-text -o - | FileCheck %s --check-prefix=CHECK_DLLEXPORT
 
-// RUN: %{ispc} %s  --target=sse2 --emit-llvm-text -o - | FileCheck %s --check-prefix=CHECK_NODLLEXPORT
-// RUN: %{ispc} %s  --target=sse2 --emit-llvm-text -o - | FileCheck %s --check-prefix=CHECK_NODLLEXPORT
+// RUN: %{ispc} %s  --target=sse2 --target-os=windows --emit-llvm-text -o - | FileCheck %s --check-prefix=CHECK_NODLLEXPORT
+// RUN: %{ispc} %s  --target=sse2 --target-os=windows --emit-llvm-text -o - | FileCheck %s --check-prefix=CHECK_NODLLEXPORT
 
 // REQUIRES: WINDOWS_ENABLED
 


### PR DESCRIPTION
Make dispatch export function callable from DLLs.
Required when producing dynamic library from ISPC object for further usage from ISPC Runtime on CPU.