### PR TITLE
CMakeLists.txt: change libclang linking logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,8 +547,18 @@ endif()
 
 # Link against Clang libraries
 foreach(clangLib ${CLANG_LIBRARY_LIST})
-    find_library(${clangLib}Path NAMES ${clangLib} HINTS ${LLVM_LIBRARY_DIRS})
-    list(APPEND CLANG_LIBRARY_FULL_PATH_LIST ${${clangLib}Path})
+    # Preferred way to build ISPC is to link it with individual clang static
+    # libraries. However, when they omitted it can be link with shared library
+    # libclang-cpp.so. Second approach would be utilized in some controlled
+    # environments, like in package managers for particular OSes (issue 2418).
+    find_library(${clangLib}Path
+                 NAMES
+                    "${CMAKE_STATIC_LIBRARY_PREFIX}${clangLib}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+                    clang-cpp
+                 HINTS ${LLVM_LIBRARY_DIRS})
+    if (NOT ${${clangLib}Path} IN_LIST CLANG_LIBRARY_FULL_PATH_LIST)
+        list(APPEND CLANG_LIBRARY_FULL_PATH_LIST ${${clangLib}Path})
+    endif()
 endforeach()
 target_link_libraries(${PROJECT_NAME} ${CLANG_LIBRARY_FULL_PATH_LIST})
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,7 +26,7 @@ By default `Dockerfile`s are assumed to be built as `x86` images, but some can b
  * [centos/7/cpu\_ispc\_build/Dockerfile](centos/7/cpu_ispc_build/Dockerfile) `CentOS 7` image. CPU only. Works on both `x86` and `aarch64`.
  * [centos/7/xpu\_ispc\_build/Dockerfile](centos/7/xpu_ispc_build/Dockerfile) `CentOS 7` image. XPU (CPU+GPU). `x86` image only. This image is used for building `ispc` package for future binary releases.
  * [centos/8/cpu\_ispc\_build/Dockerfile](centos/8/cpu_ispc_build/Dockerfile) `CentOS 8` image. CPU only. Works on both `x86` and `aarch64`.
- * [fedora/Dockerfile](fedora/Dockerfile) Outdated Fedora 26 image.
+ * [fedora/Dockerfile](fedora/Dockerfile) Fedora 36 with CPU only build linked with system LLVM and Clang shared libraries.
 
 XPU-enabled builds
 ------------------

--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -1,67 +1,41 @@
-FROM fedora:26
-LABEL maintainer="Dmitry Babokin <dmitry.y.babokin@intel.com>"
+FROM fedora:36
+LABEL maintainer="Nurmukhametov, Aleksei <aleksei.nurmukhametov@intel.com>"
 SHELL ["/bin/bash", "-c"]
 
 ARG REPO=ispc/ispc
 ARG SHA=main
 
-# !!! Make sure that your docker config provides enough memory to the container,
-# otherwise LLVM build may fail, as it will use all the cores available to container.
-
-# Packages required to build ISPC and Clang.
+# Packages required to build ISPC.
 # RUN echo "proxy=http://proxy.yourcompany.com:888" >> /etc/dnf/dnf.conf
-RUN dnf install -y vim-enhanced-2:8.0.1806 wget-1.19.5 yum-utils-1.1.31 gcc-7.3.1 gcc-c++-7.3.1 git-2.13.6 python3-3.6.4 && \
-    dnf install -y m4-1.4.18 bison-3.0.4 flex-2.6.1 patch-2.7.6 make-4.2.1 ncurses-devel-6.0 glibc-devel-2.25-13.fc26.x86_64 glibc-devel-2.25-13.fc26.i686 && \
+RUN dnf install -y git-2.39.0 cmake-3.25.1 && \
+    dnf install -y clang-devel-14.0.5 llvm-devel-14.0.5 glibc-devel-2.35-20.fc36.i686 && \
+    dnf install -y flex-2.6.4 bison-3.8.2 && \
     dnf clean -y all
-
-# These packages are required if you need to link IPSC with -static.
-RUN dnf install -y ncurses-static-6.0 libstdc++-static-7.3.1 glibc-static-2.25 && \
-    dnf clean -y all
-
-# Download and install required version of cmake (3.13) for ISPC build
-RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/Kitware/CMake/releases/download/v3.13.5/cmake-3.13.5-Linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.13.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
-    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && rm cmake-3.13.5-Linux-x86_64.sh
 
 # If you are behind a proxy, you need to configure git and svn.
-#RUN git config --global --add http.proxy http://proxy.yourcompany.com:888
+# RUN git config --global --add http.proxy http://proxy.yourcompany.com:888
 
 WORKDIR /usr/local/src
 
 # Fork ispc on github and clone *your* fork.
-RUN git clone https://github.com/$REPO.git ispc
-
-# This is home for Clang builds
-RUN mkdir /usr/local/src/llvm
+RUN git clone --depth=1 -b $SHA https://github.com/$REPO.git ispc
 
 ENV ISPC_HOME=/usr/local/src/ispc
-ENV LLVM_HOME=/usr/local/src/llvm
 
 # If you are going to run test for future platforms, go to
 # http://www.intel.com/software/sde and download the latest version,
 # extract it, add to path and set SDE_HOME.
 
-WORKDIR /usr/local/src/ispc
-RUN git checkout $SHA
-
-# Build Clang with all required patches.
-# Pass required LLVM_VERSION with --build-arg LLVM_VERSION=<version>.
-# By default 8.0 is used.
-# Note self-build options, it's required to build clang and ispc with the same compiler,
-# i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
-# or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
-# "rm" are just to keep docker image small.
-ARG LLVM_VERSION=8.0
-RUN ./alloy.py -b --version="$LLVM_VERSION" --selfbuild && \
-    rm -rf "$LLVM_HOME"/build-"$LLVM_VERSION" "$LLVM_HOME"/llvm-"$LLVM_VERSION" "$LLVM_HOME"/bin-"$LLVM_VERSION"_temp "$LLVM_HOME"/build-"$LLVM_VERSION"_temp
-
-ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
-
 # Configure ISPC build
-RUN mkdir build_$LLVM_VERSION
-WORKDIR /usr/local/src/ispc/build_$LLVM_VERSION
-RUN cmake ../ -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/usr/local/src/ispc/bin-$LLVM_VERSION
+RUN mkdir /usr/local/src/ispc/build
+WORKDIR /usr/local/src/ispc/build
+RUN cmake ../ -DCMAKE_INSTALL_PREFIX=/usr
+
+# LLVM
+# We don't build llvm here because we use system shared libraries.
 
 # Build ISPC
-RUN make ispc -j"$(nproc)" && make install
+RUN make VERBOSE=1 ispc -j"$(nproc)" && make install
+RUN make check-all && (echo "shared libs deps of ispc" && ldd ./bin/ispc)
 WORKDIR /usr/local/src/ispc
-RUN rm -rf build_$LLVM_VERSION
+RUN rm -rf build

--- a/tests/lit-tests/llvm_ident.ispc
+++ b/tests/lit-tests/llvm_ident.ispc
@@ -3,7 +3,7 @@
 
 // Check that version string embeded in !llvm.ident metadata is formed correctly.
 
-// CHECK: Intel(r) Implicit SPMD Program Compiler (Intel(r) ISPC), {{1\.[[:digit:]]+\.[[:digit:]]+(dev)?}} (build commit {{[[:xdigit:]]+}} @ {{([[:digit:]]{8})}}, LLVM [[LLVM_VERSION:[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+]])
-// CHECK: LLVM version [[LLVM_VERSION]] ({{[[:graph:]]+}} {{[[:xdigit:]]+}})
+// CHECK: Intel(r) Implicit SPMD Program Compiler (Intel(r) ISPC), {{1\.[[:digit:]]+\.[[:digit:]]+(dev)?}} (build{{( commit )?}}{{([[:xdigit:]]+)?}} @ {{([[:digit:]]{8})}}, LLVM [[LLVM_VERSION:[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+]])
+// CHECK: LLVM version [[LLVM_VERSION]]{{(\( [[:graph:]]+ [[:graph:]]+\))?}}
 
 int i;


### PR DESCRIPTION
Link with static libraries (libclangFrontend.a, ...) if they found. Otherwise, dynamically link with libclang-cpp.so.