### PR TITLE
Add support for ARM64 MSVC binary targets

### DIFF
--- a/check_isa.cpp
+++ b/check_isa.cpp
@@ -46,7 +46,7 @@
 #define HOST_IS_APPLE
 #endif
 
-#if !defined(__arm__) && !defined(__aarch64__)
+#if !defined(__arm__) && !defined(__aarch64__) && !defined(_M_ARM64)
 #if !defined(HOST_IS_WINDOWS)
 static void __cpuid(int info[4], int infoType) {
     __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(infoType));
@@ -105,7 +105,7 @@ static bool __os_has_avx512_support() {
 #endif // !__arm__
 
 static const char *lGetSystemISA() {
-#if defined(__arm__) || defined(__aarch64__)
+#if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64)
     return "ARM NEON";
 #else
     int info[4];

--- a/check_isa.cpp
+++ b/check_isa.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2013-2020, Intel Corporation
+  Copyright (c) 2013-2022, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -82,7 +82,7 @@ Module *ispc::m;
 ///////////////////////////////////////////////////////////////////////////
 // Target
 
-#if defined(__arm__) || defined(__aarch64__)
+#if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64)
 #define ARM_HOST
 #endif
 


### PR DESCRIPTION
The existing `__aarch64__` macro is not defined for MSVC ARM64 platforms, so an additional check for `_M_ARM64` needs to be made in order to compile a native ARM64 binary.