### PR TITLE
Fix wasm32 target

### DIFF
--- a/builtins/target-wasm-i32x4.ll
+++ b/builtins/target-wasm-i32x4.ll
@@ -640,10 +640,22 @@ entry:
   ret <4 x float> %div.i
 }
 
+define hidden <4 x double> @__rcp_varying_double(<4 x double> %v) local_unnamed_addr #0 {
+entry:
+  %div.i = fdiv <4 x double> <double 1.000000e+00, double 1.000000e+00, double 1.000000e+00, double 1.000000e+00>, %v
+  ret <4 x double> %div.i
+}
+
 define hidden <4 x float> @__rcp_fast_varying_float(<4 x float> %v) local_unnamed_addr #0 {
 entry:
   %div.i = fdiv <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>, %v
   ret <4 x float> %div.i
+}
+
+define hidden <4 x double> @__rcp_fast_varying_double(<4 x double> %v) local_unnamed_addr #0 {
+entry:
+  %div.i = fdiv <4 x double> <double 1.000000e+00, double 1.000000e+00, double 1.000000e+00, double 1.000000e+00>, %v
+  ret <4 x double> %div.i
 }
 
 define  float @__sqrt_uniform_float(float) nounwind readonly alwaysinline {
@@ -700,11 +712,6 @@ define  double @__rcp_fast_uniform_double(double) nounwind readonly alwaysinline
   ret double %r
 }
 
-define <4 x double> @__rcp_varying_double(<4 x double> %x) {
-entry:
-  %0 = fdiv <4 x double> <double 1.000000e+00, double 1.000000e+00, double 1.000000e+00, double 1.000000e+00>, %x
-  ret <4 x double> %0
-}
 
 define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone alwaysinline {
   %v0 = shufflevector <4 x i64> %0, <4 x i64> undef,

--- a/common.py
+++ b/common.py
@@ -89,7 +89,7 @@ def print_version(ispc_test, ispc_ref, ref_compiler, s, perf_log, is_windows):
     print_debug("\nUsing test compiler: " + take_lines(ispc_test + " --version", "first"), s, perf_log)
     if ispc_ref != "":
         print_debug("Using ref compiler:  " + take_lines(ispc_ref + " --version", "first"), s, perf_log)
-    if is_windows == False:
+    if is_windows == False or "emcc" in ref_compiler:
         temp1 = take_lines(ref_compiler + " --version", "first")
     else:
         os.system(ref_compiler + " 2>&1" + " 2> temp_detect_version > temp_detect_version1" )

--- a/scripts/install_emscripten.bat
+++ b/scripts/install_emscripten.bat
@@ -2,7 +2,7 @@ set WD=%cd%
 git clone https://github.com/emscripten-core/emsdk.git
 cd emsdk
 git pull
-git checkout 3.1.31
-call emsdk.bat install 3.1.31
-call emsdk.bat activate 3.1.31
+git checkout 3.1.17
+call emsdk.bat install 3.1.17
+call emsdk.bat activate 3.1.17
 cd %WD%

--- a/scripts/install_emscripten.bat
+++ b/scripts/install_emscripten.bat
@@ -2,7 +2,7 @@ set WD=%cd%
 git clone https://github.com/emscripten-core/emsdk.git
 cd emsdk
 git pull
-git checkout 2.0.4
-call emsdk.bat install sdk-1.39.11-64bit
-call emsdk.bat activate sdk-1.39.11-64bit
+git checkout 3.1.31
+call emsdk.bat install 3.1.31
+call emsdk.bat activate 3.1.31
 cd %WD%

--- a/scripts/install_emscripten.sh
+++ b/scripts/install_emscripten.sh
@@ -2,8 +2,8 @@ WD=`pwd`
 git clone https://github.com/emscripten-core/emsdk.git && \
 cd emsdk
 git pull && \
-git checkout 3.1.31 && \
-./emsdk install 3.1.31 && \
-./emsdk activate 3.1.31 && \
+git checkout 3.1.17 && \
+./emsdk install 3.1.17 && \
+./emsdk activate 3.1.17 && \
 source ./emsdk_env.sh
 cd $WD

--- a/scripts/install_emscripten.sh
+++ b/scripts/install_emscripten.sh
@@ -2,8 +2,8 @@ WD=`pwd`
 git clone https://github.com/emscripten-core/emsdk.git && \
 cd emsdk
 git pull && \
-git checkout 2.0.4 && \
-./emsdk install sdk-1.39.11-64bit && \
-./emsdk activate sdk-1.39.11-64bit  && \
+git checkout 3.1.31 && \
+./emsdk install 3.1.31 && \
+./emsdk activate 3.1.31 && \
 source ./emsdk_env.sh
 cd $WD


### PR DESCRIPTION
The ipsc stdlib was missing some builtins for the wasm32 target which caused the following issue: https://github.com/ispc/ispc/issues/2248

Running tests on windows was also not well supported (I don't think it ever worked ?) so I fixed it. (note I ran the x86 tests to check if everything was still working fine).

I bumped emscripten version to 3.1.31 (we could perhaps even bump to `3.1.32` or `3.1.33` ?).
The objective was to use a more recent version of emscripten to make sure we have as few issues as possible related to https://github.com/WebAssembly/simd/pull/209 (as mentionned in this old PR #1750  ).

Tests results:
```
1 / 1585 tests FAILED compilation
        .\tests\pragma-ignore-warning.ispc
167 / 1585 tests FAILED execution
        .\tests\atomics-1.ispc
        .\tests\atomics-13.ispc
        .\tests\atomics-2.ispc
        .\tests\atomics-9.ispc
        .\tests\atomics-uniform-7.ispc
        .\tests\clock.ispc
        .\tests\local-atomics-uniform-7.ispc
   ```

According to #1750 the clock test failing is expected.
However I'm not sure about the atomics. From what I saw this seems to be pretty generic code in `builtins\util.m4`, so maybe bad codegen from llvm if the version we are using predates the final renumbering of opcodes ? Those date back to 2020 though so I would expect LLVM13 to have the correct opcodes.

If @aschrein has any insight on what could be the issue it would be very helpful !