### PR TITLE
Use LLVM 15.0.7 for build and CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-#  Copyright (c) 2018-2022, Intel Corporation
+#  Copyright (c) 2018-2023, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -58,7 +58,7 @@ for:
         if "%LLVM_VERSION%"=="latest" (set WASM=ON)
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vspath="C:\Program Files (x86)\Microsoft Visual Studio\2019"))
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2022" ( (set generator="Visual Studio 17") & (set vspath="C:\Program Files\Microsoft Visual Studio\2022"))
-        set LLVM_TAR=llvm-15.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        set LLVM_TAR=llvm-15.0.7-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
         if "%LLVM_VERSION%"=="14.0" (set LLVM_TAR=llvm-14.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
         if "%LLVM_VERSION%"=="13.0" (set LLVM_TAR=llvm-13.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
         if "%LLVM_VERSION%"=="12.0" (set LLVM_TAR=llvm-12.0.1-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
@@ -112,7 +112,7 @@ for:
         export LLVM_HOME=$APPVEYOR_BUILD_FOLDER/llvm
         export CROSS_TOOLS=/usr/local/src/cross
         export WASM=OFF
-        export LLVM_TAR=llvm-15.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+        export LLVM_TAR=llvm-15.0.7-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
   install:
     - sh: |-
         sudo apt-get update

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-15.0.7-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.6-ubuntu18.04-Release-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-15.0.7-ubuntu18.04-Release-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -572,7 +572,7 @@ jobs:
     runs-on: macos-11
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.6-macos11-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-15.0.7-macos11-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@v3
@@ -780,7 +780,7 @@ jobs:
     runs-on: windows-2019
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_TAR: llvm-15.0.7-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"

--- a/.github/workflows/nightly-15.yml
+++ b/.github/workflows/nightly-15.yml
@@ -78,20 +78,20 @@ jobs:
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-15.0 .
         # Note using gzip here, instead of xz - trading of space for speed, as it's just for passing to another stage.
-        tar czvf llvm-15.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-15.0
+        tar czvf llvm-15.0.7-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-15.0
 
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
         name: llvm_15_linux
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-15.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-15.0.7-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
   linux-build-ispc-llvm-15:
     needs: [linux-build-llvm-15-2]
     runs-on: ubuntu-latest
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+      LLVM_TAR: llvm-15.0.7-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
 
     steps:
     - uses: actions/checkout@v3
@@ -208,7 +208,7 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-15.0.6-win.vs2019-Release+Asserts-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-15.0.7-win.vs2019-Release+Asserts-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-15.0
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -216,7 +216,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: llvm_15_win
-        path: llvm/llvm-15.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        path: llvm/llvm-15.0.7-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
 
 
   win-build-ispc-llvm-15:
@@ -224,7 +224,7 @@ jobs:
     runs-on: windows-2022
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_TAR: llvm-15.0.7-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"

--- a/.github/workflows/rebuild-llvm15.yml
+++ b/.github/workflows/rebuild-llvm15.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/reusable.rebuild.yml
     with:
       version: '15.0'
-      full_version: '15.0.6'
+      full_version: '15.0.7'
       ubuntu: '18.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'

--- a/.github/workflows/rebuild-llvm15.yml
+++ b/.github/workflows/rebuild-llvm15.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Intel Corporation
+# Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Rebuild LLVM 15.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-#  Copyright (c) 2018-2022, Intel Corporation
+#  Copyright (c) 2018-2023, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -51,7 +51,7 @@ jobs:
       dist: bionic
       env:
         - LLVM_VERSION=15.0 OS=Ubuntu18.04aarch64
-        - LLVM_TAR=llvm-15.0.6-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        - LLVM_TAR=llvm-15.0.7-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
         - LLVM_REPO=https://github.com/ispc/llvm-project
         - ISPC_HOME=$TRAVIS_BUILD_DIR
       before_install:

--- a/alloy.py
+++ b/alloy.py
@@ -121,7 +121,7 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     if  version_LLVM == "trunk":
         GIT_TAG="main"
     elif  version_LLVM == "15_0":
-        GIT_TAG="llvmorg-15.0.6"
+        GIT_TAG="llvmorg-15.0.7"
     elif  version_LLVM == "14_0":
         GIT_TAG="llvmorg-14.0.6"
     elif  version_LLVM == "13_0":

--- a/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
@@ -15,8 +15,8 @@ ARG EXTRA_BUILD_ARG
 RUN uname -a
 
 # Packages required to build ISPC and Clang.
-RUN apt-get -y update && apt-get --no-install-recommends install -y wget=1.19.4-1ubuntu2.2 build-essential=12.4ubuntu1 gcc=4:7.4.0-1ubuntu2.3 \
-    g++=4:7.4.0-1ubuntu2.3 git=1:2.17.1-1ubuntu0.13 python3-dev=3.6.7-1~18.04 libncurses5-dev=6.1-1ubuntu1.18.04 libtinfo-dev=6.1-1ubuntu1.18.04 ca-certificates=20211016~18.04.1 && \
+RUN apt-get -y update && apt-get --no-install-recommends install -y wget=1.19.4-1ubuntu* build-essential=12.4ubuntu* gcc=4:7.4.0-1ubuntu* \
+    g++=4:7.4.0-1ubuntu* git=1:2.17.1-1ubuntu* python3-dev=3.6.7-1~18.04 libncurses5-dev=6.1-1ubuntu* libtinfo-dev=6.1-1ubuntu* ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # Download and install required version of cmake (3.14 for x86, 3.20 for aarch64, as earlier versions are not available as binary distribution) for ISPC build
@@ -67,10 +67,10 @@ ARG LLVM_VERSION
 
 # ISPC builds in C++17 mode and will fail without modern libstdc++
 # Also install regular ISPC dependencies
-RUN if [[ $(uname -m) =~ "x86" ]]; then export CROSS_LIBS="libc6-dev-i386=2.27-3ubuntu1.6"; else export CROSS_LIBS="libc6-dev-armhf-cross=2.27-3ubuntu1cross1.1"; fi && \
+RUN if [[ $(uname -m) =~ "x86" ]]; then export CROSS_LIBS="libc6-dev-i386=2.27-3ubuntu*"; else export CROSS_LIBS="libc6-dev-armhf-cross=2.27-3ubuntu*"; fi && \
     apt-get -y update && apt-get --no-install-recommends install -y software-properties-common=0.96.24.32.18 && \
     add-apt-repository ppa:ubuntu-toolchain-r/test -y && apt-get -y update && \
-    apt-get --no-install-recommends install -y libstdc++-9-dev=9.4.0-1ubuntu1~18.04 && \
+    apt-get --no-install-recommends install -y libstdc++-9-dev=9.4.0-1ubuntu* && \
     apt-get --no-install-recommends install -y m4=1.4.18-1 bison=2:3.0.4.dfsg-1build1 flex=2.6.4-6 $CROSS_LIBS && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- Build LLVM `15.0.7` in `alloy.py` instead of `15.0.6`
- Use LLVM `15.0.7` in CI
- Fix Ubuntu 18.04 Dockerfile to avoid certain pinned package versions - more general fix is needed.