### PR TITLE
Updates for Xe targets (14)

### DIFF
--- a/builtins/target-xe.ll
+++ b/builtins/target-xe.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2019-2021, Intel Corporation
+;;  Copyright (c) 2019-2023, Intel Corporation
 ;;  All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
@@ -195,6 +195,7 @@ define float @__rcp_fast_uniform_float(float) nounwind readonly alwaysinline {
 ;; rsqrt
 
 declare float @llvm.genx.rsqrt.f32(float)
+declare half @llvm.genx.rsqrt.f16(half)
 define float @__rsqrt_uniform_float(float %v) nounwind readonly alwaysinline {
   %r = call float @llvm.genx.rsqrt.f32(float %v)
   ;; Newton-Raphson iteration to improve precision
@@ -215,9 +216,8 @@ define float @__rsqrt_fast_uniform_float(float) nounwind readonly alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; half precision rsqrt
 define half @__rsqrt_uniform_half(half %v) nounwind readonly alwaysinline {
-  %s = call half @__sqrt_uniform_half(half %v)
-  %r = call half @__rcp_uniform_half(half %s)
-  ret half %r
+  %res = call half @llvm.genx.rsqrt.f16(half %v)
+  ret half %res
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -603,6 +603,7 @@ define <WIDTH x half> @__rcp_fast_varying_half(<WIDTH x half>) nounwind readonly
 ; rsqrt
 
 declare <WIDTH x float> @llvm.genx.rsqrt.XE_SUFFIX(float)(<WIDTH x float>)
+declare <WIDTH x half> @llvm.genx.rsqrt.XE_SUFFIX(half)(<WIDTH x half>)
 define <WIDTH x float> @__rsqrt_varying_float(<WIDTH x float> %v) nounwind readonly alwaysinline {
   %r = call <WIDTH x float> @llvm.genx.rsqrt.XE_SUFFIX(float)(<WIDTH x float> %v)
   ;; Newton-Raphson iteration to improve precision
@@ -624,9 +625,8 @@ define <WIDTH x float> @__rsqrt_fast_varying_float(<WIDTH x float>) nounwind rea
 ; half precision rsqrt
 
 define <WIDTH x half> @__rsqrt_varying_half(<WIDTH x half> %v) nounwind readonly alwaysinline {
-  %s = call <WIDTH x half> @__sqrt_varying_half(<WIDTH x half> %v)
-  %r = call <WIDTH x half> @__rcp_varying_half(<WIDTH x half> %s)
-  ret <WIDTH x half> %r
+  %res = call <WIDTH x half> @llvm.genx.rsqrt.XE_SUFFIX(half)(<WIDTH x half> %v)
+  ret <WIDTH x half> %res
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/ispc_for_xe.rst
+++ b/docs/ispc_for_xe.rst
@@ -210,7 +210,7 @@ Configuration
 The behavior of ``ISPCRT`` can be configured using the following environment
 variables:
 
-* ``ISPCRT_USE_ZEBIN`` - when defined forces to use experimental L0 native binary format.
+* ``ISPCRT_USE_ZEBIN`` - when defined as ``1`` forces to use experimental L0 native binary format.
   Unlike SPIR-V files, zebin files are not portable between different GPU types.
 
 * ``ISPCRT_IGC_OPTIONS`` - ``ISPCRT`` is using an Intel® Graphics Compiler (IGC)
@@ -233,6 +233,17 @@ variables:
   set to 100000, but can be lowered (for example for testing) using this environmental variable.
   Please note that the limit cannot be set to more than 100000. If a greater value is provided,
   the ``ISPCRT`` will set the limit to the default value and display a warning message.
+
+* ``ISPCRT_VERBOSE`` - when defined as ``1`` enables verbose output.
+
+* ``ISPCRT_MEM_POOL`` - when defined as ``1`` enables usage of memory pool for
+  memory view allocations that created with appropriate shared memory allocation hints.
+
+* ``ISCPRT_MEM_POOL_MIN_CHUNK_POW2`` - provide the power of 2 for minimal chunk
+  size that can be allocated without rounding up to the nearest power of 2.
+
+* ``ISCPRT_MEM_POOL_MAX_CHUNK_POW2`` - provide the power of 2 for maximal
+  memory allocation that can fit into the memory pool.
 
 Also you can use ``ISPCRTModuleOptions`` structure to pass specific options to GPU module.
 Currently we support only one setting - ``stackSize`` which determines the stack size
@@ -476,7 +487,7 @@ By default, examples use SPIR-V format. You can try them with L0 binary format:
 
     cd examples/xpu/build
     cmake -DISPC_XE_FORMAT=zebin ../ && make
-    export ISPCRT_USE_ZEBIN=y
+    export ISPCRT_USE_ZEBIN=1
     cd simple && ./host_simple --gpu
 
 Language Limitations and Known Issues

--- a/ispcrt/cmake/Finddpcpp_compiler.cmake
+++ b/ispcrt/cmake/Finddpcpp_compiler.cmake
@@ -1,8 +1,8 @@
-## Copyright 2021 Intel Corporation
+## Copyright 2021-2023, Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 
 # First try to find the DPCPP compiler in the path
-find_program(DPCPP_COMPILER NAMES dpcpp
+find_program(DPCPP_COMPILER NAMES icpx
     PATHS ${DPCPP_DIR}
     PATH_SUFFIXES bin
 )

--- a/ispcrt/cmake/Findlevel_zero.cmake
+++ b/ispcrt/cmake/Findlevel_zero.cmake
@@ -1,4 +1,4 @@
-## Copyright 2020 Intel Corporation
+## Copyright 2020-2023, Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 
 find_path(LEVEL_ZERO_ROOT include/level_zero/ze_api.h
@@ -12,12 +12,17 @@ find_path(LEVEL_ZERO_ROOT include/level_zero/ze_api.h
 find_path(LEVEL_ZERO_INCLUDE_DIR level_zero/ze_api.h
   PATHS
     ${LEVEL_ZERO_ROOT}/include
+  PATH_SUFFIXES
+    include
 )
 
 find_library(LEVEL_ZERO_LIB_LOADER ze_loader
   HINTS
-    ${LEVEL_ZERO_ROOT}/lib
     ${LEVEL_ZERO_ROOT}/lib64
+    ${LEVEL_ZERO_ROOT}/lib
+  PATH_SUFFIXES
+    lib64
+    lib
 )
 
 set(LEVEL_ZERO_ERROR_MSG

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 Intel Corporation
+// Copyright 2020-2023 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "ispcrt.h"
@@ -89,6 +89,12 @@ void ispcrtSetErrorFunc(ISPCRTErrorFunc fcn) { g_errorFcn = fcn; }
 ///////////////////////////////////////////////////////////////////////////////
 // Object lifetime ////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
+
+long long ispcrtUseCount(ISPCRTGenericHandle h) ISPCRT_CATCH_BEGIN {
+    auto &obj = referenceFromHandle(h);
+    return obj.useCount();
+}
+ISPCRT_CATCH_END(0)
 
 void ispcrtRelease(ISPCRTGenericHandle h) ISPCRT_CATCH_BEGIN {
     auto &obj = referenceFromHandle(h);

--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 Intel Corporation
+// Copyright 2020-2023 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
@@ -64,6 +64,7 @@ void ispcrtSetErrorFunc(ISPCRTErrorFunc);
 
 // Object lifetime ////////////////////////////////////////////////////////////
 
+long long ispcrtUseCount(ISPCRTGenericHandle);
 void ispcrtRelease(ISPCRTGenericHandle);
 void ispcrtRetain(ISPCRTGenericHandle);
 

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -19,7 +19,7 @@ class MockTest : public ::testing::Test {
         ResetError();
         Config::cleanup();
         CallCounters::resetAll();
-        setenv("ISPCRT_MOCK_DEVICE", "y", 1);
+        setenv("ISPCRT_MOCK_DEVICE", "1", 1);
         // hijak ispcrt errors - we need it to test error handling
         ispcrtSetErrorFunc([](ISPCRTError e, const char *m) { sm_rt_error = e; });
     }

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -1052,6 +1052,71 @@ TEST_F(MockTest, C_API_CreateDeviceFromNativeHandler) {
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
+TEST_F(MockTest, C_API_MemPoolGeneralTest) {
+    setenv("ISPCRT_MEM_POOL", "1", 1);
+    void *p = NULL;
+    ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
+    ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
+    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, NULL, 1ULL<<10, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<10);
+    ispcrtRelease(view);
+    flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_READ_DEVICE_WRITE };
+    view = ispcrtNewMemoryViewForContext(context, NULL, 1ULL<<10, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<10);
+    ispcrtRelease(view);
+    ispcrtRelease(context);
+    unsetenv("ISPCRT_MEM_POOL");
+}
+
+TEST_F(MockTest, C_API_MemPoolFallBack) {
+    setenv("ISPCRT_MEM_POOL", "1", 1);
+    void *p = NULL;
+    ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
+    ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
+    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<21) + 1, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), (1ULL<<21) + 1);
+    ispcrtRelease(view);
+    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<10) - 12, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<10);
+    ispcrtRelease(view);
+    ispcrtRelease(context);
+    unsetenv("ISPCRT_MEM_POOL");
+}
+
+TEST_F(MockTest, C_API_MemPoolRoundUpPow2) {
+    setenv("ISPCRT_MEM_POOL", "1", 1);
+    void *p = NULL;
+    ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
+    ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
+    ISPCRTMemoryView view;
+    view = ispcrtNewMemoryViewForContext(context, NULL, 1ULL<<21, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<21);
+    ispcrtRelease(view);
+    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<21) - 1, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<21);
+    ispcrtRelease(view);
+    view = ispcrtNewMemoryViewForContext(context, NULL, 1ULL<<7, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<7);
+    ispcrtRelease(view);
+    view = ispcrtNewMemoryViewForContext(context, NULL, 1ULL<<20, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<20);
+    ispcrtRelease(view);
+    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<20) + 1, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<21);
+    ispcrtRelease(view);
+    ispcrtRelease(context);
+    unsetenv("ISPCRT_MEM_POOL");
+}
+
 /// C++ Device API
 TEST_F(MockTest, Device_DeviceCount1) {
     // CPU

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -1136,6 +1136,60 @@ TEST_F(MockTest, C_API_MemPoolLiveRange) {
     unsetenv("ISPCRT_MEM_POOL");
 }
 
+TEST_F(MockTest, C_API_MemPoolChunkSizes1) {
+    setenv("ISPCRT_MEM_POOL", "1", 1);
+    setenv("ISPCRT_MEM_POOL_MIN_CHUNK_POW2", "10", 1);
+    setenv("ISPCRT_MEM_POOL_MAX_CHUNK_POW2", "12", 1);
+    void *p = NULL;
+    ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
+    ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
+    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, NULL, 1, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<10);
+    ispcrtRelease(view);
+    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<12) - 1, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<12);
+    ispcrtRelease(view);
+    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<12) + 1, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), (1ULL<<12) + 1);
+    ispcrtRelease(view);
+    ispcrtRelease(context);
+    unsetenv("ISPCRT_MEM_POOL");
+    unsetenv("ISPCRT_MEM_POOL_MIN_CHUNK_POW2");
+    unsetenv("ISPCRT_MEM_POOL_MAX_CHUNK_POW2");
+}
+
+TEST_F(MockTest, C_API_MemPoolChunkSizes2) {
+    setenv("ISPCRT_MEM_POOL", "1", 1);
+    setenv("ISPCRT_MEM_POOL_MIN_CHUNK_POW2", "6", 1);
+    setenv("ISPCRT_MEM_POOL_MAX_CHUNK_POW2", "9", 1);
+    void *p = NULL;
+    ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
+    ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
+    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, NULL, 1, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<6);
+    ispcrtRelease(view);
+    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<6) - 1, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<6);
+    ispcrtRelease(view);
+    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<9) - 1, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), 1ULL<<9);
+    ispcrtRelease(view);
+    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<9) + 1, &flags);
+    p = ispcrtHostPtr(view);
+    ASSERT_EQ(ispcrtSize(view), (1ULL<<9) + 1);
+    ispcrtRelease(view);
+    ispcrtRelease(context);
+    unsetenv("ISPCRT_MEM_POOL");
+    unsetenv("ISPCRT_MEM_POOL_MIN_CHUNK_POW2");
+    unsetenv("ISPCRT_MEM_POOL_MAX_CHUNK_POW2");
+}
+
 /// C++ Device API
 TEST_F(MockTest, Device_DeviceCount1) {
     // CPU

--- a/src/ast.h
+++ b/src/ast.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2022, Intel Corporation
+  Copyright (c) 2011-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -109,7 +109,7 @@ class Indent {
     (AST) nodes must implement.  The base classes for both expressions
     (Expr) and statements (Stmt) inherit from this class.
 */
-class ASTNode {
+class ASTNode : public Traceable {
     const unsigned char SubclassID; // Subclass identifier (for isa/dyn_cast)
   public:
     ASTNode(SourcePos p, unsigned scid) : SubclassID(scid), pos(p) {}

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2022, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -55,7 +55,7 @@ struct CFInfo;
 /** AddressInfo is a helper class to work with pointers.
     It keeps llvm pointer, llvm element type, and ISPC type.
 */
-class AddressInfo {
+class AddressInfo : public Traceable {
   public:
     AddressInfo(llvm::Value *p, llvm::Type *t);
     AddressInfo(llvm::Value *p, const Type *t);

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2343,3 +2343,11 @@ SourcePos ispc::Union(const SourcePos &p1, const SourcePos &p2) {
     ret.last_column = std::max(p1.last_column, p2.last_column);
     return ret;
 }
+
+BookKeeper &BookKeeper::in() {
+    static BookKeeper instance;
+    return instance;
+}
+
+// Traverse all bookkeeped objects and call delete for every one.
+void BookKeeper::freeAll() { BookKeeper::in().freeOne<Traceable>(); }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1221,5 +1221,9 @@ int main(int Argc, char *Argv[]) {
         }
         llvm::timeTraceProfilerCleanup();
     }
+
+    // Free all bookkeeped objects.
+    BookKeeper::in().freeAll();
+
     return ret;
 }

--- a/src/module.h
+++ b/src/module.h
@@ -71,6 +71,8 @@ class Module {
         module name. */
     Module(const char *filename);
 
+    ~Module();
+
     /** Compiles the source file passed to the Module constructor, adding
         its global variables and functions to both the llvm::Module and
         SymbolTable.  Returns the number of errors during compilation.  */
@@ -163,19 +165,19 @@ class Module {
     static int LinkAndOutput(std::vector<std::string> linkFiles, OutputType outputType, const char *outFileName);
 
     /** Total number of errors encountered during compilation. */
-    int errorCount;
+    int errorCount{0};
 
     /** Symbol table to hold symbols visible in the current scope during
         compilation. */
-    SymbolTable *symbolTable;
+    SymbolTable *symbolTable{nullptr};
 
     /** llvm Module object into which globals and functions are added. */
-    llvm::Module *module;
+    llvm::Module *module{nullptr};
 
     /** The diBuilder manages generating debugging information */
-    llvm::DIBuilder *diBuilder;
+    llvm::DIBuilder *diBuilder{nullptr};
 
-    llvm::DICompileUnit *diCompileUnit;
+    llvm::DICompileUnit *diCompileUnit{nullptr};
 
     /** StructType cache.  This needs to be in the context of Module, so it's reset for
         any new Module in multi-target compilation.
@@ -188,8 +190,8 @@ class Module {
     std::map<std::string, llvm::StructType *> structTypeMap;
 
   private:
-    const char *filename;
-    AST *ast;
+    const char *filename{nullptr};
+    AST *ast{nullptr};
 
     // Definition and member object capturing preprocessing stream during Module lifetime.
     struct CPPBuffer {
@@ -199,7 +201,7 @@ class Module {
         std::unique_ptr<llvm::raw_string_ostream> os;
     };
 
-    std::unique_ptr<CPPBuffer> bufferCPP;
+    std::unique_ptr<CPPBuffer> bufferCPP{nullptr};
 
     std::vector<std::pair<const Type *, SourcePos>> exportedTypes;
 

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2022, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -77,8 +77,8 @@ void SymbolTable::PushScope() {
 }
 
 void SymbolTable::PopScope() {
-    Assert(variables.size() > 1);
-    Assert(types.size() > 1);
+    Assert(variables.size() > 0);
+    Assert(types.size() > 0);
     freeSymbolMaps.push_back(variables.back());
     variables.pop_back();
     types.pop_back();

--- a/src/type.h
+++ b/src/type.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2022, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -89,7 +89,7 @@ enum TypeId {
     Abstract base class that defines the interface that must be implemented
     for all types in the language.
  */
-class Type {
+class Type : public Traceable {
   public:
     /** Returns true if the underlying type is boolean.  In other words,
         this is true for individual bools and for short-vectors with

--- a/tests/lit-tests/mask_extract_first_el.ispc
+++ b/tests/lit-tests/mask_extract_first_el.ispc
@@ -1,0 +1,22 @@
+// RUN: %{ispc} %s --target=sse2-i32x4 -o %t.o
+// RUN: %{ispc} %s --target=sse2-i32x4 --emit-llvm-text --debug-phase=261:261 -o %t.o 2>&1 | FileCheck  %s --check-prefixes CHECK
+
+// REQUIRES: X86_ENABLED
+
+// CHECK: %first_elt = extractelement <4 x i32> %__mask, i32 0
+
+struct vec3ui { unsigned int x, y, z; };
+
+static const uniform size_t N = 64;
+
+export void VdbSampler_computeSampleM_stream4() {
+  uniform vec3ui domainOffset[4 * 64];
+  if (lanemask() == 15) {
+    uniform uint32 activeInstance;
+    if (reduce_equal(programIndex, &activeInstance)) {
+      foreach (o = 0 ... N) {
+        domainOffset[o + activeInstance];
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Use `icpx` as a compiler name for DPC++
- ISPCRT improvements
- Use native intrinsic for `rsqrt(float16)` on Xe targets.
- Fix for OSPRay build, caused by a bug in `lExtractFirstVectorElement()` function.
- Add "bookkeeping" for AST objects to be able to delete all of them by request, this is an alternative to "disciplined" work with memory and to using memory pools for object allocation.