### PR TITLE
 Updates for Xe targets (15)

### DIFF
--- a/examples/xpu/callback-esimd/CMakeLists.txt
+++ b/examples/xpu/callback-esimd/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2021, Intel Corporation
+#  Copyright (c) 2021-2023, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -44,10 +44,9 @@ set(DPCPP_CUSTOM_FLAGS "-Xclang" "-fsycl-allow-func-ptr")
 add_executable(${TARGET_NAME} main.cpp)
 add_dpcpp_library(${TARGET_NAME}_esimd callback-esimd.cpp)
 
-set(ISPC_XE_FORMAT "bc")
-add_ispc_kernel(${TARGET_NAME}_ispc2esimd callback-esimd.ispc "")
+add_ispc_library(${TARGET_NAME}_ispc2esimd callback-esimd.ispc)
 # Link for GPU
-link_ispc_esimd(${TARGET_NAME}_ispc2esimd ${TARGET_NAME}_esimd)
+ispc_target_link_dpcpp_esimd_libraries(${TARGET_NAME}_ispc2esimd ${TARGET_NAME}_esimd)
 # Link for CPU
 target_link_libraries(${TARGET_NAME}_ispc2esimd ${TARGET_NAME}_esimd)
 

--- a/examples/xpu/cmake/AddPerfExample.cmake
+++ b/examples/xpu/cmake/AddPerfExample.cmake
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2021, Intel Corporation
+#  Copyright (c) 2019-2023, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -72,7 +72,7 @@ function(add_perf_example)
     set(ISPC_XE_ADDITIONAL_ARGS ${parsed_ISPC_XE_ADDITIONAL_ARGS})
 
     # Add "ispcrt" suffix here to avoid CMake target conflicts with CPU examples
-    add_ispc_kernel("xe_${parsed_TEST_NAME}" "${parsed_ISPC_SRC_NAME}" "")
+    add_ispc_library(xe_${parsed_TEST_NAME} ${parsed_ISPC_SRC_NAME})
 
     # Show ispc source in VS solution:
     if (WIN32)

--- a/examples/xpu/simple-esimd/CMakeLists.txt
+++ b/examples/xpu/simple-esimd/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2021, Intel Corporation
+#  Copyright (c) 2021-2023, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -42,10 +42,9 @@ set(TARGET_NAME "simple-esimd")
 add_executable(${TARGET_NAME} simple.cpp)
 add_dpcpp_library(${TARGET_NAME}_esimd simple-esimd.cpp)
 
-set(ISPC_XE_FORMAT "bc")
-add_ispc_kernel(${TARGET_NAME}_ispc2esimd simple-esimd.ispc "")
+add_ispc_library(${TARGET_NAME}_ispc2esimd simple-esimd.ispc)
 # Link for GPU
-link_ispc_esimd(${TARGET_NAME}_ispc2esimd ${TARGET_NAME}_esimd)
+ispc_target_link_dpcpp_esimd_libraries(${TARGET_NAME}_ispc2esimd ${TARGET_NAME}_esimd)
 # Link for CPU
 target_link_libraries(${TARGET_NAME}_ispc2esimd ${TARGET_NAME}_esimd)
 

--- a/examples/xpu/vadd-esimd/CMakeLists.txt
+++ b/examples/xpu/vadd-esimd/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2021, Intel Corporation
+#  Copyright (c) 2021-2023, Intel Corporation
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -43,11 +43,10 @@ add_executable(${TARGET_NAME} vadd_usm.cpp)
 set(DPCPP_CUSTOM_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR})
 add_dpcpp_library(${TARGET_NAME}_esimd vadd_usm.cpp)
 
-set(ISPC_XE_FORMAT "bc")
-add_ispc_kernel(${TARGET_NAME}_ispc2esimd vadd_func.ispc "")
+add_ispc_library(${TARGET_NAME}_ispc2esimd vadd_func.ispc)
 
 # Link for GPU
-link_ispc_esimd(${TARGET_NAME}_ispc2esimd ${TARGET_NAME}_esimd)
+ispc_target_link_dpcpp_esimd_libraries(${TARGET_NAME}_ispc2esimd ${TARGET_NAME}_esimd)
 
 target_compile_options(${TARGET_NAME} PRIVATE "-fsycl" "-fPIE")
 target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_CURRENT_LIST_DIR}")

--- a/ispcrt/cmake/interop.cmake
+++ b/ispcrt/cmake/interop.cmake
@@ -1,4 +1,4 @@
-## Copyright 2021-2022 Intel Corporation
+## Copyright 2021-2023 Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 
 ###############################################################################
@@ -103,7 +103,8 @@ endfunction()
 
 # Extract esimd bitcode
 # target_name: name of the target to use for the extracted bitcode. The bitcode
-#              file will be set as a ISPC_CUSTOM_DEPENDENCIES property on this target
+#              file output path will be set as the LIBRARY_OUTPUT_DIRECTORY property
+#              and the file name set to the LIBRARY_OUTPUT_NAME property
 # library: the library to extract bitcode from
 function (dpcpp_get_esimd_bitcode target_name library)
     set(outdir ${CMAKE_CURRENT_BINARY_DIR})
@@ -141,13 +142,15 @@ function (dpcpp_get_esimd_bitcode target_name library)
 
     add_custom_target(${target_name} DEPENDS ${post_link_result})
     set_target_properties(${target_name} PROPERTIES
-        ISPC_CUSTOM_DEPENDENCIES ${post_link_result}
+        LIBRARY_OUTPUT_DIRECTORY ${outdir}
+        LIBRARY_OUTPUT_NAME ${target_name}_lower_esimd_0.bc
     )
 endfunction()
 
 # Extract dpcpp sycl bitcode
 # target_name: name of the target to use for the extracted bitcode. The bitcode
-#              file will be set as a ISPC_CUSTOM_DEPENDENCIES property on this target
+#              file output path will be set as the LIBRARY_OUTPUT_DIRECTORY property
+#              and the file name set to the LIBRARY_OUTPUT_NAME property
 # library: the library to extract bitcode from
 function (dpcpp_get_sycl_bitcode target_name library)
     set(outdir ${CMAKE_CURRENT_BINARY_DIR})
@@ -173,237 +176,45 @@ function (dpcpp_get_sycl_bitcode target_name library)
 
     add_custom_target(${target_name} DEPENDS ${bundler_result})
     set_target_properties(${target_name} PROPERTIES
-        ISPC_CUSTOM_DEPENDENCIES ${bundler_result}
+        LIBRARY_OUTPUT_DIRECTORY ${outdir}
+        LIBRARY_OUTPUT_NAME ${target_name}.bc
     )
 endfunction()
 
-# Link bitcode files into one
-# target_name: target to generate for the linked bitcode output
-# ARGN: targets whose ISPC_CUSTOM_DEPENDENCIES properties are the bitcode files to link
-function (link_bitcode target_name)
-    # Join all bitcode inputs to one string
-    # ispc_compile_gpu will set the outputs as the sources of the GPU target
-    # Not sure if there's a cleaner/more sensible property to get this one,
-    # technically it'd only be set as the "depends" for the target
-    set(input "")
-    foreach(bc_target ${ARGN})
-        get_target_property(BC_OUTPUTS ${bc_target} ISPC_CUSTOM_DEPENDENCIES)
-        foreach (bc ${BC_OUTPUTS})
-            get_filename_component(ext ${bc} LAST_EXT)
-            if (ext STREQUAL ".bc")
-                list(APPEND input "${bc}")
-            else()
-                # Since the ISPC_CUSTOM_DEPENDENCIES is a custom property we control and write,
-                # if the files here aren't all .bc we know that it was built for the wrong target
-                # initially.
-                message(FATAL_ERROR "Non-bitcode (bc) file found on target ${bc_target}")
-            endif()
-        endforeach()
-    endforeach()
-
-    set(outdir ${CMAKE_CURRENT_BINARY_DIR})
-    set(result "${outdir}/${target_name}.bc")
-
-    # Propagate both the target and file level dependencies
-    add_custom_command(
-        DEPENDS ${ARGN} ${input}
-        OUTPUT ${result}
-        COMMAND ${DPCPP_LLVM_LINK}
-            ${input}
-            -o ${result}
-        COMMENT "Linking LLVM Bitcode ${result}"
-    )
-
-    add_custom_target(${target_name} DEPENDS ${result})
-    set_target_properties(${target_name} PROPERTIES
-        ISPC_CUSTOM_DEPENDENCIES ${result}
-    )
-endfunction()
-
-# Link bitcode files into one
-# target_name: target to generate for the linked bitcode output
-# ispc_target: the original ISPC target being linked
-# bc_target: name of bitcode file for post-link
-function (sycl_post_link target_name ispc_target bc_target)
-    # Run sycl-post-link utility
-    set(outdir ${CMAKE_CURRENT_BINARY_DIR})
-    # Intermediate bitcode file with link to the real one
-    set(lower_post_link "${outdir}/${target_name}_post_link.bc")
-    # Final esimd bitcode file
-    set(post_link_result "${outdir}/${target_name}_post_link_0.bc")
-
-    # Get the BC file we want to process with sycl-post-link
-    get_target_property(input ${bc_target} ISPC_CUSTOM_DEPENDENCIES)
-
-    add_custom_command(
-        DEPENDS ${ispc_target} ${bc_target} ${input}
-        OUTPUT ${lower_post_link} ${post_link_result}
-        COMMAND ${DPCPP_SYCL_POST_LINK}
-            -split=auto
-            -emit-param-info
-            -symbols
-            -emit-exported-symbols
-            -lower-esimd
-            -O2
-            -spec-const=rt
-            -device-globals
-            -o ${lower_post_link}
-            ${input}
-        COMMENT "Running sycl-post-link ${bundler_result_tmp}"
-    )
-
-    add_custom_target(${target_name} DEPENDS ${post_link_result})
-    set_target_properties(${target_name} PROPERTIES
-        ISPC_CUSTOM_DEPENDENCIES ${post_link_result}
-    )
-endfunction()
-
-# Translate the linked bitcode files to SPV
-# target_name: target name to use for the output spv command, should have a single bc file
-#              as its ISPC_CUSTOM_DEPENDENCIES
-# ispc_target: the original ISPC target being linked
-# bc_target: name of bitcode file to translate
-function (translate_to_spirv target_name ispc_target bc_target)
-    # Name will be the ISPC targets bc file, but with the extension swapped to spv
-    # There may be multiple ISPC files (and so bc files) on the original ISPC target,
-    # the linked output will take the name of the first one
-    get_target_property(ISPC_BC_SOURCES ${ispc_target} ISPC_CUSTOM_DEPENDENCIES)
-    list(GET ISPC_BC_SOURCES 0 ISPC_BC_SOURCE)
-    get_filename_component(outdir ${ISPC_BC_SOURCE} DIRECTORY)
-    get_filename_component(fname ${ISPC_BC_SOURCE} NAME_WE)
-    set(spv_output "${outdir}/${fname}.spv")
-
-    list(APPEND SPV_EXT "-all"
-                        "+SPV_EXT_shader_atomic_float_add"
-                        "+SPV_EXT_shader_atomic_float_min_max"
-                        "+SPV_KHR_no_integer_wrap_decoration"
-                        "+SPV_KHR_float_controls"
-                        "+SPV_INTEL_subgroups"
-                        "+SPV_INTEL_media_block_io"
-                        "+SPV_INTEL_fpga_reg"
-                        "+SPV_INTEL_device_side_avc_motion_estimation"
-                        "+SPV_INTEL_fpga_loop_controls"
-                        "+SPV_INTEL_fpga_memory_attributes"
-                        "+SPV_INTEL_fpga_memory_accesses"
-                        "+SPV_INTEL_unstructured_loop_controls"
-                        "+SPV_INTEL_blocking_pipes"
-                        "+SPV_INTEL_io_pipes"
-                        "+SPV_INTEL_function_pointers"
-                        "+SPV_INTEL_kernel_attributes"
-                        "+SPV_INTEL_float_controls2"
-                        "+SPV_INTEL_inline_assembly"
-                        "+SPV_INTEL_optimization_hints"
-                        "+SPV_INTEL_arbitrary_precision_integers"
-                        "+SPV_INTEL_vector_compute"
-                        "+SPV_INTEL_fast_composite"
-                        "+SPV_INTEL_fpga_buffer_location"
-                        "+SPV_INTEL_arbitrary_precision_fixed_point"
-                        "+SPV_INTEL_arbitrary_precision_floating_point"
-                        "+SPV_INTEL_variable_length_array"
-                        "+SPV_INTEL_fp_fast_math_mode"
-                        "+SPV_INTEL_fpga_cluster_attributes"
-                        "+SPV_INTEL_loop_fuse"
-                        "+SPV_INTEL_long_constant_composite"
-                        "+SPV_INTEL_fpga_invocation_pipelining_attributes")
-    string(REPLACE ";" "," SPV_EXT_PARMS "${SPV_EXT}")
-
-    # Get the BC file we want to translate to SPV
-    get_target_property(input ${bc_target} ISPC_CUSTOM_DEPENDENCIES)
-
-    # Propagate both the target and file level dependencies
-    add_custom_command(
-        DEPENDS ${ispc_target} ${bc_target} ${input}
-        OUTPUT ${spv_output}
-        COMMAND ${DPCPP_LLVM_SPIRV}
-            ${input}
-            -o ${spv_output}
-            -spirv-debug-info-version=ocl-100
-            -spirv-allow-extra-diexpressions
-            -spirv-allow-unknown-intrinsics=llvm.genx.
-            # Not all extenstion are supported yet by VC backend
-            # so list here which are supported
-            #-spirv-ext=+all
-            -spirv-ext=${SPV_EXT_PARMS}
-        COMMENT "Translating LLVM Bitcode to SPIR-V ${spv_output}"
-    )
-
-    add_custom_target(${target_name} DEPENDS ${spv_output})
-    set_target_properties(${target_name} PROPERTIES
-        ISPC_CUSTOM_DEPENDENCIES ${spv_output}
-    )
-endfunction()
-
-# Link ISPC and ESIMD GPU modules to SPIR-V
-# ispc_target: the ispc kernel target previously compiled to bitcode
-# ARGN: list of compiled DPCPP targets to link the ispc target with
-function (link_ispc_esimd ispc_target)
-    if (NOT BUILD_GPU)
-        message(FATAL_ERROR "Linking of ISPC/ESIMD modules is supported on GPU only")
-    endif()
-
-    if (WIN32)
-        message(FATAL_ERROR "Linking of ISPC/ESIMD modules is currently supported on Linux only")
-    endif()
-
-    if (NOT TARGET ${ispc_target}_bc)
-        message(FATAL_ERROR "ISPC target ${ispc_target} must be compiled to bc for ISPC/ESIMD linking")
-    endif()
-
-    set(DPCPP_BC_TARGETS "")
-    foreach(lib ${ARGN})
-        set(bc_target_name ${lib}_bc)
-        if (NOT TARGET ${bc_target_name})
-            dpcpp_get_esimd_bitcode(${bc_target_name} ${lib})
-        endif()
-        list(APPEND DPCPP_BC_TARGETS ${bc_target_name})
-    endforeach()
-
-    link_bitcode(${ispc_target}_ispc2esimd_bc
-        ${ispc_target}_bc
-        ${DPCPP_BC_TARGETS})
-
-    translate_to_spirv(${ispc_target}_ispc2esimd_spv
-        ${ispc_target}_bc
-        ${ispc_target}_ispc2esimd_bc)
-
-    add_dependencies(${ispc_target} ${ispc_target}_ispc2esimd_spv)
-endfunction()
-
-# Link ISPC and DPC++ GPU modules to SPIR-V
-# ispc_target: the ispc kernel target previously compiled to bitcode
-# ARGN: list of compiled DPCPP targets to link the ispc target with
-function (link_ispc_dpcpp ispc_target)
+function(ispc_target_link_dpcpp_libraries TARGET_NAME)
     if (NOT BUILD_GPU)
         message(FATAL_ERROR "Linking of ISPC/DPC++ modules is supported on GPU only")
     endif()
+    get_property(GPU_LINK_LIBRARIES TARGET ${TARGET_NAME}_gpu PROPERTY ISPC_DPCPP_LINK_LIBRARIES)
+    # Get the library file name for each library we want to link
+    foreach (lib ${ARGN})
+      # Make the dpcpp_bc target to extract the bitcode so we can link it
+      dpcpp_get_sycl_bitcode(${lib}_dpcpp_bc ${lib})
 
-    if (NOT TARGET ${ispc_target}_bc)
-        message(FATAL_ERROR "ISPC target ${ispc_target} must be compiled to bc for ISPC/DPC++ linking")
-    endif()
-
-    set(DPCPP_BC_TARGETS "")
-    foreach(lib ${ARGN})
-        set(bc_target_name ${lib}_bc)
-        if (NOT TARGET ${bc_target_name})
-            dpcpp_get_sycl_bitcode(${bc_target_name} ${lib})
-        endif()
-        list(APPEND DPCPP_BC_TARGETS ${bc_target_name})
+      get_property(LIB_OUTPUT_PATH TARGET ${lib}_dpcpp_bc PROPERTY LIBRARY_OUTPUT_DIRECTORY)
+      get_property(LIB_OUTPUT_NAME TARGET ${lib}_dpcpp_bc PROPERTY LIBRARY_OUTPUT_NAME)
+      list(APPEND GPU_LINK_LIBRARIES ${LIB_OUTPUT_PATH}/${LIB_OUTPUT_NAME})
     endforeach()
+    set_target_properties(${TARGET_NAME}_gpu
+      PROPERTIES ISPC_DPCPP_LINK_LIBRARIES "${GPU_LINK_LIBRARIES}")
+endfunction()
 
-    # Link ISPC and DPC++ on LLVM bitcode level
-    link_bitcode(${ispc_target}_ispc2dpcpp_bc
-        ${ispc_target}_bc
-        ${DPCPP_BC_TARGETS})
+function(ispc_target_link_dpcpp_esimd_libraries TARGET_NAME)
+    if (NOT BUILD_GPU)
+        message(FATAL_ERROR "Linking of ISPC/DPC++ modules is supported on GPU only")
+    endif()
+    get_property(GPU_LINK_LIBRARIES TARGET ${TARGET_NAME}_gpu PROPERTY ISPC_DPCPP_LINK_LIBRARIES)
+    # Get the library file name for each library we want to link
+    foreach (lib ${ARGN})
+      # Make the dpcpp_bc target to extract the bitcode so we can link it
+      dpcpp_get_esimd_bitcode(${lib}_dpcpp_esimd_bc ${lib})
 
-    # Run sycl-post-link on linked bitcode
-    sycl_post_link(${ispc_target}_ispc2dpcpp_postlink
-        ${ispc_target}_bc
-        ${ispc_target}_ispc2dpcpp_bc)
-
-    # Translate linked bitcode to SPIR-V
-    translate_to_spirv(${ispc_target}_ispc2dpcpp_spv
-        ${ispc_target}_bc
-        ${ispc_target}_ispc2dpcpp_postlink)
-
-    add_dependencies(${ispc_target} ${ispc_target}_ispc2dpcpp_spv)
+      get_property(LIB_OUTPUT_PATH TARGET ${lib}_dpcpp_esimd_bc PROPERTY LIBRARY_OUTPUT_DIRECTORY)
+      get_property(LIB_OUTPUT_NAME TARGET ${lib}_dpcpp_esimd_bc PROPERTY LIBRARY_OUTPUT_NAME)
+      list(APPEND GPU_LINK_LIBRARIES ${LIB_OUTPUT_PATH}/${LIB_OUTPUT_NAME})
+    endforeach()
+    set_target_properties(${TARGET_NAME}_gpu PROPERTIES
+      ISPC_DPCPP_LINK_LIBRARIES "${GPU_LINK_LIBRARIES}"
+      ISPC_DPCPP_LINKING_ESIMD 1
+     )
 endfunction()

--- a/ispcrt/detail/cpu/CPUDevice.cpp
+++ b/ispcrt/detail/cpu/CPUDevice.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 Intel Corporation
+// Copyright 2020-2023, Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "CPUDevice.h"
@@ -98,7 +98,7 @@ struct Module : public ispcrt::base::Module {
 #endif
 
             if (!lib)
-                throw std::logic_error("could not open CPU shared module file");
+                throw std::logic_error("could not open CPU shared module file lib" + m_file + ext);
             m_libs.push_back(lib);
         }
     }

--- a/tests/lit-tests/xe_dwarf_addrspace.ispc
+++ b/tests/lit-tests/xe_dwarf_addrspace.ispc
@@ -1,0 +1,11 @@
+// This test checks that dwarfAddressSpace attribute is present in DIDerivedType metadata for Xe targets.
+// RUN: %{ispc} %s --target=gen9-x8 -g --emit-llvm-text -o - | FileCheck %s
+
+// REQUIRES: XE_ENABLED
+
+// CHECK: !DIDerivedType(tag: DW_TAG_pointer_type, {{.*}} dwarfAddressSpace: {{[0-9]}})
+// CHECK: !DIDerivedType(tag: DW_TAG_reference_type, {{.*}} dwarfAddressSpace: {{[0-9]}})
+void test_ptr(void *uniform p) {
+}
+void test_ref(const uniform int &ref) {
+}


### PR DESCRIPTION
This Xe-related PR contains two changes:
First the PR refactors ISPC's handling of CPU and GPU custom commands and targets to support building an ISPC GPU target from multiple ISPC files, linking them with `ispc link`. The PR also makes the ISPC targets act more like regular CMake targets by using generator expressions to process includes, defines, and link libraries at a per-target level. So now an application's ISPC CMakeLists would be as below:
```
add_ispc_library(my_ispc_lib filea.ispc fileb.ispc)
ispc_target_include_directories(my_ispc_lib <some directory path>)
ispc_target_compile_definitions(my_ispc_lib -DMY_DEFINE=1)

add_ispc_library(my_ispc_kernel filec.ispc)
ispc_target_link_libraries(my_ispc_kernel my_ispc_lib)
```
Second, the PR fixes generation of debug information for pointers/references on Xe targets which previously broke usage of SPIR-V tools.