### PR TITLE
Updates for Xe targets (16)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,7 +297,7 @@ if (WASM_ENABLED)
     list(APPEND ISPC_TARGETS wasm-i32x4)
 endif()
 
-set(CLANG_LIBRARY_LIST clangFrontend clangDriver clangSerialization clangParse clangSema clangAnalysis clangAST clangBasic clangEdit clangLex)
+set(CLANG_LIBRARY_LIST clangFrontend clangBasic clangEdit clangLex)
 if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "15.0.0")
     list(APPEND CLANG_LIBRARY_LIST clangSupport)
 endif()

--- a/examples/xpu/callback-esimd/CMakeLists.txt
+++ b/examples/xpu/callback-esimd/CMakeLists.txt
@@ -44,6 +44,8 @@ set(DPCPP_CUSTOM_FLAGS "-Xclang" "-fsycl-allow-func-ptr")
 add_executable(${TARGET_NAME} main.cpp)
 add_dpcpp_library(${TARGET_NAME}_esimd callback-esimd.cpp)
 
+# Use LLVM bitcode linking for interop with ESIMD
+set(ISPC_XE_FORMAT "bc")
 add_ispc_library(${TARGET_NAME}_ispc2esimd callback-esimd.ispc)
 # Link for GPU
 ispc_target_link_dpcpp_esimd_libraries(${TARGET_NAME}_ispc2esimd ${TARGET_NAME}_esimd)

--- a/examples/xpu/simple-esimd/CMakeLists.txt
+++ b/examples/xpu/simple-esimd/CMakeLists.txt
@@ -42,6 +42,8 @@ set(TARGET_NAME "simple-esimd")
 add_executable(${TARGET_NAME} simple.cpp)
 add_dpcpp_library(${TARGET_NAME}_esimd simple-esimd.cpp)
 
+# Use LLVM bitcode linking for interop with ESIMD
+set(ISPC_XE_FORMAT "bc")
 add_ispc_library(${TARGET_NAME}_ispc2esimd simple-esimd.ispc)
 # Link for GPU
 ispc_target_link_dpcpp_esimd_libraries(${TARGET_NAME}_ispc2esimd ${TARGET_NAME}_esimd)

--- a/examples/xpu/vadd-esimd/CMakeLists.txt
+++ b/examples/xpu/vadd-esimd/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(${TARGET_NAME} vadd_usm.cpp)
 set(DPCPP_CUSTOM_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR})
 add_dpcpp_library(${TARGET_NAME}_esimd vadd_usm.cpp)
 
+# Use LLVM bitcode linking for interop with ESIMD
+set(ISPC_XE_FORMAT "bc")
 add_ispc_library(${TARGET_NAME}_ispc2esimd vadd_func.ispc)
 
 # Link for GPU


### PR DESCRIPTION
These changes are not Xe specific.

- Fix for #2380 - do not link unnecessary code for preprocessor. The fix reduce ISPC binary size significantly - approximately by 23%.
- Allow 'bc' ISPC_XE_FORMAT