### PR TITLE
Fix build with GCC 13 and possibly Clang 15

### DIFF
--- a/src/target_registry.h
+++ b/src/target_registry.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2021, Intel Corporation
+  Copyright (c) 2019-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,7 @@
 #include "bitcode_lib.h"
 
 #include <bitset>
+#include <cstdint>
 #include <map>
 #include <vector>
 


### PR DESCRIPTION
This fix adds missing <cstdint> include to handle "uint32_t" when building with GCC 13 and possibly Clang 15 as illustrated below
```
In file included from /builddir/build/BUILD/ispc-1.19.0/src/bitcode_lib.cpp:40:
/builddir/build/BUILD/ispc-1.19.0/src/target_registry.h:80:14: error: 'uint32_t' was not declared in this scope
   80 |     std::map<uint32_t, const BitcodeLib *> m_builtins;
      |              ^~~~~~~~
/builddir/build/BUILD/ispc-1.19.0/src/target_registry.h:44:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   43 | #include <map>
  +++ |+#include <cstdint>
   44 | #include <vector>
/builddir/build/BUILD/ispc-1.19.0/src/target_registry.h:80:42: error: template argument 1 is invalid
   80 |     std::map<uint32_t, const BitcodeLib *> m_builtins;
     
```