### PR TITLE
Switch CI to use ispc/ispc.dependencies repo instead of ispc/llvm-project fork

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -79,7 +79,7 @@ for:
         %NONEEDDOCKER% docker cp %CONTAINER%:%CROSS_TOOLS% %CROSS_TOOLS%
         set PATH=%LLVM_HOME%\bin;%PATH%
         mkdir %LLVM_HOME% && cd %LLVM_HOME%
-        wget -q https://github.com/ispc/llvm-project/releases/download/llvm-%LLVM_VERSION%-ispc-dev/%LLVM_TAR%
+        wget -q https://github.com/ispc/ispc.dependencies/releases/download/llvm-%LLVM_VERSION%-ispc-dev/%LLVM_TAR%
         7z.exe x -t7z %LLVM_TAR%
         7z.exe x -ttar llvm*tar
         set PATH=%LLVM_HOME%\bin-%LLVM_VERSION%\bin;%PATH%
@@ -130,7 +130,7 @@ for:
           sudo docker cp $CONTAINER:$CROSS_TOOLS $CROSS_TOOLS
         fi
         mkdir $LLVM_HOME && cd $LLVM_HOME
-        wget https://github.com/ispc/llvm-project/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
+        wget https://github.com/ispc/ispc.dependencies/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
         tar xvf $LLVM_TAR
         export PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
   before_build:

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -20,7 +20,7 @@ env:
   SDE_MIRROR_ID: 684899
   SDE_TAR_NAME: sde-external-9.0.0-2021-11-07
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
-  LLVM_REPO: https://github.com/ispc/llvm-project
+  LLVM_REPO: https://github.com/ispc/ispc.dependencies
   TARGETS_SMOKE: '["avx2-i32x8"]'
   OPTSETS_SMOKE: "-O2"
   TARGETS_FULL:  '["sse2-i32x4", "sse2-i32x8",

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -11,7 +11,7 @@ env:
   SDE_MIRROR_ID: 684899
   SDE_TAR_NAME: sde-external-9.0.0-2021-11-07
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
-  LLVM_REPO: https://github.com/ispc/llvm-project
+  LLVM_REPO: https://github.com/ispc/ispc.dependencies
   TARGETS_SMOKE: '["avx2-i32x8"]'
   OPTSETS_SMOKE: "-O2"
   TARGETS_FULL:  '["sse2-i32x4", "sse2-i32x8",

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   LLVM_VERSION: "13.0"
-  LLVM_REPO: https://github.com/ispc/llvm-project
+  LLVM_REPO: https://github.com/ispc/ispc.dependencies
   LLVM_TAR: llvm-13.0.1-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
 jobs:

--- a/.github/workflows/scripts/install-build-deps.ps1
+++ b/.github/workflows/scripts/install-build-deps.ps1
@@ -22,5 +22,5 @@ mkdir ${env:CROSS_TOOLS_GNUWIN32}
 cd ${env:CROSS_TOOLS_GNUWIN32}
 # The following line is needed to enable all TLS versions. The server appears to require different TLS version depending on the specific redirect.
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls, [Net.SecurityProtocolType]::Tls11, [Net.SecurityProtocolType]::Tls12
-wget --retry-connrefused --waitretry=10 --read-timeout=20 --timeout=15 -t 5 -O libgw32c-0.4-lib.zip 'https://downloads.sourceforge.net/project/gnuwin32/libgw32c/0.4/libgw32c-0.4-lib.zip'
+wget --retry-connrefused --waitretry=10 --read-timeout=20 --timeout=15 -t 5 -O libgw32c-0.4-lib.zip 'https://github.com/ispc/ispc.dependencies/releases/download/gnuwin32-mirror/libgw32c-0.4-lib.zip'
 7z.exe x libgw32c-0.4-lib.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
       env:
         - LLVM_VERSION=15.0 OS=Ubuntu18.04aarch64
         - LLVM_TAR=llvm-15.0.7-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
-        - LLVM_REPO=https://github.com/ispc/llvm-project
+        - LLVM_REPO=https://github.com/ispc/ispc.dependencies
         - ISPC_HOME=$TRAVIS_BUILD_DIR
       before_install:
         - cat /proc/cpuinfo


### PR DESCRIPTION
Moving build dependencies to be downloadable from [ispc.dependencies](https://github.com/ispc/ispc.dependencies) to avoid confusion. Also moving `libgw32c-0.4-lib.zip` download to the same repo, as downloading from SourceForce appears to be unreliable, yielding constant CI fails.