### PR TITLE
Disable SPR targets on macOS

### DIFF
--- a/ispcrt/cmake/ispc.cmake
+++ b/ispcrt/cmake/ispc.cmake
@@ -104,7 +104,9 @@ if (ISPC_X86_ENABLED)
   append_ispc_target_list(AVX2)
   append_ispc_target_list(AVX512KNL)
   append_ispc_target_list(AVX512SKX)
-  append_ispc_target_list(AVX512SPR)
+  if (NOT APPLE)
+    append_ispc_target_list(AVX512SPR)
+  endif()
 endif()
 
 ## Macros ##

--- a/src/target_registry.cpp
+++ b/src/target_registry.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2022, Intel Corporation
+  Copyright (c) 2019-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -161,6 +161,14 @@ const BitcodeLib *TargetLibRegistry::getISPCTargetLib(ISPCTarget target, TargetO
     // This is an alias. It might be a good idea generalize this.
     if (target == ISPCTarget::avx1_i32x4) {
         target = ISPCTarget::sse4_i32x4;
+    }
+
+    // There's no Mac that supports SPR, so the decision is not support these targets when targeting macOS.
+    // If these targets are linked in, then we still can use them for cross compilation, for example for Linux.
+    if (os == TargetOS::macos && (target == ISPCTarget::avx512spr_x4 || target == ISPCTarget::avx512spr_x8 ||
+                                  target == ISPCTarget::avx512spr_x16 || target == ISPCTarget::avx512spr_x32 ||
+                                  target == ISPCTarget::avx512spr_x64)) {
+        return nullptr;
     }
 
     // Canonicalize OS, as for the target we only differentiate between Windows, Unix, and Web (WASM target).

--- a/tests/lit-tests/avx512spr-i32x8.ispc
+++ b/tests/lit-tests/avx512spr-i32x8.ispc
@@ -14,7 +14,7 @@
 //; RUN: %{ispc} %s --target=avx512spr-x8 --emit-llvm -o %t_8.bc
 //; RUN: llvm-dis %t_8.bc -o - | FileCheck %s -check-prefix=CHECK_ATTR_8
 
-// REQUIRES: X86_ENABLED && LLVM_14_0+
+// REQUIRES: X86_ENABLED && LLVM_14_0+ && !MACOS_HOST
 
 double ret_round(double val)
 {

--- a/tests/lit-tests/fp16_code_gen.ispc
+++ b/tests/lit-tests/fp16_code_gen.ispc
@@ -8,7 +8,7 @@
 // RUN: %{ispc} %s --target=avx512spr-x32 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_SPR
 // RUN: %{ispc} %s --target=avx512spr-x64 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_SPR
 
-// REQUIRES: X86_ENABLED && LLVM_14_0+
+// REQUIRES: X86_ENABLED && LLVM_14_0+ && !MACOS_HOST
 
 // CHECK_SPR-LABEL: fp16_add
 // CHECK_SPR: vaddph

--- a/tests/lit-tests/perf-warnings.ispc
+++ b/tests/lit-tests/perf-warnings.ispc
@@ -28,7 +28,10 @@
 // RUN: %{ispc} %s --nostdlib --nowrap --target=avx512spr-x32 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX512
 // RUN: %{ispc} %s --nostdlib --nowrap --target=avx512spr-x64 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX512
 
-// REQUIRES: X86_ENABLED && LLVM_14_0+
+// A note about notrunning on macOS - it's because of SPR not being supported there.
+// It should be sufficient to run this test on other platforms and not to complicate
+// with splitting it to SPR and non-SPR versions.
+// REQUIRES: X86_ENABLED && LLVM_14_0+ && !MACOS_HOST
 
 // Float16 -> integers
 

--- a/tests/lit-tests/target_x86_macos_no_spr.ispc
+++ b/tests/lit-tests/target_x86_macos_no_spr.ispc
@@ -1,0 +1,15 @@
+// The test checks that target definitions for SPR are not accepted on macOS.
+
+//; RUN: not %{ispc} %s -o %t.o --nostdlib --target-os=macos --arch=x86-64 --nowrap --target=avx512spr-x4  2>&1 | FileCheck %s
+//; RUN: not %{ispc} %s -o %t.o --nostdlib --target-os=macos --arch=x86-64 --nowrap --target=avx512spr-x8  2>&1 | FileCheck %s
+//; RUN: not %{ispc} %s -o %t.o --nostdlib --target-os=macos --arch=x86-64 --nowrap --target=avx512spr-x16 2>&1 | FileCheck %s
+//; RUN: not %{ispc} %s -o %t.o --nostdlib --target-os=macos --arch=x86-64 --nowrap --target=avx512spr-x32 2>&1 | FileCheck %s
+//; RUN: not %{ispc} %s -o %t.o --nostdlib --target-os=macos --arch=x86-64 --nowrap --target=avx512spr-x64 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED && LLVM_14_0+ && MACOS_HOST
+
+// CHECK: Error: avx512spr-x{{.*}} target for x86-64 on macOS is not supported in current build.
+
+uniform int j;
+
+int foo(int i) { return i + 1; }

--- a/tests/lit-tests/targets_x86_llvm14plus.ispc
+++ b/tests/lit-tests/targets_x86_llvm14plus.ispc
@@ -6,7 +6,7 @@
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=avx512spr-x32
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=avx512spr-x64
 
-// REQUIRES: X86_ENABLED && LLVM_14_0+
+// REQUIRES: X86_ENABLED && LLVM_14_0+ && !MACOS_HOST
 
 uniform int j;
 


### PR DESCRIPTION
There's no Mac hardware using SPR, so disabling it for macOS target.