### PR TITLE
Fix crash in main when no command argument is provided

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -630,7 +630,7 @@ int main(int Argc, char *Argv[]) {
 
     // If the first argument is "link"
     // ISPC will be used in a linkage mode
-    if (!strncmp(argv[1], "link", 4)) {
+    if (argc > 1 && !strncmp(argv[1], "link", 4)) {
         // Use bitcode format by default
         ot = Module::Bitcode;
 


### PR DESCRIPTION
#2438 introduced a new `link` command, but failed to check `argc` before reading `argv[1]`, which resulted in a crash.