### PR TITLE
Reduce complexity of ISPC opt phases

### DIFF
--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -1665,45 +1665,45 @@ bool LLVMIsValueUndef(llvm::Value *value) {
     return false;
 }
 
-llvm::Instruction *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, const llvm::Twine &name,
-                                llvm::Instruction *insertBefore) {
+llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, const llvm::Twine &name,
+                             llvm::Instruction *insertBefore) {
     llvm::Value *args[2] = {arg0, arg1};
     llvm::ArrayRef<llvm::Value *> newArgArray(&args[0], &args[2]);
     return llvm::CallInst::Create(func, newArgArray, name, insertBefore);
 }
 
-llvm::Instruction *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
-                                const llvm::Twine &name, llvm::Instruction *insertBefore) {
+llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
+                             const llvm::Twine &name, llvm::Instruction *insertBefore) {
     llvm::Value *args[3] = {arg0, arg1, arg2};
     llvm::ArrayRef<llvm::Value *> newArgArray(&args[0], &args[3]);
     return llvm::CallInst::Create(func, newArgArray, name, insertBefore);
 }
 
-llvm::Instruction *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
-                                llvm::Value *arg3, const llvm::Twine &name, llvm::Instruction *insertBefore) {
+llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
+                             llvm::Value *arg3, const llvm::Twine &name, llvm::Instruction *insertBefore) {
     llvm::Value *args[4] = {arg0, arg1, arg2, arg3};
     llvm::ArrayRef<llvm::Value *> newArgArray(&args[0], &args[4]);
     return llvm::CallInst::Create(func, newArgArray, name, insertBefore);
 }
 
-llvm::Instruction *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
-                                llvm::Value *arg3, llvm::Value *arg4, const llvm::Twine &name,
-                                llvm::Instruction *insertBefore) {
+llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
+                             llvm::Value *arg3, llvm::Value *arg4, const llvm::Twine &name,
+                             llvm::Instruction *insertBefore) {
     llvm::Value *args[5] = {arg0, arg1, arg2, arg3, arg4};
     llvm::ArrayRef<llvm::Value *> newArgArray(&args[0], &args[5]);
     return llvm::CallInst::Create(func, newArgArray, name, insertBefore);
 }
 
-llvm::Instruction *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
-                                llvm::Value *arg3, llvm::Value *arg4, llvm::Value *arg5, const llvm::Twine &name,
-                                llvm::Instruction *insertBefore) {
+llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
+                             llvm::Value *arg3, llvm::Value *arg4, llvm::Value *arg5, const llvm::Twine &name,
+                             llvm::Instruction *insertBefore) {
     llvm::Value *args[6] = {arg0, arg1, arg2, arg3, arg4, arg5};
     llvm::ArrayRef<llvm::Value *> newArgArray(&args[0], &args[6]);
     return llvm::CallInst::Create(func, newArgArray, name, insertBefore);
 }
 
-llvm::Instruction *LLVMGEPInst(llvm::Value *ptr, llvm::Type *ptrElType, llvm::Value *offset, const char *name,
-                               llvm::Instruction *insertBefore) {
+llvm::GetElementPtrInst *LLVMGEPInst(llvm::Value *ptr, llvm::Type *ptrElType, llvm::Value *offset, const char *name,
+                                     llvm::Instruction *insertBefore) {
     llvm::Value *index[1] = {offset};
     llvm::ArrayRef<llvm::Value *> arrayRef(&index[0], &index[1]);
     return llvm::GetElementPtrInst::Create(ptrElType, ptr, arrayRef, name, insertBefore);

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -42,6 +42,7 @@
 
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Instructions.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Type.h>
 
@@ -392,26 +393,25 @@ extern bool LLVMGetSourcePosFromMetadata(const llvm::Instruction *inst, SourcePo
 extern bool LLVMIsValueUndef(llvm::Value *value);
 
 /** Below are helper functions to construct LLVM instructions. */
-extern llvm::Instruction *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1,
-                                       const llvm::Twine &name, llvm::Instruction *insertBefore = NULL);
+extern llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, const llvm::Twine &name,
+                                    llvm::Instruction *insertBefore = NULL);
 
-extern llvm::Instruction *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
-                                       const llvm::Twine &name, llvm::Instruction *insertBefore = NULL);
+extern llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
+                                    const llvm::Twine &name, llvm::Instruction *insertBefore = NULL);
 
-extern llvm::Instruction *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
-                                       llvm::Value *arg3, const llvm::Twine &name,
-                                       llvm::Instruction *insertBefore = NULL);
+extern llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
+                                    llvm::Value *arg3, const llvm::Twine &name, llvm::Instruction *insertBefore = NULL);
 
-extern llvm::Instruction *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
-                                       llvm::Value *arg3, llvm::Value *arg4, const llvm::Twine &name,
-                                       llvm::Instruction *insertBefore = NULL);
+extern llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
+                                    llvm::Value *arg3, llvm::Value *arg4, const llvm::Twine &name,
+                                    llvm::Instruction *insertBefore = NULL);
 
-extern llvm::Instruction *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
-                                       llvm::Value *arg3, llvm::Value *arg4, llvm::Value *arg5, const llvm::Twine &name,
-                                       llvm::Instruction *insertBefore = NULL);
+extern llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
+                                    llvm::Value *arg3, llvm::Value *arg4, llvm::Value *arg5, const llvm::Twine &name,
+                                    llvm::Instruction *insertBefore = NULL);
 
-extern llvm::Instruction *LLVMGEPInst(llvm::Value *ptr, llvm::Type *ptrElType, llvm::Value *offset, const char *name,
-                                      llvm::Instruction *insertBefore);
+extern llvm::GetElementPtrInst *LLVMGEPInst(llvm::Value *ptr, llvm::Type *ptrElType, llvm::Value *offset,
+                                            const char *name, llvm::Instruction *insertBefore);
 
 /** Mask-related helpers */
 

--- a/src/opt/InstructionSimplify.cpp
+++ b/src/opt/InstructionSimplify.cpp
@@ -132,17 +132,19 @@ bool InstructionSimplifyPass::simplifyInstructions(llvm::BasicBlock &bb) {
 
     bool modifiedAny = false;
 
-restart:
-    for (llvm::BasicBlock::iterator iter = bb.begin(), e = bb.end(); iter != e; ++iter) {
-        llvm::SelectInst *selectInst = llvm::dyn_cast<llvm::SelectInst>(&*iter);
-        if (selectInst && lSimplifySelect(selectInst, iter)) {
+    // Note: we do modify instruction list during the traversal, so the iterator
+    // is moved forward before the instruction is processed.
+    for (llvm::BasicBlock::iterator iter = bb.begin(), e = bb.end(); iter != e;) {
+        llvm::BasicBlock::iterator curIter = iter++;
+        llvm::SelectInst *selectInst = llvm::dyn_cast<llvm::SelectInst>(&*curIter);
+        if (selectInst && lSimplifySelect(selectInst, curIter)) {
             modifiedAny = true;
-            goto restart;
+            continue;
         }
-        llvm::CallInst *callInst = llvm::dyn_cast<llvm::CallInst>(&*iter);
-        if (callInst && lSimplifyCall(callInst, iter)) {
+        llvm::CallInst *callInst = llvm::dyn_cast<llvm::CallInst>(&*curIter);
+        if (callInst && lSimplifyCall(callInst, curIter)) {
             modifiedAny = true;
-            goto restart;
+            continue;
         }
     }
 

--- a/src/opt/PeepholePass.cpp
+++ b/src/opt/PeepholePass.cpp
@@ -1,7 +1,5 @@
-
-
 /*
-  Copyright (c) 2022, Intel Corporation
+  Copyright (c) 2022-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -280,9 +278,11 @@ bool PeepholePass::matchAndReplace(llvm::BasicBlock &bb) {
     DEBUG_START_BB("PeepholePass");
 
     bool modifiedAny = false;
-restart:
-    for (llvm::BasicBlock::iterator iter = bb.begin(), e = bb.end(); iter != e; ++iter) {
-        llvm::Instruction *inst = &*iter;
+
+    // Note: we do modify instruction list during the traversal, so the iterator
+    // is moved forward before the instruction is processed.
+    for (llvm::BasicBlock::iterator iter = bb.begin(), e = bb.end(); iter != e;) {
+        llvm::Instruction *inst = &*(iter++);
 
         llvm::Instruction *builtinCall = lMatchAvgUpUInt8(inst);
         if (!builtinCall)
@@ -302,7 +302,6 @@ restart:
         if (builtinCall != NULL) {
             llvm::ReplaceInstWithInst(inst, builtinCall);
             modifiedAny = true;
-            goto restart;
         }
     }
 

--- a/src/opt/ReplacePseudoMemoryOps.cpp
+++ b/src/opt/ReplacePseudoMemoryOps.cpp
@@ -305,18 +305,17 @@ bool ReplacePseudoMemoryOpsPass::replacePseudoMemoryOps(llvm::BasicBlock &bb) {
 
     bool modifiedAny = false;
 
-restart:
-    for (llvm::BasicBlock::iterator iter = bb.begin(), e = bb.end(); iter != e; ++iter) {
-        llvm::CallInst *callInst = llvm::dyn_cast<llvm::CallInst>(&*iter);
+    // Note: we do modify instruction list during the traversal, so the iterator
+    // is moved forward before the instruction is processed.
+    for (llvm::BasicBlock::iterator iter = bb.begin(), e = bb.end(); iter != e;) {
+        llvm::CallInst *callInst = llvm::dyn_cast<llvm::CallInst>(&*(iter++));
         if (callInst == NULL || callInst->getCalledFunction() == NULL)
             continue;
 
         if (lReplacePseudoGS(callInst)) {
             modifiedAny = true;
-            goto restart;
         } else if (lReplacePseudoMaskedStore(callInst)) {
             modifiedAny = true;
-            goto restart;
         }
     }
 

--- a/src/opt/ReplaceStdlibShiftPass.cpp
+++ b/src/opt/ReplaceStdlibShiftPass.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2022, Intel Corporation
+  Copyright (c) 2022-2023, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -64,8 +64,10 @@ bool ReplaceStdlibShiftPass::replaceStdlibShiftBuiltin(llvm::BasicBlock &bb) {
     shifts[4] = m->module->getFunction("shift___vyfuni");
     shifts[5] = m->module->getFunction("shift___vyduni");
 
-    for (llvm::BasicBlock::iterator iter = bb.begin(), e = bb.end(); iter != e; ++iter) {
-        llvm::Instruction *inst = &*iter;
+    // Note: we do modify instruction list during the traversal, so the iterator
+    // is moved forward before the instruction is processed.
+    for (llvm::BasicBlock::iterator iter = bb.begin(), e = bb.end(); iter != e;) {
+        llvm::Instruction *inst = &*(iter++);
 
         if (llvm::CallInst *ci = llvm::dyn_cast<llvm::CallInst>(inst)) {
             llvm::Function *func = ci->getCalledFunction();


### PR DESCRIPTION
Many of ISPC opt phases are unnecessary O(n^2) on the number of optimization triggers in the single basic block. This is because optimization restart on the basic block once it triggers, but there's not real need for that it iteration is done more carefully. The key is to maintain a valid iterator after the optimization removes "current" instruction.

The PR makes the complexity linear.

The PR reduce compile time for small examples approximately by 5%. For large examples the benefits are way smaller.