### PR TITLE
Minor fixes

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -1946,9 +1946,9 @@ changing values in memory with pointers, and so forth is supported as in C.
 As with other basic types, pointers can be both ``uniform`` and
 ``varying``.
 
-** Like other types in ``ispc``, pointers are ``varying`` by default, if an
+**Like other types in ``ispc``, pointers are ``varying`` by default, if an
 explicit ``uniform`` qualifier isn't provided.  However, the default
-variability of the pointed-to type is uniform. ** This rule will be
+variability of the pointed-to type is uniform.** This rule will be
 illustrated and explained in examples below.
 
 For example, the ``ptr`` variable in the code below is a varying pointer to

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -4776,22 +4776,6 @@ static int lIdentifierToVectorElement(char id) {
 //////////////////////////////////////////////////
 // StructMemberExpr
 
-class StructMemberExpr : public MemberExpr {
-  public:
-    StructMemberExpr(Expr *e, const char *id, SourcePos p, SourcePos idpos, bool derefLValue);
-
-    static inline bool classof(StructMemberExpr const *) { return true; }
-    static inline bool classof(ASTNode const *N) { return N->getValueID() == StructMemberExprID; }
-
-    const Type *GetType() const;
-    const Type *GetLValueType() const;
-    int getElementNumber() const;
-    const Type *getElementType() const;
-
-  private:
-    const StructType *getStructType() const;
-};
-
 StructMemberExpr::StructMemberExpr(Expr *e, const char *id, SourcePos p, SourcePos idpos, bool derefLValue)
     : MemberExpr(e, id, p, idpos, derefLValue, StructMemberExprID) {}
 
@@ -4917,26 +4901,6 @@ const StructType *StructMemberExpr::getStructType() const {
 
 //////////////////////////////////////////////////
 // VectorMemberExpr
-
-class VectorMemberExpr : public MemberExpr {
-  public:
-    VectorMemberExpr(Expr *e, const char *id, SourcePos p, SourcePos idpos, bool derefLValue);
-
-    static inline bool classof(VectorMemberExpr const *) { return true; }
-    static inline bool classof(ASTNode const *N) { return N->getValueID() == VectorMemberExprID; }
-
-    llvm::Value *GetValue(FunctionEmitContext *ctx) const;
-    llvm::Value *GetLValue(FunctionEmitContext *ctx) const;
-    const Type *GetType() const;
-    const Type *GetLValueType() const;
-
-    int getElementNumber() const;
-    const Type *getElementType() const;
-
-  private:
-    const VectorType *exprVectorType;
-    const VectorType *memberType;
-};
 
 VectorMemberExpr::VectorMemberExpr(Expr *e, const char *id, SourcePos p, SourcePos idpos, bool derefLValue)
     : MemberExpr(e, id, p, idpos, derefLValue, VectorMemberExprID) {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -5246,15 +5246,21 @@ int MemberExpr::EstimateCost() const {
 }
 
 void MemberExpr::Print(Indent &indent) const {
+    if (getValueID() == StructMemberExprID) {
+        indent.Print("StructMemberExpr", pos);
+    } else if (getValueID() == VectorMemberExprID) {
+        indent.Print("VectorMemberExpr", pos);
+    } else {
+        indent.Print("MemberExpr", pos);
+    }
+
     if (!expr || !GetType()) {
-        indent.Print("MemberExpr: <NULL EXPR>\n");
+        indent.Print(" <NULL EXPR>\n");
         indent.Done();
         return;
     }
 
-    indent.Print("MemberExpr", pos);
-
-    printf("[%s] .%s\n", GetType()->GetString().c_str(), identifier.c_str());
+    printf("[%s] %s %s\n", GetType()->GetString().c_str(), dereferenceExpr ? "->" : ".", identifier.c_str());
     indent.pushSingle();
     expr->Print(indent);
 

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -8222,8 +8222,6 @@ bool FunctionSymbolExpr::ResolveOverloads(SourcePos argPos, const std::vector<co
     }
 }
 
-Symbol *FunctionSymbolExpr::GetMatchingFunction() { return matchingFunc; }
-
 ///////////////////////////////////////////////////////////////////////////
 // SyncExpr
 

--- a/src/expr.h
+++ b/src/expr.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2022, Intel Corporation
+  Copyright (c) 2010-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -369,6 +369,42 @@ class MemberExpr : public Expr {
 
   protected:
     mutable const Type *type, *lvalueType;
+};
+
+class StructMemberExpr : public MemberExpr {
+  public:
+    StructMemberExpr(Expr *e, const char *id, SourcePos p, SourcePos idpos, bool derefLValue);
+
+    static inline bool classof(StructMemberExpr const *) { return true; }
+    static inline bool classof(ASTNode const *N) { return N->getValueID() == StructMemberExprID; }
+
+    const Type *GetType() const;
+    const Type *GetLValueType() const;
+    int getElementNumber() const;
+    const Type *getElementType() const;
+
+  private:
+    const StructType *getStructType() const;
+};
+
+class VectorMemberExpr : public MemberExpr {
+  public:
+    VectorMemberExpr(Expr *e, const char *id, SourcePos p, SourcePos idpos, bool derefLValue);
+
+    static inline bool classof(VectorMemberExpr const *) { return true; }
+    static inline bool classof(ASTNode const *N) { return N->getValueID() == VectorMemberExprID; }
+
+    llvm::Value *GetValue(FunctionEmitContext *ctx) const;
+    llvm::Value *GetLValue(FunctionEmitContext *ctx) const;
+    const Type *GetType() const;
+    const Type *GetLValueType() const;
+
+    int getElementNumber() const;
+    const Type *getElementType() const;
+
+  private:
+    const VectorType *exprVectorType;
+    const VectorType *memberType;
 };
 
 /** @brief Expression representing a compile-time constant value.

--- a/src/expr.h
+++ b/src/expr.h
@@ -739,7 +739,6 @@ class FunctionSymbolExpr : public Expr {
     bool ResolveOverloads(SourcePos argPos, const std::vector<const Type *> &argTypes,
                           const std::vector<bool> *argCouldBeNULL = NULL,
                           const std::vector<bool> *argIsConstant = NULL);
-    Symbol *GetMatchingFunction();
 
   private:
     std::vector<Symbol *> getCandidateFunctions(int argCount) const;

--- a/src/type.h
+++ b/src/type.h
@@ -117,7 +117,7 @@ class Type : public Traceable {
     /** Returns true if the underlying type is a array type */
     bool IsArrayType() const;
 
-    /** Returns true if the underlying type is a array type */
+    /** Returns true if the underlying type is a reference type */
     bool IsReferenceType() const;
 
     /** Returns true if the underlying type is either a pointer or an array */

--- a/tests/lit-tests/ast_expr.ispc
+++ b/tests/lit-tests/ast_expr.ispc
@@ -47,7 +47,9 @@ struct S {
     int fieldB;
 } s;
 
-int member() { return s.fieldA + s.fieldB; }
+int struct_member(struct S *p) { return p->fieldA + s.fieldB; }
+
+int vector_member(int<4> v, int<4> *p) { return v.x + p->x; }
 
 void const_expr() {
     bool b1 = true;


### PR DESCRIPTION
These are minor fixes, which came up during the work on templates. To avoid distraction in template PR, I'm pushing them here.
- `StructMemberExpr` and `VectorMemberExpr` classes were declared in `expr.cpp`, now moved to `expr.h`. While these classes are more like implementation detail of `MemberExpr`, it's still preferable to keep all classes in `Expr` hierarchy in one place, otherwise it create a lot of confusion.
- Improvements to `MemberExpr::Print`
- Fix bold text highlighting in docs.
- Remove unused `FunctionSymbolExpr::GetMatchingFunction()`
- Fix a typo in comments