### PR TITLE
Updates for Xe targets (13)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,12 @@
 cmake_minimum_required(VERSION 3.13)
 
 if (UNIX)
-    set(CMAKE_C_COMPILER "clang")
-    set(CMAKE_CXX_COMPILER "clang++")
+    if (NOT CMAKE_C_COMPILER)
+        set(CMAKE_C_COMPILER "clang")
+    endif()
+    if (NOT CMAKE_CXX_COMPILER)
+        set(CMAKE_CXX_COMPILER "clang++")
+    endif()
 endif()
 
 set(PROJECT_NAME ispc)

--- a/builtins/target-gen9-x16.ll
+++ b/builtins/target-gen9-x16.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2019-2021, Intel Corporation
+;;  Copyright (c) 2019-2023, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -30,9 +30,6 @@
 ;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define(`WIDTH',`16')
-define(`HALF_WIDTH',`8')
-define(`QUARTER_WIDTH',`4')
-define(`QUAVER_WIDTH',`2')
 define(`WIDTH_X2',`32')
 define(`WIDTH_X4',`64')
 define(`XE_SUFFIX',`CONCAT(`v16', XE_TYPE($1))')

--- a/builtins/target-gen9-x8.ll
+++ b/builtins/target-gen9-x8.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2019-2021, Intel Corporation
+;;  Copyright (c) 2019-2023, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -30,9 +30,6 @@
 ;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define(`WIDTH',`8')
-define(`HALF_WIDTH',`4')
-define(`QUARTER_WIDTH',`2')
-define(`QUAVER_WIDTH',`1')
 define(`WIDTH_X2',`16')
 define(`WIDTH_X4',`32')
 define(`XE_SUFFIX',`CONCAT(`v8', XE_TYPE($1))')

--- a/builtins/target-xehpc-x16.ll
+++ b/builtins/target-xehpc-x16.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2022, Intel Corporation
+;;  Copyright (c) 2020-2023, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -30,9 +30,6 @@
 ;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define(`WIDTH',`16')
-define(`HALF_WIDTH',`8')
-define(`QUARTER_WIDTH',`4')
-define(`QUAVER_WIDTH',`2')
 define(`WIDTH_X2',`32')
 define(`WIDTH_X4',`64')
 define(`XE_SUFFIX',`CONCAT(`v16', XE_TYPE($1))')

--- a/builtins/target-xehpc-x32.ll
+++ b/builtins/target-xehpc-x32.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2022, Intel Corporation
+;;  Copyright (c) 2022-2023, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -30,9 +30,6 @@
 ;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define(`WIDTH',`32')
-define(`HALF_WIDTH',`16')
-define(`QUARTER_WIDTH',`8')
-define(`QUAVER_WIDTH',`4')
 define(`WIDTH_X2',`64')
 define(`WIDTH_X4',`128')
 define(`XE_SUFFIX',`CONCAT(`v32', XE_TYPE($1))')

--- a/builtins/target-xehpg-x16.ll
+++ b/builtins/target-xehpg-x16.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2019-2021, Intel Corporation
+;;  Copyright (c) 2019-2023, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -30,9 +30,6 @@
 ;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define(`WIDTH',`16')
-define(`HALF_WIDTH',`8')
-define(`QUARTER_WIDTH',`4')
-define(`QUAVER_WIDTH',`2')
 define(`WIDTH_X2',`32')
 define(`WIDTH_X4',`64')
 define(`XE_SUFFIX',`CONCAT(`v16', XE_TYPE($1))')

--- a/builtins/target-xehpg-x8.ll
+++ b/builtins/target-xehpg-x8.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2019-2021, Intel Corporation
+;;  Copyright (c) 2019-2023, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -30,9 +30,6 @@
 ;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define(`WIDTH',`8')
-define(`HALF_WIDTH',`4')
-define(`QUARTER_WIDTH',`2')
-define(`QUAVER_WIDTH',`1')
 define(`WIDTH_X2',`16')
 define(`WIDTH_X4',`32')
 define(`XE_SUFFIX',`CONCAT(`v8', XE_TYPE($1))')

--- a/builtins/target-xelp-x16.ll
+++ b/builtins/target-xelp-x16.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2019-2021, Intel Corporation
+;;  Copyright (c) 2019-2023, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -30,9 +30,6 @@
 ;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define(`WIDTH',`16')
-define(`HALF_WIDTH',`8')
-define(`QUARTER_WIDTH',`4')
-define(`QUAVER_WIDTH',`2')
 define(`WIDTH_X2',`32')
 define(`WIDTH_X4',`64')
 define(`XE_SUFFIX',`CONCAT(`v16', XE_TYPE($1))')

--- a/builtins/target-xelp-x8.ll
+++ b/builtins/target-xelp-x8.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2019-2021, Intel Corporation
+;;  Copyright (c) 2019-2023, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -30,9 +30,6 @@
 ;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define(`WIDTH',`8')
-define(`HALF_WIDTH',`4')
-define(`QUARTER_WIDTH',`2')
-define(`QUAVER_WIDTH',`1')
 define(`WIDTH_X2',`16')
 define(`WIDTH_X4',`32')
 define(`XE_SUFFIX',`CONCAT(`v8', XE_TYPE($1))')

--- a/examples/cpu/aobench/ao.cpp
+++ b/examples/cpu/aobench/ao.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2011, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -103,7 +103,6 @@ int main(int argc, char **argv) {
     if (argc < 3) {
         printf("%s\n", argv[0]);
         printf("Usage: ao [width] [height] [ispc iterations] [tasks iterations] [serial iterations]\n");
-        getchar();
         exit(-1);
     } else {
         if (argc == 6) {

--- a/examples/cpu/aobench/ao_serial.cpp
+++ b/examples/cpu/aobench/ao_serial.cpp
@@ -1,6 +1,6 @@
 // -*- mode: c++ -*-
 /*
-  Copyright (c) 2010-2011, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -65,6 +65,7 @@ __declspec(align(16))
         x = xx;
         y = yy;
         z = zz;
+        pad = 0.;
     }
 
     vec operator*(float f) const { return vec(x * f, y * f, z * f); }

--- a/examples/cpu/aobench_instrumented/ao.cpp
+++ b/examples/cpu/aobench_instrumented/ao.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2011, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -103,7 +103,6 @@ int main(int argc, char **argv) {
     if (argc != 4) {
         printf("%s\n", argv[0]);
         printf("Usage: ao [num test iterations] [width] [height]\n");
-        getchar();
         exit(-1);
     } else {
         test_iterations = atoi(argv[1]);

--- a/examples/cpu/deferred/common.cpp
+++ b/examples/cpu/deferred/common.cpp
@@ -123,6 +123,7 @@ InputData *CreateInputDataFromFile(const char *path) {
     if (fread(&input->header, sizeof(ispc::InputHeader), 1, in) != 1) {
         fprintf(stderr, "Preumature EOF reading file \"%s\"\n", path);
         fclose(in);
+        delete input;
         return NULL;
     }
 
@@ -131,6 +132,7 @@ InputData *CreateInputDataFromFile(const char *path) {
     if (fread(input->chunk, input->header.inputDataChunkSize, 1, in) != 1) {
         fprintf(stderr, "Preumature EOF reading file \"%s\"\n", path);
         fclose(in);
+        delete input;
         return NULL;
     }
 

--- a/examples/cpu/deferred/common.cpp
+++ b/examples/cpu/deferred/common.cpp
@@ -179,6 +179,10 @@ void WriteFrame(const char *filename, const InputData *input, const Framebuffer 
 
     // Write out simple PPM file
     FILE *out = fopen(filename, "wb");
+    if (!out) {
+        printf("Couldn't open a file '%s'\n", filename);
+        exit(1);
+    }
     fprintf(out, "P6 %d %d 255\n", input->header.framebufferWidth, input->header.framebufferHeight);
     fwrite(framebufferAOS, imageBytes, 1, out);
     fclose(out);

--- a/examples/cpu/deferred/common.cpp
+++ b/examples/cpu/deferred/common.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2022, Intel Corporation
+  Copyright (c) 2011-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -122,6 +122,7 @@ InputData *CreateInputDataFromFile(const char *path) {
     // Load header
     if (fread(&input->header, sizeof(ispc::InputHeader), 1, in) != 1) {
         fprintf(stderr, "Preumature EOF reading file \"%s\"\n", path);
+        fclose(in);
         return NULL;
     }
 
@@ -129,6 +130,7 @@ InputData *CreateInputDataFromFile(const char *path) {
     input->chunk = (uint8_t *)lAlignedMalloc(input->header.inputDataChunkSize, ALIGNMENT_BYTES);
     if (fread(input->chunk, input->header.inputDataChunkSize, 1, in) != 1) {
         fprintf(stderr, "Preumature EOF reading file \"%s\"\n", path);
+        fclose(in);
         return NULL;
     }
 

--- a/examples/cpu/gmres/matrix.cpp
+++ b/examples/cpu/gmres/matrix.cpp
@@ -134,7 +134,10 @@ CRSMatrix *CRSMatrix::matrix_from_mtf(char *path) {
     entries.resize(nz);
 
     for (int i = 0; i < nz; i++) {
-        fscanf(f, "%d %d %lg\n", &entries[i].row, &entries[i].col, &entries[i].val);
+        if (3 != fscanf(f, "%d %d %lg\n", &entries[i].row, &entries[i].col, &entries[i].val)) {
+            printf("Couldn't read input correctly\n");
+            exit(-1);
+        }
         // Adjust from 1-based to 0-based
         entries[i].row--;
         entries[i].col--;
@@ -185,7 +188,10 @@ Vector *Vector::vector_from_mtf(char *path) {
     if (mm_is_dense(matcode)) {
         double val;
         for (int i = 0; i < m; i++) {
-            fscanf(f, "%lg\n", &val);
+            if (1 != fscanf(f, "%lg\n", &val)) {
+                printf("Couldn't read input correctly\n");
+                exit(-1);
+            }
             (*x)[i] = val;
         }
     } else {
@@ -194,7 +200,10 @@ Vector *Vector::vector_from_mtf(char *path) {
         int row;
         int col;
         for (int i = 0; i < nz; i++) {
-            fscanf(f, "%d %d %lg\n", &row, &col, &val);
+            if (3 != fscanf(f, "%d %d %lg\n", &row, &col, &val)) {
+                printf("Couldn't read input correctly\n");
+                exit(-1);
+            }
             (*x)[row - 1] = val;
         }
     }

--- a/examples/cpu/gmres/matrix.h
+++ b/examples/cpu/gmres/matrix.h
@@ -186,11 +186,11 @@ class DenseMatrix : public Matrix {
     friend class Vector;
 
   public:
-    DenseMatrix(size_t size_r, size_t size_c) : Matrix(size_r, size_c) {
+    DenseMatrix(size_t size_r, size_t size_c) : Matrix(size_r, size_c), shared_ptr(false) {
         entries = (double *)malloc(size_r * size_c * sizeof(double));
     }
 
-    DenseMatrix(size_t size_r, size_t size_c, const double *content) : Matrix(size_r, size_c) {
+    DenseMatrix(size_t size_r, size_t size_c, const double *content) : Matrix(size_r, size_c), shared_ptr(false) {
         entries = (double *)malloc(size_r * size_c * sizeof(double));
         memcpy(entries, content, size_r * size_c * sizeof(double));
     }

--- a/examples/cpu/gmres/matrix.h
+++ b/examples/cpu/gmres/matrix.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012, Intel Corporation
+  Copyright (c) 2012-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -193,6 +193,10 @@ class DenseMatrix : public Matrix {
     DenseMatrix(size_t size_r, size_t size_c, const double *content) : Matrix(size_r, size_c) {
         entries = (double *)malloc(size_r * size_c * sizeof(double));
         memcpy(entries, content, size_r * size_c * sizeof(double));
+    }
+
+    ~DenseMatrix() {
+        free(entries);
     }
 
     virtual void multiply(const Vector &v, Vector &r) const;

--- a/examples/cpu/gmres/mmio.c
+++ b/examples/cpu/gmres/mmio.c
@@ -235,14 +235,23 @@ int mm_read_mtx_crd(char *fname, int *M, int *N, int *nz, int **I, int **J, doub
     else if ((f = fopen(fname, "r")) == NULL)
         return MM_COULD_NOT_READ_FILE;
 
-    if ((ret_code = mm_read_banner(f, matcode)) != 0)
+    if ((ret_code = mm_read_banner(f, matcode)) != 0) {
+        if (f != stdin)
+            fclose(f);
         return ret_code;
+    }
 
-    if (!(mm_is_valid(*matcode) && mm_is_sparse(*matcode) && mm_is_matrix(*matcode)))
+    if (!(mm_is_valid(*matcode) && mm_is_sparse(*matcode) && mm_is_matrix(*matcode))) {
+        if (f != stdin)
+            fclose(f);
         return MM_UNSUPPORTED_TYPE;
+    }
 
-    if ((ret_code = mm_read_mtx_crd_size(f, M, N, nz)) != 0)
+    if ((ret_code = mm_read_mtx_crd_size(f, M, N, nz)) != 0) {
+        if (f != stdin)
+            fclose(f);
         return ret_code;
+    }
 
     *I = (int *)malloc(*nz * sizeof(int));
     *J = (int *)malloc(*nz * sizeof(int));
@@ -251,19 +260,28 @@ int mm_read_mtx_crd(char *fname, int *M, int *N, int *nz, int **I, int **J, doub
     if (mm_is_complex(*matcode)) {
         *val = (double *)malloc(*nz * 2 * sizeof(double));
         ret_code = mm_read_mtx_crd_data(f, *M, *N, *nz, *I, *J, *val, *matcode);
-        if (ret_code != 0)
+        if (ret_code != 0) {
+            if (f != stdin)
+                fclose(f);
             return ret_code;
+        }
     } else if (mm_is_real(*matcode)) {
         *val = (double *)malloc(*nz * sizeof(double));
         ret_code = mm_read_mtx_crd_data(f, *M, *N, *nz, *I, *J, *val, *matcode);
-        if (ret_code != 0)
+        if (ret_code != 0) {
+            if (f != stdin)
+                fclose(f);
             return ret_code;
+        }
     }
 
     else if (mm_is_pattern(*matcode)) {
         ret_code = mm_read_mtx_crd_data(f, *M, *N, *nz, *I, *J, *val, *matcode);
-        if (ret_code != 0)
+        if (ret_code != 0) {
+            if (f != stdin)
+                fclose(f);
             return ret_code;
+        }
     }
 
     if (f != stdin)

--- a/examples/cpu/gmres/mmio.c
+++ b/examples/cpu/gmres/mmio.c
@@ -312,7 +312,8 @@ int mm_write_mtx_crd(char fname[], int M, int N, int nz, int I[], int J[], doubl
 
     /* print banner followed by typecode */
     fprintf(f, "%s ", MatrixMarketBanner);
-    fprintf(f, "%s\n", mm_typecode_to_str(matcode));
+    char *mm_typecoded_str =  mm_typecode_to_str(matcode);
+    fprintf(f, "%s\n", mm_typecoded_str);
 
     /* print matrix sizes and nonzeros */
     fprintf(f, "%d %d %d\n", M, N, nz);
@@ -330,12 +331,14 @@ int mm_write_mtx_crd(char fname[], int M, int N, int nz, int I[], int J[], doubl
     else {
         if (f != stdout)
             fclose(f);
+        free(mm_typecoded_str);
         return MM_UNSUPPORTED_TYPE;
     }
 
     if (f != stdout)
         fclose(f);
 
+    free(mm_typecoded_str);
     return 0;
 }
 

--- a/examples/cpu/mandelbrot/mandelbrot.cpp
+++ b/examples/cpu/mandelbrot/mandelbrot.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2011, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -52,6 +52,10 @@ extern void mandelbrot_serial(float x0, float y0, float x1, float y1, int width,
 /* Write a PPM image file with the image of the Mandelbrot set */
 static void writePPM(int *buf, int width, int height, const char *fn) {
     FILE *fp = fopen(fn, "wb");
+    if (!fp) {
+        printf("Couldn't open a file '%s'\n", fn);
+        exit(-1);
+    }
     fprintf(fp, "P6\n");
     fprintf(fp, "%d %d\n", width, height);
     fprintf(fp, "255\n");

--- a/examples/cpu/mandelbrot_tasks/mandelbrot_tasks.cpp
+++ b/examples/cpu/mandelbrot_tasks/mandelbrot_tasks.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2011, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -52,6 +52,10 @@ extern void mandelbrot_serial(float x0, float y0, float x1, float y1, int width,
 /* Write a PPM image file with the image of the Mandelbrot set */
 static void writePPM(int *buf, int width, int height, const char *fn) {
     FILE *fp = fopen(fn, "wb");
+    if (!fp) {
+        printf("Couldn't open a file '%s'\n", fn);
+        exit(1);
+    }
     fprintf(fp, "P6\n");
     fprintf(fp, "%d %d\n", width, height);
     fprintf(fp, "255\n");

--- a/examples/cpu/noise/noise.cpp
+++ b/examples/cpu/noise/noise.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2014, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -51,6 +51,10 @@ extern void noise_serial(float x0, float y0, float x1, float y1, int width, int 
 /* Write a PPM image file with the image */
 static void writePPM(float *buf, int width, int height, const char *fn) {
     FILE *fp = fopen(fn, "wb");
+    if (!fp) {
+        printf("Couldn't open a file '%s'\n", fn);
+        exit(-1);
+    }
     fprintf(fp, "P6\n");
     fprintf(fp, "%d %d\n", width, height);
     fprintf(fp, "255\n");

--- a/examples/cpu/rt/rt_serial.cpp
+++ b/examples/cpu/rt/rt_serial.cpp
@@ -46,11 +46,12 @@
 __declspec(align(16))
 #endif
     struct float3 {
-    float3() {}
+    float3() { x = y = z = pad = 0.; }
     float3(float xx, float yy, float zz) {
         x = xx;
         y = yy;
         z = zz;
+        pad = 0.;
     }
 
     float3 operator*(float f) const { return float3(x * f, y * f, z * f); }

--- a/examples/cpu/volume_rendering/volume.cpp
+++ b/examples/cpu/volume_rendering/volume.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2014, Intel Corporation
+  Copyright (c) 2011-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -113,6 +113,7 @@ static float *loadVolume(const char *fn, int n[3]) {
 
     if (fscanf(f, "%d %d %d", &n[0], &n[1], &n[2]) != 3) {
         fprintf(stderr, "Couldn't find resolution at start of density file\n");
+        fclose(f);
         exit(1);
     }
 
@@ -121,10 +122,12 @@ static float *loadVolume(const char *fn, int n[3]) {
     for (int i = 0; i < count; ++i) {
         if (fscanf(f, "%f", &v[i]) != 1) {
             fprintf(stderr, "Unexpected end of file at %d'th density value\n", i);
+            fclose(f);
             exit(1);
         }
     }
 
+    fclose(f);
     return v;
 }
 

--- a/examples/cpu/volume_rendering/volume.cpp
+++ b/examples/cpu/volume_rendering/volume.cpp
@@ -51,6 +51,10 @@ extern void volume_serial(float density[], int nVoxels[3], const float raster2ca
 /* Write a PPM image file with the image */
 static void writePPM(float *buf, int width, int height, const char *fn) {
     FILE *fp = fopen(fn, "wb");
+    if (!fp) {
+        printf("Couldn't open a file '%s'\n", fn);
+        exit(1);
+    }
     fprintf(fp, "P6\n");
     fprintf(fp, "%d %d\n", width, height);
     fprintf(fp, "255\n");

--- a/examples/cpu/volume_rendering/volume_serial.cpp
+++ b/examples/cpu/volume_rendering/volume_serial.cpp
@@ -37,11 +37,12 @@
 
 // Just enough of a float3 class to do what we need in this file.
 struct float3 {
-    float3() {}
+    float3() { x = y = z = pad = 0.; }
     float3(float xx, float yy, float zz) {
         x = xx;
         y = yy;
         z = zz;
+        pad = 0.;
     }
 
     float3 operator*(float f) const { return float3(x * f, y * f, z * f); }

--- a/examples/xpu/CMakeLists.txt
+++ b/examples/xpu/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2021, Intel Corporation
+#  Copyright (c) 2019-2022, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -97,6 +97,7 @@ add_subdirectory(aobench)
 add_subdirectory(mandelbrot)
 add_subdirectory(simple)
 add_subdirectory(simple-usm)
+add_subdirectory(usm-mem)
 
 # DPC++ related examples should not run as part of ISPC_BUILD
 # They require complete ISPC installation and ISPC_INCLUDE_DPCPP_EXAMPLES turned ON

--- a/examples/xpu/TestLists.txt
+++ b/examples/xpu/TestLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2021, Intel Corporation
+#  Copyright (c) 2019-2022, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,9 @@ test_add(NAME simple host_simple --gpu)
 test_add(NAME simple-usm host_simple-usm "")
 test_add(NAME simple-usm host_simple-usm --cpu)
 test_add(NAME simple-usm host_simple-usm --gpu)
+
+test_add(NAME usm-mem host_usm-mem 1)
+test_add(NAME usm-mem host_usm-mem 2)
 
 # iterations, width, height
 test_add(NAME aobench TEST_IS_ISPCRT_RUNTIME RES_IMAGE "ao-ispc-gpu.ppm" REF_IMAGE "ao-ispc-cpu.ppm" IMAGE_CMP_TH "0.005" host_aobench 3 32 32)

--- a/examples/xpu/aobench/ao.cpp
+++ b/examples/xpu/aobench/ao.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2021, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -136,6 +136,7 @@ static int run() {
         auto device = ispcrtGetDevice(type, gpu_device_idx);
         ISPCRTNewMemoryViewFlags flags;
         flags.allocType = ISPCRT_ALLOC_TYPE_DEVICE;
+        flags.smHint = ISPCRT_SM_HOST_WRITE_DEVICE_READ;
 
         // Setup output array
         auto buf_dev = ispcrtNewMemoryView(device, fimg, imgSize * sizeof(float), &flags);

--- a/examples/xpu/sgemm/main.cpp
+++ b/examples/xpu/sgemm/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, Intel Corporation
+ * Copyright (c) 2019-2023, Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -63,7 +63,13 @@ int main(int argc, char *argv[]) {
 
     SGEMMApp::RunResult result;
     // validate only if number of iterations is set to 1
-    app.run(result, m, niterations, gx, gy, niterations == 1);
+    try {
+        app.run(result, m, niterations, gx, gy, niterations == 1);
+    }
+    catch (const std::exception &exc) {
+        std::cerr << exc.what();
+        return -1;
+    }
 
     app.cleanup();
 

--- a/examples/xpu/simple-usm/simple-usm.cpp
+++ b/examples/xpu/simple-usm/simple-usm.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2020-2021, Intel Corporation
+  Copyright (c) 2020-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -148,6 +148,8 @@ void usage(const char *p) {
 }
 
 int main(int argc, char *argv[]) {
+    std::ios_base::fmtflags f(std::cout.flags());
+
     constexpr unsigned int SIZE = 16;
 
     // Run on CPU by default
@@ -171,5 +173,6 @@ int main(int argc, char *argv[]) {
     }
 
     int success = run(device_type, SIZE);
+    std::cout.flags(f);
     return success;
 }

--- a/examples/xpu/simple/simple.cpp
+++ b/examples/xpu/simple/simple.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2020-2021, Intel Corporation
+  Copyright (c) 2020-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -157,6 +157,8 @@ void usage(const char *p) {
 }
 
 int main(int argc, char *argv[]) {
+    std::ios_base::fmtflags f(std::cout.flags());
+
     constexpr unsigned int SIZE = 16;
 
     // Run on CPU by default
@@ -180,5 +182,6 @@ int main(int argc, char *argv[]) {
     }
 
     int success = run(device_type, SIZE);
+    std::cout.flags(f);
     return success;
 }

--- a/examples/xpu/usm-mem/CMakeLists.txt
+++ b/examples/xpu/usm-mem/CMakeLists.txt
@@ -1,0 +1,50 @@
+#
+#  Copyright (c) 2022, Intel Corporation
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of Intel Corporation nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+#
+#   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#   IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+#   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#   PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+#   OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# ispc examples: simple-usm
+#
+
+cmake_minimum_required(VERSION 3.13)
+
+set(TEST_NAME "usm-mem")
+set(ISPC_SRC_NAME "usm-mem.ispc")
+set(ISPC_TARGET_XE "gen9-x8")
+set(HOST_SOURCES usm-mem.cpp)
+
+add_perf_example(
+    ISPC_SRC_NAME ${ISPC_SRC_NAME}
+    TEST_NAME ${TEST_NAME}
+    ISPC_TARGET_XE ${ISPC_TARGET_XE}
+    HOST_SOURCES ${HOST_SOURCES}
+)
+

--- a/examples/xpu/usm-mem/usm-mem.cpp
+++ b/examples/xpu/usm-mem/usm-mem.cpp
@@ -1,0 +1,163 @@
+/*
+  Copyright (c) 2022, Intel Corporation
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+   IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+   PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+   OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <string.h>
+
+// ispcrt
+#include "ispcrt.hpp"
+
+std::ostream &operator<<(std::ostream &os, const ISPCRTDeviceType dt) {
+    switch (dt) {
+    case ISPCRT_DEVICE_TYPE_AUTO:
+        os << "Auto";
+        break;
+    case ISPCRT_DEVICE_TYPE_GPU:
+        os << "GPU";
+        break;
+    case ISPCRT_DEVICE_TYPE_CPU:
+        os << "CPU";
+        break;
+    default:
+        break;
+    }
+    return os;
+}
+
+struct Parameters {
+    float *vec;
+    int count;
+};
+
+void simple_CPU_validation(const ispcrt::SharedVector<float>& vin, std::vector<float> &vgold, const unsigned int SIZE) {
+    for (unsigned int i = 0; i < SIZE; i++) {
+        float v = vin[i];
+        if (v < 3.)
+            v = v * v;
+        else
+            v = std::sqrt(v);
+
+        vgold[i] = v;
+    }
+}
+
+#define EPSILON 0.01f
+bool validate_result(const ispcrt::SharedVector<float>& vec, const std::vector<float>& vgold, const unsigned int SIZE) {
+    bool bValid = true;
+    for (unsigned int i = 0; i < SIZE; i++) {
+        float delta = (float)fabs(vgold[i] - vec[i]);
+        if (delta > EPSILON) {
+            std::cout << "Validation failed on i=" << i << ": vec[i] = " << vec[i] << ", but " << vgold[i]
+                      << " was expected\n";
+            bValid = false;
+        }
+    }
+    return bValid;
+}
+
+static int run_same_mem(const ISPCRTDeviceType device_type, const unsigned int SIZE) {
+    ispcrt::Context context(device_type);
+    ispcrt::Device device(context);
+    ispcrt::Module module(device, "xe_usm-mem");
+    ispcrt::Kernel kernel(device, module, "usm_mem");
+
+    ispcrt::SharedMemoryAllocator<float> sma(context, ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
+
+    for (int i = 0; i < 1<<6; i++) {
+        ispcrt::SharedVector<float> vec(SIZE, sma);
+        std::vector<float> vgold(SIZE);
+
+        ispcrt::Array<Parameters, ispcrt::AllocType::Shared> p(context, ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
+        auto pp = p.sharedPtr();
+
+        // Pass data pointers to the device
+        pp->vec = vec.data();
+        pp->count = SIZE;
+
+        ispcrt::TaskQueue queue(device);
+
+        std::generate(vec.begin(), vec.end(), [i = 0]() mutable { return i++; });
+        simple_CPU_validation(vec, vgold, SIZE);
+
+        queue.launch(kernel, p, 1);
+        queue.sync();
+
+        std::cout << i << " (same) Executed on: " << device_type << '\n' << std::setprecision(6) << std::fixed;
+
+        // Check and print result
+        bool bValid = validate_result(vec, vgold, SIZE);
+        if (!bValid) {
+            std::cout << "Not valid" << std::endl;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int run_many_small(const ISPCRTDeviceType device_type) {
+    ispcrt::Context context(device_type);
+
+    ispcrt::SharedMemoryAllocator<char> sma(context, ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
+
+    for (int i = 0; i < 1<<6; i++) {
+        sma.allocate(5);
+        std::cout << i << " (small) Executed on: " << device_type << '\n' << std::setprecision(6) << std::fixed;
+    }
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+    int rc = 0;
+    constexpr unsigned int SIZE = 16;
+
+    ISPCRTDeviceType device_type = ISPCRT_DEVICE_TYPE_GPU;
+
+    if (argc != 2) {
+        printf("test 1|2\n");
+        return 1;
+    }
+
+    if (!strncmp(argv[1], "1\0", 2)) {
+        rc = run_same_mem(device_type, SIZE);
+        return rc;
+    }
+
+    if (!strncmp(argv[1], "2\0", 2)) {
+        rc = run_many_small(device_type);
+        return rc;
+    }
+    return 2;
+}

--- a/examples/xpu/usm-mem/usm-mem.cpp
+++ b/examples/xpu/usm-mem/usm-mem.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2022, Intel Corporation
+  Copyright (c) 2022-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -115,7 +115,7 @@ static int run_same_mem(const ISPCRTDeviceType device_type, const unsigned int S
         queue.launch(kernel, p, 1);
         queue.sync();
 
-        std::cout << i << " (same) Executed on: " << device_type << '\n' << std::setprecision(6) << std::fixed;
+        std::cout << i << " (same) Executed on: " << device_type << '\n';
 
         // Check and print result
         bool bValid = validate_result(vec, vgold, SIZE);
@@ -134,7 +134,7 @@ int run_many_small(const ISPCRTDeviceType device_type) {
 
     for (int i = 0; i < 1<<6; i++) {
         sma.allocate(5);
-        std::cout << i << " (small) Executed on: " << device_type << '\n' << std::setprecision(6) << std::fixed;
+        std::cout << i << " (small) Executed on: " << device_type << '\n';
     }
     return 0;
 }

--- a/examples/xpu/usm-mem/usm-mem.ispc
+++ b/examples/xpu/usm-mem/usm-mem.ispc
@@ -1,0 +1,59 @@
+/*
+  Copyright (c) 2022, Intel Corporation
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+   IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+   PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+   OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+struct Parameters {
+    float *vec;
+    int    count;
+};
+
+task void usm_mem(void *uniform _p) {
+    Parameters *uniform p = (Parameters * uniform) _p;
+
+    foreach (index = 0 ... p->count) {
+        // Load the appropriate input value for this program instance.
+        float v = p->vec[index];
+
+        // Do an arbitrary little computation, but at least make the
+        // computation dependent on the value being processed
+        if (v < 3.)
+            v = v * v;
+        else
+            v = sqrt(v);
+
+        // And write the result to the output array.
+        p->vec[index] = v;
+    }
+}
+
+#include "ispcrt.isph"
+DEFINE_CPU_ENTRY_POINT(usm_mem)

--- a/ispcrt/detail/Context.h
+++ b/ispcrt/detail/Context.h
@@ -14,7 +14,7 @@ namespace base {
 struct Context : public RefCounted {
     Context() = default;
     virtual ~Context() = default;
-    virtual MemoryView *newMemoryView(void *appMem, size_t numBytes, bool shared) const = 0;
+    virtual MemoryView *newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const = 0;
     virtual ISPCRTDeviceType getDeviceType() const = 0;
 
     virtual void* contextNativeHandle() const = 0;

--- a/ispcrt/detail/Device.h
+++ b/ispcrt/detail/Device.h
@@ -18,7 +18,7 @@ struct Device : public RefCounted {
 
     virtual ~Device() = default;
 
-    virtual MemoryView *newMemoryView(void *appMemory, size_t numBytes, bool shared) const = 0;
+    virtual MemoryView *newMemoryView(void *appMemory, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const = 0;
 
     virtual TaskQueue *newTaskQueue() const = 0;
 

--- a/ispcrt/detail/cpu/CPUContext.h
+++ b/ispcrt/detail/cpu/CPUContext.h
@@ -9,7 +9,7 @@ namespace ispcrt {
 
 struct CPUContext : public base::Context {
     CPUContext() = default;
-    base::MemoryView *newMemoryView(void *appMem, size_t numBytes, bool shared) const override;
+    base::MemoryView *newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const override;
     ISPCRTDeviceType getDeviceType() const override;
 
     virtual void* contextNativeHandle() const override;

--- a/ispcrt/detail/cpu/CPUDevice.cpp
+++ b/ispcrt/detail/cpu/CPUDevice.cpp
@@ -253,8 +253,8 @@ ISPCRTDeviceInfo deviceInfo(uint32_t deviceIdx) {
 
 } // namespace cpu
 
-ispcrt::base::MemoryView *CPUDevice::newMemoryView(void *appMem, size_t numBytes, bool shared) const {
-    return new cpu::MemoryView(appMem, numBytes, shared);
+ispcrt::base::MemoryView *CPUDevice::newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const {
+    return new cpu::MemoryView(appMem, numBytes, flags->allocType == ISPCRT_ALLOC_TYPE_SHARED);
 }
 
 ispcrt::base::TaskQueue *CPUDevice::newTaskQueue() const { return new cpu::TaskQueue(); }
@@ -283,8 +283,8 @@ ISPCRTAllocationType CPUDevice::getMemAllocType(void* appMemory) const {
     return ISPCRT_ALLOC_TYPE_UNKNOWN;
 }
 
-ispcrt::base::MemoryView *CPUContext::newMemoryView(void *appMem, size_t numBytes, bool shared) const {
-    return new cpu::MemoryView(appMem, numBytes, shared);
+ispcrt::base::MemoryView *CPUContext::newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const {
+    return new cpu::MemoryView(appMem, numBytes, flags->allocType == ISPCRT_ALLOC_TYPE_SHARED);
 }
 
 ISPCRTDeviceType CPUContext::getDeviceType() const {

--- a/ispcrt/detail/cpu/CPUDevice.h
+++ b/ispcrt/detail/cpu/CPUDevice.h
@@ -18,7 +18,7 @@ ISPCRTDeviceInfo deviceInfo(uint32_t deviceIdx);
 struct CPUDevice : public base::Device {
     CPUDevice() = default;
 
-    base::MemoryView *newMemoryView(void *appMem, size_t numBytes, bool shared) const override;
+    base::MemoryView *newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const override;
 
     base::TaskQueue *newTaskQueue() const override;
 

--- a/ispcrt/detail/gpu/GPUContext.h
+++ b/ispcrt/detail/gpu/GPUContext.h
@@ -3,20 +3,26 @@
 
 #pragma once
 #include "../Context.h"
+#include <memory>
 
 namespace ispcrt {
+namespace gpu { class ChunkedPool; }
+
 struct GPUContext : public ispcrt::base::Context {
     GPUContext();
     GPUContext(void* nativeContext);
     ~GPUContext();
-    base::MemoryView *newMemoryView(void *appMem, size_t numBytes, bool shared) const override;
+    base::MemoryView *newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const override;
     ISPCRTDeviceType getDeviceType() const override;
 
     virtual void* contextNativeHandle() const override;
+    gpu::ChunkedPool *memPool(ISPCRTSharedMemoryAllocationHint type) const;
 private:
     void *m_context{nullptr};
     void *m_driver{nullptr};
     bool  m_is_mock{false};
     bool  m_has_context_ownership{true};
+    std::unique_ptr<gpu::ChunkedPool> m_memPoolHWDR;
+    std::unique_ptr<gpu::ChunkedPool> m_memPoolHRDW;
 };
 }

--- a/ispcrt/detail/gpu/GPUDevice.h
+++ b/ispcrt/detail/gpu/GPUDevice.h
@@ -27,7 +27,7 @@ struct GPUDevice : public base::Device {
 
     ~GPUDevice();
 
-    base::MemoryView *newMemoryView(void *appMem, size_t numBytes, bool shared) const override;
+    base::MemoryView *newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const override;
 
     base::TaskQueue *newTaskQueue() const override;
 

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -285,7 +285,7 @@ ISPCRTMemoryView ispcrtNewMemoryView(ISPCRTDevice d, void *appMemory, size_t num
     if (flags->allocType != ISPCRT_ALLOC_TYPE_SHARED && flags->allocType != ISPCRT_ALLOC_TYPE_DEVICE) {
         throw std::runtime_error("Unsupported memory allocation type requested!");
     }
-    return (ISPCRTMemoryView)device.newMemoryView(appMemory, numBytes, flags->allocType == ISPCRT_ALLOC_TYPE_SHARED);
+    return (ISPCRTMemoryView)device.newMemoryView(appMemory, numBytes, flags);
 }
 ISPCRT_CATCH_END(nullptr)
 
@@ -295,7 +295,7 @@ ISPCRTMemoryView ispcrtNewMemoryViewForContext(ISPCRTContext c, void *appMemory,
     if (flags->allocType != ISPCRT_ALLOC_TYPE_SHARED) {
         throw std::runtime_error("Only shared memory allocation is allowed for context!");
     }
-    return (ISPCRTMemoryView)context.newMemoryView(appMemory, numBytes, true);
+    return (ISPCRTMemoryView)context.newMemoryView(appMemory, numBytes, flags);
 }
 ISPCRT_CATCH_END(nullptr)
 

--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -111,8 +111,17 @@ typedef enum {
     ISPCRT_ALLOC_TYPE_UNKNOWN,
 } ISPCRTAllocationType;
 
+// Choose shared memory allocation flags
+typedef enum {
+    ISPCRT_SM_HOST_DEVICE_READ_WRITE = 0,
+    ISPCRT_SM_HOST_WRITE_DEVICE_READ,
+    ISPCRT_SM_HOST_READ_DEVICE_WRITE,
+    ISPCRT_SM_UNKNOWN,
+} ISPCRTSharedMemoryAllocationHint;
+
 typedef struct {
     ISPCRTAllocationType allocType;
+    ISPCRTSharedMemoryAllocationHint smHint;
 } ISPCRTNewMemoryViewFlags;
 
 ISPCRTMemoryView ispcrtNewMemoryView(ISPCRTDevice, void *appMemory, size_t numBytes, ISPCRTNewMemoryViewFlags *flags);

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -1028,7 +1028,7 @@ TEST_F(MockTest, C_API_AllocateDeviceMemory) {
     mem_flags.smHint = ISPCRT_SM_HOST_WRITE_DEVICE_READ;
     ISPCRTMemoryView mem = ispcrtNewMemoryViewForContext(context, buffer.data(), buffer.size(), &mem_flags);
     if (mem) ispcrtRelease(mem);
-    if (context) ispcrtRelease(context);
+    ispcrtRelease(context);
     ASSERT_EQ(sm_rt_error, ISPCRT_UNKNOWN_ERROR);
 }
 

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 Intel Corporation
+// Copyright 2020-2023 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "ispcrt.hpp"
@@ -1001,6 +1001,7 @@ TEST_F(MockTest, C_API_AllocateSharedMemoryForGPU) {
     std::vector<uint8_t> buffer;
     ISPCRTNewMemoryViewFlags mem_flags;
     mem_flags.allocType = ISPCRT_ALLOC_TYPE_SHARED;
+    mem_flags.smHint = ISPCRT_SM_HOST_WRITE_DEVICE_READ;
     ISPCRTMemoryView mem = ispcrtNewMemoryViewForContext(context, buffer.data(), buffer.size(), &mem_flags);
     ispcrtRelease(mem);
     ispcrtRelease(context);
@@ -1012,6 +1013,7 @@ TEST_F(MockTest, C_API_AllocateSharedMemoryForCPU) {
     std::vector<uint8_t> buffer;
     ISPCRTNewMemoryViewFlags mem_flags;
     mem_flags.allocType = ISPCRT_ALLOC_TYPE_SHARED;
+    mem_flags.smHint = ISPCRT_SM_HOST_WRITE_DEVICE_READ;
     ISPCRTMemoryView mem = ispcrtNewMemoryViewForContext(context, buffer.data(), buffer.size(), &mem_flags);
     ispcrtRelease(mem);
     ispcrtRelease(context);
@@ -1023,6 +1025,7 @@ TEST_F(MockTest, C_API_AllocateDeviceMemory) {
     std::vector<uint8_t> buffer;
     ISPCRTNewMemoryViewFlags mem_flags;
     mem_flags.allocType = ISPCRT_ALLOC_TYPE_DEVICE;
+    mem_flags.smHint = ISPCRT_SM_HOST_WRITE_DEVICE_READ;
     ISPCRTMemoryView mem = ispcrtNewMemoryViewForContext(context, buffer.data(), buffer.size(), &mem_flags);
     if (mem) ispcrtRelease(mem);
     if (context) ispcrtRelease(context);

--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2022, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -70,6 +70,8 @@ using namespace ispc;
 extern int yyparse();
 struct yy_buffer_state;
 extern yy_buffer_state *yy_scan_string(const char *);
+typedef struct yy_buffer_state *YY_BUFFER_STATE;
+extern void yy_delete_buffer(YY_BUFFER_STATE);
 
 /** Given an LLVM type, try to find the equivalent ispc type.  Note that
     this is an under-constrained problem due to LLVM's type representations
@@ -1264,25 +1266,27 @@ void ispc::DefineStdlib(SymbolTable *symbolTable, llvm::LLVMContext *ctx, llvm::
         // definitions added.
         extern const char stdlib_mask1_code[], stdlib_mask8_code[];
         extern const char stdlib_mask16_code[], stdlib_mask32_code[], stdlib_mask64_code[];
+        YY_BUFFER_STATE strbuf;
         switch (g->target->getMaskBitCount()) {
         case 1:
-            yy_scan_string(stdlib_mask1_code);
+            strbuf = yy_scan_string(stdlib_mask1_code);
             break;
         case 8:
-            yy_scan_string(stdlib_mask8_code);
+            strbuf = yy_scan_string(stdlib_mask8_code);
             break;
         case 16:
-            yy_scan_string(stdlib_mask16_code);
+            strbuf = yy_scan_string(stdlib_mask16_code);
             break;
         case 32:
-            yy_scan_string(stdlib_mask32_code);
+            strbuf = yy_scan_string(stdlib_mask32_code);
             break;
         case 64:
-            yy_scan_string(stdlib_mask64_code);
+            strbuf = yy_scan_string(stdlib_mask64_code);
             break;
         default:
             FATAL("Unhandled mask bit size for stdlib.ispc");
         }
         yyparse();
+        yy_delete_buffer(strbuf);
     }
 }

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -1285,9 +1285,11 @@ std::vector<std::string> FunctionEmitContext::GetLabels() {
 void FunctionEmitContext::CurrentLanesReturned(Expr *expr, bool doCoherenceCheck) {
     const Type *returnType = function->GetReturnType();
     if (returnType->IsVoidType()) {
-        if (expr != NULL)
-            Error(expr->pos, "Can't return non-void type \"%s\" from void function.",
-                  expr->GetType()->GetString().c_str());
+        if (expr != NULL) {
+            const Type *exprType = expr->GetType();
+            Assert(exprType);
+            Error(expr->pos, "Can't return non-void type \"%s\" from void function.", exprType->GetString().c_str());
+        }
     } else {
         if (expr == NULL) {
             Error(funcStartPos, "Must provide return value for return "

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -2546,7 +2546,7 @@ llvm::Value *FunctionEmitContext::gather(llvm::Value *ptr, const PointerType *pt
 
             // It is a kludge. When we dereference varying pointer to uniform struct
             // with "bound uniform" member, we should return first unmasked member.
-            int need_one_elem = CastType<StructType>(ptrType->GetBaseType()) &&
+            int need_one_elem = CastType<StructType>(ptrType->GetBaseType()) && returnCollectionType &&
                                 returnCollectionType->GetElementType(i)->IsUniformType();
             // This in turn will be another gather
             llvm::Value *eltValues = LoadInst(eltPtr, mask, eltPtrType, name, need_one_elem);

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -2664,6 +2664,7 @@ void FunctionEmitContext::addGSMetadata(llvm::Value *v, SourcePos pos) {
 llvm::Value *FunctionEmitContext::AddrSpaceCastInst(llvm::Value *val, AddressSpace as, bool atEntryBlock) {
     Assert(llvm::isa<llvm::PointerType>(val->getType()));
     llvm::PointerType *pt = llvm::dyn_cast<llvm::PointerType>(val->getType());
+    Assert(pt);
     if (pt->getAddressSpace() == (unsigned)as) {
         return val;
     }

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -8345,7 +8345,9 @@ llvm::Value *NewExpr::GetValue(FunctionEmitContext *ctx) const {
     // Compute the total amount of memory to allocate, allocSize, as the
     // product of the number of elements to allocate and the size of a
     // single element.
-    llvm::Value *eltSize = g->target->SizeOf(allocType->LLVMType(g->ctx), ctx->GetCurrentBasicBlock());
+    llvm::Type *llvmAllocType = allocType->LLVMType(g->ctx);
+    Assert(llvmAllocType);
+    llvm::Value *eltSize = g->target->SizeOf(llvmAllocType, ctx->GetCurrentBasicBlock());
     if (isVarying)
         eltSize = ctx->SmearUniform(eltSize, "smear_size");
     llvm::Value *allocSize = ctx->BinaryOperator(llvm::Instruction::Mul, countValue, eltSize, "alloc_size");

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -2729,7 +2729,7 @@ Expr *BinaryExpr::TypeCheck() {
             pt1 = CastType<PointerType>(type1);
         } else if (pt1 != NULL && lIsAllIntZeros(arg0)) {
             arg0 = new NullPointerExpr(pos);
-            type0 = arg1->GetType();
+            type0 = arg0->GetType();
             pt0 = CastType<PointerType>(type0);
         }
 

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -4202,7 +4202,6 @@ static std::pair<llvm::Constant *, bool> lGetExprListConstant(const Type *type, 
             return std::pair<llvm::Constant *, bool>(llvm::ConstantVector::get(cv), isNotValidForMultiTargetGlobal);
         }
     }
-    return std::pair<llvm::Constant *, bool>(NULL, false);
 }
 
 std::pair<llvm::Constant *, bool> ExprList::GetStorageConstant(const Type *type) const {

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -582,7 +582,6 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
         llvm::Type *i32Type = llvm::Type::getInt32Ty(fContext);
         llvm::SmallVector<llvm::Metadata *, 8> argKinds;
         llvm::SmallVector<llvm::Metadata *, 8> argInOutKinds;
-        llvm::SmallVector<llvm::Metadata *, 8> argOffsets;
         llvm::SmallVector<llvm::Metadata *, 8> argTypeDescs;
 
         // In ISPC we need only AK_NORMAL and IK_NORMAL now, in future it can change.
@@ -614,8 +613,6 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
                     // GRF align if arg would cross GRF boundary
                     offset = llvm::alignTo(offset, grf_size);
             }
-
-            argOffsets.push_back(llvm::ValueAsMetadata::get(llvm::ConstantInt::get(i32Type, offset)));
 
             offset += bytes;
         }

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -435,7 +435,8 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
                 ctx->SetFunctionMask(&*argIter);
             }
 
-            Assert(++argIter == function->arg_end());
+            ++argIter;
+            Assert(argIter == function->arg_end());
         }
         if (g->target->isXeTarget() && type->isTask) {
             // Assign threadIndex and threadCount to the result of calling of corresponding builtins.

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -606,7 +606,9 @@ static bool lIsFirstElementConstVector(llvm::Value *v) {
     // TODO: after fixing FIXME above isXeTarget() needs to be removed.
     if (g->target->isXeTarget()) {
         if (cv == NULL && llvm::isa<llvm::Instruction>(v)) {
-            cv = llvm::dyn_cast<llvm::ConstantVector>(llvm::dyn_cast<llvm::Instruction>(v)->getOperand(1));
+            llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(v);
+            Assert(inst);
+            cv = llvm::dyn_cast<llvm::ConstantVector>(inst->getOperand(1));
         }
     }
     if (cv != NULL) {
@@ -742,6 +744,7 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
             }
             if (ie != NULL && llvm::isa<llvm::UndefValue>(ie->getOperand(0))) {
                 llvm::ConstantInt *ci = llvm::dyn_cast<llvm::ConstantInt>(ie->getOperand(2));
+                Assert(ci);
                 if (ci->isZero()) {
                     return ie->getOperand(1);
                 }
@@ -1518,6 +1521,7 @@ static llvm::Value *lExtractFirstVectorElement(llvm::Value *v, std::map<llvm::PH
     // "lExtractFirstVectorElement" function.
     if (llvm::isa<llvm::ShuffleVectorInst>(v)) {
         llvm::ShuffleVectorInst *shuf = llvm::dyn_cast<llvm::ShuffleVectorInst>(v);
+        Assert(shuf);
         llvm::Value *indices = shuf->getShuffleMaskForBitcode();
         if (llvm::isa<llvm::ConstantAggregateZero>(indices)) {
             return lExtractFirstVectorElement(shuf->getOperand(0), phiMap);

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -1879,6 +1879,7 @@ static void lGetAddressSpace(llvm::Value *v, std::set<llvm::Value *> &done, std:
         // This is the only return point that constant expression instruction
         // can reach, drop all references here
         inst->dropAllReferences();
+        inst->deleteValue();
     }
 }
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1136,6 +1136,7 @@ bool Module::writeBitcode(llvm::Module *module, const char *outFileName, OutputT
     // go.  If we open it, it'll be closed by the llvm::raw_fd_ostream
     // destructor.
     int fd;
+    Assert(outFileName);
     if (!strcmp(outFileName, "-"))
         fd = 1; // stdout
     else {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1482,8 +1482,8 @@ static void lEmitEnumDecls(const std::vector<const EnumType *> &enumTypes, FILE 
         for (int j = 0; j < enumTypes[i]->GetEnumeratorCount(); ++j) {
             const Symbol *e = enumTypes[i]->GetEnumerator(j);
             Assert(e->constValue != NULL);
-            unsigned int enumValue;
-            int count = e->constValue->GetValues(&enumValue);
+            unsigned int enumValue[1];
+            int count = e->constValue->GetValues(enumValue);
             Assert(count == 1);
 
             // Always print an initializer to set the value.  We could be
@@ -1491,7 +1491,7 @@ static void lEmitEnumDecls(const std::vector<const EnumType *> &enumTypes, FILE 
             // one plus the previous enumerator value (or zero, for the
             // first enumerator) is the same as the value stored with the
             // enumerator, though that doesn't seem worth the trouble...
-            fprintf(file, "    %s = %d%c\n", e->name.c_str(), enumValue,
+            fprintf(file, "    %s = %d%c\n", e->name.c_str(), enumValue[0],
                     (j < enumTypes[i]->GetEnumeratorCount() - 1) ? ',' : ' ');
         }
         fprintf(file, "};\n");

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1443,7 +1443,9 @@ static void lEmitStructDecl(const StructType *st, std::vector<const StructType *
     llvm::Type *stype = st->LLVMType(g->ctx);
     const llvm::DataLayout *DL = g->target->getDataLayout();
 
-    if (!(pack = llvm::dyn_cast<llvm::StructType>(stype)->isPacked())) {
+    llvm::StructType *stypeStructType = llvm::dyn_cast<llvm::StructType>(stype);
+    Assert(stypeStructType);
+    if (!(pack = stypeStructType->isPacked())) {
         for (int i = 0; !needsAlign && (i < st->GetElementCount()); ++i) {
             const Type *ftype = st->GetElementType(i)->GetAsNonConstType();
             needsAlign |= ftype->IsVaryingType() && (CastType<StructType>(ftype) == NULL);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -378,7 +378,9 @@ Symbol *Module::AddLLVMIntrinsicDecl(const std::string &name, ExprList *args, So
         int nInits = args->exprs.size();
         if (llvm::GenXIntrinsic::isOverloadedRet(ID) || llvm::GenXIntrinsic::isOverloadedArg(ID, nInits)) {
             for (int i = 0; i < nInits; ++i) {
-                exprType.push_back((args->exprs[i])->GetType()->LLVMType(g->ctx));
+                const Type *argType = (args->exprs[i])->GetType();
+                Assert(argType);
+                exprType.push_back(argType->LLVMType(g->ctx));
             }
         }
         llvm::ArrayRef<llvm::Type *> argArr(exprType);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -402,7 +402,9 @@ Symbol *Module::AddLLVMIntrinsicDecl(const std::string &name, ExprList *args, So
         if (llvm::Intrinsic::isOverloaded(ID)) {
             int nInits = args->exprs.size();
             for (int i = 0; i < nInits; ++i) {
-                exprType.push_back((args->exprs[i])->GetType()->LLVMType(g->ctx));
+                const Type *argType = (args->exprs[i])->GetType();
+                Assert(argType);
+                exprType.push_back(argType->LLVMType(g->ctx));
             }
         }
         llvm::ArrayRef<llvm::Type *> argArr(exprType);

--- a/src/module.h
+++ b/src/module.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2022, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -160,6 +160,7 @@ class Module {
                                 OutputFlags outputFlags, OutputType outputType, const char *outFileName,
                                 const char *headerFileName, const char *depsFileName, const char *depsTargetName,
                                 const char *hostStubFileName, const char *devStubFileName);
+    static int LinkAndOutput(std::vector<std::string> linkFiles, OutputType outputType, const char *outFileName);
 
     /** Total number of errors encountered during compilation. */
     int errorCount;
@@ -221,6 +222,7 @@ class Module {
                                           OutputType outputType, const char *outFileName);
     static bool writeBitcode(llvm::Module *module, const char *outFileName, OutputType outputType);
 #ifdef ISPC_XE_ENABLED
+    static std::unique_ptr<llvm::Module> translateFromSPIRV(std::ifstream &outString);
     static bool translateToSPIRV(llvm::Module *module, std::stringstream &outString);
     static bool writeSPIRV(llvm::Module *module, const char *outFileName);
     static bool writeZEBin(llvm::Module *module, const char *outFileName);

--- a/src/opt/XeGatherCoalescePass.cpp
+++ b/src/opt/XeGatherCoalescePass.cpp
@@ -106,11 +106,13 @@ MemoryCoalescing::BasePtrInfo MemoryCoalescing::analyseVarOffsetGEP(llvm::GetEle
     // Find the last constant idxs: we may be able to use them as constant offset for
     // several GEPs with common pre-constant part
     auto FirstConstIdx = GEP->getNumOperands();
-    for (unsigned i = FirstConstIdx - 1; i >= 0; --i) {
+    Assert(FirstConstIdx);
+    unsigned i = FirstConstIdx - 1;
+    do {
         if (!llvm::isa<llvm::ConstantInt>(GEP->getOperand(i)))
             break;
         FirstConstIdx = i;
-    }
+    } while (i--);
     // Early return in case when no constant offset was found:
     // further actions are useless.
     if (GEP->getNumOperands() == FirstConstIdx) {

--- a/src/opt/XeGatherCoalescePass.cpp
+++ b/src/opt/XeGatherCoalescePass.cpp
@@ -458,8 +458,9 @@ llvm::Value *MemoryCoalescing::extractValueFromBlock(const MemoryCoalescing::Blo
                                                      MemoryCoalescing::OffsetT OffsetBytes, llvm::Type *DstTy,
                                                      llvm::Instruction *InsertBefore) const {
     Assert(BlockInstsVec.size() > 0);
-    OffsetT BlockSizeInBytes = getScalarTypeSize(BlockInstsVec[0]->getType()) *
-                               llvm::cast<llvm::FixedVectorType>(BlockInstsVec[0]->getType())->getNumElements();
+    OffsetT ScalarTypeSize = getScalarTypeSize(BlockInstsVec[0]->getType());
+    OffsetT BlockSizeInBytes =
+        ScalarTypeSize * llvm::cast<llvm::FixedVectorType>(BlockInstsVec[0]->getType())->getNumElements();
     unsigned StartIdx = OffsetBytes / BlockSizeInBytes;
     unsigned EndIdx = (OffsetBytes + getScalarTypeSize(DstTy) - 1) / BlockSizeInBytes;
     unsigned BlocksAffected = EndIdx - StartIdx + 1;

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2022, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -3145,11 +3145,11 @@ class PrintArgsBuilder {
     FunctionEmitContext *ctx;
 
     struct AdditionalData {
-        llvm::Value *mask;
+        llvm::Value *mask{NULL};
         enum { LeftParenthesisIdx = 0, RightParenthesisIdx, EmptyIdx, FalseIdx, TrueIdx, NumStrings };
-        std::array<llvm::Value *, NumStrings> strings;
+        std::array<llvm::Value *, NumStrings> strings{};
 
-        AdditionalData() { mask = NULL; }
+        AdditionalData() {}
         AdditionalData(FunctionEmitContext *ctx) {
             if (ctx->emitXeHardwareMask())
                 mask = ctx->XeSimdCFPredicate(LLVMMaskAllOn);

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -3501,6 +3501,7 @@ void PrintStmt::emitCode4LZ(FunctionEmitContext *ctx) const {
 static AddressInfo *lEmitPrintArgCode(Expr *expr, FunctionEmitContext *ctx) {
     const Type *type = expr->GetType();
 
+    Assert(type);
     llvm::Type *llvmExprType = type->LLVMType(g->ctx);
     AddressInfo *ptrInfo = ctx->AllocaInst(llvmExprType, "print_arg");
     llvm::Value *val = expr->GetValue(ctx);

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1315,6 +1315,7 @@ const Type *ArrayType::SizeUnsizedArrays(const Type *type, Expr *initExpr) {
     if (nextList == NULL)
         return type;
 
+    Assert(at);
     const Type *nextType = at->GetElementType();
     const ArrayType *nextArrayType = CastType<ArrayType>(nextType);
     if (nextArrayType != NULL && nextArrayType->GetElementCount() == 0) {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -741,12 +741,12 @@ llvm::DIType *EnumType::GetDIType(llvm::DIScope *scope) const {
 
     std::vector<llvm::Metadata *> enumeratorDescriptors;
     for (unsigned int i = 0; i < enumerators.size(); ++i) {
-        unsigned int enumeratorValue;
+        unsigned int enumeratorValue[1];
         Assert(enumerators[i]->constValue != NULL);
-        int count = enumerators[i]->constValue->GetValues(&enumeratorValue);
+        int count = enumerators[i]->constValue->GetValues(enumeratorValue);
         Assert(count == 1);
 
-        llvm::Metadata *descriptor = m->diBuilder->createEnumerator(enumerators[i]->name, enumeratorValue);
+        llvm::Metadata *descriptor = m->diBuilder->createEnumerator(enumerators[i]->name, enumeratorValue[0]);
         enumeratorDescriptors.push_back(descriptor);
     }
 

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -559,8 +559,9 @@ llvm::DIType *AtomicType::GetDIType(llvm::DIScope *scope) const {
 
         llvm::DINodeArray subArray = m->diBuilder->getOrCreateArray(sub);
         llvm::DIType *unifType = GetAsUniformType()->GetDIType(scope);
-        uint64_t size = unifType->getSizeInBits() * g->target->getVectorWidth();
-        uint64_t align = unifType->getAlignInBits() * g->target->getVectorWidth();
+        uint64_t width = g->target->getVectorWidth();
+        uint64_t size = unifType->getSizeInBits() * width;
+        uint64_t align = unifType->getAlignInBits() * width;
         return m->diBuilder->createVectorType(size, align, unifType, subArray);
     } else {
         Assert(variability == Variability::SOA);
@@ -765,8 +766,9 @@ llvm::DIType *EnumType::GetDIType(llvm::DIScope *scope) const {
 
         llvm::DINodeArray subArray = m->diBuilder->getOrCreateArray(sub);
         // llvm::DebugNodeArray subArray = m->diBuilder->getOrCreateArray(sub);
-        uint64_t size = diType->getSizeInBits() * g->target->getVectorWidth();
-        uint64_t align = diType->getAlignInBits() * g->target->getVectorWidth();
+        uint64_t width = g->target->getVectorWidth();
+        uint64_t size = diType->getSizeInBits() * width;
+        uint64_t align = diType->getAlignInBits() * width;
         return m->diBuilder->createVectorType(size, align, diType, subArray);
     }
     case Variability::SOA: {

--- a/tests/lit-tests/arg_parsing_errors.ispc
+++ b/tests/lit-tests/arg_parsing_errors.ispc
@@ -19,6 +19,11 @@
 //; RUN: not %{ispc} %s -o %t.o --nowrap --target=sse3,avx2-i32x8,gost 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_19
 //; RUN: not %{ispc} %s -o %t.o --nowrap --target sse3,avx2-i32x8,gost 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_20
 //; RUN: %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 --arch=x86 --arch=x86_64 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_21
+//; RUN: not %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 link 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_22
+//; RUN: not %{ispc} link %s 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_23
+//; RUN: not %{ispc} link --emit-obj %s 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_24
+//; RUN: %{ispc} %s -o %t.bc --emit-llvm | not %{ispc} link %t.bc 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_25
+//; RUN: %{ispc} %s -o %t.bc --emit-llvm | %{ispc} link %t.bc -o %t.bc
 //; RUN: %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 --help
 //; RUN: %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 --help-dev
 //; RUN: %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 --support-matrix
@@ -57,6 +62,10 @@
 //; CHECK_ERROR_19: Error: Incorrect targets: sse3,gost. Choices are:
 //; CHECK_ERROR_20: Error: Incorrect targets: sse3,gost. Choices are:
 //; CHECK_ERROR_21: Warning: Overwriting --arch=x86 with --arch=x86-64
+//; CHECK_ERROR_22: Error: Option "link" can't be used in compilation mode. Use "ispc link --help" for details
+//; CHECK_ERROR_23: Unrecognized format of input file
+//; CHECK_ERROR_24: Error: Unknown option "--emit-obj"
+//; CHECK_ERROR_25: Warning: No output file name specified
 
 //; CHECK_ERROR_QUIET-NOT: Error
 

--- a/tests/lit-tests/assume_uniform_xe.ispc
+++ b/tests/lit-tests/assume_uniform_xe.ispc
@@ -1,9 +1,8 @@
 // RUN: %{ispc} --emit-spirv --target=gen9-x8 %s -o %t.spv
-// RUN: ocloc compile -file %t.spv -spirv_input -options "-vc-codegen" -device SKL -output %t.bin -output_no_suffix
-// RUN: ocloc disasm -file %t.bin -device SKL -dump ./
-// RUN: FileCheck %s -check-prefix=CHECK_FOO1 -input-file=foo1_kernel_KernelHeap.asm
-// RUN: FileCheck %s -check-prefix=CHECK_FOO2 -input-file=foo2_kernel_KernelHeap.asm
-// RUN: FileCheck %s -check-prefix=CHECK_FOO3 -input-file=foo3_kernel_KernelHeap.asm
+// RUN: ocloc compile -file %t.spv -spirv_input -options "-vc-codegen -Xfinalizer -output" -device skl -output %t.bin -output_no_suffix
+// RUN: FileCheck %s -check-prefix=CHECK_FOO1 -input-file=foo1_kernel.asm
+// RUN: FileCheck %s -check-prefix=CHECK_FOO2 -input-file=foo2_kernel.asm
+// RUN: FileCheck %s -check-prefix=CHECK_FOO3 -input-file=foo3_kernel.asm
 
 // REQUIRES: XE_ENABLED
 // REQUIRES: OCLOC_INSTALLED

--- a/tests/lit-tests/xe_task_count.ispc
+++ b/tests/lit-tests/xe_task_count.ispc
@@ -1,15 +1,14 @@
 // This test checks number of mul operations for taskIndex/taskCount calculations for Xe targets.
 // RUN: %{ispc} --emit-spirv --target=gen9-x8 %s -o %t.spv
-// RUN: ocloc compile -file %t.spv -spirv_input -options "-vc-codegen" -device SKL -output %t.bin -output_no_suffix
-// RUN: ocloc disasm -file %t.bin -device SKL -dump ./
-// RUN: FileCheck %s -check-prefix=CHECK_TASKCOUNT -input-file=taskCount_kernel_KernelHeap.asm
-// RUN: FileCheck %s -check-prefix=CHECK_TASKCOUNT0 -input-file=taskCount0_kernel_KernelHeap.asm
-// RUN: FileCheck %s -check-prefix=CHECK_TASKCOUNT1 -input-file=taskCount1_kernel_KernelHeap.asm
-// RUN: FileCheck %s -check-prefix=CHECK_TASKCOUNT2 -input-file=taskCount2_kernel_KernelHeap.asm
-// RUN: FileCheck %s -check-prefix=CHECK_TASKINDEX -input-file=taskIndex_kernel_KernelHeap.asm
-// RUN: FileCheck %s -check-prefix=CHECK_TASKINDEX0 -input-file=taskIndex0_kernel_KernelHeap.asm
-// RUN: FileCheck %s -check-prefix=CHECK_TASKINDEX1 -input-file=taskIndex1_kernel_KernelHeap.asm
-// RUN: FileCheck %s -check-prefix=CHECK_TASKINDEX2 -input-file=taskIndex2_kernel_KernelHeap.asm
+// RUN: ocloc compile -file %t.spv -spirv_input -options "-vc-codegen -Xfinalizer -output" -device SKL -output %t.bin -output_no_suffix
+// RUN: FileCheck %s -check-prefix=CHECK_TASKCOUNT -input-file=taskCount_kernel.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKCOUNT0 -input-file=taskCount0_kernel.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKCOUNT1 -input-file=taskCount1_kernel.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKCOUNT2 -input-file=taskCount2_kernel.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKINDEX -input-file=taskIndex_kernel.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKINDEX0 -input-file=taskIndex0_kernel.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKINDEX1 -input-file=taskIndex1_kernel.asm
+// RUN: FileCheck %s -check-prefix=CHECK_TASKINDEX2 -input-file=taskIndex2_kernel.asm
 
 // REQUIRES: XE_ENABLED
 // REQUIRES: OCLOC_INSTALLED


### PR DESCRIPTION
The portion of Xe-related changed plus fixes of static analysis problems.
The Xe changes includes 2 main features:
1. ISPC Runtime chunking allocator that can be enabled with `ISPCRT_MEM_POOL` (see details are [here).](https://github.com/ispc/ispc/pull/2438/commits/21e54e6e9dca2fbb4dbf2d840383b8d7d7aecd7b)
2. ISPC "link" mode allowing to link several LLVM bitcode or SPIR-V files and output the result as bitcode or SPIR-V.
For example:
`ispc link test_a.bc test_b.bc --emit-spirv -o test.spv`