### PR TITLE
LLVM build and usage: NODUMPs, discard-value-names

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -17,8 +17,8 @@ on:
         - 'smoke'
 
 env:
-  SDE_MIRROR_ID: 684899
-  SDE_TAR_NAME: sde-external-9.0.0-2021-11-07
+  SDE_MIRROR_ID: 751535
+  SDE_TAR_NAME: sde-external-9.14.0-2022-10-25
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
   LLVM_REPO: https://github.com/ispc/ispc.dependencies
   TARGETS_SMOKE: '["avx2-i32x8"]'

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -8,8 +8,8 @@ on:
         required: true
         default: 'full'
 env:
-  SDE_MIRROR_ID: 684899
-  SDE_TAR_NAME: sde-external-9.0.0-2021-11-07
+  SDE_MIRROR_ID: 751535
+  SDE_TAR_NAME: sde-external-9.14.0-2022-10-25
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
   LLVM_REPO: https://github.com/ispc/ispc.dependencies
   TARGETS_SMOKE: '["avx2-i32x8"]'

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -12,8 +12,8 @@ on:
   workflow_dispatch:
 
 env:
-  SDE_MIRROR_ID: 684899
-  SDE_TAR_NAME: sde-external-9.0.0-2021-11-07
+  SDE_MIRROR_ID: 751535
+  SDE_TAR_NAME: sde-external-9.14.0-2022-10-25
 
 jobs:
   # Building LLVM in docker, as using native Ubuntu 18.04 github-hosted image contains newer-than-expected libs and

--- a/.github/workflows/nightly-15.yml
+++ b/.github/workflows/nightly-15.yml
@@ -13,8 +13,8 @@ on:
   workflow_dispatch:
 
 env:
-  SDE_MIRROR_ID: 684899
-  SDE_TAR_NAME: sde-external-9.0.0-2021-11-07
+  SDE_MIRROR_ID: 751535
+  SDE_TAR_NAME: sde-external-9.14.0-2022-10-25
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
 
 jobs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,9 @@ set(CLANG_LIBRARY_LIST clangFrontend clangDriver clangSerialization clangParse c
 if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "15.0.0")
     list(APPEND CLANG_LIBRARY_LIST clangSupport)
 endif()
+if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "16.0.0")
+    list(APPEND CLANG_LIBRARY_LIST clangASTMatchers)
+endif()
 
 set(LLVM_COMPONENTS engine ipo bitreader bitwriter instrumentation linker option frontendopenmp)
 if (XE_ENABLED AND ${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "14.0.0")

--- a/alloy.py
+++ b/alloy.py
@@ -154,12 +154,6 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     try_do_LLVM(f"clone {component} with tag {GIT_TAG} from {GIT_REPO_BASE} to {target_dir}",
                 git_clone_cmd, from_validation, verbose)
 
-# ISPC uses LLVM dumps for debug output, so build correctly it requires these functions to be
-# present in LLVM libraries. In LLVM 5.0 they are not there by default and require explicit enabling.
-# In later version this functionality is triggered by enabling assertions.
-def get_llvm_enable_dump_switch(version_LLVM):
-    return " -DLLVM_ENABLE_DUMP=ON "
-
 def get_llvm_disable_assertions_switch(llvm_disable_assertions):
     if llvm_disable_assertions == True:
         return "  -DLLVM_ENABLE_ASSERTIONS=OFF"
@@ -274,7 +268,6 @@ def build_LLVM(version_LLVM, folder, debug, selfbuild, extra, from_validation, f
                 "  -DCMAKE_INSTALL_PREFIX=" + llvm_home + "/" + LLVM_BIN_selfbuild +
                 "  -DCMAKE_BUILD_TYPE=Release" +
                 llvm_enable_projects +
-                get_llvm_enable_dump_switch(version_LLVM) +
                 get_llvm_disable_assertions_switch(llvm_disable_assertions) +
                 "  -DLLVM_INSTALL_UTILS=ON" +
                 (("  -DGCC_INSTALL_PREFIX=" + gcc_toolchain_path) if gcc_toolchain_path != "" else "") +
@@ -309,7 +302,6 @@ def build_LLVM(version_LLVM, folder, debug, selfbuild, extra, from_validation, f
                     "  -DCMAKE_INSTALL_PREFIX=" + llvm_home + "/" + LLVM_BIN +
                     "  -DCMAKE_BUILD_TYPE=" + build_type +
                     llvm_enable_projects +
-                    get_llvm_enable_dump_switch(version_LLVM) +
                     get_llvm_disable_assertions_switch(llvm_disable_assertions) +
                     "  -DLLVM_INSTALL_UTILS=ON" +
                     (("  -DGCC_INSTALL_PREFIX=" + gcc_toolchain_path) if gcc_toolchain_path != "" else "") +
@@ -324,7 +316,6 @@ def build_LLVM(version_LLVM, folder, debug, selfbuild, extra, from_validation, f
                     'cmake -Thost=x64 -G ' + '\"' + generator + '\"' + ' -DCMAKE_INSTALL_PREFIX="..\\'+ LLVM_BIN + '" ' +
                     '  -DCMAKE_BUILD_TYPE=' + build_type +
                     llvm_enable_projects +
-                    get_llvm_enable_dump_switch(version_LLVM) +
                     get_llvm_disable_assertions_switch(llvm_disable_assertions) +
                     '  -DLLVM_INSTALL_UTILS=ON' +
                     targets_and_common_options +

--- a/tests/lit-tests/discard_value_names.ispc
+++ b/tests/lit-tests/discard_value_names.ispc
@@ -1,14 +1,22 @@
 
+// Check that --[no]discard-value-names has an effect
 // RUN: %{ispc} %s --target=host --nowrap -O2 --emit-llvm-text --discard-value-names -o - | FileCheck %s -check-prefix=CHECK_DISCARD
 // RUN: %{ispc} %s --target=host --nowrap -O2 --emit-llvm-text --no-discard-value-names -o - | FileCheck %s -check-prefix=CHECK_NODISCARD
 
-// CHECK_DISCARD-NOT: allocas:
-// CHECK_NODISCARD: allocas:
+// Check that by default values are generated for LLVM IR dump
+// RUN: %{ispc} %s --target=host --nowrap -O2 --emit-llvm-text -o - | FileCheck %s -check-prefix=CHECK_NODISCARD
+
+// Check that for assembler by default there no names and that we can still see them if commanded so.
+// RUN: %{ispc} %s --target=host --nowrap -O2 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_DISCARD
+// RUN: %{ispc} %s --target=host --nowrap -O2 --emit-asm --no-discard-value-names -o - | FileCheck %s -check-prefix=CHECK_NODISCARD
+
+// CHECK_DISCARD-NOT: allocas
+// CHECK_NODISCARD: allocas
 
 extern void goo_for(uniform int);
 void foo_for() {
     for (uniform int iter1 = 0; iter1 < 45; iter1++) {
         goo_for(iter1);
-    }   
+    }
 }
 


### PR DESCRIPTION
- Remove `LLVM_ENABLE_DUMP` for optimized/release LLVM build. The functionality is enabled by default for debug build (`--debug` switch for `alloy.py`) anyway. For optimized build it costs us ~1.5Mb of binary size and slight slowdown for compile time.
- Change the default behavior for `--[no]discard-value-names`. By default it's only enabled for if the output is bitcode (text or binary). This reduces compile time **significantly**. For the test case I use for the measurement, it brought down compile time from 3:52 to 3:25 (LLVM build was with asserts).
- Add libclangASTMatchers for the list of linked libraries for LLVM 16, as it's required now.
- Upgrade SDE in CI `9.0.0` -> `9.14.0`.