### PR TITLE
Redesign target-dependent performance warnings

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -6218,6 +6218,7 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
                 PerformanceWarning(pos, "Conversion from float16 to unsigned int is slow. Use \"int\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
+            break;
         case AtomicType::TYPE_FLOAT:
             if (fromType->IsVaryingType())
                 PerformanceWarning(pos, "Conversion from float to unsigned int is slow. Use \"int\" if possible");

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -6214,20 +6214,14 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
             cast = ctx->TruncInst(exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_FLOAT16:
-            if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float16 to uint8 is slow. Use \"int8\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_FLOAT:
-            if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float to uint8 is slow. Use \"int8\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_DOUBLE:
-            if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from double to uint8 is slow. Use \"int8\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
@@ -6296,20 +6290,14 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
             cast = ctx->TruncInst(exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_FLOAT16:
-            if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float16 to uint16 is slow. Use \"int16\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_FLOAT:
-            if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float to uint16 is slow. Use \"int16\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_DOUBLE:
-            if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from double to uint16 is slow. Use \"int16\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -6215,19 +6215,19 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
             break;
         case AtomicType::TYPE_FLOAT16:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float16 to unsigned int is slow. Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from float16 to uint8 is slow. Use \"int8\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_FLOAT:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float to unsigned int is slow. Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from float to uint8 is slow. Use \"int8\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_DOUBLE:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from double to unsigned int is slow. Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from double to uint8 is slow. Use \"int8\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
@@ -6297,19 +6297,19 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
             break;
         case AtomicType::TYPE_FLOAT16:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float16 to unsigned int is slow. Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from float16 to uint16 is slow. Use \"int16\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_FLOAT:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float to unsigned int is slow. Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from float to uint16 is slow. Use \"int16\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_DOUBLE:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from double to unsigned int is slow. Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from double to uint16 is slow. Use \"int16\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
@@ -6379,19 +6379,19 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
             break;
         case AtomicType::TYPE_FLOAT16:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float16 to unsigned int is slow. Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from float16 to uint32 is slow. Use \"int32\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_FLOAT:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float to unsigned int is slow. Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from float to uint32 is slow. Use \"int32\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_DOUBLE:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from double to unsigned int is slow. Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from double to uint32 is slow. Use \"int32\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
@@ -6457,19 +6457,19 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
             break;
         case AtomicType::TYPE_FLOAT16:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float16 to unsigned int64 is slow. Use \"int64\" if possible");
+                PerformanceWarning(pos, "Conversion from float16 to uint64 is slow. Use \"int64\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // signed int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_FLOAT:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float to unsigned int64 is slow. Use \"int64\" if possible");
+                PerformanceWarning(pos, "Conversion from float to uint64 is slow. Use \"int64\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // signed int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_DOUBLE:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from double to unsigned int64 is slow. Use \"int64\" if possible");
+                PerformanceWarning(pos, "Conversion from double to uint64 is slow. Use \"int64\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // signed int
                                  exprVal, targetType, cOpName);
             break;

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1554,16 +1554,14 @@ static llvm::Value *lEmitBinaryArith(BinaryExpr::Op op, llvm::Value *value0, llv
         case BinaryExpr::Div:
             opName = "div";
             if (type0->IsVaryingType() && !isFloatOp)
-                PerformanceWarning(pos, "Division with varying integer types is "
-                                        "very inefficient.");
+                PerformanceWarning(pos, "Division with varying integer types is very inefficient.");
             inst = isFloatOp ? llvm::Instruction::FDiv
                              : (isUnsignedOp ? llvm::Instruction::UDiv : llvm::Instruction::SDiv);
             break;
         case BinaryExpr::Mod:
             opName = "mod";
             if (type0->IsVaryingType() && !isFloatOp)
-                PerformanceWarning(pos, "Modulus operator with varying types is "
-                                        "very inefficient.");
+                PerformanceWarning(pos, "Modulus operator with varying types is very inefficient.");
             inst = isFloatOp ? llvm::Instruction::FRem
                              : (isUnsignedOp ? llvm::Instruction::URem : llvm::Instruction::SRem);
             break;
@@ -2035,8 +2033,7 @@ llvm::Value *BinaryExpr::GetValue(FunctionEmitContext *ctx) const {
     case BitXor:
     case BitOr: {
         if (op == Shr && lIsDifficultShiftAmount(arg1))
-            PerformanceWarning(pos, "Shift right is inefficient for "
-                                    "varying shift amounts.");
+            PerformanceWarning(pos, "Shift right is inefficient for varying shift amounts.");
         return lEmitBinaryBitOp(op, value0, value1, arg0->GetType()->IsUnsignedType(), ctx);
     }
     case Comma:
@@ -6107,8 +6104,7 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
             // arm/x86 cpu targets. Revisit for Xe/wasm.
             if (fromType->IsVaryingType() && (g->target->warnFtoU32IsExpensive() == true) &&
                 (fromType->basicType == AtomicType::TYPE_UINT32))
-                PerformanceWarning(pos, "Conversion from unsigned int to float is slow. "
-                                        "Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from unsigned int to float is slow. Use \"int\" if possible");
             cast = ctx->CastInst(llvm::Instruction::UIToFP, // unsigned int to float
                                  exprVal, targetType, cOpName);
             break;
@@ -6218,21 +6214,18 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
             break;
         case AtomicType::TYPE_FLOAT16:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float16 to unsigned int is slow. "
-                                        "Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from float16 to unsigned int is slow. Use \"int\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
         case AtomicType::TYPE_FLOAT:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float to unsigned int is slow. "
-                                        "Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from float to unsigned int is slow. Use \"int\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_DOUBLE:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from double to unsigned int is slow. "
-                                        "Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from double to unsigned int is slow. Use \"int\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
@@ -6302,22 +6295,19 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
             break;
         case AtomicType::TYPE_FLOAT16:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float16 to unsigned int is slow. "
-                                        "Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from float16 to unsigned int is slow. Use \"int\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_FLOAT:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float to unsigned int is slow. "
-                                        "Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from float to unsigned int is slow. Use \"int\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_DOUBLE:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from double to unsigned int is slow. "
-                                        "Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from double to unsigned int is slow. Use \"int\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
@@ -6387,22 +6377,19 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
             break;
         case AtomicType::TYPE_FLOAT16:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float16 to unsigned int is slow. "
-                                        "Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from float16 to unsigned int is slow. Use \"int\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_FLOAT:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float to unsigned int is slow. "
-                                        "Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from float to unsigned int is slow. Use \"int\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_DOUBLE:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from double to unsigned int is slow. "
-                                        "Use \"int\" if possible");
+                PerformanceWarning(pos, "Conversion from double to unsigned int is slow. Use \"int\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // unsigned int
                                  exprVal, targetType, cOpName);
             break;
@@ -6468,22 +6455,19 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
             break;
         case AtomicType::TYPE_FLOAT16:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float16 to unsigned int64 is slow. "
-                                        "Use \"int64\" if possible");
+                PerformanceWarning(pos, "Conversion from float16 to unsigned int64 is slow. Use \"int64\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // signed int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_FLOAT:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from float to unsigned int64 is slow. "
-                                        "Use \"int64\" if possible");
+                PerformanceWarning(pos, "Conversion from float to unsigned int64 is slow. Use \"int64\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // signed int
                                  exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_DOUBLE:
             if (fromType->IsVaryingType())
-                PerformanceWarning(pos, "Conversion from double to unsigned int64 is slow. "
-                                        "Use \"int64\" if possible");
+                PerformanceWarning(pos, "Conversion from double to unsigned int64 is slow. Use \"int64\" if possible");
             cast = ctx->CastInst(llvm::Instruction::FPToUI, // signed int
                                  exprVal, targetType, cOpName);
             break;

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -607,7 +607,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
       m_maskingIsFree(false), m_maskBitCount(-1), m_hasHalf(false), m_hasRand(false), m_hasGather(false),
       m_hasScatter(false), m_hasTranscendentals(false), m_hasTrigonometry(false), m_hasRsqrtd(false), m_hasRcpd(false),
       m_hasVecPrefetch(false), m_hasSaturatingArithmetic(false), m_hasFp16Support(false), m_hasFp64Support(true),
-      m_warnFtoU32IsExpensive(false) {
+      m_warnings(0) {
     DeviceType CPUID = CPU_None, CPUfromISA = CPU_None;
     AllCPUs a;
     std::string featuresString;
@@ -819,7 +819,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 4;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_x86_64;
         break;
     case ISPCTarget::sse2_i32x8:
@@ -830,7 +830,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 8;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Core2;
         break;
     case ISPCTarget::sse4_i8x16:
@@ -841,7 +841,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 16;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 8;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Nehalem;
         break;
     case ISPCTarget::sse4_i16x8:
@@ -852,7 +852,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 8;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 16;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Nehalem;
         break;
     case ISPCTarget::sse4_i32x4:
@@ -863,7 +863,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 4;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Nehalem;
         break;
     case ISPCTarget::sse4_i32x8:
@@ -874,7 +874,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 8;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Nehalem;
         break;
     case ISPCTarget::avx1_i32x4:
@@ -885,7 +885,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 4;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_SandyBridge;
         break;
     case ISPCTarget::avx1_i32x8:
@@ -896,7 +896,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 8;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_SandyBridge;
         break;
     case ISPCTarget::avx1_i32x16:
@@ -907,7 +907,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 16;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_SandyBridge;
         break;
     case ISPCTarget::avx1_i64x4:
@@ -918,7 +918,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 4;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 64;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_SandyBridge;
         break;
     case ISPCTarget::avx2_i8x32:
@@ -932,7 +932,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Haswell;
         break;
     case ISPCTarget::avx2_i16x16:
@@ -946,7 +946,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Haswell;
         break;
     case ISPCTarget::avx2_i32x4:
@@ -960,7 +960,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Haswell;
         break;
     case ISPCTarget::avx2_i32x8:
@@ -974,7 +974,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Haswell;
         break;
     case ISPCTarget::avx2_i32x16:
@@ -988,7 +988,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Haswell;
         break;
     case ISPCTarget::avx2_i64x4:
@@ -1002,7 +1002,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->m_warnFtoU32IsExpensive = true;
+        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Haswell;
         break;
     case ISPCTarget::avx512knl_x16:

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -819,7 +819,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 4;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_x86_64;
         break;
     case ISPCTarget::sse2_i32x8:
@@ -830,7 +829,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 8;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Core2;
         break;
     case ISPCTarget::sse4_i8x16:
@@ -841,7 +839,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 16;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 8;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Nehalem;
         break;
     case ISPCTarget::sse4_i16x8:
@@ -852,7 +849,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 8;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 16;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Nehalem;
         break;
     case ISPCTarget::sse4_i32x4:
@@ -863,7 +859,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 4;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Nehalem;
         break;
     case ISPCTarget::sse4_i32x8:
@@ -874,7 +869,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 8;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Nehalem;
         break;
     case ISPCTarget::avx1_i32x4:
@@ -885,7 +879,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 4;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_SandyBridge;
         break;
     case ISPCTarget::avx1_i32x8:
@@ -896,7 +889,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 8;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_SandyBridge;
         break;
     case ISPCTarget::avx1_i32x16:
@@ -907,7 +899,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 16;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 32;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_SandyBridge;
         break;
     case ISPCTarget::avx1_i64x4:
@@ -918,7 +909,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_vectorWidth = 4;
         this->m_maskingIsFree = false;
         this->m_maskBitCount = 64;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_SandyBridge;
         break;
     case ISPCTarget::avx2_i8x32:
@@ -932,7 +922,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Haswell;
         break;
     case ISPCTarget::avx2_i16x16:
@@ -946,7 +935,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Haswell;
         break;
     case ISPCTarget::avx2_i32x4:
@@ -960,7 +948,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Haswell;
         break;
     case ISPCTarget::avx2_i32x8:
@@ -974,7 +961,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Haswell;
         break;
     case ISPCTarget::avx2_i32x16:
@@ -988,7 +974,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Haswell;
         break;
     case ISPCTarget::avx2_i64x4:
@@ -1002,7 +987,6 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         this->m_hasHalf = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->setWarning(PerfWarningType::UInt32ToFloatCVT);
         CPUfromISA = CPU_Haswell;
         break;
     case ISPCTarget::avx512knl_x16:
@@ -1353,6 +1337,29 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         // Proper reporting about incorrect targets is done during options parsing.
         std::string target_string = "Problem with target (" + ISPCTargetToString(m_ispc_target) + ")";
         FATAL(target_string.c_str());
+    }
+
+    // Enable ISA-dependnent warnings
+    switch (this->m_isa) {
+    case Target::SSE2:
+    case Target::SSE4:
+    case Target::AVX:
+        this->setWarning(PerfWarningType::CVTUIntFloat);
+        this->setWarning(PerfWarningType::DIVModInt);
+        this->setWarning(PerfWarningType::VariableShiftRight);
+        break;
+    case Target::AVX2:
+        this->setWarning(PerfWarningType::CVTUIntFloat);
+        this->setWarning(PerfWarningType::CVTUIntFloat16);
+        this->setWarning(PerfWarningType::DIVModInt);
+        break;
+    case Target::KNL_AVX512:
+    case Target::SKX_AVX512:
+        this->setWarning(PerfWarningType::DIVModInt);
+        break;
+    default:
+        // Fall through
+        ;
     }
 
 #if defined(ISPC_ARM_ENABLED)

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -160,7 +160,21 @@ SourcePos Union(const SourcePos &p1, const SourcePos &p2);
 
 /** An enum to represent different types of perfarmance warnings that should be triggered for specific target */
 enum class PerfWarningType {
-    UInt32ToFloatCVT = 0x1,
+    // x86, SSE2/SSE4/AVX/AVX2.
+    // Converts between [float|double] and uint[32|64] types (both directions) are much more expensive than similar
+    // converts involving signed integers.
+    CVTUIntFloat = 0x1,
+    // x86, AVX2.
+    // Converts between float16 and uint[32|64] types (both directions) are much more expensive than similar
+    // converts involving signed integers.
+    // SSE2/SSE4/AVX does not warn about FP16, as it is extreamly slow due to emulation of any FP16 ops.
+    CVTUIntFloat16 = 0x2,
+    // x86
+    // Varying integer division and modulo operations are not supported in hardware and are scalarized.
+    DIVModInt = 0x4,
+    // x86, SSE2, SSE4.
+    // Shift right by variable amount.
+    VariableShiftRight = 0x8,
 };
 
 /** @brief Structure that defines a compilation target

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2022, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -157,6 +157,11 @@ struct SourcePos {
 /** Returns a SourcePos that encompasses the extent of both of the given
     extents. */
 SourcePos Union(const SourcePos &p1, const SourcePos &p2);
+
+/** An enum to represent different types of perfarmance warnings that should be triggered for specific target */
+enum class PerfWarningType {
+    UInt32ToFloatCVT = 0x1,
+};
 
 /** @brief Structure that defines a compilation target
 
@@ -327,7 +332,9 @@ class Target {
 
     bool hasFp64Support() const { return m_hasFp64Support; }
 
-    bool warnFtoU32IsExpensive() const { return m_warnFtoU32IsExpensive; }
+    void setWarning(PerfWarningType warningType) { m_warnings |= static_cast<unsigned int>(warningType); }
+
+    bool shouldWarn(PerfWarningType warningType) { return (m_warnings & static_cast<unsigned int>(warningType)) != 0; }
 
   private:
     /** llvm Target object representing this target. */
@@ -441,8 +448,8 @@ class Target {
     /** Indicates whether the target has FP64 support. */
     bool m_hasFp64Support;
 
-    /** Indicates whether the target has uint32 -> float cvt support **/
-    bool m_warnFtoU32IsExpensive;
+    /** A bitset of PerfWarningType values indicating the warnings that are relevant for the target. */
+    unsigned int m_warnings;
 };
 
 /** @brief Structure that collects optimization options

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -158,8 +158,10 @@ struct SourcePos {
     extents. */
 SourcePos Union(const SourcePos &p1, const SourcePos &p2);
 
+typedef unsigned int PerfWarningTypeUnderlyingType;
+
 /** An enum to represent different types of perfarmance warnings that should be triggered for specific target */
-enum class PerfWarningType {
+enum class PerfWarningType : PerfWarningTypeUnderlyingType {
     // x86, SSE2/SSE4/AVX/AVX2.
     // Converts between [float|double] and uint[32|64] types (both directions) are much more expensive than similar
     // converts involving signed integers.
@@ -463,7 +465,7 @@ class Target {
     bool m_hasFp64Support;
 
     /** A bitset of PerfWarningType values indicating the warnings that are relevant for the target. */
-    unsigned int m_warnings;
+    PerfWarningTypeUnderlyingType m_warnings;
 };
 
 /** @brief Structure that collects optimization options

--- a/tests/lit-tests/1963.ispc
+++ b/tests/lit-tests/1963.ispc
@@ -12,20 +12,20 @@
 
 //; REQUIRES: X86_ENABLED
 
-//; CHECK_SSE2_WARNING: Performance Warning: Conversion from unsigned int to float is slow. Use "int" if possible
+//; CHECK_SSE2_WARNING: Performance Warning: Conversion from uint32 to float is slow. Use "int32" if possible
 //; CHECK_SSE2_ASM-NOT: vcvt
 
-//; CHECK_AVX2_WARNING: Performance Warning: Conversion from unsigned int to float is slow. Use "int" if possible
+//; CHECK_AVX2_WARNING: Performance Warning: Conversion from uint32 to float is slow. Use "int32" if possible
 //; CHECK_AVX2_ASM-NOT: vcvt
 
-//; CHECK_AVX512SKX_WARNING-NOT: Performance Warning: Conversion from unsigned int to float is slow. Use "int" if possible
+//; CHECK_AVX512SKX_WARNING-NOT: Performance Warning: Conversion from uint32 to float is slow. Use "int32" if possible
 //; CHECK_AVX512SKX_ASM: vcvt
 
-//; CHECK_AVX512KNL_WARNING-NOT: Performance Warning: Conversion from unsigned int to float is slow. Use "int" if possible
+//; CHECK_AVX512KNL_WARNING-NOT: Performance Warning: Conversion from uint32 to float is slow. Use "int32" if possible
 //; CHECK_AVX512KNL_ASM: vcvt
 
 
-unmasked varying float test_uint_f( varying uint arg1)
+unmasked varying float test_uint_f(varying uint arg1)
 {
     varying float ret = (varying float) arg1;
     return ret;

--- a/tests/lit-tests/arg_parsing_errors.ispc
+++ b/tests/lit-tests/arg_parsing_errors.ispc
@@ -27,6 +27,7 @@
 //; RUN: %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 --help
 //; RUN: %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 --help-dev
 //; RUN: %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 --support-matrix
+//; RUN: not %{ispc} 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_26
 
 //; RUN: not %{ispc} %s -o %t.o --nowrap --target=avx2-i32x8 -not-existing-opt --quiet 2>&1 | FileCheck %s --allow-empty -check-prefix=CHECK_ERROR_QUIET
 
@@ -66,6 +67,9 @@
 //; CHECK_ERROR_23: Unrecognized format of input file
 //; CHECK_ERROR_24: Error: Unknown option "--emit-obj"
 //; CHECK_ERROR_25: Warning: No output file name specified
+// The next check veryfies output of ispc executable without any other command line parameters,
+// so `--nowrap` was not passed, hence matching just the first word of the output.
+//; CHECK_ERROR_26: Error:
 
 //; CHECK_ERROR_QUIET-NOT: Error
 

--- a/tests/lit-tests/perf-warnings.ispc
+++ b/tests/lit-tests/perf-warnings.ispc
@@ -1,0 +1,171 @@
+// RUN: %{ispc} %s --nostdlib --nowrap --target=sse2-i32x4 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_SSE
+// RUN: %{ispc} %s --nostdlib --nowrap --target=sse2-i32x8 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_SSE
+// RUN: %{ispc} %s --nostdlib --nowrap --target=sse4-i8x16 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_SSE
+// RUN: %{ispc} %s --nostdlib --nowrap --target=sse4-i16x8 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_SSE
+// RUN: %{ispc} %s --nostdlib --nowrap --target=sse4-i32x4 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_SSE
+// RUN: %{ispc} %s --nostdlib --nowrap --target=sse4-i32x8 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_SSE
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx1-i32x4 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_SSE
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx1-i32x8 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_SSE
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx1-i32x16 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_SSE
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx1-i64x4 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_SSE
+
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx2-i8x32 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX2
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx2-i16x16 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX2
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx2-i32x4 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX2
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx2-i32x8 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX2
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx2-i32x16 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX2
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx2-i64x4 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX2
+
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx512knl-x16 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX512
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx512skx-x4 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX512
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx512skx-x8 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX512
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx512skx-x16 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX512
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx512skx-x32 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX512
+// RUN: %{ispc} %s --nostdlib --nowrap --target=avx512skx-x64 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX512
+
+// REQUIRES: X86_ENABLED
+
+// Float16 -> integers
+
+int8 cvt_fp16_to_i8(float16 f) { return f; }
+
+uint8 cvt_fp16_to_ui8(float16 f) { return f; }
+
+int16 cvt_fp16_to_i16(float16 f) { return f; }
+
+uint16 cvt_fp16_to_ui16(float16 f) { return f; }
+
+int32 cvt_fp16_to_i32(float16 f) { return f; }
+
+// CHECK_AVX2: Performance Warning: Conversion from float16 to uint32 is slow. Use "int32" if possible
+uint32 cvt_fp16_to_ui32(float16 f) { return f; }
+
+int64 cvt_fp16_to_i64(float16 f) { return f; }
+
+// CHECK_AVX2: Performance Warning: Conversion from float16 to uint64 is slow. Use "int64" if possible
+uint64 cvt_fp16_to_ui64(float16 f) { return f; }
+
+// Float -> integers
+
+int8 cvt_fp32_to_i8(float f) { return f; }
+
+uint8 cvt_fp32_to_ui8(float f) { return f; }
+
+int16 cvt_fp32_to_i16(float f) { return f; }
+
+uint16 cvt_fp32_to_ui16(float f) { return f; }
+
+int32 cvt_fp32_to_i32(float f) { return f; }
+
+// CHECK_SSE: Performance Warning: Conversion from float to uint32 is slow. Use "int32" if possible
+// CHECK_AVX2: Performance Warning: Conversion from float to uint32 is slow. Use "int32" if possible
+uint32 cvt_fp32_to_ui32(float f) { return f; }
+
+int64 cvt_fp32_to_i64(float f) { return f; }
+
+// CHECK_SSE: Performance Warning: Conversion from float to uint64 is slow. Use "int64" if possible
+// CHECK_AVX2: Performance Warning: Conversion from float to uint64 is slow. Use "int64" if possible
+uint64 cvt_fp32_to_ui64(float f) { return f; }
+
+// Double -> integers
+
+int8 cvt_fp64_to_i8(double f) { return f; }
+
+uint8 cvt_fp64_to_ui8(double f) { return f; }
+
+int16 cvt_fp64_to_i16(double f) { return f; }
+
+uint16 cvt_fp64_to_ui16(double f) { return f; }
+
+int32 cvt_fp64_to_i32(double f) { return f; }
+
+// CHECK_SSE: Performance Warning: Conversion from double to uint32 is slow. Use "int32" if possible
+// CHECK_AVX2 Performance Warning: Conversion from double to uint32 is slow. Use "int32" if possible
+uint32 cvt_fp64_to_ui32(double f) { return f; }
+
+int64 cvt_fp64_to_i64(double f) { return f; }
+
+// CHECK_SSE: Performance Warning: Conversion from double to uint64 is slow. Use "int64" if possible
+// CHECK_AVX2: Performance Warning: Conversion from double to uint64 is slow. Use "int64" if possible
+uint64 cvt_fp64_to_ui64(double f) { return f; }
+
+// Integers -> float16
+
+float16 cvt_i8_to_fp16(int8 i) { return i; }
+
+float16 cvt_ui8_to_fp16(uint8 i) { return i; }
+
+float16 cvt_i16_to_fp16(int16 i) { return i; }
+
+float16 cvt_ui16_to_fp16(uint16 i) { return i; }
+
+float16 cvt_i32_to_fp16(int32 i) { return i; }
+// CHECK_AVX2: Performance Warning: Conversion from uint32 to float16 is slow. Use "int32" if possible
+float16 cvt_ui32_to_fp16(uint32 i) { return i; }
+
+float16 cvt_i64_to_fp16(int64 i) { return i; }
+// CHECK_AVX2: Performance Warning: Conversion from uint64 to float16 is slow. Use "int32" if possible
+float16 cvt_ui64_to_fp16(uint64 i) { return i; }
+
+// Integers -> float
+
+float cvt_i8_to_fp32(int8 i) { return i; }
+
+float cvt_ui8_to_fp32(uint8 i) { return i; }
+
+float cvt_i16_to_fp32(int16 i) { return i; }
+
+float cvt_ui16_to_fp32(uint16 i) { return i; }
+
+float cvt_i32_to_fp32(int32 i) { return i; }
+
+// CHECK_SSE: Performance Warning: Conversion from uint32 to float is slow. Use "int32" if possible
+// CHECK_AVX2: Performance Warning: Conversion from uint32 to float is slow. Use "int32" if possible
+float cvt_ui32_to_fp32(uint32 i) { return i; }
+
+float cvt_i64_to_fp32(int64 i) { return i; }
+
+// CHECK_SSE: Performance Warning: Conversion from uint64 to float is slow. Use "int64" if possible
+// CHECK_AVX2: Performance Warning: Conversion from uint64 to float is slow. Use "int64" if possible
+float cvt_ui64_to_fp32(uint64 i) { return i; }
+
+// Integers -> double
+
+double cvt_i8_to_fp64(int8 i) { return i; }
+
+double cvt_ui8_to_fp64(uint8 i) { return i; }
+
+double cvt_i16_to_fp64(int16 i) { return i; }
+
+double cvt_ui16_to_fp64(uint16 i) { return i; }
+
+double cvt_i32_to_fp64(int32 i) { return i; }
+
+// CHECK_SSE: Performance Warning: Conversion from uint32 to double is slow. Use "int32" if possible
+// CHECK_AVX2: Performance Warning: Conversion from uint32 to double is slow. Use "int32" if possible
+double cvt_ui32_to_fp64(uint32 i) { return i; }
+
+double cvt_i64_to_fp64(int64 i) { return i; }
+
+// CHECK_SSE: Performance Warning: Conversion from uint64 to double is slow. Use "int32" if possible
+// CHECK_AVX2: Performance Warning: Conversion from uint64 to double is slow. Use "int32" if possible
+double cvt_ui64_to_fp64(uint64 i) { return i; }
+
+// Integer div/mod, no need to check all types.
+
+// CHECK_SSE-COUNT-2: Performance Warning: Division with varying integer types is very inefficient.
+// CHECK_AVX2-COUNT-2: Performance Warning: Division with varying integer types is very inefficient.
+// CHECK_AVX512-COUNT-2: Performance Warning: Division with varying integer types is very inefficient.
+int32 div_i32(int32 a, int32 b) { return a / b; }
+uint32 div_ui32(uint32 a, uint32 b) { return a / b; }
+
+// CHECK_SSE-COUNT-2: Performance Warning: Modulus operator with varying types is very inefficient.
+// CHECK_AVX2-COUNT-2: Performance Warning: Modulus operator with varying types is very inefficient.
+// CHECK_AVX512-COUNT-2: Performance Warning: Modulus operator with varying types is very inefficient.
+int32 mod_i32(int32 a, int32 b) { return a % b; }
+uint32 mod_ui32(uint32 a, uint32 b) { return a % b; }
+
+// Shift Right by variable amount
+
+// CHECK_SSE: Performance Warning: Shift right is inefficient for varying shift amounts.
+int32 shr_i32(int32 a, int32 b) { return a >> b; }


### PR DESCRIPTION
This PR add a generic mechanism to enable performance warnings only for selected targets. Such warnings are enumerated in `PerfWarningType` enum and are explicitly enabled for every target (or class of targets based on ISA).

Also, the set of warnings for inefficient converts were changed:
- warnings for `[float16|float|double]` -> `uint[8|16]` were removed, as they are not a problem on any of existing target. Looks like it was a copy-past error for these warnings from day-one (most of them were added really long time ago).
- warnings for `uint[32|64]` -> `[float16|float|double]` were added, because they are as problematic as converts in reverse direction (which we warn for).

Warnings related to `float16` converts were disabled for SSE2/SSE4/AVX1 targets, as these targets do not have any instruction for `float16` type support and anything related to `float16` is dead slow anyway.

Most of covered warnings were disabled for non-x86 targets (because they were not intended to be enabled there in the first place and we need a dedicated investigation of what needs to be covered for ARM and possibly Xe) and AVX512 targets (because they don't have these problems).

PS This redesign was triggered by enabling SPR targets, as I observed the warnings that are not relevant for them.