### PR TITLE
Refactoring: NULL => nullptr

### DIFF
--- a/examples/common/tasksys.cpp
+++ b/examples/common/tasksys.cpp
@@ -226,12 +226,12 @@ inline TaskGroupBase::TaskGroupBase() {
     memBuffers[0] = mem;
     memBufferSize[0] = sizeof(mem) / sizeof(mem[0]);
     for (int i = 1; i < NUM_MEM_BUFFERS; ++i) {
-        memBuffers[i] = NULL;
+        memBuffers[i] = nullptr;
         memBufferSize[i] = 0;
     }
 
     for (int i = 0; i < MAX_TASK_QUEUE_CHUNKS; ++i)
-        taskInfo[i] = NULL;
+        taskInfo[i] = nullptr;
 }
 
 inline TaskGroupBase::~TaskGroupBase() {
@@ -268,7 +268,7 @@ inline TaskInfo *TaskGroupBase::GetTaskInfo(int index) {
         exit(1);
     }
 
-    if (taskInfo[chunk] == NULL)
+    if (taskInfo[chunk] == nullptr)
         taskInfo[chunk] = new TaskInfo[TASK_QUEUE_CHUNK_SIZE];
     return &taskInfo[chunk][offset];
 }
@@ -454,14 +454,14 @@ static dispatch_queue_t gcdQueue;
 static volatile int32_t lock = 0;
 
 static void InitTaskSystem() {
-    if (gcdQueue != NULL)
+    if (gcdQueue != nullptr)
         return;
 
     while (1) {
         if (lAtomicCompareAndSwap32(&lock, 1, 0) == 0) {
-            if (gcdQueue == NULL) {
+            if (gcdQueue == nullptr) {
                 gcdQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-                assert(gcdQueue != NULL);
+                assert(gcdQueue != nullptr);
                 lMemFence();
             }
             lock = 0;
@@ -542,7 +542,7 @@ inline void TaskGroup::Sync() {
 static volatile int32_t lock = 0;
 
 static int nThreads;
-static pthread_t *threads = NULL;
+static pthread_t *threads = nullptr;
 
 static pthread_mutex_t taskSysMutex;
 static std::vector<TaskGroup *> activeTaskGroups;
@@ -620,22 +620,22 @@ static void *lTaskEntry(void *arg) {
         lAtomicAdd(&tg->numUnfinishedTasks, -1);
     }
 
-    pthread_exit(NULL);
+    pthread_exit(nullptr);
     return 0;
 }
 
 static void InitTaskSystem() {
-    if (threads == NULL) {
+    if (threads == nullptr) {
         while (1) {
             if (lAtomicCompareAndSwap32(&lock, 1, 0) == 0) {
-                if (threads == NULL) {
+                if (threads == nullptr) {
                     // We launch one fewer thread than there are cores,
                     // since the main thread here will also grab jobs from
                     // the task queue itself.
                     nThreads = sysconf(_SC_NPROCESSORS_ONLN) - 1;
 
                     int err;
-                    if ((err = pthread_mutex_init(&taskSysMutex, NULL)) != 0) {
+                    if ((err = pthread_mutex_init(&taskSysMutex, nullptr)) != 0) {
                         fprintf(stderr, "Error creating mutex: %s\n", strerror(err));
                         exit(1);
                     }
@@ -643,7 +643,7 @@ static void InitTaskSystem() {
                     constexpr std::size_t FILENAME_MAX_LEN{1024UL};
                     char name[FILENAME_MAX_LEN];
                     bool success = false;
-                    srand(time(NULL));
+                    srand(time(nullptr));
                     for (int i = 0; i < 10; i++) {
                         // Some platforms (e.g. FreeBSD) require the name to begin with a slash
                         snprintf(name, FILENAME_MAX_LEN, "/ispc_task.%d.%d", static_cast<int>(getpid()), static_cast<int>(rand()));
@@ -661,13 +661,13 @@ static void InitTaskSystem() {
                     }
 
                     threads = (pthread_t *)malloc(nThreads * sizeof(pthread_t));
-                    if (threads == NULL) {
+                    if (threads == nullptr) {
                         fprintf(stderr, "Error creating pthreads: %s\n", strerror(err));
                         exit(1);
                     }
 
                     for (int i = 0; i < nThreads; ++i) {
-                        err = pthread_create(&threads[i], NULL, &lTaskEntry, (void *)((long long)i));
+                        err = pthread_create(&threads[i], nullptr, &lTaskEntry, (void *)((long long)i));
                         if (err != 0) {
                             fprintf(stderr, "Error creating pthread %d: %s\n", i, strerror(err));
                             exit(1);
@@ -755,7 +755,7 @@ inline void TaskGroup::Sync() {
             exit(1);
         }
 
-        TaskInfo *myTask = NULL;
+        TaskInfo *myTask = nullptr;
         TaskGroup *runtg = this;
         if (waitingTasks.size() > 0) {
             int taskNumber = waitingTasks.back();
@@ -945,9 +945,9 @@ static TaskGroup *freeTaskGroups[MAX_FREE_TASK_GROUPS];
 static inline TaskGroup *AllocTaskGroup() {
     for (int i = 0; i < MAX_FREE_TASK_GROUPS; ++i) {
         TaskGroup *tg = freeTaskGroups[i];
-        if (tg != NULL) {
-            void *ptr = lAtomicCompareAndSwapPointer((void **)(&freeTaskGroups[i]), NULL, tg);
-            if (ptr != NULL) {
+        if (tg != nullptr) {
+            void *ptr = lAtomicCompareAndSwapPointer((void **)(&freeTaskGroups[i]), nullptr, tg);
+            if (ptr != nullptr) {
                 return (TaskGroup *)ptr;
             }
         }
@@ -960,9 +960,9 @@ static inline void FreeTaskGroup(TaskGroup *tg) {
     tg->Reset();
 
     for (int i = 0; i < MAX_FREE_TASK_GROUPS; ++i) {
-        if (freeTaskGroups[i] == NULL) {
-            void *ptr = lAtomicCompareAndSwapPointer((void **)&freeTaskGroups[i], tg, NULL);
-            if (ptr == NULL)
+        if (freeTaskGroups[i] == nullptr) {
+            void *ptr = lAtomicCompareAndSwapPointer((void **)&freeTaskGroups[i], tg, nullptr);
+            if (ptr == nullptr)
                 return;
         }
     }
@@ -975,7 +975,7 @@ static inline void FreeTaskGroup(TaskGroup *tg) {
 void ISPCLaunch(void **taskGroupPtr, void *func, void *data, int count0, int count1, int count2) {
     const int count = count0 * count1 * count2;
     TaskGroup *taskGroup;
-    if (*taskGroupPtr == NULL) {
+    if (*taskGroupPtr == nullptr) {
         InitTaskSystem();
         taskGroup = AllocTaskGroup();
         *taskGroupPtr = taskGroup;
@@ -997,7 +997,7 @@ void ISPCLaunch(void **taskGroupPtr, void *func, void *data, int count0, int cou
 
 void ISPCSync(void *h) {
     TaskGroup *taskGroup = (TaskGroup *)h;
-    if (taskGroup != NULL) {
+    if (taskGroup != nullptr) {
         taskGroup->Sync();
         FreeTaskGroup(taskGroup);
     }
@@ -1005,7 +1005,7 @@ void ISPCSync(void *h) {
 
 void *ISPCAlloc(void **taskGroupPtr, int64_t size, int32_t alignment) {
     TaskGroup *taskGroup;
-    if (*taskGroupPtr == NULL) {
+    if (*taskGroupPtr == nullptr) {
         InitTaskSystem();
         taskGroup = AllocTaskGroup();
         *taskGroupPtr = taskGroup;
@@ -1112,7 +1112,7 @@ class TaskSys {
         if (global)
             return;
         pthread_mutex_lock(&mutex);
-        if (global == NULL)
+        if (global == nullptr)
             global = new TaskSys;
         pthread_mutex_unlock(&mutex);
     }
@@ -1180,7 +1180,7 @@ inline void Task::run(int idx, int threadIdx) {
 
 void *_threadFct(void *data) {
     ((TaskSys *)data)->threadFct();
-    return NULL;
+    return nullptr;
 }
 
 void TaskSys::createThreads() {
@@ -1212,7 +1212,7 @@ void TaskSys::createThreads() {
     }
 }
 
-TaskSys *TaskSys::global = NULL;
+TaskSys *TaskSys::global = nullptr;
 int TaskSys::numThreadsRunning = 0;
 
 ///////////////////////////////////////////////////////////////////////////

--- a/examples/common/timing.h
+++ b/examples/common/timing.h
@@ -16,13 +16,13 @@ __inline__ uint64_t rdtsc() {
     static bool first = true;
     static struct timeval tv_start;
     if (first) {
-        gettimeofday(&tv_start, NULL);
+        gettimeofday(&tv_start, nullptr);
         first = false;
         return 0;
     }
 
     struct timeval tv;
-    gettimeofday(&tv, NULL);
+    gettimeofday(&tv, nullptr);
     tv.tv_sec -= tv_start.tv_sec;
     tv.tv_usec -= tv_start.tv_usec;
     return (1000000ull * tv.tv_sec + tv.tv_usec) * 1000ull;

--- a/examples/cpu/deferred/common.cpp
+++ b/examples/cpu/deferred/common.cpp
@@ -97,7 +97,7 @@ InputData *CreateInputDataFromFile(const char *path) {
         fprintf(stderr, "Preumature EOF reading file \"%s\"\n", path);
         fclose(in);
         delete input;
-        return NULL;
+        return nullptr;
     }
 
     // Load data chunk and update pointers
@@ -106,7 +106,7 @@ InputData *CreateInputDataFromFile(const char *path) {
         fprintf(stderr, "Preumature EOF reading file \"%s\"\n", path);
         fclose(in);
         delete input;
-        return NULL;
+        return nullptr;
     }
 
     input->arrays.zBuffer = (float *)&input->chunk[input->header.inputDataArrayOffsets[idaZBuffer]];

--- a/examples/cpu/gmres/main.cpp
+++ b/examples/cpu/gmres/main.cpp
@@ -20,13 +20,13 @@ int main(int argc, char **argv) {
 
     DEBUG_PRINT("Loading A...\n");
     Matrix *A = CRSMatrix::matrix_from_mtf(argv[1]);
-    if (A == NULL)
+    if (A == nullptr)
         return -1;
     DEBUG_PRINT("... size: %lu\n", A->cols());
 
     DEBUG_PRINT("Loading b...\n");
     Vector *b = Vector::vector_from_mtf(argv[2]);
-    if (b == NULL)
+    if (b == nullptr)
         return -1;
 
     Vector x(A->cols());

--- a/examples/cpu/gmres/matrix.cpp
+++ b/examples/cpu/gmres/matrix.cpp
@@ -67,7 +67,7 @@ bool compare_entries(struct entry i, struct entry j) {
 #define ERR_OUT(...)                                                                                                   \
     do {                                                                                                               \
         fprintf(stderr, __VA_ARGS__);                                                                                  \
-        return NULL;                                                                                                   \
+        return nullptr;                                                                                                \
     } while(0)
 
 #define ERR_OUT_WITH_CLOSE(file, ...)                                                                                  \
@@ -82,7 +82,7 @@ CRSMatrix *CRSMatrix::matrix_from_mtf(char *path) {
 
     int m, n, nz;
 
-    if ((f = fopen(path, "r")) == NULL)
+    if ((f = fopen(path, "r")) == nullptr)
         ERR_OUT("Error: %s does not name a valid/readable file.\n", path);
 
     if (mm_read_banner(f, &matcode) != 0)
@@ -137,7 +137,7 @@ Vector *Vector::vector_from_mtf(char *path) {
 
     int m, n, nz;
 
-    if ((f = fopen(path, "r")) == NULL)
+    if ((f = fopen(path, "r")) == nullptr)
         ERR_OUT("Error: %s does not name a valid/readable file.\n", path);
 
     if (mm_read_banner(f, &matcode) != 0)
@@ -200,7 +200,7 @@ void Vector::to_mtf(char *path) {
     mm_set_dense(&matcode);
     mm_set_general(&matcode);
 
-    if ((f = fopen(path, "w")) == NULL)
+    if ((f = fopen(path, "w")) == nullptr)
         ERR("Error: cannot open/write to %s\n", path);
 
     mm_write_banner(f, matcode);

--- a/examples/cpu/gmres/matrix.h
+++ b/examples/cpu/gmres/matrix.h
@@ -35,7 +35,7 @@ class Vector {
             entries = (double *)malloc(sizeof(double) * _size);
         else {
             shared_ptr = true;
-            entries = NULL;
+            entries = nullptr;
         }
     }
 

--- a/examples/cpu/rt/rt.cpp
+++ b/examples/cpu/rt/rt.cpp
@@ -72,7 +72,7 @@ static void usage() {
 int main(int argc, char *argv[]) {
     static unsigned int test_iterations[] = {3, 7, 1};
     float scale = 1.f;
-    const char *filename = NULL;
+    const char *filename = nullptr;
     if (argc < 2)
         usage();
     filename = argv[1];

--- a/examples/xpu/sgemm/Matrix.h
+++ b/examples/xpu/sgemm/Matrix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, Intel Corporation
+ * Copyright (c) 2019-2023, Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -133,7 +133,7 @@ class Matrix {
     }
 
     // friend ostream& operator<<(ostream&, const Matrix&);
-    void Print(const char *str = NULL) {
+    void Print(const char *str = nullptr) {
         if (str)
             printf("%s ", str);
         printf(" %d x %d\n", this->n_row(), this->l_dim());

--- a/examples/xpu/sgemm/sgemm.cpp
+++ b/examples/xpu/sgemm/sgemm.cpp
@@ -126,9 +126,9 @@ void SGEMMApp::run(SGEMMApp::RunResult &result, int m, int niter, int gx, int gy
         printf("Thread-group setting: %d x %d \n", gx, gy);
     }
     // Allocate matrices
-    Matrix A(m, k, lda, NULL, true, "A", st);
-    Matrix B(k, n, ldb, NULL, true, "B", st);
-    Matrix C(m, n, ldc, NULL, false, "C", st);
+    Matrix A(m, k, lda, nullptr, true, "A", st);
+    Matrix B(k, n, ldb, nullptr, true, "B", st);
+    Matrix C(m, n, ldc, nullptr, false, "C", st);
     Matrix C_gold(C, "C_gold");
 
     if (validate) {

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -1163,7 +1163,7 @@ struct TaskQueue : public ispcrt::base::TaskQueue {
                 queueGroupCount * sizeof(ze_command_queue_group_properties_t));
             zeDeviceGetCommandQueueGroupProperties(device, &queueGroupCount, queueGroupProperties);
 
-            if (queueGroupProperties != NULL) {
+            if (queueGroupProperties != nullptr) {
                 for (uint32_t i = 0; i < queueGroupCount; i++) {
                     if (queueGroupProperties[i].flags & ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COMPUTE) {
                         computeOrdinal = i;

--- a/ispcrt/ispc_tasking.cpp
+++ b/ispcrt/ispc_tasking.cpp
@@ -226,12 +226,12 @@ inline TaskGroupBase::TaskGroupBase() {
     memBuffers[0] = mem;
     memBufferSize[0] = sizeof(mem) / sizeof(mem[0]);
     for (int i = 1; i < NUM_MEM_BUFFERS; ++i) {
-        memBuffers[i] = NULL;
+        memBuffers[i] = nullptr;
         memBufferSize[i] = 0;
     }
 
     for (int i = 0; i < MAX_TASK_QUEUE_CHUNKS; ++i)
-        taskInfo[i] = NULL;
+        taskInfo[i] = nullptr;
 }
 
 inline TaskGroupBase::~TaskGroupBase() {
@@ -268,7 +268,7 @@ inline TaskInfo *TaskGroupBase::GetTaskInfo(int index) {
         exit(1);
     }
 
-    if (taskInfo[chunk] == NULL)
+    if (taskInfo[chunk] == nullptr)
         taskInfo[chunk] = new TaskInfo[TASK_QUEUE_CHUNK_SIZE];
     return &taskInfo[chunk][offset];
 }
@@ -454,14 +454,14 @@ static dispatch_queue_t gcdQueue;
 static volatile int32_t lock = 0;
 
 static void InitTaskSystem() {
-    if (gcdQueue != NULL)
+    if (gcdQueue != nullptr)
         return;
 
     while (1) {
         if (lAtomicCompareAndSwap32(&lock, 1, 0) == 0) {
-            if (gcdQueue == NULL) {
+            if (gcdQueue == nullptr) {
                 gcdQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-                assert(gcdQueue != NULL);
+                assert(gcdQueue != nullptr);
                 lMemFence();
             }
             lock = 0;
@@ -542,7 +542,7 @@ inline void TaskGroup::Sync() {
 static volatile int32_t lock = 0;
 
 static int nThreads;
-static pthread_t *threads = NULL;
+static pthread_t *threads = nullptr;
 
 static pthread_mutex_t taskSysMutex;
 static std::vector<TaskGroup *> activeTaskGroups;
@@ -620,22 +620,22 @@ static void *lTaskEntry(void *arg) {
         lAtomicAdd(&tg->numUnfinishedTasks, -1);
     }
 
-    pthread_exit(NULL);
+    pthread_exit(nullptr);
     return 0;
 }
 
 static void InitTaskSystem() {
-    if (threads == NULL) {
+    if (threads == nullptr) {
         while (1) {
             if (lAtomicCompareAndSwap32(&lock, 1, 0) == 0) {
-                if (threads == NULL) {
+                if (threads == nullptr) {
                     // We launch one fewer thread than there are cores,
                     // since the main thread here will also grab jobs from
                     // the task queue itself.
                     nThreads = sysconf(_SC_NPROCESSORS_ONLN) - 1;
 
                     int err;
-                    if ((err = pthread_mutex_init(&taskSysMutex, NULL)) != 0) {
+                    if ((err = pthread_mutex_init(&taskSysMutex, nullptr)) != 0) {
                         fprintf(stderr, "Error creating mutex: %s\n", strerror(err));
                         exit(1);
                     }
@@ -643,7 +643,7 @@ static void InitTaskSystem() {
                     constexpr std::size_t SEM_NAME_MAX_SIZE{1024UL};
                     char semaphoreName[SEM_NAME_MAX_SIZE];
                     bool success = false;
-                    srand(time(NULL));
+                    srand(time(nullptr));
                     for (int i = 0; i < 10; i++) {
                         // Some platforms (e.g. FreeBSD) require the name to begin with a slash
                         snprintf(semaphoreName, SEM_NAME_MAX_SIZE, "/ispc_task.%d.%d", static_cast<int>(getpid()), static_cast<int>(rand()));
@@ -661,13 +661,13 @@ static void InitTaskSystem() {
                     }
 
                     threads = (pthread_t *)malloc(nThreads * sizeof(pthread_t));
-                    if (threads == NULL) {
+                    if (threads == nullptr) {
                         fprintf(stderr, "Error creating pthreads: %s\n", strerror(err));
                         exit(1);
                     }
 
                     for (int i = 0; i < nThreads; ++i) {
-                        err = pthread_create(&threads[i], NULL, &lTaskEntry, (void *)((long long)i));
+                        err = pthread_create(&threads[i], nullptr, &lTaskEntry, (void *)((long long)i));
                         if (err != 0) {
                             fprintf(stderr, "Error creating pthread %d: %s\n", i, strerror(err));
                             exit(1);
@@ -755,7 +755,7 @@ inline void TaskGroup::Sync() {
             exit(1);
         }
 
-        TaskInfo *myTask = NULL;
+        TaskInfo *myTask = nullptr;
         TaskGroup *runtg = this;
         if (waitingTasks.size() > 0) {
             int taskNumber = waitingTasks.back();
@@ -945,9 +945,9 @@ static TaskGroup *freeTaskGroups[MAX_FREE_TASK_GROUPS];
 static inline TaskGroup *AllocTaskGroup() {
     for (int i = 0; i < MAX_FREE_TASK_GROUPS; ++i) {
         TaskGroup *tg = freeTaskGroups[i];
-        if (tg != NULL) {
-            void *ptr = lAtomicCompareAndSwapPointer((void **)(&freeTaskGroups[i]), NULL, tg);
-            if (ptr != NULL) {
+        if (tg != nullptr) {
+            void *ptr = lAtomicCompareAndSwapPointer((void **)(&freeTaskGroups[i]), nullptr, tg);
+            if (ptr != nullptr) {
                 return (TaskGroup *)ptr;
             }
         }
@@ -960,9 +960,9 @@ static inline void FreeTaskGroup(TaskGroup *tg) {
     tg->Reset();
 
     for (int i = 0; i < MAX_FREE_TASK_GROUPS; ++i) {
-        if (freeTaskGroups[i] == NULL) {
-            void *ptr = lAtomicCompareAndSwapPointer((void **)&freeTaskGroups[i], tg, NULL);
-            if (ptr == NULL)
+        if (freeTaskGroups[i] == nullptr) {
+            void *ptr = lAtomicCompareAndSwapPointer((void **)&freeTaskGroups[i], tg, nullptr);
+            if (ptr == nullptr)
                 return;
         }
     }
@@ -975,7 +975,7 @@ static inline void FreeTaskGroup(TaskGroup *tg) {
 void ISPCLaunch(void **taskGroupPtr, void *func, void *data, int count0, int count1, int count2) {
     const int count = count0 * count1 * count2;
     TaskGroup *taskGroup;
-    if (*taskGroupPtr == NULL) {
+    if (*taskGroupPtr == nullptr) {
         InitTaskSystem();
         taskGroup = AllocTaskGroup();
         *taskGroupPtr = taskGroup;
@@ -997,7 +997,7 @@ void ISPCLaunch(void **taskGroupPtr, void *func, void *data, int count0, int cou
 
 void ISPCSync(void *h) {
     TaskGroup *taskGroup = (TaskGroup *)h;
-    if (taskGroup != NULL) {
+    if (taskGroup != nullptr) {
         taskGroup->Sync();
         FreeTaskGroup(taskGroup);
     }
@@ -1005,7 +1005,7 @@ void ISPCSync(void *h) {
 
 void *ISPCAlloc(void **taskGroupPtr, int64_t size, int32_t alignment) {
     TaskGroup *taskGroup;
-    if (*taskGroupPtr == NULL) {
+    if (*taskGroupPtr == nullptr) {
         InitTaskSystem();
         taskGroup = AllocTaskGroup();
         *taskGroupPtr = taskGroup;
@@ -1112,7 +1112,7 @@ class TaskSys {
         if (global)
             return;
         pthread_mutex_lock(&mutex);
-        if (global == NULL)
+        if (global == nullptr)
             global = new TaskSys;
         pthread_mutex_unlock(&mutex);
     }
@@ -1180,7 +1180,7 @@ inline void Task::run(int idx, int threadIdx) {
 
 void *_threadFct(void *data) {
     ((TaskSys *)data)->threadFct();
-    return NULL;
+    return nullptr;
 }
 
 void TaskSys::createThreads() {
@@ -1212,7 +1212,7 @@ void TaskSys::createThreads() {
     }
 }
 
-TaskSys *TaskSys::global = NULL;
+TaskSys *TaskSys::global = nullptr;
 int TaskSys::numThreadsRunning = 0;
 
 ///////////////////////////////////////////////////////////////////////////

--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -168,7 +168,7 @@ void ispcrtCopyToDevice(ISPCRTTaskQueue, ISPCRTMemoryView);
 void ispcrtCopyToHost(ISPCRTTaskQueue, ISPCRTMemoryView);
 void ispcrtCopyMemoryView(ISPCRTTaskQueue, ISPCRTMemoryView, ISPCRTMemoryView, const size_t size);
 
-// NOTE: 'params' can be a NULL handle (NULL will get passed to the ISPC task as the function parameter)
+// NOTE: 'params' can be a nullptr handle (nullptr will get passed to the ISPC task as the function parameter)
 ISPCRTFuture ispcrtLaunch1D(ISPCRTTaskQueue, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0);
 ISPCRTFuture ispcrtLaunch2D(ISPCRTTaskQueue, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0, size_t dim1);
 ISPCRTFuture ispcrtLaunch3D(ISPCRTTaskQueue, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0, size_t dim1,

--- a/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
+++ b/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 Intel Corporation
+// Copyright 2020-2023 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "ze_mock.h"
@@ -281,7 +281,7 @@ ze_result_t zeModuleDestroy(ze_module_handle_t hModule) {
 ze_result_t zeModuleDynamicLink(uint32_t numModules, ze_module_handle_t *phModules,
                                 ze_module_build_log_handle_t *phLinkLog) {
     MOCK_CNT_CALL;
-    if (phModules == NULL)
+    if (phModules == nullptr)
         return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
     MOCK_RET;
 }
@@ -294,17 +294,17 @@ ze_result_t zeModuleBuildLogGetString(ze_module_build_log_handle_t hModuleBuildL
 
 ze_result_t zeModuleBuildLogDestroy(ze_module_build_log_handle_t hModuleBuildLog) {
     MOCK_CNT_CALL;
-    if (hModuleBuildLog == NULL)
+    if (hModuleBuildLog == nullptr)
         return ZE_RESULT_ERROR_UNINITIALIZED;
     MOCK_RET;
 }
 
-static void *pfnFunctionMem = NULL;
+static void *pfnFunctionMem = nullptr;
 ze_result_t zeModuleGetFunctionPointer(ze_module_handle_t hModule, const char *pFunctionName, void **pfnFunction) {
     MOCK_CNT_CALL;
     if (hModule != ModuleHandle.get())
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
-    if (pFunctionName == NULL)
+    if (pFunctionName == nullptr)
         return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
     *pfnFunction = &pfnFunctionMem;
     MOCK_RET;
@@ -346,7 +346,7 @@ ze_result_t zeKernelSuggestGroupSize(ze_kernel_handle_t hKernel, uint32_t global
     if (hKernel != KernelHandle.get()) {
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;
     }
-    if (groupSizeX == NULL || groupSizeY == NULL || groupSizeZ == NULL) {
+    if (groupSizeX == nullptr || groupSizeY == nullptr || groupSizeZ == nullptr) {
         return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
     }
     *groupSizeX = 1;

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -1054,15 +1054,15 @@ TEST_F(MockTest, C_API_CreateDeviceFromNativeHandler) {
 
 TEST_F(MockTest, C_API_MemPoolGeneralTest) {
     setenv("ISPCRT_MEM_POOL", "1", 1);
-    void *p = NULL;
+    void *p = nullptr;
     ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
     ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
-    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, NULL, 1ULL<<10, &flags);
+    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL<<10, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<10);
     ispcrtRelease(view);
     flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_READ_DEVICE_WRITE };
-    view = ispcrtNewMemoryViewForContext(context, NULL, 1ULL<<10, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL<<10, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<10);
     ispcrtRelease(view);
@@ -1072,14 +1072,14 @@ TEST_F(MockTest, C_API_MemPoolGeneralTest) {
 
 TEST_F(MockTest, C_API_MemPoolFallBack) {
     setenv("ISPCRT_MEM_POOL", "1", 1);
-    void *p = NULL;
+    void *p = nullptr;
     ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
     ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
-    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<21) + 1, &flags);
+    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<21) + 1, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), (1ULL<<21) + 1);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<10) - 12, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<10) - 12, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<10);
     ispcrtRelease(view);
@@ -1089,27 +1089,27 @@ TEST_F(MockTest, C_API_MemPoolFallBack) {
 
 TEST_F(MockTest, C_API_MemPoolRoundUpPow2) {
     setenv("ISPCRT_MEM_POOL", "1", 1);
-    void *p = NULL;
+    void *p = nullptr;
     ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
     ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
     ISPCRTMemoryView view;
-    view = ispcrtNewMemoryViewForContext(context, NULL, 1ULL<<21, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL<<21, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<21);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<21) - 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<21) - 1, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<21);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, NULL, 1ULL<<7, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL<<7, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<7);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, NULL, 1ULL<<20, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL<<20, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<20);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<20) + 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<20) + 1, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<21);
     ispcrtRelease(view);
@@ -1119,11 +1119,11 @@ TEST_F(MockTest, C_API_MemPoolRoundUpPow2) {
 
 TEST_F(MockTest, C_API_MemPoolLiveRange) {
     setenv("ISPCRT_MEM_POOL", "1", 1);
-    void *p = NULL;
+    void *p = nullptr;
     ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
     ASSERT_EQ(ispcrtUseCount(context), 1);
     ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
-    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, NULL, 1ULL<<10, &flags);
+    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL<<10, &flags);
     ASSERT_EQ(ispcrtUseCount(context), 2);
     ASSERT_EQ(ispcrtUseCount(view), 1);
     p = ispcrtHostPtr(view);
@@ -1140,18 +1140,18 @@ TEST_F(MockTest, C_API_MemPoolChunkSizes1) {
     setenv("ISPCRT_MEM_POOL", "1", 1);
     setenv("ISPCRT_MEM_POOL_MIN_CHUNK_POW2", "10", 1);
     setenv("ISPCRT_MEM_POOL_MAX_CHUNK_POW2", "12", 1);
-    void *p = NULL;
+    void *p = nullptr;
     ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
     ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
-    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, NULL, 1, &flags);
+    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, 1, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<10);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<12) - 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<12) - 1, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<12);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<12) + 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<12) + 1, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), (1ULL<<12) + 1);
     ispcrtRelease(view);
@@ -1165,22 +1165,22 @@ TEST_F(MockTest, C_API_MemPoolChunkSizes2) {
     setenv("ISPCRT_MEM_POOL", "1", 1);
     setenv("ISPCRT_MEM_POOL_MIN_CHUNK_POW2", "6", 1);
     setenv("ISPCRT_MEM_POOL_MAX_CHUNK_POW2", "9", 1);
-    void *p = NULL;
+    void *p = nullptr;
     ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
     ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
-    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, NULL, 1, &flags);
+    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, 1, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<6);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<6) - 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<6) - 1, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<6);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<9) - 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<9) - 1, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), 1ULL<<9);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, NULL, (1ULL<<9) + 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<9) + 1, &flags);
     p = ispcrtHostPtr(view);
     ASSERT_EQ(ispcrtSize(view), (1ULL<<9) + 1);
     ispcrtRelease(view);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -112,7 +112,7 @@ void ASTNode::Print() const {
 // AST
 
 void AST::AddFunction(Symbol *sym, Stmt *code) {
-    if (sym == NULL)
+    if (sym == nullptr)
         return;
     functions.push_back(new Function(sym, code));
 }
@@ -188,11 +188,11 @@ void AST::Print(Globals::ASTDumpKind printKind) const {
 ///////////////////////////////////////////////////////////////////////////
 
 ASTNode *ispc::WalkAST(ASTNode *node, ASTPreCallBackFunc preFunc, ASTPostCallBackFunc postFunc, void *data) {
-    if (node == NULL)
+    if (node == nullptr)
         return node;
 
     // Call the callback function
-    if (preFunc != NULL) {
+    if (preFunc != nullptr) {
         if (preFunc(node, data) == false)
             // The function asked us to not continue recursively, so stop.
             return node;
@@ -200,7 +200,7 @@ ASTNode *ispc::WalkAST(ASTNode *node, ASTPreCallBackFunc preFunc, ASTPostCallBac
 
     ////////////////////////////////////////////////////////////////////////////
     // Handle Statements
-    if (llvm::dyn_cast<Stmt>(node) != NULL) {
+    if (llvm::dyn_cast<Stmt>(node) != nullptr) {
         ExprStmt *es;
         DeclStmt *ds;
         IfStmt *is;
@@ -220,66 +220,66 @@ ASTNode *ispc::WalkAST(ASTNode *node, ASTPreCallBackFunc preFunc, ASTPostCallBac
         DeleteStmt *dels;
         UnmaskedStmt *ums;
 
-        if ((es = llvm::dyn_cast<ExprStmt>(node)) != NULL)
+        if ((es = llvm::dyn_cast<ExprStmt>(node)) != nullptr)
             es->expr = (Expr *)WalkAST(es->expr, preFunc, postFunc, data);
-        else if ((ds = llvm::dyn_cast<DeclStmt>(node)) != NULL) {
+        else if ((ds = llvm::dyn_cast<DeclStmt>(node)) != nullptr) {
             for (unsigned int i = 0; i < ds->vars.size(); ++i)
                 ds->vars[i].init = (Expr *)WalkAST(ds->vars[i].init, preFunc, postFunc, data);
-        } else if ((is = llvm::dyn_cast<IfStmt>(node)) != NULL) {
+        } else if ((is = llvm::dyn_cast<IfStmt>(node)) != nullptr) {
             is->test = (Expr *)WalkAST(is->test, preFunc, postFunc, data);
             is->trueStmts = (Stmt *)WalkAST(is->trueStmts, preFunc, postFunc, data);
             is->falseStmts = (Stmt *)WalkAST(is->falseStmts, preFunc, postFunc, data);
-        } else if ((dos = llvm::dyn_cast<DoStmt>(node)) != NULL) {
+        } else if ((dos = llvm::dyn_cast<DoStmt>(node)) != nullptr) {
             dos->testExpr = (Expr *)WalkAST(dos->testExpr, preFunc, postFunc, data);
             dos->bodyStmts = (Stmt *)WalkAST(dos->bodyStmts, preFunc, postFunc, data);
-        } else if ((fs = llvm::dyn_cast<ForStmt>(node)) != NULL) {
+        } else if ((fs = llvm::dyn_cast<ForStmt>(node)) != nullptr) {
             fs->init = (Stmt *)WalkAST(fs->init, preFunc, postFunc, data);
             fs->test = (Expr *)WalkAST(fs->test, preFunc, postFunc, data);
             fs->step = (Stmt *)WalkAST(fs->step, preFunc, postFunc, data);
             fs->stmts = (Stmt *)WalkAST(fs->stmts, preFunc, postFunc, data);
-        } else if ((fes = llvm::dyn_cast<ForeachStmt>(node)) != NULL) {
+        } else if ((fes = llvm::dyn_cast<ForeachStmt>(node)) != nullptr) {
             for (unsigned int i = 0; i < fes->startExprs.size(); ++i)
                 fes->startExprs[i] = (Expr *)WalkAST(fes->startExprs[i], preFunc, postFunc, data);
             for (unsigned int i = 0; i < fes->endExprs.size(); ++i)
                 fes->endExprs[i] = (Expr *)WalkAST(fes->endExprs[i], preFunc, postFunc, data);
             fes->stmts = (Stmt *)WalkAST(fes->stmts, preFunc, postFunc, data);
-        } else if ((fas = llvm::dyn_cast<ForeachActiveStmt>(node)) != NULL) {
+        } else if ((fas = llvm::dyn_cast<ForeachActiveStmt>(node)) != nullptr) {
             fas->stmts = (Stmt *)WalkAST(fas->stmts, preFunc, postFunc, data);
-        } else if ((fus = llvm::dyn_cast<ForeachUniqueStmt>(node)) != NULL) {
+        } else if ((fus = llvm::dyn_cast<ForeachUniqueStmt>(node)) != nullptr) {
             fus->expr = (Expr *)WalkAST(fus->expr, preFunc, postFunc, data);
             fus->stmts = (Stmt *)WalkAST(fus->stmts, preFunc, postFunc, data);
-        } else if ((cs = llvm::dyn_cast<CaseStmt>(node)) != NULL)
+        } else if ((cs = llvm::dyn_cast<CaseStmt>(node)) != nullptr)
             cs->stmts = (Stmt *)WalkAST(cs->stmts, preFunc, postFunc, data);
-        else if ((defs = llvm::dyn_cast<DefaultStmt>(node)) != NULL)
+        else if ((defs = llvm::dyn_cast<DefaultStmt>(node)) != nullptr)
             defs->stmts = (Stmt *)WalkAST(defs->stmts, preFunc, postFunc, data);
-        else if ((ss = llvm::dyn_cast<SwitchStmt>(node)) != NULL) {
+        else if ((ss = llvm::dyn_cast<SwitchStmt>(node)) != nullptr) {
             ss->expr = (Expr *)WalkAST(ss->expr, preFunc, postFunc, data);
             ss->stmts = (Stmt *)WalkAST(ss->stmts, preFunc, postFunc, data);
-        } else if (llvm::dyn_cast<BreakStmt>(node) != NULL || llvm::dyn_cast<ContinueStmt>(node) != NULL ||
-                   llvm::dyn_cast<GotoStmt>(node) != NULL) {
+        } else if (llvm::dyn_cast<BreakStmt>(node) != nullptr || llvm::dyn_cast<ContinueStmt>(node) != nullptr ||
+                   llvm::dyn_cast<GotoStmt>(node) != nullptr) {
             // nothing
-        } else if ((ls = llvm::dyn_cast<LabeledStmt>(node)) != NULL)
+        } else if ((ls = llvm::dyn_cast<LabeledStmt>(node)) != nullptr)
             ls->stmt = (Stmt *)WalkAST(ls->stmt, preFunc, postFunc, data);
-        else if ((rs = llvm::dyn_cast<ReturnStmt>(node)) != NULL)
+        else if ((rs = llvm::dyn_cast<ReturnStmt>(node)) != nullptr)
             rs->expr = (Expr *)WalkAST(rs->expr, preFunc, postFunc, data);
-        else if ((sl = llvm::dyn_cast<StmtList>(node)) != NULL) {
+        else if ((sl = llvm::dyn_cast<StmtList>(node)) != nullptr) {
             std::vector<Stmt *> &sls = sl->stmts;
             for (unsigned int i = 0; i < sls.size(); ++i)
                 sls[i] = (Stmt *)WalkAST(sls[i], preFunc, postFunc, data);
-        } else if ((ps = llvm::dyn_cast<PrintStmt>(node)) != NULL)
+        } else if ((ps = llvm::dyn_cast<PrintStmt>(node)) != nullptr)
             ps->values = (Expr *)WalkAST(ps->values, preFunc, postFunc, data);
-        else if ((as = llvm::dyn_cast<AssertStmt>(node)) != NULL)
+        else if ((as = llvm::dyn_cast<AssertStmt>(node)) != nullptr)
             as->expr = (Expr *)WalkAST(as->expr, preFunc, postFunc, data);
-        else if ((dels = llvm::dyn_cast<DeleteStmt>(node)) != NULL)
+        else if ((dels = llvm::dyn_cast<DeleteStmt>(node)) != nullptr)
             dels->expr = (Expr *)WalkAST(dels->expr, preFunc, postFunc, data);
-        else if ((ums = llvm::dyn_cast<UnmaskedStmt>(node)) != NULL)
+        else if ((ums = llvm::dyn_cast<UnmaskedStmt>(node)) != nullptr)
             ums->stmts = (Stmt *)WalkAST(ums->stmts, preFunc, postFunc, data);
         else
             FATAL("Unhandled statement type in WalkAST()");
     } else {
         ///////////////////////////////////////////////////////////////////////////
         // Handle expressions
-        Assert(llvm::dyn_cast<Expr>(node) != NULL);
+        Assert(llvm::dyn_cast<Expr>(node) != nullptr);
         UnaryExpr *ue;
         BinaryExpr *be;
         AssignExpr *ae;
@@ -297,58 +297,58 @@ ASTNode *ispc::WalkAST(ASTNode *node, ASTPreCallBackFunc preFunc, ASTPostCallBac
         NewExpr *newe;
         AllocaExpr *alloce;
 
-        if ((ue = llvm::dyn_cast<UnaryExpr>(node)) != NULL)
+        if ((ue = llvm::dyn_cast<UnaryExpr>(node)) != nullptr)
             ue->expr = (Expr *)WalkAST(ue->expr, preFunc, postFunc, data);
-        else if ((be = llvm::dyn_cast<BinaryExpr>(node)) != NULL) {
+        else if ((be = llvm::dyn_cast<BinaryExpr>(node)) != nullptr) {
             be->arg0 = (Expr *)WalkAST(be->arg0, preFunc, postFunc, data);
             be->arg1 = (Expr *)WalkAST(be->arg1, preFunc, postFunc, data);
-        } else if ((ae = llvm::dyn_cast<AssignExpr>(node)) != NULL) {
+        } else if ((ae = llvm::dyn_cast<AssignExpr>(node)) != nullptr) {
             ae->lvalue = (Expr *)WalkAST(ae->lvalue, preFunc, postFunc, data);
             ae->rvalue = (Expr *)WalkAST(ae->rvalue, preFunc, postFunc, data);
-        } else if ((se = llvm::dyn_cast<SelectExpr>(node)) != NULL) {
+        } else if ((se = llvm::dyn_cast<SelectExpr>(node)) != nullptr) {
             se->test = (Expr *)WalkAST(se->test, preFunc, postFunc, data);
             se->expr1 = (Expr *)WalkAST(se->expr1, preFunc, postFunc, data);
             se->expr2 = (Expr *)WalkAST(se->expr2, preFunc, postFunc, data);
-        } else if ((el = llvm::dyn_cast<ExprList>(node)) != NULL) {
+        } else if ((el = llvm::dyn_cast<ExprList>(node)) != nullptr) {
             for (unsigned int i = 0; i < el->exprs.size(); ++i)
                 el->exprs[i] = (Expr *)WalkAST(el->exprs[i], preFunc, postFunc, data);
-        } else if ((fce = llvm::dyn_cast<FunctionCallExpr>(node)) != NULL) {
+        } else if ((fce = llvm::dyn_cast<FunctionCallExpr>(node)) != nullptr) {
             fce->func = (Expr *)WalkAST(fce->func, preFunc, postFunc, data);
             fce->args = (ExprList *)WalkAST(fce->args, preFunc, postFunc, data);
             for (int k = 0; k < 3; k++)
                 fce->launchCountExpr[k] = (Expr *)WalkAST(fce->launchCountExpr[k], preFunc, postFunc, data);
-        } else if ((ie = llvm::dyn_cast<IndexExpr>(node)) != NULL) {
+        } else if ((ie = llvm::dyn_cast<IndexExpr>(node)) != nullptr) {
             ie->baseExpr = (Expr *)WalkAST(ie->baseExpr, preFunc, postFunc, data);
             ie->index = (Expr *)WalkAST(ie->index, preFunc, postFunc, data);
-        } else if ((me = llvm::dyn_cast<MemberExpr>(node)) != NULL)
+        } else if ((me = llvm::dyn_cast<MemberExpr>(node)) != nullptr)
             me->expr = (Expr *)WalkAST(me->expr, preFunc, postFunc, data);
-        else if ((tce = llvm::dyn_cast<TypeCastExpr>(node)) != NULL)
+        else if ((tce = llvm::dyn_cast<TypeCastExpr>(node)) != nullptr)
             tce->expr = (Expr *)WalkAST(tce->expr, preFunc, postFunc, data);
-        else if ((re = llvm::dyn_cast<ReferenceExpr>(node)) != NULL)
+        else if ((re = llvm::dyn_cast<ReferenceExpr>(node)) != nullptr)
             re->expr = (Expr *)WalkAST(re->expr, preFunc, postFunc, data);
-        else if ((ptrderef = llvm::dyn_cast<PtrDerefExpr>(node)) != NULL)
+        else if ((ptrderef = llvm::dyn_cast<PtrDerefExpr>(node)) != nullptr)
             ptrderef->expr = (Expr *)WalkAST(ptrderef->expr, preFunc, postFunc, data);
-        else if ((refderef = llvm::dyn_cast<RefDerefExpr>(node)) != NULL)
+        else if ((refderef = llvm::dyn_cast<RefDerefExpr>(node)) != nullptr)
             refderef->expr = (Expr *)WalkAST(refderef->expr, preFunc, postFunc, data);
-        else if ((soe = llvm::dyn_cast<SizeOfExpr>(node)) != NULL)
+        else if ((soe = llvm::dyn_cast<SizeOfExpr>(node)) != nullptr)
             soe->expr = (Expr *)WalkAST(soe->expr, preFunc, postFunc, data);
-        else if ((alloce = llvm::dyn_cast<AllocaExpr>(node)) != NULL)
+        else if ((alloce = llvm::dyn_cast<AllocaExpr>(node)) != nullptr)
             alloce->expr = (Expr *)WalkAST(alloce->expr, preFunc, postFunc, data);
-        else if ((aoe = llvm::dyn_cast<AddressOfExpr>(node)) != NULL)
+        else if ((aoe = llvm::dyn_cast<AddressOfExpr>(node)) != nullptr)
             aoe->expr = (Expr *)WalkAST(aoe->expr, preFunc, postFunc, data);
-        else if ((newe = llvm::dyn_cast<NewExpr>(node)) != NULL) {
+        else if ((newe = llvm::dyn_cast<NewExpr>(node)) != nullptr) {
             newe->countExpr = (Expr *)WalkAST(newe->countExpr, preFunc, postFunc, data);
             newe->initExpr = (Expr *)WalkAST(newe->initExpr, preFunc, postFunc, data);
-        } else if (llvm::dyn_cast<SymbolExpr>(node) != NULL || llvm::dyn_cast<ConstExpr>(node) != NULL ||
-                   llvm::dyn_cast<FunctionSymbolExpr>(node) != NULL || llvm::dyn_cast<SyncExpr>(node) != NULL ||
-                   llvm::dyn_cast<NullPointerExpr>(node) != NULL) {
+        } else if (llvm::dyn_cast<SymbolExpr>(node) != nullptr || llvm::dyn_cast<ConstExpr>(node) != nullptr ||
+                   llvm::dyn_cast<FunctionSymbolExpr>(node) != nullptr || llvm::dyn_cast<SyncExpr>(node) != nullptr ||
+                   llvm::dyn_cast<NullPointerExpr>(node) != nullptr) {
             // nothing to do
         } else
             FATAL("Unhandled expression type in WalkAST().");
     }
 
     // Call the callback function
-    if (postFunc != NULL)
+    if (postFunc != nullptr)
         return postFunc(node, data);
     else
         return node;
@@ -356,7 +356,7 @@ ASTNode *ispc::WalkAST(ASTNode *node, ASTPreCallBackFunc preFunc, ASTPostCallBac
 
 static ASTNode *lOptimizeNode(ASTNode *node, void *) { return node->Optimize(); }
 
-ASTNode *ispc::Optimize(ASTNode *root) { return WalkAST(root, NULL, lOptimizeNode, NULL); }
+ASTNode *ispc::Optimize(ASTNode *root) { return WalkAST(root, nullptr, lOptimizeNode, nullptr); }
 
 Expr *ispc::Optimize(Expr *expr) { return (Expr *)Optimize((ASTNode *)expr); }
 
@@ -364,7 +364,7 @@ Stmt *ispc::Optimize(Stmt *stmt) { return (Stmt *)Optimize((ASTNode *)stmt); }
 
 static ASTNode *lTypeCheckNode(ASTNode *node, void *) { return node->TypeCheck(); }
 
-ASTNode *ispc::TypeCheck(ASTNode *root) { return WalkAST(root, NULL, lTypeCheckNode, NULL); }
+ASTNode *ispc::TypeCheck(ASTNode *root) { return WalkAST(root, nullptr, lTypeCheckNode, nullptr); }
 
 Expr *ispc::TypeCheck(Expr *expr) { return (Expr *)TypeCheck((ASTNode *)expr); }
 
@@ -379,7 +379,7 @@ struct CostData {
 
 static bool lCostCallbackPre(ASTNode *node, void *d) {
     CostData *data = (CostData *)d;
-    if (llvm::dyn_cast<ForeachStmt>(node) != NULL)
+    if (llvm::dyn_cast<ForeachStmt>(node) != nullptr)
         ++data->foreachDepth;
     if (data->foreachDepth == 0)
         data->cost += node->EstimateCost();
@@ -388,7 +388,7 @@ static bool lCostCallbackPre(ASTNode *node, void *d) {
 
 static ASTNode *lCostCallbackPost(ASTNode *node, void *d) {
     CostData *data = (CostData *)d;
-    if (llvm::dyn_cast<ForeachStmt>(node) != NULL)
+    if (llvm::dyn_cast<ForeachStmt>(node) != nullptr)
         --data->foreachDepth;
     return node;
 }
@@ -406,16 +406,16 @@ static bool lCheckAllOffSafety(ASTNode *node, void *data) {
     bool *okPtr = (bool *)data;
 
     FunctionCallExpr *fce;
-    if ((fce = llvm::dyn_cast<FunctionCallExpr>(node)) != NULL) {
-        if (fce->func == NULL)
+    if ((fce = llvm::dyn_cast<FunctionCallExpr>(node)) != nullptr) {
+        if (fce->func == nullptr)
             return false;
 
         const Type *type = fce->func->GetType();
         const PointerType *pt = CastType<PointerType>(type);
-        if (pt != NULL)
+        if (pt != nullptr)
             type = pt->GetBaseType();
         const FunctionType *ftype = CastType<FunctionType>(type);
-        Assert(ftype != NULL);
+        Assert(ftype != nullptr);
 
         if (ftype->isSafe == false) {
             *okPtr = false;
@@ -423,7 +423,7 @@ static bool lCheckAllOffSafety(ASTNode *node, void *data) {
         }
     }
 
-    if (llvm::dyn_cast<AssertStmt>(node) != NULL) {
+    if (llvm::dyn_cast<AssertStmt>(node) != nullptr) {
         // While it's fine to run the assert for varying tests, it's not
         // desirable to check an assert on a uniform variable if all of the
         // lanes are off.
@@ -431,12 +431,12 @@ static bool lCheckAllOffSafety(ASTNode *node, void *data) {
         return false;
     }
 
-    if (llvm::dyn_cast<PrintStmt>(node) != NULL) {
+    if (llvm::dyn_cast<PrintStmt>(node) != nullptr) {
         *okPtr = false;
         return false;
     }
 
-    if (llvm::dyn_cast<NewExpr>(node) != NULL || llvm::dyn_cast<DeleteStmt>(node) != NULL) {
+    if (llvm::dyn_cast<NewExpr>(node) != nullptr || llvm::dyn_cast<DeleteStmt>(node) != nullptr) {
         // We definitely don't want to run the uniform variants of these if
         // the mask is all off.  It's also worth skipping the overhead of
         // executing the varying versions of them in the all-off mask case.
@@ -444,8 +444,8 @@ static bool lCheckAllOffSafety(ASTNode *node, void *data) {
         return false;
     }
 
-    if (llvm::dyn_cast<ForeachStmt>(node) != NULL || llvm::dyn_cast<ForeachActiveStmt>(node) != NULL ||
-        llvm::dyn_cast<ForeachUniqueStmt>(node) != NULL || llvm::dyn_cast<UnmaskedStmt>(node) != NULL) {
+    if (llvm::dyn_cast<ForeachStmt>(node) != nullptr || llvm::dyn_cast<ForeachActiveStmt>(node) != nullptr ||
+        llvm::dyn_cast<ForeachUniqueStmt>(node) != nullptr || llvm::dyn_cast<UnmaskedStmt>(node) != nullptr) {
         // The various foreach statements also shouldn't be run with an
         // all-off mask.  Since they can re-establish an 'all on' mask,
         // this would be pretty unintuitive.  (More generally, it's
@@ -460,36 +460,36 @@ static bool lCheckAllOffSafety(ASTNode *node, void *data) {
     }
 
     BinaryExpr *binaryExpr;
-    if ((binaryExpr = llvm::dyn_cast<BinaryExpr>(node)) != NULL) {
+    if ((binaryExpr = llvm::dyn_cast<BinaryExpr>(node)) != nullptr) {
         if (binaryExpr->op == BinaryExpr::Mod || binaryExpr->op == BinaryExpr::Div) {
             *okPtr = false;
             return false;
         }
     }
     IndexExpr *ie;
-    if ((ie = llvm::dyn_cast<IndexExpr>(node)) != NULL && ie->baseExpr != NULL) {
+    if ((ie = llvm::dyn_cast<IndexExpr>(node)) != nullptr && ie->baseExpr != nullptr) {
         const Type *type = ie->baseExpr->GetType();
-        if (type == NULL)
+        if (type == nullptr)
             return true;
-        if (CastType<ReferenceType>(type) != NULL)
+        if (CastType<ReferenceType>(type) != nullptr)
             type = type->GetReferenceTarget();
 
         ConstExpr *ce = llvm::dyn_cast<ConstExpr>(ie->index);
-        if (ce == NULL) {
+        if (ce == nullptr) {
             // indexing with a variable... -> not safe
             *okPtr = false;
             return false;
         }
 
         const PointerType *pointerType = CastType<PointerType>(type);
-        if (pointerType != NULL) {
+        if (pointerType != nullptr) {
             // pointer[index] -> can't be sure -> not safe
             *okPtr = false;
             return false;
         }
 
         const SequentialType *seqType = CastType<SequentialType>(type);
-        Assert(seqType != NULL);
+        Assert(seqType != nullptr);
         int nElements = seqType->GetElementCount();
         if (nElements == 0) {
             // Unsized array, so we can't be sure -> not safe
@@ -512,12 +512,12 @@ static bool lCheckAllOffSafety(ASTNode *node, void *data) {
     }
 
     MemberExpr *me;
-    if ((me = llvm::dyn_cast<MemberExpr>(node)) != NULL && me->dereferenceExpr) {
+    if ((me = llvm::dyn_cast<MemberExpr>(node)) != nullptr && me->dereferenceExpr) {
         *okPtr = false;
         return false;
     }
 
-    if (llvm::dyn_cast<PtrDerefExpr>(node) != NULL) {
+    if (llvm::dyn_cast<PtrDerefExpr>(node) != nullptr) {
         *okPtr = false;
         return false;
     }
@@ -527,7 +527,7 @@ static bool lCheckAllOffSafety(ASTNode *node, void *data) {
       assign to a uniform or post-/pre- increment/decrement.
     */
     AssignExpr *ae;
-    if ((ae = llvm::dyn_cast<AssignExpr>(node)) != NULL) {
+    if ((ae = llvm::dyn_cast<AssignExpr>(node)) != nullptr) {
         if (ae->GetType() && ae->GetType()->IsUniformType()) {
             *okPtr = false;
             return false;
@@ -535,7 +535,7 @@ static bool lCheckAllOffSafety(ASTNode *node, void *data) {
     }
 
     UnaryExpr *ue;
-    if ((ue = llvm::dyn_cast<UnaryExpr>(node)) != NULL &&
+    if ((ue = llvm::dyn_cast<UnaryExpr>(node)) != nullptr &&
         (ue->op == UnaryExpr::PreInc || ue->op == UnaryExpr::PreDec || ue->op == UnaryExpr::PostInc ||
          ue->op == UnaryExpr::PostDec)) {
         if (ue->GetType() && ue->GetType()->IsUniformType()) {
@@ -544,7 +544,7 @@ static bool lCheckAllOffSafety(ASTNode *node, void *data) {
         }
     }
 
-    if (llvm::dyn_cast<SyncExpr>(node) != NULL || llvm::dyn_cast<AllocaExpr>(node) != NULL) {
+    if (llvm::dyn_cast<SyncExpr>(node) != nullptr || llvm::dyn_cast<AllocaExpr>(node) != nullptr) {
         *okPtr = false;
         return false;
     }
@@ -554,6 +554,6 @@ static bool lCheckAllOffSafety(ASTNode *node, void *data) {
 
 bool ispc::SafeToRunWithMaskAllOff(ASTNode *root) {
     bool safe = true;
-    WalkAST(root, lCheckAllOffSafety, NULL, &safe);
+    WalkAST(root, lCheckAllOffSafety, nullptr, &safe);
     return safe;
 }

--- a/src/ast.h
+++ b/src/ast.h
@@ -92,12 +92,12 @@ class ASTNode : public Traceable {
         optimizations on the node (e.g. constant folding).  This method
         will be called after the node's children have already been
         optimized, and the caller will store the returned ASTNode * in
-        place of the original node.  This method should return NULL if an
+        place of the original node.  This method should return nullptr if an
         error is encountered during optimization. */
     virtual ASTNode *Optimize() = 0;
 
     /** Type checking should be performed by the node when this method is
-        called.  In the event of an error, a NULL value may be returned.
+        called.  In the event of an error, a nullptr value may be returned.
         As with ASTNode::Optimize(), the caller should store the returned
         pointer in place of the original ASTNode *. */
     virtual ASTNode *TypeCheck() = 0;
@@ -211,7 +211,7 @@ typedef bool (*ASTPreCallBackFunc)(ASTNode *node, void *data);
 typedef ASTNode *(*ASTPostCallBackFunc)(ASTNode *node, void *data);
 
 /** Walk (some portion of) an AST, starting from the given root node.  At
-    each node, if preFunc is non-NULL, call it, passing the given void
+    each node, if preFunc is non-nullptr, call it, passing the given void
     *data pointer; if the call to preFunc function returns false, then the
     children of the node aren't visited.  This function then makes
     recursive calls to WalkAST() to process the node's children; after

--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -131,7 +131,7 @@ static const Type *lLLVMTypeToISPCType(const llvm::Type *t, bool intAsUnsigned) 
     else if (t == LLVMTypes::DoubleVectorPointerType)
         return PointerType::GetUniform(AtomicType::VaryingDouble);
 
-    return NULL;
+    return nullptr;
 }
 
 static void lCreateSymbol(const std::string &name, const Type *returnType, llvm::SmallVector<const Type *, 8> &argTypes,
@@ -190,7 +190,7 @@ static bool lCreateISPCSymbol(llvm::Function *func, SymbolTable *symbolTable) {
         bool intAsUnsigned = (i == 1);
 
         const Type *returnType = lLLVMTypeToISPCType(ftype->getReturnType(), intAsUnsigned);
-        if (returnType == NULL) {
+        if (returnType == nullptr) {
             Debug(SourcePos(),
                   "Return type not representable for "
                   "builtin %s.",
@@ -206,7 +206,7 @@ static bool lCreateISPCSymbol(llvm::Function *func, SymbolTable *symbolTable) {
         for (unsigned int j = 0; j < ftype->getNumParams(); ++j) {
             const llvm::Type *llvmArgType = ftype->getParamType(j);
             const Type *type = lLLVMTypeToISPCType(llvmArgType, intAsUnsigned);
-            if (type == NULL) {
+            if (type == nullptr) {
                 Debug(SourcePos(),
                       "Type of parameter %d not "
                       "representable for builtin %s",
@@ -228,7 +228,7 @@ static bool lCreateISPCSymbol(llvm::Function *func, SymbolTable *symbolTable) {
 
 Symbol *ispc::CreateISPCSymbolForLLVMIntrinsic(llvm::Function *func, SymbolTable *symbolTable) {
     Symbol *existingSym = symbolTable->LookupIntrinsics(func);
-    if (existingSym != NULL) {
+    if (existingSym != nullptr) {
         return existingSym;
     }
     SourcePos noPos;
@@ -236,7 +236,7 @@ Symbol *ispc::CreateISPCSymbolForLLVMIntrinsic(llvm::Function *func, SymbolTable
     const llvm::FunctionType *ftype = func->getFunctionType();
     std::string name = std::string(func->getName());
     const Type *returnType = lLLVMTypeToISPCType(ftype->getReturnType(), false);
-    if (returnType == NULL) {
+    if (returnType == nullptr) {
         Error(SourcePos(),
               "Return type not representable for "
               "Intrinsic %s.",
@@ -248,7 +248,7 @@ Symbol *ispc::CreateISPCSymbolForLLVMIntrinsic(llvm::Function *func, SymbolTable
     for (unsigned int j = 0; j < ftype->getNumParams(); ++j) {
         const llvm::Type *llvmArgType = ftype->getParamType(j);
         const Type *type = lLLVMTypeToISPCType(llvmArgType, false);
-        if (type == NULL) {
+        if (type == nullptr) {
             Error(SourcePos(),
                   "Type of parameter %d not "
                   "representable for Intrinsic %s",
@@ -961,7 +961,7 @@ static void lSetInternalFunctions(llvm::Module *module) {
     // clang-format on
     for (auto name : names) {
         llvm::Function *f = module->getFunction(name);
-        if (f != NULL && f->empty() == false) {
+        if (f != nullptr && f->empty() == false) {
             f->setLinkage(llvm::GlobalValue::InternalLinkage);
             // TO-DO : Revisit adding this back for ARM support.
             // g->target->markFuncWithTargetAttr(f);
@@ -1059,7 +1059,7 @@ void ispc::AddBitcodeToModule(const BitcodeLib *lib, llvm::Module *module, Symbo
 
         lSetInternalFunctions(module);
 
-        if (symbolTable != NULL)
+        if (symbolTable != nullptr)
             lAddModuleSymbols(module, symbolTable);
         lCheckModuleIntrinsics(module);
     }
@@ -1079,7 +1079,7 @@ static void lDefineConstantInt(const char *name, int val, llvm::Module *module, 
     sym->storageInfo = new AddressInfo(GV, GV->getValueType());
     symbolTable->AddVariable(sym);
 
-    if (m->diBuilder != NULL) {
+    if (m->diBuilder != nullptr) {
         llvm::DIFile *file = m->diCompileUnit->getFile();
         llvm::DICompileUnit *cu = m->diCompileUnit;
         llvm::DIType *diType = sym->type->GetDIType(file);
@@ -1107,7 +1107,7 @@ static void lDefineConstantIntFunc(const char *name, int val, llvm::Module *modu
 
     llvm::Function *func = module->getFunction(name);
     dbg_sym.push_back(func);
-    Assert(func != NULL); // it should be declared already...
+    Assert(func != nullptr); // it should be declared already...
     func->addFnAttr(llvm::Attribute::AlwaysInline);
     llvm::BasicBlock *bblock = llvm::BasicBlock::Create(*g->ctx, "entry", func, 0);
     llvm::ReturnInst::Create(*g->ctx, LLVMInt32(val), bblock);
@@ -1134,7 +1134,7 @@ static void lDefineProgramIndex(llvm::Module *module, SymbolTable *symbolTable,
     sym->storageInfo = new AddressInfo(GV, GV->getValueType());
     symbolTable->AddVariable(sym);
 
-    if (m->diBuilder != NULL) {
+    if (m->diBuilder != nullptr) {
         llvm::DIFile *file = m->diCompileUnit->getFile();
         llvm::DICompileUnit *cu = m->diCompileUnit;
         llvm::DIType *diType = sym->type->GetDIType(file);

--- a/src/builtins.h
+++ b/src/builtins.h
@@ -28,7 +28,7 @@ namespace ispc {
  */
 void DefineStdlib(SymbolTable *symbolTable, llvm::LLVMContext *ctx, llvm::Module *module, bool includeStdlib);
 
-void AddBitcodeToModule(const BitcodeLib *lib, llvm::Module *module, SymbolTable *symbolTable = NULL);
+void AddBitcodeToModule(const BitcodeLib *lib, llvm::Module *module, SymbolTable *symbolTable = nullptr);
 
 /** Create ISPC symbol for LLVM intrinsics and add it to the given module.
 

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -89,20 +89,20 @@ struct CFInfo {
         type = t;
         isUniform = uniformIf;
         isUniformEmulated = uniformEmu;
-        savedBreakTarget = savedContinueTarget = NULL;
-        savedBreakLanesAddressInfo = savedContinueLanesAddressInfo = NULL;
+        savedBreakTarget = savedContinueTarget = nullptr;
+        savedBreakLanesAddressInfo = savedContinueLanesAddressInfo = nullptr;
         savedMask = savedBlockEntryMask = sm;
-        savedSwitchExpr = NULL;
-        savedSwitchFallThroughMaskAddressInfo = NULL;
-        savedDefaultBlock = NULL;
-        savedCaseBlocks = NULL;
-        savedNextBlocks = NULL;
+        savedSwitchExpr = nullptr;
+        savedSwitchFallThroughMaskAddressInfo = nullptr;
+        savedDefaultBlock = nullptr;
+        savedCaseBlocks = nullptr;
+        savedNextBlocks = nullptr;
         savedSwitchConditionWasUniform = false;
     }
     CFInfo(CFType t, bool iu, bool uniformEmulated, llvm::BasicBlock *bt, llvm::BasicBlock *ct, AddressInfo *sb,
-           AddressInfo *sc, llvm::Value *sm, llvm::Value *lm, llvm::Value *sse = NULL, AddressInfo *ssftmp = NULL,
-           llvm::BasicBlock *bbd = NULL, const std::vector<std::pair<int, llvm::BasicBlock *>> *bbc = NULL,
-           const std::map<llvm::BasicBlock *, llvm::BasicBlock *> *bbn = NULL, bool scu = false) {
+           AddressInfo *sc, llvm::Value *sm, llvm::Value *lm, llvm::Value *sse = nullptr, AddressInfo *ssftmp = nullptr,
+           llvm::BasicBlock *bbd = nullptr, const std::vector<std::pair<int, llvm::BasicBlock *>> *bbc = nullptr,
+           const std::map<llvm::BasicBlock *, llvm::BasicBlock *> *bbn = nullptr, bool scu = false) {
         Assert(t == Loop || t == Switch);
         type = t;
         isUniform = iu;
@@ -132,11 +132,11 @@ struct CFInfo {
         savedContinueLanesAddressInfo = sc;
         savedMask = sm;
         savedBlockEntryMask = lm;
-        savedSwitchExpr = NULL;
-        savedSwitchFallThroughMaskAddressInfo = NULL;
-        savedDefaultBlock = NULL;
-        savedCaseBlocks = NULL;
-        savedNextBlocks = NULL;
+        savedSwitchExpr = nullptr;
+        savedSwitchFallThroughMaskAddressInfo = nullptr;
+        savedDefaultBlock = nullptr;
+        savedCaseBlocks = nullptr;
+        savedNextBlocks = nullptr;
         savedSwitchConditionWasUniform = false;
     }
 };
@@ -170,7 +170,7 @@ CFInfo *CFInfo::GetForeach(bool isUniformEmulated, FunctionEmitContext::ForeachT
         break;
     default:
         FATAL("Unhandled foreach type");
-        return NULL;
+        return nullptr;
     }
 
     return new CFInfo(cfType, isUniformEmulated, breakTarget, continueTarget, savedBreakLanesAddressInfo,
@@ -242,22 +242,22 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::F
     if (((func->GetType()->isExported || func->GetType()->IsISPCExternal()) &&
          (lf->getFunctionType()->getNumParams() == func->GetType()->GetNumParameters())) ||
         (func->GetType()->isUnmasked) || func->GetType()->isTask) {
-        functionMaskValue = NULL;
-        fullMaskAddressInfo = NULL;
+        functionMaskValue = nullptr;
+        fullMaskAddressInfo = nullptr;
     } else {
         functionMaskValue = LLVMMaskAllOn;
         fullMaskAddressInfo = AllocaInst(LLVMTypes::MaskType, "full_mask_memory");
         StoreInst(LLVMMaskAllOn, fullMaskAddressInfo);
     }
 
-    blockEntryMask = NULL;
-    breakLanesAddressInfo = continueLanesAddressInfo = NULL;
-    breakTarget = continueTarget = NULL;
+    blockEntryMask = nullptr;
+    breakLanesAddressInfo = continueLanesAddressInfo = nullptr;
+    breakTarget = continueTarget = nullptr;
 
-    switchExpr = NULL;
-    caseBlocks = NULL;
-    defaultBlock = NULL;
-    nextBlocks = NULL;
+    switchExpr = nullptr;
+    caseBlocks = nullptr;
+    defaultBlock = nullptr;
+    nextBlocks = nullptr;
 
     returnedLanesAddressInfo = AllocaInst(LLVMTypes::MaskType, "returned_lanes_memory");
     StoreInst(LLVMMaskAllOff, returnedLanesAddressInfo);
@@ -270,7 +270,7 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::F
 
     const Type *returnType = function->GetReturnType();
     if (!returnType || returnType->IsVoidType())
-        returnValueAddressInfo = NULL;
+        returnValueAddressInfo = nullptr;
     else {
         returnValueAddressInfo = AllocaInst(returnType, "return_value_memory");
     }
@@ -280,7 +280,7 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::F
         /* Create return point for Xe */
         returnPoint = llvm::BasicBlock::Create(*g->ctx, "return_point", llvmFunction, 0);
         /* Load return value and return it */
-        if (returnValueAddressInfo != NULL) {
+        if (returnValueAddressInfo != nullptr) {
             // We have value(s) to return; load them from their storage
             // location
             // Note that LoadInst() needs to be used instead of direct llvm instruction generation
@@ -314,7 +314,7 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::F
         // dummy function that sets __all_on_mask be "all off".  (That
         // function is never actually called.)
         llvm::Value *globalAllOnMaskPtr = m->module->getNamedGlobal("__all_on_mask");
-        if (globalAllOnMaskPtr == NULL) {
+        if (globalAllOnMaskPtr == nullptr) {
             globalAllOnMaskPtr =
                 new llvm::GlobalVariable(*m->module, LLVMTypes::MaskType, false, llvm::GlobalValue::InternalLinkage,
                                          LLVMMaskAllOn, "__all_on_mask");
@@ -334,7 +334,7 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::F
         }
 
         llvm::Value *allOnMask =
-            LoadInst(new AddressInfo(globalAllOnMaskPtr, LLVMTypes::MaskType), NULL, "all_on_mask");
+            LoadInst(new AddressInfo(globalAllOnMaskPtr, LLVMTypes::MaskType), nullptr, "all_on_mask");
         SetInternalMaskAnd(LLVMMaskAllOn, allOnMask);
     }
 
@@ -353,7 +353,7 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::F
             g->target->getArch() == Arch::aarch64 ? LLVMTypes::Int64Type : LLVMTypes::Int32Type, "func_entry_ftz");
 
     } else {
-        functionFTZ_DAZValue = NULL;
+        functionFTZ_DAZValue = nullptr;
     }
 
     if (m->diBuilder) {
@@ -364,10 +364,10 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::F
         diFile = funcStartPos.GetDIFile();
         diSpace = funcStartPos.GetDINamespace();
         llvm::DIScope *scope = m->diCompileUnit;
-        llvm::DIType *diSubprogramType = NULL;
+        llvm::DIType *diSubprogramType = nullptr;
 
         const FunctionType *functionType = function->GetType();
-        if (functionType == NULL)
+        if (functionType == nullptr)
             AssertPos(currentPos, m->errorCount > 0);
         else {
             diSubprogramType = functionType->GetDIType(scope);
@@ -404,9 +404,9 @@ FunctionEmitContext::FunctionEmitContext(Function *func, Symbol *funSym, llvm::F
         /* And start a scope representing the initial function scope */
         StartScope();
     } else {
-        diSubprogram = NULL;
-        diFile = NULL;
-        diSpace = NULL;
+        diSubprogram = nullptr;
+        diFile = nullptr;
+        diSpace = nullptr;
     }
 }
 
@@ -423,7 +423,7 @@ void FunctionEmitContext::SetCurrentBasicBlock(llvm::BasicBlock *bb) { bblock = 
 
 llvm::Value *FunctionEmitContext::GetFunctionMask() { return fullMaskAddressInfo ? functionMaskValue : LLVMMaskAllOn; }
 
-llvm::Value *FunctionEmitContext::GetInternalMask() { return LoadInst(internalMaskAddressInfo, NULL, "load_mask"); }
+llvm::Value *FunctionEmitContext::GetInternalMask() { return LoadInst(internalMaskAddressInfo, nullptr, "load_mask"); }
 
 llvm::Value *FunctionEmitContext::GetFullMask() {
     return fullMaskAddressInfo ? BinaryOperator(llvm::Instruction::And, GetInternalMask(), functionMaskValue,
@@ -436,9 +436,9 @@ AddressInfo *FunctionEmitContext::GetFullMaskAddressInfo() {
 }
 
 void FunctionEmitContext::SetFunctionMask(llvm::Value *value) {
-    if (fullMaskAddressInfo != NULL) {
+    if (fullMaskAddressInfo != nullptr) {
         functionMaskValue = value;
-        if (bblock != NULL)
+        if (bblock != nullptr)
             StoreInst(GetFullMask(), fullMaskAddressInfo);
     }
 }
@@ -464,31 +464,31 @@ void FunctionEmitContext::SetInternalMaskAndNot(llvm::Value *oldMask, llvm::Valu
 }
 
 llvm::Instruction *FunctionEmitContext::BranchIfMaskAny(llvm::BasicBlock *btrue, llvm::BasicBlock *bfalse) {
-    AssertPos(currentPos, bblock != NULL);
+    AssertPos(currentPos, bblock != nullptr);
     llvm::Value *any = Any(GetFullMask());
     llvm::Instruction *bInst = BranchInst(btrue, bfalse, any);
     // It's illegal to add any additional instructions to the basic block
-    // now that it's terminated, so set bblock to NULL to be safe
-    bblock = NULL;
+    // now that it's terminated, so set bblock to nullptr to be safe
+    bblock = nullptr;
     return bInst;
 }
 
 void FunctionEmitContext::BranchIfMaskAll(llvm::BasicBlock *btrue, llvm::BasicBlock *bfalse) {
-    AssertPos(currentPos, bblock != NULL);
+    AssertPos(currentPos, bblock != nullptr);
     llvm::Value *all = All(GetFullMask());
     BranchInst(btrue, bfalse, all);
     // It's illegal to add any additional instructions to the basic block
-    // now that it's terminated, so set bblock to NULL to be safe
-    bblock = NULL;
+    // now that it's terminated, so set bblock to nullptr to be safe
+    bblock = nullptr;
 }
 
 void FunctionEmitContext::BranchIfMaskNone(llvm::BasicBlock *btrue, llvm::BasicBlock *bfalse) {
-    AssertPos(currentPos, bblock != NULL);
+    AssertPos(currentPos, bblock != nullptr);
     // switch sense of true/false bblocks
     BranchIfMaskAny(bfalse, btrue);
     // It's illegal to add any additional instructions to the basic block
-    // now that it's terminated, so set bblock to NULL to be safe
-    bblock = NULL;
+    // now that it's terminated, so set bblock to nullptr to be safe
+    bblock = nullptr;
 }
 
 void FunctionEmitContext::StartUniformIf(bool emulateUniform) {
@@ -506,7 +506,7 @@ void FunctionEmitContext::EndIf() {
 
     // 'uniform' ifs don't change the mask so we only need to restore the
     // mask going into the if for 'varying' if statements
-    if (ci->IsUniform() || bblock == NULL)
+    if (ci->IsUniform() || bblock == nullptr)
         return;
 
     // We can't just restore the mask as it was going into the 'if'
@@ -527,23 +527,23 @@ void FunctionEmitContext::EndIf() {
     //
     // There are three general cases to deal with here:
     // - Loops: both break and continue are allowed, and thus the corresponding
-    //   lane mask pointers are non-NULL
-    // - Foreach: only continueLanesAddressInfo may be non-NULL
-    // - Switch: only breakLanesAddressInfo may be non-NULL
-    if (continueLanesAddressInfo != NULL || breakLanesAddressInfo != NULL) {
+    //   lane mask pointers are non-nullptr
+    // - Foreach: only continueLanesAddressInfo may be non-nullptr
+    // - Switch: only breakLanesAddressInfo may be non-nullptr
+    if (continueLanesAddressInfo != nullptr || breakLanesAddressInfo != nullptr) {
         // We want to compute:
         // newMask = (oldMask & ~(breakLanes | continueLanes)),
         // treading breakLanes or continueLanes as "all off" if the
-        // corresponding pointer is NULL.
-        llvm::Value *bcLanes = NULL;
+        // corresponding pointer is nullptr.
+        llvm::Value *bcLanes = nullptr;
 
-        if (continueLanesAddressInfo != NULL)
-            bcLanes = LoadInst(continueLanesAddressInfo, NULL, "continue_lanes");
+        if (continueLanesAddressInfo != nullptr)
+            bcLanes = LoadInst(continueLanesAddressInfo, nullptr, "continue_lanes");
         else
             bcLanes = LLVMMaskAllOff;
 
-        if (breakLanesAddressInfo != NULL) {
-            llvm::Value *breakLanes = LoadInst(breakLanesAddressInfo, NULL, "break_lanes");
+        if (breakLanesAddressInfo != nullptr) {
+            llvm::Value *breakLanes = LoadInst(breakLanesAddressInfo, nullptr, "break_lanes");
             bcLanes = BinaryOperator(llvm::Instruction::Or, bcLanes, breakLanes, "|break_lanes");
         }
 
@@ -567,7 +567,7 @@ void FunctionEmitContext::StartLoop(llvm::BasicBlock *bt, llvm::BasicBlock *ct, 
         // If the loop has a uniform condition, we don't need to track
         // which lanes 'break' or 'continue'; all of the running ones go
         // together, so we just jump
-        breakLanesAddressInfo = continueLanesAddressInfo = NULL;
+        breakLanesAddressInfo = continueLanesAddressInfo = nullptr;
     else {
         // For loops with varying conditions, allocate space to store masks
         // that record which lanes have done these
@@ -579,7 +579,7 @@ void FunctionEmitContext::StartLoop(llvm::BasicBlock *bt, llvm::BasicBlock *ct, 
 
     breakTarget = bt;
     continueTarget = ct;
-    blockEntryMask = NULL; // this better be set by the loop!
+    blockEntryMask = nullptr; // this better be set by the loop!
 }
 
 void FunctionEmitContext::EndLoop() {
@@ -617,18 +617,18 @@ void FunctionEmitContext::StartForeach(ForeachType ft, bool isEmulatedUniform) {
     controlFlowInfo.push_back(CFInfo::GetForeach(isEmulatedUniform, ft, breakTarget, continueTarget,
                                                  breakLanesAddressInfo, continueLanesAddressInfo, oldMask,
                                                  blockEntryMask));
-    breakLanesAddressInfo = NULL;
-    breakTarget = NULL;
+    breakLanesAddressInfo = nullptr;
+    breakTarget = nullptr;
 
-    continueLanesAddressInfo = NULL;
+    continueLanesAddressInfo = nullptr;
     if (!isEmulatedUniform) {
         continueLanesAddressInfo = AllocaInst(LLVMTypes::MaskType, "foreach_continue_lanes");
         StoreInst(LLVMMaskAllOff, continueLanesAddressInfo);
     }
 
-    continueTarget = NULL; // should be set by SetContinueTarget()
+    continueTarget = nullptr; // should be set by SetContinueTarget()
 
-    blockEntryMask = NULL;
+    blockEntryMask = nullptr;
 }
 
 void FunctionEmitContext::EndForeach() {
@@ -643,7 +643,7 @@ void FunctionEmitContext::restoreMaskGivenReturns(llvm::Value *oldMask) {
     // Restore the mask to the given old mask, but leave off any lanes that
     // executed a return statement.
     // newMask = (oldMask & ~returnedLanes)
-    llvm::Value *returnedLanes = LoadInst(returnedLanesAddressInfo, NULL, "returned_lanes");
+    llvm::Value *returnedLanes = LoadInst(returnedLanesAddressInfo, nullptr, "returned_lanes");
     llvm::Value *notReturned = BinaryOperator(llvm::Instruction::Xor, returnedLanes, LLVMMaskAllOn, "~returned_lanes");
     llvm::Value *newMask = BinaryOperator(llvm::Instruction::And, oldMask, notReturned, "new_mask");
     SetInternalMask(newMask);
@@ -665,22 +665,22 @@ bool FunctionEmitContext::inSwitchStatement() const {
 }
 
 void FunctionEmitContext::Break(bool doCoherenceCheck) {
-    if (breakTarget == NULL) {
+    if (breakTarget == nullptr) {
         Error(currentPos, "\"break\" statement is illegal outside of "
                           "for/while/do loops and \"switch\" statements.");
         return;
     }
     AssertPos(currentPos, controlFlowInfo.size() > 0);
 
-    if (bblock == NULL)
+    if (bblock == nullptr)
         return;
 
     if (inSwitchStatement() == true && switchConditionWasUniform == true && ifsInCFAllUniform(CFInfo::Switch)) {
         // We know that all program instances are executing the break, so
         // just jump to the block immediately after the switch.
-        AssertPos(currentPos, breakTarget != NULL);
+        AssertPos(currentPos, breakTarget != nullptr);
         BranchInst(breakTarget);
-        bblock = NULL;
+        bblock = nullptr;
         return;
     }
 
@@ -689,18 +689,18 @@ void FunctionEmitContext::Break(bool doCoherenceCheck) {
     // jump to the break location.
     if (inSwitchStatement() == false && ifsInCFAllUniform(CFInfo::Loop)) {
         BranchInst(breakTarget);
-        // Set bblock to NULL since the jump has terminated the basic block
-        bblock = NULL;
+        // Set bblock to nullptr since the jump has terminated the basic block
+        bblock = nullptr;
     } else {
         // Varying switch, uniform switch where the 'break' is under
         // varying control flow, or a loop with varying 'if's above the
         // break.  In these cases, we need to update the mask of the lanes
         // that have executed a 'break' statement:
         // breakLanes = breakLanes | mask
-        AssertPos(currentPos, breakLanesAddressInfo != NULL);
+        AssertPos(currentPos, breakLanesAddressInfo != nullptr);
 
         llvm::Value *mask = GetInternalMask();
-        llvm::Value *breakMask = LoadInst(breakLanesAddressInfo, NULL, "break_mask");
+        llvm::Value *breakMask = LoadInst(breakLanesAddressInfo, nullptr, "break_mask");
         llvm::Value *newMask = BinaryOperator(llvm::Instruction::Or, mask, breakMask, "mask|break_mask");
         StoreInst(newMask, breakLanesAddressInfo);
 
@@ -711,7 +711,7 @@ void FunctionEmitContext::Break(bool doCoherenceCheck) {
         SetInternalMask(LLVMMaskAllOff);
 
         if (doCoherenceCheck) {
-            if (continueTarget != NULL)
+            if (continueTarget != nullptr)
                 // If the user has indicated that this is a 'coherent'
                 // break statement, then check to see if the mask is all
                 // off.  If so, we have to conservatively jump to the
@@ -719,7 +719,7 @@ void FunctionEmitContext::Break(bool doCoherenceCheck) {
                 // reason the mask is all off may be due to 'continue'
                 // statements that executed in the current loop iteration.
                 jumpIfAllLoopLanesAreDone(continueTarget);
-            else if (breakTarget != NULL)
+            else if (breakTarget != nullptr)
                 // Similarly handle these for switch statements, where we
                 // only have a break target.
                 jumpIfAllLoopLanesAreDone(breakTarget);
@@ -752,13 +752,13 @@ void FunctionEmitContext::Continue(bool doCoherenceCheck) {
         // executing.
         AddInstrumentationPoint("continue: uniform CF, jumped");
         BranchInst(continueTarget);
-        bblock = NULL;
+        bblock = nullptr;
     } else {
         // Otherwise update the stored value of which lanes have 'continue'd.
         // continueLanes = continueLanes | mask
         AssertPos(currentPos, continueLanesAddressInfo);
         llvm::Value *mask = GetInternalMask();
-        llvm::Value *continueMask = LoadInst(continueLanesAddressInfo, NULL, "continue_mask");
+        llvm::Value *continueMask = LoadInst(continueLanesAddressInfo, nullptr, "continue_mask");
         llvm::Value *newMask = BinaryOperator(llvm::Instruction::Or, mask, continueMask, "mask|continueMask");
         StoreInst(newMask, continueLanesAddressInfo);
 
@@ -794,22 +794,22 @@ bool FunctionEmitContext::ifsInCFAllUniform(int type) const {
 }
 
 void FunctionEmitContext::jumpIfAllLoopLanesAreDone(llvm::BasicBlock *target) {
-    llvm::Value *allDone = NULL;
+    llvm::Value *allDone = nullptr;
 
-    if (breakLanesAddressInfo == NULL) {
-        llvm::Value *continued = LoadInst(continueLanesAddressInfo, NULL, "continue_lanes");
+    if (breakLanesAddressInfo == nullptr) {
+        llvm::Value *continued = LoadInst(continueLanesAddressInfo, nullptr, "continue_lanes");
         continued = BinaryOperator(llvm::Instruction::And, continued, GetFunctionMask(), "continued&func");
         allDone = MasksAllEqual(continued, blockEntryMask);
     } else {
         // Check to see if (returned lanes | continued lanes | break lanes) is
         // equal to the value of mask at the start of the loop iteration.  If
         // so, everyone is done and we can jump to the given target
-        llvm::Value *returned = LoadInst(returnedLanesAddressInfo, NULL, "returned_lanes");
-        llvm::Value *breaked = LoadInst(breakLanesAddressInfo, NULL, "break_lanes");
+        llvm::Value *returned = LoadInst(returnedLanesAddressInfo, nullptr, "returned_lanes");
+        llvm::Value *breaked = LoadInst(breakLanesAddressInfo, nullptr, "break_lanes");
         llvm::Value *finishedLanes = BinaryOperator(llvm::Instruction::Or, returned, breaked, "returned|breaked");
-        if (continueLanesAddressInfo != NULL) {
-            // It's NULL for "switch" statements...
-            llvm::Value *continued = LoadInst(continueLanesAddressInfo, NULL, "continue_lanes");
+        if (continueLanesAddressInfo != nullptr) {
+            // It's nullptr for "switch" statements...
+            llvm::Value *continued = LoadInst(continueLanesAddressInfo, nullptr, "continue_lanes");
             finishedLanes =
                 BinaryOperator(llvm::Instruction::Or, finishedLanes, continued, "returned|breaked|continued");
         }
@@ -838,12 +838,12 @@ void FunctionEmitContext::jumpIfAllLoopLanesAreDone(llvm::BasicBlock *target) {
 }
 
 void FunctionEmitContext::RestoreContinuedLanes() {
-    if (continueLanesAddressInfo == NULL)
+    if (continueLanesAddressInfo == nullptr)
         return;
 
     // mask = mask & continueFlags
     llvm::Value *mask = GetInternalMask();
-    llvm::Value *continueMask = LoadInst(continueLanesAddressInfo, NULL, "continue_mask");
+    llvm::Value *continueMask = LoadInst(continueLanesAddressInfo, nullptr, "continue_mask");
     llvm::Value *orMask = BinaryOperator(llvm::Instruction::Or, mask, continueMask, "mask|continue_mask");
     SetInternalMask(orMask);
 
@@ -852,7 +852,7 @@ void FunctionEmitContext::RestoreContinuedLanes() {
 }
 
 void FunctionEmitContext::ClearBreakLanes() {
-    if (breakLanesAddressInfo == NULL)
+    if (breakLanesAddressInfo == nullptr)
         return;
 
     // breakLanes = 0
@@ -870,23 +870,23 @@ void FunctionEmitContext::StartSwitch(bool cfIsUniform, llvm::BasicBlock *bbBrea
     StoreInst(LLVMMaskAllOff, breakLanesAddressInfo);
     breakTarget = bbBreak;
 
-    continueLanesAddressInfo = NULL;
-    continueTarget = NULL;
-    blockEntryMask = NULL;
+    continueLanesAddressInfo = nullptr;
+    continueTarget = nullptr;
+    blockEntryMask = nullptr;
 
     // These will be set by the SwitchInst() method
-    switchExpr = NULL;
-    switchFallThroughMaskAddressInfo = NULL;
-    defaultBlock = NULL;
-    caseBlocks = NULL;
-    nextBlocks = NULL;
+    switchExpr = nullptr;
+    switchFallThroughMaskAddressInfo = nullptr;
+    defaultBlock = nullptr;
+    caseBlocks = nullptr;
+    nextBlocks = nullptr;
 }
 
 void FunctionEmitContext::EndSwitch() {
-    AssertPos(currentPos, bblock != NULL);
+    AssertPos(currentPos, bblock != nullptr);
 
     CFInfo *ci = popCFState();
-    if (ci->IsVarying() && bblock != NULL)
+    if (ci->IsVarying() && bblock != nullptr)
         restoreMaskGivenReturns(ci->savedMask);
 }
 
@@ -929,17 +929,17 @@ void FunctionEmitContext::EmitDefaultLabel(bool checkMask, SourcePos pos) {
 
     // If there's a default label in the switch, a basic block for it
     // should have been provided in the previous call to SwitchInst().
-    AssertPos(currentPos, defaultBlock != NULL);
+    AssertPos(currentPos, defaultBlock != nullptr);
 
 #ifdef ISPC_XE_ENABLED
-    llvm::BasicBlock *bbDefaultImpl = NULL;
+    llvm::BasicBlock *bbDefaultImpl = nullptr;
     if (emitXeHardwareMask()) {
         // Create basic block with actual default implementation
         bbDefaultImpl = CreateBasicBlock("default_impl", defaultBlock);
     }
 #endif
 
-    if (bblock != NULL) {
+    if (bblock != nullptr) {
         // The previous case in the switch fell through, or we're in a
         // varying switch; terminate the current block with a jump to the
         // block for the code for the default label.
@@ -971,7 +971,7 @@ void FunctionEmitContext::EmitDefaultLabel(bool checkMask, SourcePos pos) {
 
         for (auto e = caseBlocks->end(); caseBlocksIt != e; ++caseBlocksIt) {
             int value = caseBlocksIt->first;
-            llvm::Value *val = NULL;
+            llvm::Value *val = nullptr;
             if (llvm::isa<llvm::VectorType>(switchExpr->getType())) {
                 val = (switchExpr->getType() == LLVMTypes::Int32VectorType) ? LLVMInt32Vector(value)
                                                                             : LLVMInt64Vector(value);
@@ -1048,24 +1048,24 @@ void FunctionEmitContext::EmitCaseLabel(int value, bool checkMask, SourcePos pos
     }
 
     // Find the basic block for this case statement.
-    llvm::BasicBlock *bbCase = NULL;
-    AssertPos(currentPos, caseBlocks != NULL);
+    llvm::BasicBlock *bbCase = nullptr;
+    AssertPos(currentPos, caseBlocks != nullptr);
     for (int i = 0; i < (int)caseBlocks->size(); ++i)
         if ((*caseBlocks)[i].first == value) {
             bbCase = (*caseBlocks)[i].second;
             break;
         }
-    AssertPos(currentPos, bbCase != NULL);
+    AssertPos(currentPos, bbCase != nullptr);
 
 #ifdef ISPC_XE_ENABLED
-    llvm::BasicBlock *bbCaseImpl = NULL;
+    llvm::BasicBlock *bbCaseImpl = nullptr;
     if (emitXeHardwareMask()) {
         // Create basic block with actual case implementation
         bbCaseImpl = CreateBasicBlock(llvm::Twine(bbCase->getName()) + "_impl", bbCase);
     }
 #endif
 
-    if (bblock != NULL) {
+    if (bblock != nullptr) {
         // fall through from the previous case
 #ifdef ISPC_XE_ENABLED
         if (emitXeHardwareMask() && llvm::isa<llvm::VectorType>(switchExpr->getType())) {
@@ -1093,10 +1093,10 @@ void FunctionEmitContext::EmitCaseLabel(int value, bool checkMask, SourcePos pos
         llvm::BasicBlock *bbNext = iter->second;
 
         // Create compare value
-        llvm::Value *caseTest = NULL;
+        llvm::Value *caseTest = nullptr;
         if (llvm::isa<llvm::VectorType>(switchExpr->getType())) {
             // Take fall through lanes to turn them on in the next block
-            llvm::Value *fallThroughMask = LoadInst(switchFallThroughMaskAddressInfo, NULL, "fall_through_mask");
+            llvm::Value *fallThroughMask = LoadInst(switchFallThroughMaskAddressInfo, nullptr, "fall_through_mask");
             llvm::Value *val =
                 (switchExpr->getType() == LLVMTypes::Int32VectorType) ? LLVMInt32Vector(value) : LLVMInt64Vector(value);
             llvm::Value *cmpVal =
@@ -1171,7 +1171,7 @@ void FunctionEmitContext::SwitchInst(llvm::Value *expr, llvm::BasicBlock *bbDefa
 
         AddDebugPos(s);
         // switch is a terminator
-        bblock = NULL;
+        bblock = nullptr;
     } else {
         if (emitXeHardwareMask()) {
             // Init fall through mask
@@ -1187,11 +1187,11 @@ void FunctionEmitContext::SwitchInst(llvm::Value *expr, llvm::BasicBlock *bbDefa
             // one; any code before the first label won't be executed by
             // anyone.
             std::map<llvm::BasicBlock *, llvm::BasicBlock *>::const_iterator iter;
-            iter = nextBlocks->find(NULL);
+            iter = nextBlocks->find(nullptr);
             AssertPos(currentPos, iter != nextBlocks->end());
             llvm::BasicBlock *bbFirst = iter->second;
             BranchInst(bbFirst);
-            bblock = NULL;
+            bblock = nullptr;
         }
     }
 }
@@ -1217,7 +1217,7 @@ void FunctionEmitContext::EnableGatherScatterWarnings() { --disableGSWarningCoun
 
 bool FunctionEmitContext::initLabelBBlocks(ASTNode *node, void *data) {
     LabeledStmt *ls = llvm::dyn_cast<LabeledStmt>(node);
-    if (ls == NULL)
+    if (ls == nullptr)
         return true;
 
     FunctionEmitContext *ctx = (FunctionEmitContext *)data;
@@ -1233,14 +1233,14 @@ bool FunctionEmitContext::initLabelBBlocks(ASTNode *node, void *data) {
 
 void FunctionEmitContext::InitializeLabelMap(Stmt *code) {
     labelMap.erase(labelMap.begin(), labelMap.end());
-    WalkAST(code, initLabelBBlocks, NULL, this);
+    WalkAST(code, initLabelBBlocks, nullptr, this);
 }
 
 llvm::BasicBlock *FunctionEmitContext::GetLabeledBasicBlock(const std::string &label) {
     if (labelMap.find(label) != labelMap.end())
         return labelMap[label];
     else
-        return NULL;
+        return nullptr;
 }
 
 std::vector<std::string> FunctionEmitContext::GetLabels() {
@@ -1258,23 +1258,23 @@ std::vector<std::string> FunctionEmitContext::GetLabels() {
 void FunctionEmitContext::CurrentLanesReturned(Expr *expr, bool doCoherenceCheck) {
     const Type *returnType = function->GetReturnType();
     if (returnType->IsVoidType()) {
-        if (expr != NULL) {
+        if (expr != nullptr) {
             const Type *exprType = expr->GetType();
             Assert(exprType);
             Error(expr->pos, "Can't return non-void type \"%s\" from void function.", exprType->GetString().c_str());
         }
     } else {
-        if (expr == NULL) {
+        if (expr == nullptr) {
             Error(funcStartPos, "Must provide return value for return "
                                 "statement for non-void function.");
             return;
         }
 
         expr = TypeConvertExpr(expr, returnType, "return statement");
-        if (expr != NULL) {
+        if (expr != nullptr) {
             llvm::Value *retVal = expr->GetValue(this);
-            if (retVal != NULL) {
-                if (returnType->IsUniformType() || CastType<ReferenceType>(returnType) != NULL)
+            if (retVal != nullptr) {
+                if (returnType->IsUniformType() || CastType<ReferenceType>(returnType) != nullptr)
                     StoreInst(retVal, returnValueAddressInfo, returnType);
                 else {
                     // Use a masked store to store the value of the expression
@@ -1300,7 +1300,7 @@ void FunctionEmitContext::CurrentLanesReturned(Expr *expr, bool doCoherenceCheck
     } else {
         // Otherwise we update the returnedLanes value by ANDing it with
         // the current lane mask.
-        llvm::Value *oldReturnedLanes = LoadInst(returnedLanesAddressInfo, NULL, "old_returned_lanes");
+        llvm::Value *oldReturnedLanes = LoadInst(returnedLanesAddressInfo, nullptr, "old_returned_lanes");
         llvm::Value *newReturnedLanes =
             BinaryOperator(llvm::Instruction::Or, oldReturnedLanes, GetFullMask(), "old_mask|returned_lanes");
 
@@ -1329,19 +1329,19 @@ void FunctionEmitContext::CurrentLanesReturned(Expr *expr, bool doCoherenceCheck
 }
 
 void FunctionEmitContext::SetFunctionFTZ_DAZFlags() {
-    if (functionFTZ_DAZValue == NULL)
+    if (functionFTZ_DAZValue == nullptr)
         return;
     std::vector<Symbol *> mm;
     m->symbolTable->LookupFunction("__set_ftz_daz_flags", &mm);
     AssertPos(currentPos, mm.size() >= 1);
     llvm::Function *fmm = mm[0]->function;
     std::vector<llvm::Value *> args;
-    llvm::Value *oldFTZ = CallInst(fmm, NULL, args, "");
+    llvm::Value *oldFTZ = CallInst(fmm, nullptr, args, "");
     StoreInst(oldFTZ, functionFTZ_DAZValue);
 }
 
 void FunctionEmitContext::RestoreFunctionFTZ_DAZFlags() {
-    if (functionFTZ_DAZValue == NULL)
+    if (functionFTZ_DAZValue == nullptr)
         return;
     std::vector<Symbol *> mm;
     m->symbolTable->LookupFunction("__restore_ftz_daz_flags", &mm);
@@ -1350,7 +1350,7 @@ void FunctionEmitContext::RestoreFunctionFTZ_DAZFlags() {
     llvm::Value *oldFTZ = LoadInst(functionFTZ_DAZValue);
     std::vector<llvm::Value *> args;
     args.push_back(oldFTZ);
-    CallInst(fmm, NULL, args, "");
+    CallInst(fmm, nullptr, args, "");
 }
 
 llvm::Value *FunctionEmitContext::Any(llvm::Value *mask) {
@@ -1366,7 +1366,7 @@ llvm::Value *FunctionEmitContext::Any(llvm::Value *mask) {
     // We can actually call either one, since both are i32s as far as
     // LLVM's type system is concerned...
     llvm::Function *fmm = mm[0]->function;
-    return CallInst(fmm, NULL, mask, llvm::Twine(mask->getName()) + "_any");
+    return CallInst(fmm, nullptr, mask, llvm::Twine(mask->getName()) + "_any");
 }
 
 llvm::Value *FunctionEmitContext::All(llvm::Value *mask) {
@@ -1382,7 +1382,7 @@ llvm::Value *FunctionEmitContext::All(llvm::Value *mask) {
     // We can actually call either one, since both are i32s as far as
     // LLVM's type system is concerned...
     llvm::Function *fmm = mm[0]->function;
-    return CallInst(fmm, NULL, mask, llvm::Twine(mask->getName()) + "_all");
+    return CallInst(fmm, nullptr, mask, llvm::Twine(mask->getName()) + "_all");
 }
 
 llvm::Value *FunctionEmitContext::None(llvm::Value *mask) {
@@ -1398,7 +1398,7 @@ llvm::Value *FunctionEmitContext::None(llvm::Value *mask) {
     // We can actually call either one, since both are i32s as far as
     // LLVM's type system is concerned...
     llvm::Function *fmm = mm[0]->function;
-    return CallInst(fmm, NULL, mask, llvm::Twine(mask->getName()) + "_none");
+    return CallInst(fmm, nullptr, mask, llvm::Twine(mask->getName()) + "_none");
 }
 
 llvm::Value *FunctionEmitContext::LaneMask(llvm::Value *v) {
@@ -1416,7 +1416,7 @@ llvm::Value *FunctionEmitContext::LaneMask(llvm::Value *v) {
     // We can actually call either one, since both are i32s as far as
     // LLVM's type system is concerned...
     llvm::Function *fmm = mm[0]->function;
-    return CallInst(fmm, NULL, v, llvm::Twine(v->getName()) + "_movmsk");
+    return CallInst(fmm, nullptr, v, llvm::Twine(v->getName()) + "_movmsk");
 }
 
 llvm::Value *FunctionEmitContext::MasksAllEqual(llvm::Value *v1, llvm::Value *v2) {
@@ -1431,7 +1431,8 @@ llvm::Value *FunctionEmitContext::MasksAllEqual(llvm::Value *v1, llvm::Value *v2
 #else
     if (g->target->getArch() == Arch::wasm32) {
         llvm::Function *fmm = m->module->getFunction("__wasm_cmp_msk_eq");
-        return CallInst(fmm, NULL, {v1, v2}, ((llvm::Twine("wasm_cmp_msk_eq_") + v1->getName()) + "_") + v2->getName());
+        return CallInst(fmm, nullptr, {v1, v2},
+                        ((llvm::Twine("wasm_cmp_msk_eq_") + v1->getName()) + "_") + v2->getName());
     }
     llvm::Value *mm1 = LaneMask(v1);
     llvm::Value *mm2 = LaneMask(v2);
@@ -1468,9 +1469,9 @@ llvm::BasicBlock *FunctionEmitContext::CreateBasicBlock(const llvm::Twine &name,
 }
 
 llvm::Value *FunctionEmitContext::I1VecToBoolVec(llvm::Value *b) {
-    if (b == NULL) {
+    if (b == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::ArrayType *at = llvm::dyn_cast<llvm::ArrayType>(b->getType());
@@ -1509,7 +1510,7 @@ static llvm::Value *lGetStringAsValue(llvm::BasicBlock *bblock, const char *s) {
 }
 
 void FunctionEmitContext::AddInstrumentationPoint(const char *note) {
-    AssertPos(currentPos, note != NULL);
+    AssertPos(currentPos, note != nullptr);
     if (!g->emitInstrumentation)
         return;
 
@@ -1524,7 +1525,7 @@ void FunctionEmitContext::AddInstrumentationPoint(const char *note) {
     args.push_back(LaneMask(GetFullMask()));
 
     llvm::Function *finst = m->module->getFunction("ISPCInstrument");
-    CallInst(finst, NULL, args, "");
+    CallInst(finst, nullptr, args, "");
 }
 
 void FunctionEmitContext::SetDebugPos(SourcePos pos) { currentPos = pos; }
@@ -1533,7 +1534,7 @@ SourcePos FunctionEmitContext::GetDebugPos() const { return currentPos; }
 
 void FunctionEmitContext::AddDebugPos(llvm::Value *value, const SourcePos *pos, llvm::DIScope *scope) {
     llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(value);
-    if (inst != NULL && m->diBuilder) {
+    if (inst != nullptr && m->diBuilder) {
         SourcePos p = pos ? *pos : currentPos;
         if (p.first_line != 0) {
             // If first_line == 0, then we're in the middle of setting up
@@ -1548,7 +1549,7 @@ void FunctionEmitContext::AddDebugPos(llvm::Value *value, const SourcePos *pos, 
 }
 
 void FunctionEmitContext::StartScope() {
-    if (m->diBuilder != NULL) {
+    if (m->diBuilder != nullptr) {
         llvm::DIScope *parentScope;
         llvm::DILexicalBlock *lexicalBlock;
         if (debugScopes.size() > 0)
@@ -1564,7 +1565,7 @@ void FunctionEmitContext::StartScope() {
 }
 
 void FunctionEmitContext::EndScope() {
-    if (m->diBuilder != NULL) {
+    if (m->diBuilder != nullptr) {
         AssertPos(currentPos, debugScopes.size() > 0);
         debugScopes.pop_back();
     }
@@ -1576,7 +1577,7 @@ llvm::DIScope *FunctionEmitContext::GetDIScope() const {
 }
 
 void FunctionEmitContext::EmitVariableDebugInfo(Symbol *sym) {
-    if (m->diBuilder == NULL)
+    if (m->diBuilder == nullptr)
         return;
 
     llvm::DIScope *scope = GetDIScope();
@@ -1592,7 +1593,7 @@ void FunctionEmitContext::EmitVariableDebugInfo(Symbol *sym) {
 }
 
 void FunctionEmitContext::EmitFunctionParameterDebugInfo(Symbol *sym, int argNum) {
-    if (m->diBuilder == NULL)
+    if (m->diBuilder == nullptr)
         return;
 
     llvm::DINode::DIFlags flags = llvm::DINode::FlagZero;
@@ -1616,23 +1617,23 @@ void FunctionEmitContext::EmitFunctionParameterDebugInfo(Symbol *sym, int argNum
  */
 static int lArrayVectorWidth(llvm::Type *t) {
     llvm::ArrayType *arrayType = llvm::dyn_cast<llvm::ArrayType>(t);
-    if (arrayType == NULL) {
+    if (arrayType == nullptr) {
         return 0;
     }
 
     // We shouldn't be seeing arrays of anything but vectors being passed
     // to things like FunctionEmitContext::BinaryOperator() as operands.
     llvm::FixedVectorType *vectorElementType = llvm::dyn_cast<llvm::FixedVectorType>(arrayType->getElementType());
-    Assert((vectorElementType != NULL && (int)vectorElementType->getNumElements() == g->target->getVectorWidth()));
+    Assert((vectorElementType != nullptr && (int)vectorElementType->getNumElements() == g->target->getVectorWidth()));
 
     return (int)arrayType->getNumElements();
 }
 
 llvm::Value *FunctionEmitContext::BinaryOperator(llvm::Instruction::BinaryOps inst, llvm::Value *v0, llvm::Value *v1,
                                                  const llvm::Twine &name) {
-    if (v0 == NULL || v1 == NULL) {
+    if (v0 == nullptr || v1 == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     AssertPos(currentPos, v0->getType() == v1->getType());
@@ -1658,9 +1659,9 @@ llvm::Value *FunctionEmitContext::BinaryOperator(llvm::Instruction::BinaryOps in
 }
 
 llvm::Value *FunctionEmitContext::NotOperator(llvm::Value *v, const llvm::Twine &name) {
-    if (v == NULL) {
+    if (v == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     // Similarly to BinaryOperator, do the operation on all the elements of
@@ -1689,10 +1690,10 @@ llvm::Value *FunctionEmitContext::NotOperator(llvm::Value *v, const llvm::Twine 
 // be returned from CmpInst with ispc VectorTypes).
 static llvm::Type *lGetMatchingBoolVectorType(llvm::Type *type) {
     llvm::ArrayType *arrayType = llvm::dyn_cast<llvm::ArrayType>(type);
-    Assert(arrayType != NULL);
+    Assert(arrayType != nullptr);
 
     llvm::FixedVectorType *vectorElementType = llvm::dyn_cast<llvm::FixedVectorType>(arrayType->getElementType());
-    Assert(vectorElementType != NULL);
+    Assert(vectorElementType != nullptr);
     Assert((int)vectorElementType->getNumElements() == g->target->getVectorWidth());
 
     llvm::Type *base = LLVMVECTOR::get(LLVMTypes::BoolType, g->target->getVectorWidth());
@@ -1701,9 +1702,9 @@ static llvm::Type *lGetMatchingBoolVectorType(llvm::Type *type) {
 
 llvm::Value *FunctionEmitContext::CmpInst(llvm::Instruction::OtherOps inst, llvm::CmpInst::Predicate pred,
                                           llvm::Value *v0, llvm::Value *v1, const llvm::Twine &name) {
-    if (v0 == NULL || v1 == NULL) {
+    if (v0 == nullptr || v1 == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     AssertPos(currentPos, v0->getType() == v1->getType());
@@ -1728,17 +1729,17 @@ llvm::Value *FunctionEmitContext::CmpInst(llvm::Instruction::OtherOps inst, llvm
 }
 
 llvm::Value *FunctionEmitContext::SmearUniform(llvm::Value *value, const llvm::Twine &name) {
-    if (value == NULL) {
+    if (value == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
-    llvm::Value *ret = NULL;
+    llvm::Value *ret = nullptr;
     llvm::Type *eltType = value->getType();
-    llvm::Type *vecType = NULL;
+    llvm::Type *vecType = nullptr;
 
     llvm::PointerType *pt = llvm::dyn_cast<llvm::PointerType>(eltType);
-    if (pt != NULL) {
+    if (pt != nullptr) {
         // Varying pointers are represented as vectors of i32/i64s
         vecType = LLVMTypes::VoidPointerVectorType;
         value = PtrToIntInst(value);
@@ -1761,9 +1762,9 @@ llvm::Value *FunctionEmitContext::SmearUniform(llvm::Value *value, const llvm::T
 }
 
 llvm::Value *FunctionEmitContext::BitCastInst(llvm::Value *value, llvm::Type *type, const llvm::Twine &name) {
-    if (value == NULL) {
+    if (value == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::Instruction *inst = new llvm::BitCastInst(
@@ -1773,9 +1774,9 @@ llvm::Value *FunctionEmitContext::BitCastInst(llvm::Value *value, llvm::Type *ty
 }
 
 llvm::Value *FunctionEmitContext::PtrToIntInst(llvm::Value *value, const llvm::Twine &name) {
-    if (value == NULL) {
+    if (value == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (llvm::isa<llvm::VectorType>(value->getType()))
@@ -1790,9 +1791,9 @@ llvm::Value *FunctionEmitContext::PtrToIntInst(llvm::Value *value, const llvm::T
 }
 
 llvm::Value *FunctionEmitContext::PtrToIntInst(llvm::Value *value, llvm::Type *toType, const llvm::Twine &name) {
-    if (value == NULL) {
+    if (value == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::Type *fromType = value->getType();
@@ -1817,9 +1818,9 @@ llvm::Value *FunctionEmitContext::PtrToIntInst(llvm::Value *value, llvm::Type *t
 }
 
 llvm::Value *FunctionEmitContext::IntToPtrInst(llvm::Value *value, llvm::Type *toType, const llvm::Twine &name) {
-    if (value == NULL) {
+    if (value == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::Type *fromType = value->getType();
@@ -1844,9 +1845,9 @@ llvm::Value *FunctionEmitContext::IntToPtrInst(llvm::Value *value, llvm::Type *t
 }
 
 llvm::Instruction *FunctionEmitContext::TruncInst(llvm::Value *value, llvm::Type *type, const llvm::Twine &name) {
-    if (value == NULL) {
+    if (value == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     // TODO: we should probably handle the array case as in
@@ -1859,9 +1860,9 @@ llvm::Instruction *FunctionEmitContext::TruncInst(llvm::Value *value, llvm::Type
 
 llvm::Instruction *FunctionEmitContext::CastInst(llvm::Instruction::CastOps op, llvm::Value *value, llvm::Type *type,
                                                  const llvm::Twine &name) {
-    if (value == NULL) {
+    if (value == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     // TODO: we should probably handle the array case as in
@@ -1873,9 +1874,9 @@ llvm::Instruction *FunctionEmitContext::CastInst(llvm::Instruction::CastOps op, 
 }
 
 llvm::Instruction *FunctionEmitContext::FPCastInst(llvm::Value *value, llvm::Type *type, const llvm::Twine &name) {
-    if (value == NULL) {
+    if (value == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     // TODO: we should probably handle the array case as in
@@ -1887,9 +1888,9 @@ llvm::Instruction *FunctionEmitContext::FPCastInst(llvm::Value *value, llvm::Typ
 }
 
 llvm::Instruction *FunctionEmitContext::SExtInst(llvm::Value *value, llvm::Type *type, const llvm::Twine &name) {
-    if (value == NULL) {
+    if (value == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     // TODO: we should probably handle the array case as in
@@ -1901,9 +1902,9 @@ llvm::Instruction *FunctionEmitContext::SExtInst(llvm::Value *value, llvm::Type 
 }
 
 llvm::Instruction *FunctionEmitContext::ZExtInst(llvm::Value *value, llvm::Type *type, const llvm::Twine &name) {
-    if (value == NULL) {
+    if (value == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     // TODO: we should probably handle the array case as in
@@ -1925,11 +1926,11 @@ llvm::Value *FunctionEmitContext::applyVaryingGEP(llvm::Value *basePtr, llvm::Va
     // that the pointer(s) point(s) to.
     const Type *scaleType = ptrType->GetBaseType();
     llvm::Type *llvmScaleType = scaleType->LLVMType(g->ctx);
-    Assert(llvmScaleType != NULL);
+    Assert(llvmScaleType != nullptr);
     llvm::Value *scale = g->target->SizeOf(llvmScaleType, bblock);
 
     bool indexIsVarying = llvm::isa<llvm::VectorType>(index->getType());
-    llvm::Value *offset = NULL;
+    llvm::Value *offset = nullptr;
     if (indexIsVarying == false) {
         // Truncate or sign extend the index as appropriate to a 32 or
         // 64-bit type.
@@ -1954,7 +1955,7 @@ llvm::Value *FunctionEmitContext::applyVaryingGEP(llvm::Value *basePtr, llvm::Va
             index = SExtInst(index, LLVMTypes::Int64VectorType);
 
         scale = SmearUniform(scale);
-        Assert(index != NULL);
+        Assert(index != nullptr);
         // offset = index * scale
         offset = BinaryOperator(llvm::Instruction::Mul, scale, index,
                                 ((llvm::Twine("mul_") + scale->getName()) + "_") + index->getName());
@@ -2021,7 +2022,7 @@ static llvm::Value *lComputeSliceIndex(FunctionEmitContext *ctx, int soaWidth, l
     Assert((1 << logWidth) == soaWidth);
 
     ctx->MatchIntegerTypes(&indexValue, &ptrSliceOffset);
-    Assert(indexValue != NULL);
+    Assert(indexValue != nullptr);
     llvm::Type *indexType = indexValue->getType();
     llvm::Value *shift = LLVMIntAsType(logWidth, indexType);
     llvm::Value *mask = LLVMIntAsType(soaWidth - 1, indexType);
@@ -2057,7 +2058,7 @@ llvm::Value *FunctionEmitContext::MakeSlicePointer(llvm::Value *ptr, llvm::Value
 
 const PointerType *FunctionEmitContext::RegularizePointer(const Type *ptrRefType) {
     const PointerType *ptrType;
-    if (CastType<ReferenceType>(ptrRefType) != NULL)
+    if (CastType<ReferenceType>(ptrRefType) != nullptr)
         ptrType = PointerType::GetUniform(ptrRefType->GetReferenceTarget());
     else {
         ptrType = CastType<PointerType>(ptrRefType);
@@ -2067,9 +2068,9 @@ const PointerType *FunctionEmitContext::RegularizePointer(const Type *ptrRefType
 
 llvm::Value *FunctionEmitContext::GetElementPtrInst(llvm::Value *basePtr, llvm::Value *index, const Type *ptrRefType,
                                                     const llvm::Twine &name) {
-    if (basePtr == NULL || index == NULL) {
+    if (basePtr == nullptr || index == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     // Regularize to a standard pointer type for basePtr's type
@@ -2094,9 +2095,9 @@ llvm::Value *FunctionEmitContext::GetElementPtrInst(llvm::Value *basePtr, llvm::
         // Handle the indexing into the soa<> structs with the major
         // component of the index through a recursive call
         llvm::Value *p = GetElementPtrInst(ExtractInst(basePtr, 0), index, ptrType->GetAsNonSlice(), name);
-        if (p == NULL) {
+        if (p == nullptr) {
             AssertPos(currentPos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
         // And mash the results together for the return value
         return MakeSlicePointer(p, ptrSliceOffset);
@@ -2127,9 +2128,9 @@ llvm::Value *FunctionEmitContext::GetElementPtrInst(llvm::Value *basePtr, llvm::
 
 llvm::Value *FunctionEmitContext::GetElementPtrInst(llvm::Value *basePtr, llvm::Value *index0, llvm::Value *index1,
                                                     const Type *ptrRefType, const llvm::Twine &name) {
-    if (basePtr == NULL || index0 == NULL || index1 == NULL) {
+    if (basePtr == nullptr || index0 == nullptr || index1 == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     // Regularize the pointer type for basePtr
@@ -2149,9 +2150,9 @@ llvm::Value *FunctionEmitContext::GetElementPtrInst(llvm::Value *basePtr, llvm::
         }
 
         llvm::Value *p = GetElementPtrInst(ExtractInst(basePtr, 0), index0, index1, ptrType->GetAsNonSlice(), name);
-        if (p == NULL) {
+        if (p == nullptr) {
             AssertPos(currentPos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
         return MakeSlicePointer(p, ptrSliceOffset);
     }
@@ -2177,7 +2178,7 @@ llvm::Value *FunctionEmitContext::GetElementPtrInst(llvm::Value *basePtr, llvm::
         // out the type of ptr0.
         const Type *baseType = ptrType->GetBaseType();
         const SequentialType *st = CastType<SequentialType>(baseType);
-        AssertPos(currentPos, st != NULL);
+        AssertPos(currentPos, st != nullptr);
 
         bool ptr0IsUniform = llvm::isa<llvm::PointerType>(ptr0->getType());
         const Type *ptr0BaseType = st->GetElementType();
@@ -2191,19 +2192,19 @@ llvm::Value *FunctionEmitContext::GetElementPtrInst(llvm::Value *basePtr, llvm::
 llvm::Value *FunctionEmitContext::AddElementOffset(AddressInfo *fullBasePtrInfo, int elementNum,
                                                    const llvm::Twine &name, const PointerType **resultPtrType) {
     llvm::Value *fullBasePtr = fullBasePtrInfo->getPointer();
-    if (resultPtrType != NULL)
-        AssertPos(currentPos, fullBasePtrInfo->getISPCType() != NULL);
+    if (resultPtrType != nullptr)
+        AssertPos(currentPos, fullBasePtrInfo->getISPCType() != nullptr);
 
     llvm::StructType *llvmStructType = llvm::dyn_cast<llvm::StructType>(fullBasePtrInfo->getElementType());
-    if (llvmStructType != NULL && llvmStructType->isSized() == false) {
+    if (llvmStructType != nullptr && llvmStructType->isSized() == false) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
-    // (Unfortunately) it's not required to have a non-NULL ispcType in fullBasePtrInfo, but
+    // (Unfortunately) it's not required to have a non-nullptr ispcType in fullBasePtrInfo, but
     // if we have one, regularize into a pointer type.
-    const PointerType *ptrType = NULL;
-    if (fullBasePtrInfo->getISPCType() != NULL) {
+    const PointerType *ptrType = nullptr;
+    if (fullBasePtrInfo->getISPCType() != nullptr) {
         ptrType = RegularizePointer(fullBasePtrInfo->getISPCType());
     }
 
@@ -2214,28 +2215,28 @@ llvm::Value *FunctionEmitContext::AddElementOffset(AddressInfo *fullBasePtrInfo,
     bool baseIsSlicePtr = llvm::isa<llvm::StructType>(fullBasePtr->getType());
     const PointerType *rpt;
     if (baseIsSlicePtr) {
-        AssertPos(currentPos, ptrType != NULL);
+        AssertPos(currentPos, ptrType != nullptr);
         // Update basePtr to just be the part that actually points to the
         // start of an soa<> struct for now; the element offset computation
         // doesn't change the slice offset, so we'll incorporate that into
         // the final value right before this method returns.
         basePtr = ExtractInst(fullBasePtr, 0);
-        if (resultPtrType == NULL)
+        if (resultPtrType == nullptr)
             resultPtrType = &rpt;
     }
 
     // Return the pointer type of the result of this call, for callers that
     // want it.
-    if (resultPtrType != NULL) {
-        AssertPos(currentPos, ptrType != NULL);
+    if (resultPtrType != nullptr) {
+        AssertPos(currentPos, ptrType != nullptr);
         const CollectionType *ct = CastType<CollectionType>(ptrType->GetBaseType());
-        AssertPos(currentPos, ct != NULL);
+        AssertPos(currentPos, ct != nullptr);
         *resultPtrType = new PointerType(ct->GetElementType(elementNum), ptrType->GetVariability(),
                                          ptrType->IsConstType(), ptrType->IsSlice());
     }
 
-    llvm::Value *resultPtr = NULL;
-    if (ptrType == NULL || ptrType->IsUniformType()) {
+    llvm::Value *resultPtr = nullptr;
+    if (ptrType == nullptr || ptrType->IsUniformType()) {
         // If the pointer is uniform, we can use the regular LLVM GEP.
         llvm::Value *offsets[2] = {LLVMInt32(0), LLVMInt32(elementNum)};
         llvm::ArrayRef<llvm::Value *> arrayRef(&offsets[0], &offsets[2]);
@@ -2245,8 +2246,8 @@ llvm::Value *FunctionEmitContext::AddElementOffset(AddressInfo *fullBasePtrInfo,
         // Otherwise do the math to find the offset and add it to the given
         // varying pointers
         const StructType *st = CastType<StructType>(ptrType->GetBaseType());
-        llvm::Value *offset = NULL;
-        if (st != NULL)
+        llvm::Value *offset = nullptr;
+        if (st != nullptr)
             // If the pointer is to a structure, Target::StructOffset() gives
             // us the offset in bytes to the given element of the structure
             offset = g->target->StructOffset(st->LLVMType(g->ctx), elementNum, bblock);
@@ -2255,7 +2256,7 @@ llvm::Value *FunctionEmitContext::AddElementOffset(AddressInfo *fullBasePtrInfo,
             // is given by the element number times the size of the element
             // type of the vector.
             const SequentialType *st = CastType<SequentialType>(ptrType->GetBaseType());
-            AssertPos(currentPos, st != NULL);
+            AssertPos(currentPos, st != nullptr);
             llvm::Type *elemLLVMType = st->GetElementType()->LLVMType(g->ctx);
             Assert(elemLLVMType);
             llvm::Value *size = g->target->SizeOf(elemLLVMType, bblock);
@@ -2284,9 +2285,9 @@ llvm::Value *FunctionEmitContext::AddElementOffset(AddressInfo *fullBasePtrInfo,
 }
 
 llvm::Value *FunctionEmitContext::SwitchBoolSize(llvm::Value *value, llvm::Type *toType, const llvm::Twine &name) {
-    if ((value == NULL) || (toType == NULL)) {
+    if ((value == nullptr) || (toType == nullptr)) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::Type *fromType = value->getType();
@@ -2306,13 +2307,13 @@ llvm::Value *FunctionEmitContext::SwitchBoolSize(llvm::Value *value, llvm::Type 
 }
 
 llvm::Value *FunctionEmitContext::LoadInst(AddressInfo *ptrInfo, const Type *type, const llvm::Twine &name) {
-    if (ptrInfo == NULL) {
+    if (ptrInfo == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     llvm::Value *ptr = ptrInfo->getPointer();
     llvm::PointerType *pt = llvm::dyn_cast<llvm::PointerType>(ptr->getType());
-    AssertPos(currentPos, pt != NULL);
+    AssertPos(currentPos, pt != nullptr);
 
     llvm::LoadInst *inst =
         new llvm::LoadInst(ptrInfo->getElementType(), ptr,
@@ -2326,12 +2327,12 @@ llvm::Value *FunctionEmitContext::LoadInst(AddressInfo *ptrInfo, const Type *typ
 
     llvm::Value *loadVal = inst;
     // bool type is stored as i8. So, it requires some processing.
-    if ((type != NULL) && (type->IsBoolType())) {
-        if (CastType<AtomicType>(type) != NULL) {
+    if ((type != nullptr) && (type->IsBoolType())) {
+        if (CastType<AtomicType>(type) != nullptr) {
             loadVal = SwitchBoolSize(loadVal, type->LLVMType(g->ctx));
-        } else if ((CastType<VectorType>(type) != NULL)) {
+        } else if ((CastType<VectorType>(type) != nullptr)) {
             const VectorType *vType = CastType<VectorType>(type);
-            if (CastType<AtomicType>(vType->GetElementType()) != NULL) {
+            if (CastType<AtomicType>(vType->GetElementType()) != nullptr) {
                 loadVal = SwitchBoolSize(loadVal, type->LLVMType(g->ctx));
             }
         }
@@ -2344,7 +2345,7 @@ llvm::Value *FunctionEmitContext::LoadInst(AddressInfo *ptrInfo, const Type *typ
     the appropriate individual data element(s).
  */
 static llvm::Value *lFinalSliceOffset(FunctionEmitContext *ctx, llvm::Value *ptr, const PointerType **ptrType) {
-    Assert(CastType<PointerType>(*ptrType) != NULL);
+    Assert(CastType<PointerType>(*ptrType) != nullptr);
 
     llvm::Value *slicePtr = ctx->ExtractInst(ptr, 0, llvm::Twine(ptr->getName()) + "_ptr");
     llvm::Value *sliceOffset = ctx->ExtractInst(ptr, 1, llvm::Twine(ptr->getName()) + "_offset");
@@ -2377,7 +2378,7 @@ llvm::Value *FunctionEmitContext::loadUniformFromSOA(llvm::Value *ptr, llvm::Val
     const Type *unifType = ptrType->GetBaseType()->GetAsUniformType();
 
     const CollectionType *ct = CastType<CollectionType>(ptrType->GetBaseType());
-    if (ct != NULL) {
+    if (ct != nullptr) {
         // If we have a struct/array, we need to decompose it into
         // individual element loads to fill in the result structure since
         // the SOA slice of values we need isn't contiguous in memory...
@@ -2403,16 +2404,16 @@ llvm::Value *FunctionEmitContext::loadUniformFromSOA(llvm::Value *ptr, llvm::Val
 
 llvm::Value *FunctionEmitContext::LoadInst(llvm::Value *ptr, llvm::Value *mask, const Type *ptrRefType,
                                            const llvm::Twine &name, bool one_elem) {
-    if (ptr == NULL) {
+    if (ptr == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
-    AssertPos(currentPos, ptrRefType != NULL && mask != NULL);
+    AssertPos(currentPos, ptrRefType != nullptr && mask != nullptr);
 
     const PointerType *ptrType = RegularizePointer(ptrRefType);
     const Type *elType;
-    if (CastType<ReferenceType>(ptrRefType) != NULL) {
+    if (CastType<ReferenceType>(ptrRefType) != nullptr) {
         elType = ptrRefType->GetReferenceTarget();
     } else {
         elType = ptrType->GetBaseType();
@@ -2421,7 +2422,7 @@ llvm::Value *FunctionEmitContext::LoadInst(llvm::Value *ptr, llvm::Value *mask, 
     if (CastType<UndefinedStructType>(ptrType->GetBaseType())) {
         Error(currentPos, "Unable to load to undefined struct type \"%s\".",
               ptrType->GetBaseType()->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
 
     if (ptrType->IsUniformType()) {
@@ -2443,7 +2444,7 @@ llvm::Value *FunctionEmitContext::LoadInst(llvm::Value *ptr, llvm::Value *mask, 
                 llvmPtrType, ptr, name.isTriviallyEmpty() ? (llvm::Twine(ptr->getName()) + "_load") : name,
                 false /* not volatile */, bblock);
 
-            if (atomicType != NULL && atomicType->IsVaryingType()) {
+            if (atomicType != nullptr && atomicType->IsVaryingType()) {
                 // We actually just want to align to the vector element
                 // alignment, but can't easily get that here, so just tell LLVM
                 // it's totally unaligned.  (This shouldn't make any difference
@@ -2456,7 +2457,7 @@ llvm::Value *FunctionEmitContext::LoadInst(llvm::Value *ptr, llvm::Value *mask, 
             AddDebugPos(inst);
             llvm::Value *loadVal = inst;
             // bool type is stored as i8. So, it requires some processing.
-            if (elType->IsBoolType() && (CastType<AtomicType>(elType) != NULL)) {
+            if (elType->IsBoolType() && (CastType<AtomicType>(elType) != nullptr)) {
                 loadVal = SwitchBoolSize(loadVal, elType->LLVMType(g->ctx));
             }
             return loadVal;
@@ -2485,11 +2486,11 @@ llvm::Value *FunctionEmitContext::LoadInst(llvm::Value *ptr, llvm::Value *mask, 
         // We can actually call either one, since both are i32s as far as
         // LLVM's type system is concerned...
         llvm::Function *fmm = mm[0]->function;
-        llvm::Value *int_mask = CallInst(fmm, NULL, mask, llvm::Twine(mask->getName()) + "_movmsk");
+        llvm::Value *int_mask = CallInst(fmm, nullptr, mask, llvm::Twine(mask->getName()) + "_movmsk");
         std::vector<Symbol *> lz;
         m->symbolTable->LookupFunction("__count_trailing_zeros_i64", &lz);
         llvm::Function *flz = lz[0]->function;
-        llvm::Value *elem_idx = CallInst(flz, NULL, int_mask, llvm::Twine(mask->getName()) + "_clz");
+        llvm::Value *elem_idx = CallInst(flz, nullptr, int_mask, llvm::Twine(mask->getName()) + "_clz");
         llvm::Value *elem = llvm::ExtractElementInst::Create(
             gather_result, elem_idx, llvm::Twine(gather_result->getName()) + "_umasked_elem", bblock);
         return elem;
@@ -2504,7 +2505,7 @@ llvm::Value *FunctionEmitContext::gather(llvm::Value *ptr, const PointerType *pt
     const Type *returnType = ptrType->GetBaseType()->GetAsVaryingType();
     llvm::Type *llvmReturnType = returnType->LLVMType(g->ctx);
     const CollectionType *collectionType = CastType<CollectionType>(ptrType->GetBaseType());
-    if (collectionType != NULL) {
+    if (collectionType != nullptr) {
         // For collections, recursively gather element wise to find the
         // result.
         llvm::Value *retValue = llvm::UndefValue::get(llvmReturnType);
@@ -2542,8 +2543,8 @@ llvm::Value *FunctionEmitContext::gather(llvm::Value *ptr, const PointerType *pt
     // Figure out which gather function to call based on the size of
     // the elements.
     const PointerType *pt = CastType<PointerType>(returnType);
-    const char *funcName = NULL;
-    if (pt != NULL)
+    const char *funcName = nullptr;
+    if (pt != nullptr)
         funcName = g->target->is32Bit() ? "__pseudo_gather32_i32" : "__pseudo_gather64_i64";
     // bool type is stored as i8.
     else if (returnType->IsBoolType())
@@ -2566,7 +2567,7 @@ llvm::Value *FunctionEmitContext::gather(llvm::Value *ptr, const PointerType *pt
     }
 
     llvm::Function *gatherFunc = m->module->getFunction(funcName);
-    AssertPos(currentPos, gatherFunc != NULL);
+    AssertPos(currentPos, gatherFunc != nullptr);
 #ifdef ISPC_XE_ENABLED
     if (emitXeHardwareMask()) {
         // Predicate ISPC mask with Xe execution mask so
@@ -2575,7 +2576,7 @@ llvm::Value *FunctionEmitContext::gather(llvm::Value *ptr, const PointerType *pt
     }
 #endif
 
-    llvm::Value *gatherCall = CallInst(gatherFunc, NULL, ptr, mask, name);
+    llvm::Value *gatherCall = CallInst(gatherFunc, nullptr, ptr, mask, name);
 
     // Add metadata about the source file location so that the
     // optimization passes can print useful performance warnings if we
@@ -2613,7 +2614,7 @@ llvm::Value *FunctionEmitContext::gather(llvm::Value *ptr, const PointerType *pt
 */
 void FunctionEmitContext::addGSMetadata(llvm::Value *v, SourcePos pos) {
     llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(v);
-    if (inst == NULL)
+    if (inst == nullptr)
         return;
     llvm::MDString *str = llvm::MDString::get(*g->ctx, pos.name);
     llvm::MDNode *md = llvm::MDNode::get(*g->ctx, str);
@@ -2660,12 +2661,12 @@ llvm::Value *FunctionEmitContext::AddrSpaceCastInst(llvm::Value *val, AddressSpa
 
 AddressInfo *FunctionEmitContext::AllocaInst(llvm::Type *llvmType, llvm::Value *size, const llvm::Twine &name,
                                              int align, bool atEntryBlock) {
-    if ((llvmType == NULL) || (size == NULL)) {
+    if ((llvmType == nullptr) || (size == nullptr)) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
-    llvm::AllocaInst *inst = NULL;
+    llvm::AllocaInst *inst = nullptr;
     unsigned AS = llvmFunction->getParent()->getDataLayout().getAllocaAddrSpace();
     if (atEntryBlock) {
         // We usually insert it right before the jump instruction at the
@@ -2685,7 +2686,7 @@ AddressInfo *FunctionEmitContext::AllocaInst(llvm::Type *llvmType, llvm::Value *
     // what will be aligned accesses if the uniform -> varying load is done
     // in regular chunks.
     llvm::ArrayType *arrayType = llvm::dyn_cast<llvm::ArrayType>(llvmType);
-    if (align == 0 && arrayType != NULL && !llvm::isa<llvm::VectorType>(arrayType->getElementType()))
+    if (align == 0 && arrayType != nullptr && !llvm::isa<llvm::VectorType>(arrayType->getElementType()))
         align = g->target->getNativeVectorAlignment();
 
     if (align != 0) {
@@ -2697,12 +2698,12 @@ AddressInfo *FunctionEmitContext::AllocaInst(llvm::Type *llvmType, llvm::Value *
 
 AddressInfo *FunctionEmitContext::AllocaInst(llvm::Type *llvmType, const llvm::Twine &name, int align,
                                              bool atEntryBlock) {
-    if (llvmType == NULL) {
+    if (llvmType == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
-    llvm::AllocaInst *inst = NULL;
+    llvm::AllocaInst *inst = nullptr;
     unsigned AS = llvmFunction->getParent()->getDataLayout().getAllocaAddrSpace();
     if (atEntryBlock) {
         // We usually insert it right before the jump instruction at the
@@ -2722,7 +2723,7 @@ AddressInfo *FunctionEmitContext::AllocaInst(llvm::Type *llvmType, const llvm::T
     // what will be aligned accesses if the uniform -> varying load is done
     // in regular chunks.
     llvm::ArrayType *arrayType = llvm::dyn_cast<llvm::ArrayType>(llvmType);
-    if (align == 0 && arrayType != NULL && !llvm::isa<llvm::VectorType>(arrayType->getElementType()))
+    if (align == 0 && arrayType != nullptr && !llvm::isa<llvm::VectorType>(arrayType->getElementType()))
         align = g->target->getNativeVectorAlignment();
 
     if (align != 0) {
@@ -2734,15 +2735,15 @@ AddressInfo *FunctionEmitContext::AllocaInst(llvm::Type *llvmType, const llvm::T
 
 AddressInfo *FunctionEmitContext::AllocaInst(const Type *ptrType, const llvm::Twine &name, int align,
                                              bool atEntryBlock) {
-    if (ptrType == NULL) {
+    if (ptrType == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::Type *llvmStorageType = ptrType->LLVMType(g->ctx);
-    if ((((CastType<AtomicType>(ptrType) != NULL) || (CastType<VectorType>(ptrType) != NULL)) &&
+    if ((((CastType<AtomicType>(ptrType) != nullptr) || (CastType<VectorType>(ptrType) != nullptr)) &&
          (ptrType->IsBoolType())) ||
-        ((CastType<ArrayType>(ptrType) != NULL) && (ptrType->GetBaseType()->IsBoolType()))) {
+        ((CastType<ArrayType>(ptrType) != nullptr) && (ptrType->GetBaseType()->IsBoolType()))) {
         llvmStorageType = ptrType->LLVMStorageType(g->ctx);
     }
 
@@ -2756,23 +2757,23 @@ AddressInfo *FunctionEmitContext::AllocaInst(const Type *ptrType, const llvm::Tw
     instance (that case is handled by scatters).
  */
 void FunctionEmitContext::maskedStore(llvm::Value *value, llvm::Value *ptr, const Type *ptrType, llvm::Value *mask) {
-    if (value == NULL || ptr == NULL) {
+    if (value == nullptr || ptr == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
         return;
     }
 
-    AssertPos(currentPos, CastType<PointerType>(ptrType) != NULL);
+    AssertPos(currentPos, CastType<PointerType>(ptrType) != nullptr);
     AssertPos(currentPos, ptrType->IsUniformType());
 
     const Type *valueType = ptrType->GetBaseType();
     const CollectionType *collectionType = CastType<CollectionType>(valueType);
-    if (collectionType != NULL) {
+    if (collectionType != nullptr) {
         // Assigning a structure / array / vector. Handle each element
         // individually with what turns into a recursive call to
         // makedStore()
         for (int i = 0; i < collectionType->GetElementCount(); ++i) {
             const Type *eltType = collectionType->GetElementType(i);
-            if (eltType == NULL) {
+            if (eltType == nullptr) {
                 Assert(m->errorCount > 0);
                 continue;
             }
@@ -2790,16 +2791,16 @@ void FunctionEmitContext::maskedStore(llvm::Value *value, llvm::Value *ptr, cons
     valueType = valueType->GetAsNonConstType();
 
     // Figure out if we need a 8, 16, 32 or 64-bit masked store.
-    llvm::Function *maskedStoreFunc = NULL;
+    llvm::Function *maskedStoreFunc = nullptr;
     llvm::Type *llvmValueType = value->getType();
     llvm::Type *llvmValueStorageType = llvmValueType;
 
     const PointerType *pt = CastType<PointerType>(valueType);
     // bool type is stored as i8. So, it requires some processing.
-    if ((pt == NULL) && (valueType->IsBoolType())) {
+    if ((pt == nullptr) && (valueType->IsBoolType())) {
         llvmValueStorageType = LLVMTypes::BoolVectorStorageType;
     }
-    if (pt != NULL) {
+    if (pt != nullptr) {
         if (pt->IsSlice()) {
             // Masked store of (varying) slice pointer.
             AssertPos(currentPos, pt->IsVaryingType());
@@ -2849,7 +2850,7 @@ void FunctionEmitContext::maskedStore(llvm::Value *value, llvm::Value *ptr, cons
         maskedStoreFunc = m->module->getFunction("__pseudo_masked_store_i8");
         value = SwitchBoolSize(value, llvmValueStorageType);
     }
-    AssertPos(currentPos, maskedStoreFunc != NULL);
+    AssertPos(currentPos, maskedStoreFunc != nullptr);
 
 #ifdef ISPC_XE_ENABLED
     if (emitXeHardwareMask()) {
@@ -2861,7 +2862,7 @@ void FunctionEmitContext::maskedStore(llvm::Value *value, llvm::Value *ptr, cons
     args.push_back(value);
     args.push_back(mask);
 
-    CallInst(maskedStoreFunc, NULL, args);
+    CallInst(maskedStoreFunc, nullptr, args);
 }
 
 /** Scatter the given varying value to the locations given by the varying
@@ -2873,10 +2874,10 @@ void FunctionEmitContext::maskedStore(llvm::Value *value, llvm::Value *ptr, cons
 void FunctionEmitContext::scatter(llvm::Value *value, llvm::Value *ptr, const Type *valueType, const Type *origPt,
                                   llvm::Value *mask) {
     const PointerType *ptrType = CastType<PointerType>(origPt);
-    AssertPos(currentPos, ptrType != NULL);
+    AssertPos(currentPos, ptrType != nullptr);
     AssertPos(currentPos, ptrType->IsVaryingType());
     const CollectionType *srcCollectionType = CastType<CollectionType>(valueType);
-    if (srcCollectionType != NULL) {
+    if (srcCollectionType != nullptr) {
         // We're scattering a collection type--we need to keep track of the
         // source type (the type of the data values to be stored) and the
         // destination type (the type of objects in memory that will be
@@ -2886,7 +2887,7 @@ void FunctionEmitContext::scatter(llvm::Value *value, llvm::Value *ptr, const Ty
         // same struct type, versus scattering into an array of varying
         // instances of the struct type, etc.
         const CollectionType *dstCollectionType = CastType<CollectionType>(ptrType->GetBaseType());
-        AssertPos(currentPos, dstCollectionType != NULL);
+        AssertPos(currentPos, dstCollectionType != nullptr);
 
         // Scatter the collection elements individually
         for (int i = 0; i < srcCollectionType->GetElementCount(); ++i) {
@@ -2933,17 +2934,17 @@ void FunctionEmitContext::scatter(llvm::Value *value, llvm::Value *ptr, const Ty
 
     // And everything should be a pointer or atomic (or enum) from here on out...
     AssertPos(currentPos,
-              pt != NULL || CastType<AtomicType>(valueType) != NULL || CastType<EnumType>(valueType) != NULL);
+              pt != nullptr || CastType<AtomicType>(valueType) != nullptr || CastType<EnumType>(valueType) != nullptr);
 
     llvm::Type *llvmStorageType = value->getType();
     ;
     // bool type is stored as i8. So, it requires some processing.
-    if ((pt == NULL) && (valueType->IsBoolType())) {
+    if ((pt == nullptr) && (valueType->IsBoolType())) {
         llvmStorageType = LLVMTypes::BoolVectorStorageType;
         value = SwitchBoolSize(value, llvmStorageType);
     }
-    const char *funcName = NULL;
-    if (pt != NULL) {
+    const char *funcName = nullptr;
+    if (pt != nullptr) {
         funcName = g->target->is32Bit() ? "__pseudo_scatter32_i32" : "__pseudo_scatter64_i64";
     } else if (llvmStorageType == LLVMTypes::DoubleVectorType) {
         funcName = g->target->is32Bit() ? "__pseudo_scatter32_double" : "__pseudo_scatter64_double";
@@ -2962,7 +2963,7 @@ void FunctionEmitContext::scatter(llvm::Value *value, llvm::Value *ptr, const Ty
     }
 
     llvm::Function *scatterFunc = m->module->getFunction(funcName);
-    AssertPos(currentPos, scatterFunc != NULL);
+    AssertPos(currentPos, scatterFunc != nullptr);
 
     AddInstrumentationPoint("scatter");
 #ifdef ISPC_XE_ENABLED
@@ -2976,14 +2977,14 @@ void FunctionEmitContext::scatter(llvm::Value *value, llvm::Value *ptr, const Ty
     args.push_back(ptr);
     args.push_back(value);
     args.push_back(mask);
-    llvm::Value *inst = CallInst(scatterFunc, NULL, args);
+    llvm::Value *inst = CallInst(scatterFunc, nullptr, args);
 
     if (disableGSWarningCount == 0)
         addGSMetadata(inst, currentPos);
 }
 
 void FunctionEmitContext::StoreInst(llvm::Value *value, AddressInfo *ptrInfo, const Type *ptrType) {
-    if (value == NULL || ptrInfo == NULL) {
+    if (value == nullptr || ptrInfo == nullptr) {
         // may happen due to error elsewhere
         AssertPos(currentPos, m->errorCount > 0);
         return;
@@ -2991,13 +2992,13 @@ void FunctionEmitContext::StoreInst(llvm::Value *value, AddressInfo *ptrInfo, co
     llvm::Value *ptr = ptrInfo->getPointer();
 
     llvm::PointerType *pt = llvm::dyn_cast<llvm::PointerType>(ptr->getType());
-    AssertPos(currentPos, pt != NULL);
-    if ((ptrType != NULL) && (ptrType->IsBoolType())) {
-        if ((CastType<AtomicType>(ptrType) != NULL)) {
+    AssertPos(currentPos, pt != nullptr);
+    if ((ptrType != nullptr) && (ptrType->IsBoolType())) {
+        if ((CastType<AtomicType>(ptrType) != nullptr)) {
             value = SwitchBoolSize(value, ptrType->LLVMStorageType(g->ctx));
-        } else if (CastType<VectorType>(ptrType) != NULL) {
+        } else if (CastType<VectorType>(ptrType) != nullptr) {
             const VectorType *vType = CastType<VectorType>(ptrType);
-            if (CastType<AtomicType>(vType->GetElementType()) != NULL) {
+            if (CastType<AtomicType>(vType->GetElementType()) != nullptr) {
                 value = SwitchBoolSize(value, ptrType->LLVMStorageType(g->ctx));
             }
         }
@@ -3014,7 +3015,7 @@ void FunctionEmitContext::StoreInst(llvm::Value *value, AddressInfo *ptrInfo, co
 
 void FunctionEmitContext::StoreInst(llvm::Value *value, llvm::Value *ptr, llvm::Value *mask, const Type *valueType,
                                     const Type *ptrRefType) {
-    if (value == NULL || ptr == NULL) {
+    if (value == nullptr || ptr == nullptr) {
         // may happen due to error elsewhere
         AssertPos(currentPos, m->errorCount > 0);
         return;
@@ -3059,7 +3060,7 @@ void FunctionEmitContext::storeUniformToSOA(llvm::Value *value, llvm::Value *ptr
     AssertPos(currentPos, Type::EqualIgnoringConst(ptrType->GetBaseType()->GetAsUniformType(), valueType));
 
     const CollectionType *ct = CastType<CollectionType>(valueType);
-    if (ct != NULL) {
+    if (ct != nullptr) {
         // Handle collections element wise...
         for (int i = 0; i < ct->GetElementCount(); ++i) {
             llvm::Value *eltValue = ExtractInst(value, i);
@@ -3084,7 +3085,7 @@ void FunctionEmitContext::MemcpyInst(llvm::Value *dest, llvm::Value *src, llvm::
         AssertPos(currentPos, count->getType() == LLVMTypes::Int32Type);
         count = ZExtInst(count, LLVMTypes::Int64Type, "count_to_64");
     }
-    if (align == NULL)
+    if (align == nullptr)
         align = LLVMInt32(1);
     llvm::FunctionCallee mcFuncCallee =
 #ifdef ISPC_OPAQUE_PTR_MODE
@@ -3095,7 +3096,7 @@ void FunctionEmitContext::MemcpyInst(llvm::Value *dest, llvm::Value *src, llvm::
                                        LLVMTypes::VoidPointerType, LLVMTypes::Int64Type, LLVMTypes::BoolType);
 #endif
     llvm::Constant *mcFunc = llvm::cast<llvm::Constant>(mcFuncCallee.getCallee());
-    AssertPos(currentPos, mcFunc != NULL);
+    AssertPos(currentPos, mcFunc != nullptr);
     AssertPos(currentPos, llvm::isa<llvm::Function>(mcFunc));
 
     std::vector<llvm::Value *> args;
@@ -3104,19 +3105,19 @@ void FunctionEmitContext::MemcpyInst(llvm::Value *dest, llvm::Value *src, llvm::
     args.push_back(count);
     args.push_back(LLVMFalse); /* not volatile */
 #ifdef ISPC_XE_ENABLED
-    llvm::Value *callinst = CallInst(mcFunc, NULL, args, "");
+    llvm::Value *callinst = CallInst(mcFunc, nullptr, args, "");
     if (emitXeHardwareMask()) {
         XeUniformMetadata(callinst);
     }
 #else
-    CallInst(mcFunc, NULL, args, "");
+    CallInst(mcFunc, nullptr, args, "");
 #endif
 }
 
 void FunctionEmitContext::setLoopUnrollMetadata(llvm::Instruction *inst,
                                                 std::pair<Globals::pragmaUnrollType, int> loopAttribute,
                                                 SourcePos pos) {
-    if (inst == NULL) {
+    if (inst == nullptr) {
         return;
     }
 
@@ -3157,8 +3158,8 @@ llvm::Instruction *FunctionEmitContext::BranchInst(llvm::BasicBlock *dest) {
 
 llvm::Instruction *FunctionEmitContext::BranchInst(llvm::BasicBlock *trueBlock, llvm::BasicBlock *falseBlock,
                                                    llvm::Value *test) {
-    llvm::Instruction *b = NULL;
-    if (test == NULL) {
+    llvm::Instruction *b = nullptr;
+    if (test == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
         return b;
     }
@@ -3172,12 +3173,12 @@ llvm::Instruction *FunctionEmitContext::BranchInst(llvm::BasicBlock *trueBlock, 
 }
 
 llvm::Value *FunctionEmitContext::ExtractInst(llvm::Value *v, int elt, const llvm::Twine &name) {
-    if (v == NULL) {
+    if (v == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
-    llvm::Instruction *ei = NULL;
+    llvm::Instruction *ei = nullptr;
     if (llvm::isa<llvm::VectorType>(v->getType()))
         ei = llvm::ExtractElementInst::Create(
             v, LLVMInt32(elt),
@@ -3191,12 +3192,12 @@ llvm::Value *FunctionEmitContext::ExtractInst(llvm::Value *v, int elt, const llv
 }
 
 llvm::Value *FunctionEmitContext::InsertInst(llvm::Value *v, llvm::Value *eltVal, int elt, const llvm::Twine &name) {
-    if (v == NULL || eltVal == NULL) {
+    if (v == nullptr || eltVal == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
-    llvm::Instruction *ii = NULL;
+    llvm::Instruction *ii = nullptr;
     if (llvm::isa<llvm::VectorType>(v->getType()))
         ii = llvm::InsertElementInst::Create(
             v, eltVal, LLVMInt32(elt),
@@ -3211,9 +3212,9 @@ llvm::Value *FunctionEmitContext::InsertInst(llvm::Value *v, llvm::Value *eltVal
 
 llvm::Value *FunctionEmitContext::ShuffleInst(llvm::Value *v1, llvm::Value *v2, llvm::Value *mask,
                                               const llvm::Twine &name) {
-    if (v1 == NULL || v2 == NULL || mask == NULL) {
+    if (v1 == nullptr || v2 == nullptr || mask == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::Instruction *ii = new llvm::ShuffleVectorInst(
@@ -3224,9 +3225,9 @@ llvm::Value *FunctionEmitContext::ShuffleInst(llvm::Value *v1, llvm::Value *v2, 
 }
 
 llvm::Value *FunctionEmitContext::BroadcastValue(llvm::Value *v, llvm::Type *vecType, const llvm::Twine &name) {
-    if (v == NULL || vecType == NULL) {
+    if (v == nullptr || vecType == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::FixedVectorType *ty = llvm::dyn_cast<llvm::FixedVectorType>(vecType);
@@ -3262,9 +3263,9 @@ llvm::PHINode *FunctionEmitContext::PhiNode(llvm::Type *type, int count, const l
 
 llvm::Instruction *FunctionEmitContext::SelectInst(llvm::Value *test, llvm::Value *val0, llvm::Value *val1,
                                                    const llvm::Twine &name) {
-    if (test == NULL || val0 == NULL || val1 == NULL) {
+    if (test == nullptr || val0 == nullptr || val1 == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::Instruction *inst = llvm::SelectInst::Create(
@@ -3282,7 +3283,7 @@ static unsigned int lCalleeArgCount(llvm::Value *callee, const FunctionType *fun
     if (calleeFunc) {
         return calleeFunc->getFunctionType()->getNumParams();
     } else {
-        // Uniform or varying function pointer must have funcType != NULL
+        // Uniform or varying function pointer must have funcType != nullptr
         Assert(funcType != nullptr);
         // These calls are always unmasked, others have mask
         if (funcType->isExternC || funcType->isExternSYCL || funcType->isUnmasked)
@@ -3300,9 +3301,9 @@ static unsigned int lCalleeArgCount(llvm::Value *callee, const FunctionType *fun
 
 llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType *funcType,
                                            const std::vector<llvm::Value *> &args, const llvm::Twine &name) {
-    if (func == NULL) {
+    if (func == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     std::vector<llvm::Value *> argVals;
     // Most of the time, the mask is passed as the last argument.  this
@@ -3332,7 +3333,7 @@ llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType
     AssertPos(currentPos, (llvm::isa<llvm::Function>(func) && llvm::cast<llvm::Function>(func)->isVarArg()) ||
                               argVals.size() + 1 == calleeArgCount || argVals.size() == calleeArgCount);
     if (argVals.size() + 1 == calleeArgCount) {
-        llvm::Value *mask = NULL;
+        llvm::Value *mask = nullptr;
 
 #ifdef ISPC_XE_ENABLED
         if (emitXeHardwareMask())
@@ -3372,7 +3373,7 @@ llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType
             if (g->calling_conv == CallingConv::x86_vectorcall) {
                 callinst->setCallingConv(llvm::CallingConv::X86_VectorCall);
             } else {
-                if (funcType != NULL)
+                if (funcType != nullptr)
                     callinst->setCallingConv(funcType->GetCallingConv());
             }
         }
@@ -3416,8 +3417,8 @@ llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType
         llvm::BasicBlock *bbCall = CreateBasicBlock("varying_funcall_call", bbTest);
         llvm::BasicBlock *bbDone = CreateBasicBlock("varying_funcall_done", bbCall);
 
-        llvm::BasicBlock *bbSIMDCall = NULL;
-        llvm::BasicBlock *bbSIMDCallJoin = NULL;
+        llvm::BasicBlock *bbSIMDCall = nullptr;
+        llvm::BasicBlock *bbSIMDCallJoin = nullptr;
         if (emitXeHardwareMask()) {
             bbSIMDCall = CreateBasicBlock("varying_funcall_simd_call", bbCall);
             bbSIMDCallJoin = CreateBasicBlock("varying_funcall_simd_call_join", bbSIMDCall);
@@ -3428,10 +3429,10 @@ llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType
 
         // First allocate memory to accumulate the various program
         // instances' return values...
-        Assert(funcType != NULL);
+        Assert(funcType != nullptr);
         const Type *returnType = funcType->GetReturnType();
         llvm::Type *llvmReturnType = returnType->LLVMType(g->ctx);
-        AddressInfo *resultPtrInfo = NULL;
+        AddressInfo *resultPtrInfo = nullptr;
         Assert(llvmReturnType);
         if (llvmReturnType->isVoidTy() == false)
             resultPtrInfo = AllocaInst(returnType);
@@ -3440,7 +3441,7 @@ llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType
         // instances for which we still need to call the function they are
         // pointing to.  It starts out initialized with the mask of
         // currently running program instances.
-        llvm::Value *oldFullMask = NULL;
+        llvm::Value *oldFullMask = nullptr;
         AddressInfo *maskPtrInfo = AllocaInst(LLVMTypes::MaskType);
         if (emitXeHardwareMask()) {
 #ifdef ISPC_XE_ENABLED
@@ -3453,7 +3454,7 @@ llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType
         StoreInst(oldFullMask, maskPtrInfo);
 
         // Mask wasn't initialized
-        Assert(oldFullMask != NULL && "Mask is not initialized");
+        Assert(oldFullMask != nullptr && "Mask is not initialized");
 
         // And now we branch to the test to see if there's more work to be
         // done.
@@ -3476,8 +3477,8 @@ llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType
             // pointer to be called.
             llvm::Value *currentMask = LoadInst(maskPtrInfo);
             llvm::Function *cttz = m->module->getFunction("__count_trailing_zeros_i64");
-            AssertPos(currentPos, cttz != NULL);
-            llvm::Value *firstLane64 = CallInst(cttz, NULL, LaneMask(currentMask), "first_lane64");
+            AssertPos(currentPos, cttz != nullptr);
+            llvm::Value *firstLane64 = CallInst(cttz, nullptr, LaneMask(currentMask), "first_lane64");
             llvm::Value *firstLane = TruncInst(firstLane64, LLVMTypes::Int32Type, "first_lane32");
 
             // Get the pointer to the function we're going to call this
@@ -3526,8 +3527,8 @@ llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType
 
             // Now, do a masked store into the memory allocated to
             // accumulate the result using the call mask.
-            if (callResult != NULL && callResult->getType() != LLVMTypes::VoidType) {
-                AssertPos(currentPos, resultPtrInfo != NULL);
+            if (callResult != nullptr && callResult->getType() != LLVMTypes::VoidType) {
+                AssertPos(currentPos, resultPtrInfo != nullptr);
                 if (emitXeHardwareMask()) {
                     // This store will be predicated during SIMD CF Lowering
                     StoreInst(callResult, resultPtrInfo);
@@ -3536,7 +3537,7 @@ llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType
                               PointerType::GetUniform(returnType));
                 }
             } else
-                AssertPos(currentPos, resultPtrInfo == NULL);
+                AssertPos(currentPos, resultPtrInfo == nullptr);
 
             if (emitXeHardwareMask()) {
                 // Finish SIMDCall BB
@@ -3560,7 +3561,7 @@ llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType
         // accumulated in the result memory.
         SetCurrentBasicBlock(bbDone);
         SetInternalMask(origMask);
-        return resultPtrInfo ? LoadInst(resultPtrInfo, funcType->GetReturnType()) : NULL;
+        return resultPtrInfo ? LoadInst(resultPtrInfo, funcType->GetReturnType()) : nullptr;
     }
 }
 
@@ -3592,17 +3593,17 @@ llvm::Instruction *FunctionEmitContext::ReturnInst() {
         // TODO: this is a temporary workaround and will be
         // changed with SPIR-V emitting solution
         BranchInst(returnPoint);
-        bblock = NULL;
+        bblock = nullptr;
         // We don't actually create return instruction here
-        return NULL;
+        return nullptr;
     }
 #endif
     // Restore DAZ/FTZ flags if they were set before return statement
-    if (functionFTZ_DAZValue != NULL) {
+    if (functionFTZ_DAZValue != nullptr) {
         RestoreFunctionFTZ_DAZFlags();
     }
-    llvm::Instruction *rinst = NULL;
-    if (returnValueAddressInfo != NULL) {
+    llvm::Instruction *rinst = nullptr;
+    if (returnValueAddressInfo != nullptr) {
         // We have value(s) to return; load them from their storage
         // location
         llvm::Value *retVal = LoadInst(returnValueAddressInfo, function->GetReturnType(), "return_value");
@@ -3613,7 +3614,7 @@ llvm::Instruction *FunctionEmitContext::ReturnInst() {
     }
 
     AddDebugPos(rinst);
-    bblock = NULL;
+    bblock = nullptr;
     return rinst;
 }
 
@@ -3621,23 +3622,23 @@ llvm::Value *FunctionEmitContext::LaunchInst(llvm::Value *callee, std::vector<ll
                                              llvm::Value *launchCount[3], const FunctionType *funcType) {
     if (g->target->isXeTarget()) {
         Error(currentPos, "\"launch\" keyword is not supported for Xe targets");
-        return NULL;
+        return nullptr;
     }
 
-    if (callee == NULL) {
+    if (callee == nullptr) {
         AssertPos(currentPos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (!(llvm::isa<llvm::Function>(callee) || llvm::isa<llvm::PointerType>(callee->getType()))) {
         Error(currentPos, "Must provide function name or uniform function pointer to \"task\"-qualified function for "
                           "\"launch\" expression");
-        return NULL;
+        return nullptr;
     }
 
     launchedTasks = true;
 
-    AssertPos(currentPos, funcType != NULL);
+    AssertPos(currentPos, funcType != nullptr);
     llvm::Type *llvmFuncType = funcType->LLVMFunctionType(g->ctx);
     AssertPos(currentPos, funcType->LLVMFunctionType(g->ctx)->getFunctionNumParams() > 0);
     llvm::Type *argType = llvmFuncType->getFunctionParamType(0);
@@ -3647,10 +3648,10 @@ llvm::Value *FunctionEmitContext::LaunchInst(llvm::Value *callee, std::vector<ll
     AssertPos(currentPos, pt);
     std::vector<llvm::Type *> llvmArgTypes = funcType->LLVMFunctionArgTypes(g->ctx);
     llvm::StructType *argStructType = llvm::StructType::get(*g->ctx, llvmArgTypes);
-    AssertPos(currentPos, argStructType != NULL);
+    AssertPos(currentPos, argStructType != nullptr);
 
     llvm::Function *falloc = m->module->getFunction("ISPCAlloc");
-    AssertPos(currentPos, falloc != NULL);
+    AssertPos(currentPos, falloc != nullptr);
     llvm::Value *structSize = g->target->SizeOf(argStructType, bblock);
     if (structSize->getType() != LLVMTypes::Int64Type)
         // ISPCAlloc expects the size as an uint64_t, but on 32-bit
@@ -3662,7 +3663,7 @@ llvm::Value *FunctionEmitContext::LaunchInst(llvm::Value *callee, std::vector<ll
     allocArgs.push_back(launchGroupHandleAddressInfo->getPointer());
     allocArgs.push_back(structSize);
     allocArgs.push_back(LLVMInt32(align));
-    llvm::Value *voidmem = CallInst(falloc, NULL, allocArgs, "args_ptr");
+    llvm::Value *voidmem = CallInst(falloc, nullptr, allocArgs, "args_ptr");
     llvm::Value *argmem = BitCastInst(voidmem, pt);
 
     // Copy the values of the parameters into the appropriate place in
@@ -3686,7 +3687,7 @@ llvm::Value *FunctionEmitContext::LaunchInst(llvm::Value *callee, std::vector<ll
     // argument block we just filled in
     llvm::Value *fptr = BitCastInst(callee, LLVMTypes::VoidPointerType);
     llvm::Function *flaunch = m->module->getFunction("ISPCLaunch");
-    AssertPos(currentPos, flaunch != NULL);
+    AssertPos(currentPos, flaunch != nullptr);
     std::vector<llvm::Value *> args;
     args.push_back(launchGroupHandleAddressInfo->getPointer());
     args.push_back(fptr);
@@ -3694,7 +3695,7 @@ llvm::Value *FunctionEmitContext::LaunchInst(llvm::Value *callee, std::vector<ll
     args.push_back(launchCount[0]);
     args.push_back(launchCount[1]);
     args.push_back(launchCount[2]);
-    return CallInst(flaunch, NULL, args, "");
+    return CallInst(flaunch, nullptr, args, "");
 }
 
 void FunctionEmitContext::SyncInst() {
@@ -3712,9 +3713,9 @@ void FunctionEmitContext::SyncInst() {
 
     SetCurrentBasicBlock(bSync);
     llvm::Function *fsync = m->module->getFunction("ISPCSync");
-    if (fsync == NULL)
+    if (fsync == nullptr)
         FATAL("Couldn't find ISPCSync declaration?!");
-    CallInst(fsync, NULL, launchGroupHandle, "");
+    CallInst(fsync, nullptr, launchGroupHandle, "");
 
     // zero out the handle so that if ISPCLaunch is called again in this
     // function, it knows it's starting out from scratch
@@ -3823,7 +3824,7 @@ llvm::Value *FunctionEmitContext::XeSimdCFAny(llvm::Value *value) {
 llvm::Value *FunctionEmitContext::XeSimdCFPredicate(llvm::Value *value, llvm::Value *defaults) {
     AssertPos(currentPos, llvm::isa<llvm::VectorType>(value->getType()));
     llvm::FixedVectorType *vt = llvm::dyn_cast<llvm::FixedVectorType>(value->getType());
-    if (defaults == NULL) {
+    if (defaults == nullptr) {
         defaults = llvm::ConstantVector::getSplat(
             llvm::ElementCount::get(static_cast<unsigned int>(vt->getNumElements()), false),
             llvm::Constant::getNullValue(vt->getElementType()));
@@ -3847,7 +3848,7 @@ llvm::Value *FunctionEmitContext::XePrepareVectorBranch(llvm::Value *value) {
             return ret;
         ret = BroadcastValue(value, LLVMTypes::Int1VectorType);
     }
-    Assert(ret != NULL);
+    Assert(ret != nullptr);
     return XeSimdCFAny(ret);
 }
 
@@ -3869,7 +3870,7 @@ void FunctionEmitContext::XeEndUnmaskedRegion(llvm::Value *execMask) {
 void FunctionEmitContext::XeUniformMetadata(llvm::Value *v) {
     llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(v);
     // Set ISPC-Uniform to exclude instruction from predication in CMSIMDCFLowering.
-    if (inst != NULL) {
+    if (inst != nullptr) {
         llvm::MDNode *N = llvm::MDNode::get(*g->ctx, llvm::MDString::get(*g->ctx, "ISPC-Uniform"));
         inst->setMetadata("ISPC-Uniform", N);
     }
@@ -3898,7 +3899,7 @@ llvm::Constant *FunctionEmitContext::XeGetOrCreateConstantString(llvm::StringRef
 
 llvm::Value *FunctionEmitContext::XeUpdateAddrSpaceForParam(llvm::Value *val, const llvm::FunctionType *fType,
                                                             const unsigned int paramIndex, bool atEntryBlock) {
-    Assert(val != NULL);
+    Assert(val != nullptr);
     llvm::Value *adrCast = val;
     if (fType->getFunctionNumParams() >= paramIndex) {
         // We need to check addrspace for arguments with pointer type only
@@ -3928,7 +3929,7 @@ bool FunctionEmitContext::emitXeHardwareMask() {
 
 llvm::Value *FunctionEmitContext::InvokeSyclInst(llvm::Value *func, const FunctionType *funcType,
                                                  const std::vector<llvm::Value *> &args) {
-    Assert(funcType != NULL);
+    Assert(funcType != nullptr);
     const Type *returnType = funcType->GetReturnType();
     // Broadcast uniform return value to varying to match IGC signature by vISA level
     // for extern "SYCL" functions on Xe targets
@@ -3941,10 +3942,10 @@ llvm::Value *FunctionEmitContext::InvokeSyclInst(llvm::Value *func, const Functi
 // in convergent CF only.
 // TODO: enable setting HW mask when it is supported in backend
 #if 0
-    llvm::BasicBlock *bbExternalCall = NULL;
-    llvm::BasicBlock *bbExternalCallJoin = NULL;
+    llvm::BasicBlock *bbExternalCall = nullptr;
+    llvm::BasicBlock *bbExternalCallJoin = nullptr;
 #endif
-    AddressInfo *resultPtrInfo = NULL;
+    AddressInfo *resultPtrInfo = nullptr;
     if (returnType->IsVoidType() == false)
         resultPtrInfo = AllocaInst(returnType);
 #if 0
@@ -3996,7 +3997,7 @@ llvm::Value *FunctionEmitContext::InvokeSyclInst(llvm::Value *func, const Functi
         }
         return res;
     }
-    return NULL;
+    return nullptr;
 }
 
 } // namespace ispc

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -40,7 +40,7 @@ class AddressInfo : public Traceable {
     // Return the type of the values stored in this address.
     llvm::Type *getElementType() const { return elementType; }
 
-    // Return the ISPC type. May be NULL.
+    // Return the ISPC type. May be nullptr.
     const Type *getISPCType() const { return ispcType; }
 
     // Return the address space that this address resides in.
@@ -213,7 +213,7 @@ class FunctionEmitContext {
     /** Emits code for a "switch" statement in the program.
         @param expr         Gives the value of the expression after the "switch"
         @param defaultBlock Basic block to execute for the "default" case.  This
-                            should be NULL if there is no "default" label inside
+                            should be nullptr if there is no "default" label inside
                             the switch.
         @param caseBlocks   vector that stores the mapping from label values
                             after "case" statements to basic blocks corresponding
@@ -269,7 +269,7 @@ class FunctionEmitContext {
     std::vector<std::string> GetLabels();
 
     /** Called to generate code for 'return' statement; value is the
-        expression in the return statement (if non-NULL), and
+        expression in the return statement (if non-nullptr), and
         doCoherenceCheck indicates whether instructions should be generated
         to see if all of the currently-running lanes have returned (if
         we're under varying control flow).  */
@@ -320,7 +320,7 @@ class FunctionEmitContext {
     llvm::Value *GetStringPtr(const std::string &str);
 
     /** Create a new basic block with given name */
-    llvm::BasicBlock *CreateBasicBlock(const llvm::Twine &name, llvm::BasicBlock *insertAfter = NULL);
+    llvm::BasicBlock *CreateBasicBlock(const llvm::Twine &name, llvm::BasicBlock *insertAfter = nullptr);
 
     /** Given a vector with element type i1, return a vector of type
         LLVMTypes::BoolVectorType.  This method handles the conversion for
@@ -344,7 +344,7 @@ class FunctionEmitContext {
 
     SourcePos GetDebugPos() const;
 
-    /** Adds debugging metadata to the given instruction.  If pos == NULL,
+    /** Adds debugging metadata to the given instruction.  If pos == nullptr,
         use FunctionEmitContext::currentPos as the source file position for
         the instruction.  Similarly, if a DIScope is provided, it's used
         and otherwise the scope is found from a GetDIScope() call.  This
@@ -352,8 +352,8 @@ class FunctionEmitContext {
         llvm::Instruction for convenience; in calling code we often have
         Instructions stored using Value pointers; the code here returns
         silently if it's not actually given an instruction. */
-    void AddDebugPos(llvm::Value *instruction, const SourcePos *pos = NULL, llvm::DIScope *scope = NULL);
-    // llvm::MDScope *scope = NULL );
+    void AddDebugPos(llvm::Value *instruction, const SourcePos *pos = nullptr, llvm::DIScope *scope = nullptr);
+    // llvm::MDScope *scope = nullptr );
 
     /** Inform the debugging information generation code that a new scope
         is starting in the source program. */
@@ -437,7 +437,7 @@ class FunctionEmitContext {
     llvm::Value *MakeSlicePointer(llvm::Value *ptr, llvm::Value *offset);
 
     /* Regularize to a standard pointer type.
-       May return NULL if type is not PointerType or ReferenceType */
+       May return nullptr if type is not PointerType or ReferenceType */
     const PointerType *RegularizePointer(const Type *ptrRefType);
 
     /** These GEP methods are generalizations of the standard ones in LLVM;
@@ -457,7 +457,7 @@ class FunctionEmitContext {
         structure type that the base pointer points to.  (The provided
         pointer in AddressInfo must be a pointer to a structure type.) */
     llvm::Value *AddElementOffset(AddressInfo *basePtrInfo, int elementNum, const llvm::Twine &name = "",
-                                  const PointerType **resultPtrType = NULL);
+                                  const PointerType **resultPtrType = nullptr);
 
     /** Bool is stored as i8 and <WIDTH x i8> but represented in IR as i1 and
      * <WIDTH x MASK>. This is a helper function to match bool size at storage
@@ -467,15 +467,15 @@ class FunctionEmitContext {
         mask.  The lvalue may be varying, in which case this corresponds to
         a gather from the multiple memory locations given by the array of
         pointer values given by the lvalue.  If the lvalue is not varying,
-        then both the mask pointer and the type pointer may be NULL. */
+        then both the mask pointer and the type pointer may be nullptr. */
     llvm::Value *LoadInst(llvm::Value *ptr, llvm::Value *mask, const Type *ptrType, const llvm::Twine &name = "",
                           bool one_elem = false);
 
     /* Load from memory location(s) given.
      * 'type' needs to be provided when storage type is different from IR type. For example,
      * 'unform bool' is 'i1' in IR but stored as 'i8'.
-     * Otherwise leave this as NULL. */
-    llvm::Value *LoadInst(AddressInfo *ptrInfo, const Type *type = NULL, const llvm::Twine &name = "");
+     * Otherwise leave this as nullptr. */
+    llvm::Value *LoadInst(AddressInfo *ptrInfo, const Type *type = nullptr, const llvm::Twine &name = "");
 
     /** Emits addrspacecast instruction. Depending on atEntryBlock it is generated in
         alloca block or in the current block.
@@ -515,7 +515,7 @@ class FunctionEmitContext {
         'ptrType' needs to be provided when storage type is different from IR type. For example,
         'unform bool' is 'i1' in IR but stored as 'i8'. */
     /*  TODO: keep all info about type in ptrInfo so we can eliminate usage of ptrType optional arg */
-    void StoreInst(llvm::Value *value, AddressInfo *ptrInfo, const Type *ptrType = NULL);
+    void StoreInst(llvm::Value *value, AddressInfo *ptrInfo, const Type *ptrType = nullptr);
 
     /** In this variant of StoreInst(), the lvalue may be varying.  If so,
         this corresponds to a scatter.  Whether the lvalue is uniform of
@@ -527,7 +527,7 @@ class FunctionEmitContext {
     /** Copy count bytes of memory from the location pointed to by src to
         the location pointed to by dest.  (src and dest must not be
         overlapping.) */
-    void MemcpyInst(llvm::Value *dest, llvm::Value *src, llvm::Value *count, llvm::Value *align = NULL);
+    void MemcpyInst(llvm::Value *dest, llvm::Value *src, llvm::Value *count, llvm::Value *align = nullptr);
 
     void setLoopUnrollMetadata(llvm::Instruction *inst, std::pair<Globals::pragmaUnrollType, int> loopAttribute,
                                SourcePos pos);
@@ -558,7 +558,7 @@ class FunctionEmitContext {
 
     /** Emits IR to do a function call with the given arguments.  If the
         function type is a varying function pointer type, its full type
-        must be provided in funcType.  funcType can be NULL if func is a
+        must be provided in funcType.  funcType can be nullptr if func is a
         uniform function pointer. */
     llvm::Value *CallInst(llvm::Value *func, const FunctionType *funcType, const std::vector<llvm::Value *> &args,
                           const llvm::Twine &name = "");
@@ -593,7 +593,7 @@ class FunctionEmitContext {
 
     /** Emit genx_simdcf_predicate intrinsic
         Required when Xe hardware mask is emitted. */
-    llvm::Value *XeSimdCFPredicate(llvm::Value *values, llvm::Value *defaults = NULL);
+    llvm::Value *XeSimdCFPredicate(llvm::Value *values, llvm::Value *defaults = nullptr);
 
     /** Start unmasked region. Sets execution mask to all-active, and return the old mask.*/
     llvm::Value *XeStartUnmaskedRegion();
@@ -687,7 +687,7 @@ class FunctionEmitContext {
     /** If currently in a loop body or switch statement, this is an AddressInfo with pointer
         to memory to store a mask value that represents which of the lanes
         have executed a 'break' statement.  If we're not in a loop body or
-        switch, this should be NULL. */
+        switch, this should be nullptr. */
     AddressInfo *breakLanesAddressInfo;
 
     /** Similar to breakLanesAddressInfo, if we're inside a loop, this is an AddressInfo with a pointer
@@ -714,7 +714,7 @@ class FunctionEmitContext {
     /** @name Switch statement state
 
         These variables store various state that's active when we're
-        generating code for a switch statement.  They should all be NULL
+        generating code for a switch statement.  They should all be nullptr
         outside of a switch.
         @{
     */

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -48,8 +48,8 @@ static void lPrintTypeQualifiers(int typeQualifiers) {
     the type, returning the type that is the result.
 */
 static const Type *lApplyTypeQualifiers(int typeQualifiers, const Type *type, SourcePos pos) {
-    if (type == NULL)
-        return NULL;
+    if (type == nullptr)
+        return nullptr;
 
     if ((typeQualifiers & TYPEQUAL_CONST) != 0) {
         type = type->GetAsConstType();
@@ -80,7 +80,7 @@ static const Type *lApplyTypeQualifiers(int typeQualifiers, const Type *type, So
                        "qualifiers.");
 
         const Type *unsignedType = type->GetAsUnsignedType();
-        if (unsignedType != NULL)
+        if (unsignedType != nullptr)
             type = unsignedType;
         else {
             const Type *resolvedType = type->ResolveUnboundVariability(Variability::Varying);
@@ -108,7 +108,7 @@ DeclSpecs::DeclSpecs(const Type *t, StorageClass sc, int tq) {
     typeQualifiers = tq;
     soaWidth = 0;
     vectorSize = 0;
-    if (t != NULL) {
+    if (t != nullptr) {
         if (m->symbolTable->ContainsType(t)) {
             // Typedefs might have uniform/varying qualifiers inside.
             if (t->IsVaryingType()) {
@@ -123,17 +123,17 @@ DeclSpecs::DeclSpecs(const Type *t, StorageClass sc, int tq) {
 const Type *DeclSpecs::GetBaseType(SourcePos pos) const {
     const Type *retType = baseType;
 
-    if (retType == NULL) {
+    if (retType == nullptr) {
         Warning(pos, "No type specified in declaration.  Assuming int32.");
         retType = AtomicType::UniformInt32->GetAsUnboundVariabilityType();
     }
 
     if (vectorSize > 0) {
         const AtomicType *atomicType = CastType<AtomicType>(retType);
-        if (atomicType == NULL) {
+        if (atomicType == nullptr) {
             Error(pos, "Only atomic types (int, float, ...) are legal for vector "
                        "types.");
-            return NULL;
+            return nullptr;
         }
         retType = new VectorType(atomicType, vectorSize);
     }
@@ -143,18 +143,18 @@ const Type *DeclSpecs::GetBaseType(SourcePos pos) const {
     if (soaWidth > 0) {
         const StructType *st = CastType<StructType>(retType);
 
-        if (st == NULL) {
+        if (st == nullptr) {
             Error(pos,
                   "Illegal to provide soa<%d> qualifier with non-struct "
                   "type \"%s\".",
                   soaWidth, retType ? retType->GetString().c_str() : "NULL");
-            return NULL;
+            return nullptr;
         } else if (soaWidth <= 0 || (soaWidth & (soaWidth - 1)) != 0) {
             Error(pos,
                   "soa<%d> width illegal. Value must be positive power "
                   "of two.",
                   soaWidth);
-            return NULL;
+            return nullptr;
         }
 
         if (st->IsUniformType()) {
@@ -162,13 +162,13 @@ const Type *DeclSpecs::GetBaseType(SourcePos pos) const {
                   "\"uniform\" qualifier and \"soa<%d>\" qualifier can't "
                   "both be used in a type declaration.",
                   soaWidth);
-            return NULL;
+            return nullptr;
         } else if (st->IsVaryingType()) {
             Error(pos,
                   "\"varying\" qualifier and \"soa<%d>\" qualifier can't "
                   "both be used in a type declaration.",
                   soaWidth);
-            return NULL;
+            return nullptr;
         } else
             retType = st->GetAsSOAType(soaWidth);
 
@@ -220,12 +220,12 @@ void DeclSpecs::Print() const {
 // Declarator
 
 Declarator::Declarator(DeclaratorKind dk, SourcePos p) : pos(p), kind(dk) {
-    child = NULL;
+    child = nullptr;
     typeQualifiers = 0;
     storageClass = SC_NONE;
     arraySize = -1;
-    type = NULL;
-    initExpr = NULL;
+    type = nullptr;
+    initExpr = nullptr;
 }
 
 void Declarator::InitFromDeclSpecs(DeclSpecs *ds) {
@@ -233,14 +233,14 @@ void Declarator::InitFromDeclSpecs(DeclSpecs *ds) {
 
     InitFromType(baseType, ds);
 
-    if (type == NULL) {
+    if (type == nullptr) {
         AssertPos(pos, m->errorCount > 0);
         return;
     }
 
     storageClass = ds->storageClass;
 
-    if (ds->declSpecList.size() > 0 && CastType<FunctionType>(type) == NULL) {
+    if (ds->declSpecList.size() > 0 && CastType<FunctionType>(type) == nullptr) {
         Error(pos,
               "__declspec specifiers for non-function type \"%s\" are "
               "not used.",
@@ -352,14 +352,14 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
         // All of the type qualifiers should be in the DeclSpecs for the
         // base declarator
         AssertPos(pos, typeQualifiers == 0);
-        AssertPos(pos, child == NULL);
+        AssertPos(pos, child == nullptr);
         type = baseType;
     } else if (kind == DK_POINTER) {
         /* For now, any pointer to an SOA type gets the slice property; if
            we add the capability to declare pointers as slices or not,
            we'll want to set this based on a type qualifier here. */
         const Type *ptrType = new PointerType(baseType, variability, isConst, baseType->IsSOAType());
-        if (child != NULL) {
+        if (child != nullptr) {
             child->InitFromType(ptrType, ds);
             type = child->type;
             name = child->name;
@@ -379,13 +379,13 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
             return;
         }
         // The parser should disallow this already, but double check.
-        if (CastType<ReferenceType>(baseType) != NULL) {
+        if (CastType<ReferenceType>(baseType) != nullptr) {
             Error(pos, "References to references are illegal.");
             return;
         }
 
         const Type *refType = new ReferenceType(baseType);
-        if (child != NULL) {
+        if (child != nullptr) {
             child->InitFromType(refType, ds);
             type = child->type;
             name = child->name;
@@ -402,7 +402,7 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
         }
 
         const Type *arrayType = new ArrayType(baseType, arraySize);
-        if (child != NULL) {
+        if (child != nullptr) {
             child->InitFromType(arrayType, ds);
             type = child->type;
             name = child->name;
@@ -421,7 +421,7 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
         for (unsigned int i = 0; i < functionParams.size(); ++i) {
             Declaration *d = functionParams[i];
 
-            if (d == NULL) {
+            if (d == nullptr) {
                 AssertPos(pos, m->errorCount > 0);
                 continue;
             }
@@ -434,7 +434,7 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
 
             AssertPos(pos, d->declarators.size() == 1);
             Declarator *decl = d->declarators[0];
-            if (decl == NULL || decl->type == NULL) {
+            if (decl == nullptr || decl->type == nullptr) {
                 AssertPos(pos, m->errorCount > 0);
                 continue;
             }
@@ -457,11 +457,11 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
             if (decl->type->IsVoidType()) {
                 Error(decl->pos, "Parameter with type \"void\" illegal in function "
                                  "parameter list.");
-                decl->type = NULL;
+                decl->type = nullptr;
             }
 
             const ArrayType *at = CastType<ArrayType>(decl->type);
-            if (at != NULL) {
+            if (at != nullptr) {
                 // As in C, arrays are passed to functions as pointers to
                 // their element type.  We'll just immediately make this
                 // change now.  (One shortcoming of losing the fact that
@@ -471,7 +471,7 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
                 // in the function, but it's not clear that this is a
                 // significant problem.)
                 const Type *targetType = at->GetElementType();
-                if (targetType == NULL) {
+                if (targetType == nullptr) {
                     AssertPos(pos, m->errorCount > 0);
                     return;
                 }
@@ -481,7 +481,7 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
                 // Make sure there are no unsized arrays (other than the
                 // first dimension) in function parameter lists.
                 at = CastType<ArrayType>(targetType);
-                while (at != NULL) {
+                while (at != nullptr) {
                     if (at->GetElementCount() == 0)
                         Error(decl->pos, "Arrays with unsized dimensions in "
                                          "dimensions after the first one are illegal in "
@@ -494,17 +494,17 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
             argNames.push_back(decl->name);
             argPos.push_back(decl->pos);
 
-            Expr *init = NULL;
+            Expr *init = nullptr;
             // Try to find an initializer expression.
-            while (decl != NULL) {
-                if (decl->initExpr != NULL) {
+            while (decl != nullptr) {
+                if (decl->initExpr != nullptr) {
                     decl->initExpr = TypeCheck(decl->initExpr);
                     decl->initExpr = Optimize(decl->initExpr);
-                    if (decl->initExpr != NULL) {
+                    if (decl->initExpr != nullptr) {
                         init = llvm::dyn_cast<ConstExpr>(decl->initExpr);
-                        if (init == NULL)
+                        if (init == nullptr)
                             init = llvm::dyn_cast<NullPointerExpr>(decl->initExpr);
-                        if (init == NULL)
+                        if (init == nullptr)
                             Error(decl->initExpr->pos,
                                   "Default value for parameter "
                                   "\"%s\" must be a compile-time constant.",
@@ -518,12 +518,12 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
         }
 
         const Type *returnType = baseType;
-        if (returnType == NULL) {
+        if (returnType == nullptr) {
             Error(pos, "No return type provided in function declaration.");
             return;
         }
 
-        if (CastType<FunctionType>(returnType) != NULL) {
+        if (CastType<FunctionType>(returnType) != nullptr) {
             Error(pos, "Illegal to return function type from function.");
             return;
         }
@@ -569,7 +569,7 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
             Warning(pos, "\"unmasked\" qualifier is redundant for exported "
                          "functions.");
 
-        if (child == NULL) {
+        if (child == nullptr) {
             AssertPos(pos, m->errorCount > 0);
             return;
         }
@@ -579,7 +579,7 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
                              isExternSYCL, isUnmasked, isVectorCall, isRegCall);
 
         // handle any explicit __declspecs on the function
-        if (ds != NULL) {
+        if (ds != nullptr) {
             for (int i = 0; i < (int)ds->declSpecList.size(); ++i) {
                 std::string str = ds->declSpecList[i].first;
                 SourcePos ds_spec_pos = ds->declSpecList[i].second;
@@ -609,16 +609,16 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
 
 Declaration::Declaration(DeclSpecs *ds, std::vector<Declarator *> *dlist) {
     declSpecs = ds;
-    if (dlist != NULL)
+    if (dlist != nullptr)
         declarators = *dlist;
     for (unsigned int i = 0; i < declarators.size(); ++i)
-        if (declarators[i] != NULL)
+        if (declarators[i] != nullptr)
             declarators[i]->InitFromDeclSpecs(declSpecs);
 }
 
 Declaration::Declaration(DeclSpecs *ds, Declarator *d) {
     declSpecs = ds;
-    if (d != NULL) {
+    if (d != nullptr) {
         d->InitFromDeclSpecs(ds);
         declarators.push_back(d);
     }
@@ -630,7 +630,7 @@ std::vector<VariableDeclaration> Declaration::GetVariableDeclarations() const {
 
     for (unsigned int i = 0; i < declarators.size(); ++i) {
         Declarator *decl = declarators[i];
-        if (decl == NULL || decl->type == NULL) {
+        if (decl == nullptr || decl->type == nullptr) {
             // Ignore earlier errors
             Assert(m->errorCount > 0);
             continue;
@@ -638,7 +638,7 @@ std::vector<VariableDeclaration> Declaration::GetVariableDeclarations() const {
 
         if (decl->type->IsVoidType())
             Error(decl->pos, "\"void\" type variable illegal in declaration.");
-        else if (CastType<FunctionType>(decl->type) == NULL) {
+        else if (CastType<FunctionType>(decl->type) == nullptr) {
             if (!decl->type->IsDependentType()) {
                 decl->type = decl->type->ResolveUnboundVariability(Variability::Varying);
             }
@@ -658,14 +658,14 @@ void Declaration::DeclareFunctions() {
 
     for (unsigned int i = 0; i < declarators.size(); ++i) {
         Declarator *decl = declarators[i];
-        if (decl == NULL || decl->type == NULL) {
+        if (decl == nullptr || decl->type == nullptr) {
             // Ignore earlier errors
             Assert(m->errorCount > 0);
             continue;
         }
 
         const FunctionType *ftype = CastType<FunctionType>(decl->type);
-        if (ftype == NULL)
+        if (ftype == nullptr)
             continue;
 
         bool isInline = (declSpecs->typeQualifiers & TYPEQUAL_INLINE);
@@ -706,7 +706,7 @@ void ispc::GetStructTypesNamesPositions(const std::vector<StructDeclaration *> &
     std::set<std::string> seenNames;
     for (unsigned int i = 0; i < sd.size(); ++i) {
         const Type *type = sd[i]->type;
-        if (type == NULL)
+        if (type == nullptr)
             continue;
 
         // FIXME: making this fake little DeclSpecs here is really
@@ -747,7 +747,7 @@ void ispc::GetStructTypesNamesPositions(const std::vector<StructDeclaration *> &
     for (int i = 0; i < (int)elementTypes->size() - 1; ++i) {
         const ArrayType *arrayType = CastType<ArrayType>((*elementTypes)[i]);
 
-        if (arrayType != NULL && arrayType->GetElementCount() == 0)
+        if (arrayType != nullptr && arrayType->GetElementCount() == 0)
             Error((*elementPositions)[i], "Unsized arrays aren't allowed except "
                                           "for the last member in a struct definition.");
     }

--- a/src/decl.h
+++ b/src/decl.h
@@ -62,7 +62,7 @@ class Declarator;
  */
 class DeclSpecs {
   public:
-    DeclSpecs(const Type *t = NULL, StorageClass sc = SC_NONE, int tq = TYPEQUAL_NONE);
+    DeclSpecs(const Type *t = nullptr, StorageClass sc = SC_NONE, int tq = TYPEQUAL_NONE);
 
     void Print() const;
 
@@ -124,7 +124,7 @@ class Declarator {
         int). */
     const DeclaratorKind kind;
 
-    /** Child pointer if needed; this can only be non-NULL if the
+    /** Child pointer if needed; this can only be non-nullptr if the
         declarator's kind isn't DK_BASE. */
     Declarator *child;
 
@@ -140,10 +140,10 @@ class Declarator {
     /** Name associated with the declarator. */
     std::string name;
 
-    /** Initialization expression for the variable.  May be NULL. */
+    /** Initialization expression for the variable.  May be nullptr. */
     Expr *initExpr;
 
-    /** Type of the declarator.  This is NULL until InitFromDeclSpecs() or
+    /** Type of the declarator.  This is nullptr until InitFromDeclSpecs() or
         InitFromType() is called. */
     const Type *type;
 
@@ -157,7 +157,7 @@ class Declarator {
  */
 class Declaration {
   public:
-    Declaration(DeclSpecs *ds, std::vector<Declarator *> *dlist = NULL);
+    Declaration(DeclSpecs *ds, std::vector<Declarator *> *dlist = nullptr);
     Declaration(DeclSpecs *ds, Declarator *d);
 
     void Print() const;

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -49,26 +49,26 @@ using namespace ispc;
 // Expr
 
 llvm::Value *Expr::GetLValue(FunctionEmitContext *ctx) const {
-    // Expressions that can't provide an lvalue can just return NULL
-    return NULL;
+    // Expressions that can't provide an lvalue can just return nullptr
+    return nullptr;
 }
 
 const Type *Expr::GetLValueType() const {
     // This also only needs to be overrided by Exprs that implement the
     // GetLValue() method.
-    return NULL;
+    return nullptr;
 }
 
 std::pair<llvm::Constant *, bool> Expr::GetStorageConstant(const Type *type) const { return GetConstant(type); }
 std::pair<llvm::Constant *, bool> Expr::GetConstant(const Type *type) const {
-    // The default is failure; just return NULL
-    return std::pair<llvm::Constant *, bool>(NULL, false);
+    // The default is failure; just return nullptr
+    return std::pair<llvm::Constant *, bool>(nullptr, false);
 }
 
 Symbol *Expr::GetBaseSymbol() const {
     // Not all expressions can do this, so provide a generally-useful
     // default implementation.
-    return NULL;
+    return nullptr;
 }
 
 bool Expr::HasAmbiguousVariability(std::vector<const Expr *> &warn) const { return false; }
@@ -133,26 +133,26 @@ static llvm::APFloat lCreateAPFloat(double value, llvm::Type *type) {
 }
 
 static Expr *lArrayToPointer(Expr *expr) {
-    Assert(expr != NULL);
+    Assert(expr != nullptr);
     AssertPos(expr->pos, CastType<ArrayType>(expr->GetType()));
 
     Expr *zero = new ConstExpr(AtomicType::UniformInt32, 0, expr->pos);
     Expr *index = new IndexExpr(expr, zero, expr->pos);
     Expr *addr = new AddressOfExpr(index, expr->pos);
     addr = TypeCheck(addr);
-    Assert(addr != NULL);
+    Assert(addr != nullptr);
     addr = Optimize(addr);
-    Assert(addr != NULL);
+    Assert(addr != nullptr);
     return addr;
 }
 
 static bool lIsAllIntZeros(Expr *expr) {
     const Type *type = expr->GetType();
-    if (type == NULL || type->IsIntType() == false)
+    if (type == nullptr || type->IsIntType() == false)
         return false;
 
     ConstExpr *ce = llvm::dyn_cast<ConstExpr>(expr);
-    if (ce == NULL)
+    if (ce == nullptr)
         return false;
 
     uint64_t vals[ISPC_MAX_NVEC];
@@ -171,9 +171,9 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
                         SourcePos pos) {
     /* This function is way too long and complex.  Is type conversion stuff
        always this messy, or can this be cleaned up somehow? */
-    AssertPos(pos, failureOk || errorMsgBase != NULL);
+    AssertPos(pos, failureOk || errorMsgBase != nullptr);
 
-    if (toType == NULL || fromType == NULL)
+    if (toType == nullptr || fromType == nullptr)
         return false;
 
     // The types are equal; there's nothing to do
@@ -193,16 +193,16 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
     }
 
     if (CastType<FunctionType>(fromType)) {
-        if (CastType<PointerType>(toType) != NULL) {
+        if (CastType<PointerType>(toType) != nullptr) {
             // Convert function type to pointer to function type
-            if (expr != NULL) {
+            if (expr != nullptr) {
                 Expr *aoe = new AddressOfExpr(*expr, (*expr)->pos);
                 if (lDoTypeConv(aoe->GetType(), toType, &aoe, failureOk, errorMsgBase, pos)) {
                     *expr = aoe;
                     return true;
                 }
             } else
-                return lDoTypeConv(PointerType::GetUniform(fromType), toType, NULL, failureOk, errorMsgBase, pos);
+                return lDoTypeConv(PointerType::GetUniform(fromType), toType, nullptr, failureOk, errorMsgBase, pos);
         } else {
             if (!failureOk)
                 Error(pos, "Can't convert function type \"%s\" to \"%s\" for %s.", fromType->GetString().c_str(),
@@ -246,7 +246,7 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
     // Do this early, since for the case of a conversion like
     // "float foo[10]" -> "float * uniform foo", we have what's seemingly
     // a varying to uniform conversion (but not really)
-    if (fromArrayType != NULL && toPointerType != NULL) {
+    if (fromArrayType != nullptr && toPointerType != nullptr) {
         // can convert any array to a void pointer (both uniform and
         // varying).
         if (PointerType::IsVoidPointer(toPointerType))
@@ -277,16 +277,16 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
         return false;
     }
 
-    if (fromPointerType != NULL) {
-        if (CastType<AtomicType>(toType) != NULL && toType->IsBoolType())
+    if (fromPointerType != nullptr) {
+        if (CastType<AtomicType>(toType) != nullptr && toType->IsBoolType())
             // Allow implicit conversion of pointers to bools
             goto typecast_ok;
 
-        if (toArrayType != NULL && Type::Equal(fromType->GetBaseType(), toArrayType->GetElementType())) {
+        if (toArrayType != nullptr && Type::Equal(fromType->GetBaseType(), toArrayType->GetElementType())) {
             // Can convert pointers to arrays of the same type
             goto typecast_ok;
         }
-        if (toPointerType == NULL) {
+        if (toPointerType == nullptr) {
             if (!failureOk)
                 Error(pos,
                       "Can't convert between from pointer type "
@@ -310,9 +310,9 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
             // any pointer type can be converted to a void *
             // ...almost. #731
             goto typecast_ok;
-        } else if (PointerType::IsVoidPointer(fromPointerType) && expr != NULL &&
-                   llvm::dyn_cast<NullPointerExpr>(*expr) != NULL) {
-            // and a NULL convert to any other pointer type
+        } else if (PointerType::IsVoidPointer(fromPointerType) && expr != nullptr &&
+                   llvm::dyn_cast<NullPointerExpr>(*expr) != nullptr) {
+            // and a nullptr convert to any other pointer type
             goto typecast_ok;
         } else if (!Type::Equal(fromPointerType->GetBaseType(), toPointerType->GetBaseType()) &&
                    !Type::Equal(fromPointerType->GetBaseType()->GetAsConstType(), toPointerType->GetBaseType())) {
@@ -345,10 +345,10 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
         return true;
     }
 
-    if (toPointerType != NULL && fromAtomicType != NULL && fromAtomicType->IsIntType() && expr != NULL &&
+    if (toPointerType != nullptr && fromAtomicType != nullptr && fromAtomicType->IsIntType() && expr != nullptr &&
         lIsAllIntZeros(*expr)) {
         // We have a zero-valued integer expression, which can also be
-        // treated as a NULL pointer that can be converted to any other
+        // treated as a nullptr pointer that can be converted to any other
         // pointer type.
         Expr *npe = new NullPointerExpr(pos);
         if (lDoTypeConv(PointerType::Void, toType, &npe, failureOk, errorMsgBase, pos)) {
@@ -385,7 +385,7 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
             const ArrayType *atFrom = CastType<ArrayType>(fromType->GetReferenceTarget());
             const ArrayType *atTo = CastType<ArrayType>(toType->GetReferenceTarget());
 
-            if (atFrom != NULL && atTo != NULL && Type::Equal(atFrom->GetElementType(), atTo->GetElementType())) {
+            if (atFrom != nullptr && atTo != nullptr && Type::Equal(atFrom->GetElementType(), atTo->GetElementType())) {
                 goto typecast_ok;
             } else {
                 if (!failureOk)
@@ -397,7 +397,7 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
             }
         } else {
             // convert from a reference T -> T
-            if (expr != NULL) {
+            if (expr != nullptr) {
                 Expr *drExpr = new RefDerefExpr(*expr, pos);
                 if (lDoTypeConv(drExpr->GetType(), toType, &drExpr, failureOk, errorMsgBase, pos) == true) {
                     *expr = drExpr;
@@ -405,11 +405,11 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
                 }
                 return false;
             } else
-                return lDoTypeConv(fromType->GetReferenceTarget(), toType, NULL, failureOk, errorMsgBase, pos);
+                return lDoTypeConv(fromType->GetReferenceTarget(), toType, nullptr, failureOk, errorMsgBase, pos);
         }
     } else if (CastType<ReferenceType>(toType)) {
         // T -> reference T
-        if (expr != NULL) {
+        if (expr != nullptr) {
             Expr *rExpr = new ReferenceExpr(*expr, pos);
             if (lDoTypeConv(rExpr->GetType(), toType, &rExpr, failureOk, errorMsgBase, pos) == true) {
                 *expr = rExpr;
@@ -418,7 +418,7 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
             return false;
         } else {
             ReferenceType rt(fromType);
-            return lDoTypeConv(&rt, toType, NULL, failureOk, errorMsgBase, pos);
+            return lDoTypeConv(&rt, toType, nullptr, failureOk, errorMsgBase, pos);
         }
     } else if (Type::Equal(toType, fromType->GetAsNonConstType()))
         // convert: const T -> T (as long as T isn't a reference)
@@ -469,7 +469,7 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
         goto typecast_ok;
     }
 
-    if (toEnumType != NULL && fromEnumType != NULL) {
+    if (toEnumType != nullptr && fromEnumType != nullptr) {
         // No implicit conversions between different enum types
         if (!Type::EqualIgnoringConst(toEnumType->GetAsUniformType(), fromEnumType->GetAsUniformType())) {
             if (!failureOk)
@@ -483,9 +483,9 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
     }
 
     // enum -> atomic (integer, generally...) is always ok
-    if (fromEnumType != NULL) {
+    if (fromEnumType != nullptr) {
         // Cannot convert to anything other than atomic
-        if (toAtomicType == NULL && toVectorType == NULL) {
+        if (toAtomicType == nullptr && toVectorType == nullptr) {
             if (!failureOk)
                 Error(pos,
                       "Type conversion from \"%s\" to \"%s\" for %s is not "
@@ -498,7 +498,7 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
 
     // from here on out, the from type can only be atomic something or
     // other...
-    if (fromAtomicType == NULL) {
+    if (fromAtomicType == nullptr) {
         if (!failureOk)
             Error(pos,
                   "Type conversion from \"%s\" to \"%s\" for %s is not "
@@ -508,11 +508,11 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
     }
 
     // scalar -> short-vector conversions
-    if (toVectorType != NULL && (fromType->GetSOAWidth() == toType->GetSOAWidth()))
+    if (toVectorType != nullptr && (fromType->GetSOAWidth() == toType->GetSOAWidth()))
         goto typecast_ok;
 
     // ok, it better be a scalar->scalar conversion of some sort by now
-    if (toAtomicType == NULL) {
+    if (toAtomicType == nullptr) {
         if (!failureOk)
             Error(pos,
                   "Type conversion from \"%s\" to \"%s\" for %s is "
@@ -531,18 +531,18 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
     }
 
 typecast_ok:
-    if (expr != NULL)
+    if (expr != nullptr)
         *expr = new TypeCastExpr(toType, *expr, pos);
     return true;
 }
 
 bool ispc::CanConvertTypes(const Type *fromType, const Type *toType, const char *errorMsgBase, SourcePos pos) {
-    return lDoTypeConv(fromType, toType, NULL, errorMsgBase == NULL, errorMsgBase, pos);
+    return lDoTypeConv(fromType, toType, nullptr, errorMsgBase == nullptr, errorMsgBase, pos);
 }
 
 Expr *ispc::TypeConvertExpr(Expr *expr, const Type *toType, const char *errorMsgBase) {
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
 
 #if 0
     Debug(expr->pos, "type convert %s -> %s.", expr->GetType()->GetString().c_str(),
@@ -554,14 +554,14 @@ Expr *ispc::TypeConvertExpr(Expr *expr, const Type *toType, const char *errorMsg
     if (lDoTypeConv(fromType, toType, &e, false, errorMsgBase, expr->pos))
         return e;
     else
-        return NULL;
+        return nullptr;
 }
 
 bool ispc::PossiblyResolveFunctionOverloads(Expr *expr, const Type *type) {
-    FunctionSymbolExpr *fse = NULL;
-    const FunctionType *funcType = NULL;
-    if (CastType<PointerType>(type) != NULL && (funcType = CastType<FunctionType>(type->GetBaseType())) &&
-        (fse = llvm::dyn_cast<FunctionSymbolExpr>(expr)) != NULL) {
+    FunctionSymbolExpr *fse = nullptr;
+    const FunctionType *funcType = nullptr;
+    if (CastType<PointerType>(type) != nullptr && (funcType = CastType<FunctionType>(type->GetBaseType())) &&
+        (fse = llvm::dyn_cast<FunctionSymbolExpr>(expr)) != nullptr) {
         // We're initializing a function pointer with a function symbol,
         // which in turn may represent an overloaded function.  So we need
         // to try to resolve the overload based on the type of the symbol
@@ -588,14 +588,14 @@ bool ispc::PossiblyResolveFunctionOverloads(Expr *expr, const Type *type) {
 */
 void ispc::InitSymbol(AddressInfo *ptrInfo, const Type *symType, Expr *initExpr, FunctionEmitContext *ctx,
                       SourcePos pos) {
-    if (initExpr == NULL)
+    if (initExpr == nullptr)
         // leave it uninitialized
         return;
 
     // See if we have a constant initializer a this point
     std::pair<llvm::Constant *, bool> constValPair = initExpr->GetStorageConstant(symType);
     llvm::Constant *constValue = constValPair.first;
-    if (constValue != NULL) {
+    if (constValue != nullptr) {
         // It'd be nice if we could just do a StoreInst(constValue, ptr)
         // at this point, but unfortunately that doesn't generate great
         // code (e.g. a bunch of scalar moves for a constant array.)  So
@@ -603,7 +603,7 @@ void ispc::InitSymbol(AddressInfo *ptrInfo, const Type *symType, Expr *initExpr,
         // constant value and emit a memcpy to put its value into the
         // pointer we have.
         llvm::Type *llvmType = symType->LLVMStorageType(g->ctx);
-        if (llvmType == NULL) {
+        if (llvmType == nullptr) {
             AssertPos(pos, m->errorCount > 0);
             return;
         }
@@ -624,16 +624,16 @@ void ispc::InitSymbol(AddressInfo *ptrInfo, const Type *symType, Expr *initExpr,
     // If the initializer is a straight up expression that isn't an
     // ExprList, then we'll see if we can type convert it to the type of
     // the variable.
-    if (llvm::dyn_cast<ExprList>(initExpr) == NULL) {
+    if (llvm::dyn_cast<ExprList>(initExpr) == nullptr) {
         if (PossiblyResolveFunctionOverloads(initExpr, symType) == false)
             return;
         initExpr = TypeConvertExpr(initExpr, symType, "initializer");
 
-        if (initExpr == NULL)
+        if (initExpr == nullptr)
             return;
 
         llvm::Value *initializerValue = initExpr->GetValue(ctx);
-        if (initializerValue != NULL)
+        if (initializerValue != nullptr)
             // Bingo; store the value in the variable's storage
             ctx->StoreInst(initializerValue, ptrInfo, symType);
         return;
@@ -644,7 +644,7 @@ void ispc::InitSymbol(AddressInfo *ptrInfo, const Type *symType, Expr *initExpr,
     // which are handled below).
     if (symType->IsSOAType() == false && Type::IsBasicType(symType)) {
         ExprList *elist = llvm::dyn_cast<ExprList>(initExpr);
-        if (elist != NULL) {
+        if (elist != nullptr) {
             if (elist->exprs.size() == 1) {
                 InitSymbol(ptrInfo, symType, elist->exprs[0], ctx, pos);
                 return;
@@ -680,7 +680,7 @@ void ispc::InitSymbol(AddressInfo *ptrInfo, const Type *symType, Expr *initExpr,
     // Handle initiailizers for SOA types as well as for structs, arrays,
     // and vectors.
     const CollectionType *collectionType = CastType<CollectionType>(symType);
-    if (collectionType != NULL || symType->IsSOAType() ||
+    if (collectionType != nullptr || symType->IsSOAType() ||
         (Type::IsBasicType(symType) && symType->IsVaryingType() == true)) {
         // Make default value equivalent to number of elements for varying
         int nElements = g->target->getVectorWidth();
@@ -690,11 +690,11 @@ void ispc::InitSymbol(AddressInfo *ptrInfo, const Type *symType, Expr *initExpr,
             nElements = symType->GetSOAWidth();
 
         std::string name;
-        if (CastType<StructType>(symType) != NULL)
+        if (CastType<StructType>(symType) != nullptr)
             name = "struct";
-        else if (CastType<ArrayType>(symType) != NULL)
+        else if (CastType<ArrayType>(symType) != nullptr)
             name = "array";
-        else if (CastType<VectorType>(symType) != NULL)
+        else if (CastType<VectorType>(symType) != nullptr)
             name = "vector";
         else if (symType->IsSOAType() || (Type::IsBasicType(symType) && symType->IsVaryingType() == true))
             name = symType->GetVariability().GetString();
@@ -708,7 +708,7 @@ void ispc::InitSymbol(AddressInfo *ptrInfo, const Type *symType, Expr *initExpr,
         // in which case the elements are initialized with the
         // corresponding values.
         ExprList *exprList = llvm::dyn_cast<ExprList>(initExpr);
-        if (exprList != NULL) {
+        if (exprList != nullptr) {
             // The { ... } case; make sure we have the no more expressions
             // in the ExprList as we have struct members
             int nInits = exprList->exprs.size();
@@ -735,7 +735,7 @@ void ispc::InitSymbol(AddressInfo *ptrInfo, const Type *symType, Expr *initExpr,
                     collectionType ? collectionType->GetElementType(i) : symType->GetAsUniformType();
 
                 llvm::Value *ep;
-                if (CastType<StructType>(symType) != NULL)
+                if (CastType<StructType>(symType) != nullptr)
                     ep = ctx->AddElementOffset(new AddressInfo(ptrInfo->getPointer(), CastType<StructType>(symType)), i,
                                                "element");
                 else {
@@ -750,7 +750,7 @@ void ispc::InitSymbol(AddressInfo *ptrInfo, const Type *symType, Expr *initExpr,
                     // If we don't have enough initializer values, initialize the
                     // rest as zero.
                     llvm::Type *llvmType = elementType->LLVMStorageType(g->ctx);
-                    if (llvmType == NULL) {
+                    if (llvmType == nullptr) {
                         AssertPos(pos, m->errorCount > 0);
                         return;
                     }
@@ -763,7 +763,7 @@ void ispc::InitSymbol(AddressInfo *ptrInfo, const Type *symType, Expr *initExpr,
             Error(initExpr->pos, "Can't assign type \"%s\" to \"%s\".", initExpr->GetType()->GetString().c_str(),
                   collectionType->GetString().c_str());
         } else {
-            FATAL("CollectionType is NULL in InitSymbol()");
+            FATAL("CollectionType is nullptr in InitSymbol()");
         }
         return;
     }
@@ -781,7 +781,7 @@ static const Type *lMatchingBoolType(const Type *type) {
     bool uniformTest = type->IsUniformType();
     const AtomicType *boolBase = uniformTest ? AtomicType::UniformBool : AtomicType::VaryingBool;
     const VectorType *vt = CastType<VectorType>(type);
-    if (vt != NULL)
+    if (vt != nullptr)
         return new VectorType(boolBase, vt->GetElementCount());
     else {
         Assert(Type::IsBasicType(type) || type->IsReferenceType());
@@ -799,19 +799,19 @@ static llvm::Constant *lLLVMConstantValue(const Type *type, llvm::LLVMContext *c
 
     // This function is only called with, and only works for atomic, enum,
     // and vector types.
-    Assert(atomicType != NULL || enumType != NULL || vectorType != NULL || pointerType != NULL);
+    Assert(atomicType != nullptr || enumType != nullptr || vectorType != nullptr || pointerType != nullptr);
 
-    if (atomicType != NULL || enumType != NULL) {
+    if (atomicType != nullptr || enumType != nullptr) {
         // If it's an atomic or enuemrator type, then figure out which of
         // the llvmutil.h functions to call to get the corresponding
         // constant and then call it...
         bool isUniform = type->IsUniformType();
-        AtomicType::BasicType basicType = (enumType != NULL) ? AtomicType::TYPE_UINT32 : atomicType->basicType;
+        AtomicType::BasicType basicType = (enumType != nullptr) ? AtomicType::TYPE_UINT32 : atomicType->basicType;
 
         switch (basicType) {
         case AtomicType::TYPE_VOID:
             FATAL("can't get constant value for void type");
-            return NULL;
+            return nullptr;
         case AtomicType::TYPE_BOOL:
             if (isUniform)
                 return (value != 0.) ? LLVMTrue : LLVMFalse;
@@ -868,9 +868,9 @@ static llvm::Constant *lLLVMConstantValue(const Type *type, llvm::LLVMContext *c
         }
         default:
             FATAL("logic error in lLLVMConstantValue");
-            return NULL;
+            return nullptr;
         }
-    } else if (pointerType != NULL) {
+    } else if (pointerType != nullptr) {
         Assert(value == 0);
         if (pointerType->IsUniformType())
             return llvm::Constant::getNullValue(LLVMTypes::VoidPointerType);
@@ -891,14 +891,14 @@ static llvm::Constant *lLLVMConstantValue(const Type *type, llvm::LLVMContext *c
         // should be better encapsulated?
         if (baseType->IsUniformType()) {
             llvm::FixedVectorType *lvt = llvm::dyn_cast<llvm::FixedVectorType>(llvmVectorType);
-            Assert(lvt != NULL);
+            Assert(lvt != nullptr);
             std::vector<llvm::Constant *> vals;
             for (unsigned int i = 0; i < lvt->getNumElements(); ++i)
                 vals.push_back(constElement);
             return llvm::ConstantVector::get(vals);
         } else {
             llvm::ArrayType *lat = llvm::dyn_cast<llvm::ArrayType>(llvmVectorType);
-            Assert(lat != NULL);
+            Assert(lat != nullptr);
             std::vector<llvm::Constant *> vals;
             for (unsigned int i = 0; i < lat->getNumElements(); ++i)
                 vals.push_back(constElement);
@@ -908,10 +908,10 @@ static llvm::Constant *lLLVMConstantValue(const Type *type, llvm::LLVMContext *c
 }
 
 static llvm::Value *lMaskForSymbol(Symbol *baseSym, FunctionEmitContext *ctx) {
-    if (baseSym == NULL)
+    if (baseSym == nullptr)
         return ctx->GetFullMask();
 
-    if (CastType<PointerType>(baseSym->type) != NULL || CastType<ReferenceType>(baseSym->type) != NULL)
+    if (CastType<PointerType>(baseSym->type) != nullptr || CastType<ReferenceType>(baseSym->type) != nullptr)
         // FIXME: for pointers, we really only want to do this for
         // dereferencing the pointer, not for things like pointer
         // arithmetic, when we may be able to use the internal mask,
@@ -928,10 +928,10 @@ static llvm::Value *lMaskForSymbol(Symbol *baseSym, FunctionEmitContext *ctx) {
  */
 static void lStoreAssignResult(llvm::Value *value, llvm::Value *ptr, const Type *valueType, const Type *ptrType,
                                FunctionEmitContext *ctx, Symbol *baseSym) {
-    Assert(baseSym == NULL || baseSym->varyingCFDepth <= ctx->VaryingCFDepth());
-    if (!g->opt.disableMaskedStoreToStore && !g->opt.disableMaskAllOnOptimizations && baseSym != NULL &&
+    Assert(baseSym == nullptr || baseSym->varyingCFDepth <= ctx->VaryingCFDepth());
+    if (!g->opt.disableMaskedStoreToStore && !g->opt.disableMaskAllOnOptimizations && baseSym != nullptr &&
         baseSym->varyingCFDepth == ctx->VaryingCFDepth() && baseSym->storageClass != SC_STATIC &&
-        CastType<ReferenceType>(baseSym->type) == NULL && CastType<PointerType>(baseSym->type) == NULL) {
+        CastType<ReferenceType>(baseSym->type) == nullptr && CastType<PointerType>(baseSym->type) == nullptr) {
         // If the variable is declared at the same varying control flow
         // depth as where it's being assigned, then we don't need to do any
         // masking but can just do the assignment as if all the lanes were
@@ -951,13 +951,13 @@ static void lStoreAssignResult(llvm::Value *value, llvm::Value *ptr, const Type 
  */
 static llvm::Value *lEmitPrePostIncDec(UnaryExpr::Op op, Expr *expr, SourcePos pos, FunctionEmitContext *ctx) {
     const Type *type = expr->GetType();
-    if (type == NULL)
-        return NULL;
+    if (type == nullptr)
+        return nullptr;
 
     // Get both the lvalue and the rvalue of the given expression
-    llvm::Value *lvalue = NULL, *rvalue = NULL;
-    const Type *lvalueType = NULL;
-    if (CastType<ReferenceType>(type) != NULL) {
+    llvm::Value *lvalue = nullptr, *rvalue = nullptr;
+    const Type *lvalueType = nullptr;
+    if (CastType<ReferenceType>(type) != nullptr) {
         lvalueType = type;
         type = type->GetReferenceTarget();
         lvalue = expr->GetValue(ctx);
@@ -970,18 +970,18 @@ static llvm::Value *lEmitPrePostIncDec(UnaryExpr::Op op, Expr *expr, SourcePos p
         rvalue = expr->GetValue(ctx);
     }
 
-    if (lvalue == NULL) {
+    if (lvalue == nullptr) {
         // If we can't get a lvalue, then we have an error here
         const char *prepost = (op == UnaryExpr::PreInc || op == UnaryExpr::PreDec) ? "pre" : "post";
         const char *incdec = (op == UnaryExpr::PreInc || op == UnaryExpr::PostInc) ? "increment" : "decrement";
         Error(pos, "Can't %s-%s non-lvalues.", prepost, incdec);
-        return NULL;
+        return nullptr;
     }
 
     // Emit code to do the appropriate addition/subtraction to the
     // expression's old value
     ctx->SetDebugPos(pos);
-    llvm::Value *binop = NULL;
+    llvm::Value *binop = nullptr;
     int delta = (op == UnaryExpr::PreInc || op == UnaryExpr::PostInc) ? 1 : -1;
 
     std::string opName = rvalue->getName().str();
@@ -990,7 +990,7 @@ static llvm::Value *lEmitPrePostIncDec(UnaryExpr::Op op, Expr *expr, SourcePos p
     else
         opName += "_minus1";
 
-    if (CastType<PointerType>(type) != NULL) {
+    if (CastType<PointerType>(type) != nullptr) {
         const Type *incType = type->IsUniformType() ? AtomicType::UniformInt32 : AtomicType::VaryingInt32;
         llvm::Constant *dval = lLLVMConstantValue(incType, g->ctx, delta);
         binop = ctx->GetElementPtrInst(rvalue, dval, type, opName.c_str());
@@ -1017,8 +1017,8 @@ static llvm::Value *lEmitPrePostIncDec(UnaryExpr::Op op, Expr *expr, SourcePos p
 static llvm::Value *lEmitNegate(Expr *arg, SourcePos pos, FunctionEmitContext *ctx) {
     const Type *type = arg->GetType();
     llvm::Value *argVal = arg->GetValue(ctx);
-    if (type == NULL || argVal == NULL)
-        return NULL;
+    if (type == nullptr || argVal == nullptr)
+        return nullptr;
 
     // Negate by subtracting from zero...
     ctx->SetDebugPos(pos);
@@ -1035,8 +1035,8 @@ static llvm::Value *lEmitNegate(Expr *arg, SourcePos pos, FunctionEmitContext *c
 UnaryExpr::UnaryExpr(Op o, Expr *e, SourcePos p) : Expr(p, UnaryExprID), op(o) { expr = e; }
 
 llvm::Value *UnaryExpr::GetValue(FunctionEmitContext *ctx) const {
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
 
     ctx->SetDebugPos(pos);
 
@@ -1058,17 +1058,17 @@ llvm::Value *UnaryExpr::GetValue(FunctionEmitContext *ctx) const {
     }
     default:
         FATAL("logic error");
-        return NULL;
+        return nullptr;
     }
 }
 
 const Type *UnaryExpr::GetType() const {
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
 
     const Type *type = expr->GetType();
-    if (type == NULL)
-        return NULL;
+    if (type == nullptr)
+        return nullptr;
 
     if (type->IsDependentType()) {
         return AtomicType::Dependent;
@@ -1076,7 +1076,7 @@ const Type *UnaryExpr::GetType() const {
 
     // Unary expressions should be returning target types after updating
     // reference address.
-    if (CastType<ReferenceType>(type) != NULL) {
+    if (CastType<ReferenceType>(type) != nullptr) {
         type = type->GetReferenceTarget();
     }
     // For all unary expressions besides logical not, the returned type is
@@ -1094,7 +1094,7 @@ const Type *UnaryExpr::GetType() const {
         return lMatchingBoolType(type);
     default:
         FATAL("error");
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -1118,11 +1118,11 @@ Expr *UnaryExpr::Optimize() {
     ConstExpr *constExpr = llvm::dyn_cast<ConstExpr>(expr);
     // If the operand isn't a constant, then we can't do any optimization
     // here...
-    if (constExpr == NULL)
+    if (constExpr == nullptr)
         return this;
 
     const Type *type = constExpr->GetType();
-    bool isEnumType = CastType<EnumType>(type) != NULL;
+    bool isEnumType = CastType<EnumType>(type) != nullptr;
 
     switch (op) {
     case PreInc:
@@ -1210,15 +1210,15 @@ Expr *UnaryExpr::Optimize() {
     }
     default:
         FATAL("unexpected op in UnaryExpr::Optimize()");
-        return NULL;
+        return nullptr;
     }
 }
 
 Expr *UnaryExpr::TypeCheck() {
     const Type *type;
-    if (expr == NULL || (type = expr->GetType()) == NULL)
+    if (expr == nullptr || (type = expr->GetType()) == nullptr)
         // something went wrong in type checking...
-        return NULL;
+        return nullptr;
 
     if (type->IsDependentType()) {
         return this;
@@ -1226,7 +1226,7 @@ Expr *UnaryExpr::TypeCheck() {
 
     if (type->IsSOAType()) {
         Error(pos, "Can't apply unary operator to SOA type \"%s\".", type->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
 
     if (op == PreInc || op == PreDec || op == PostInc || op == PostDec) {
@@ -1235,31 +1235,31 @@ Expr *UnaryExpr::TypeCheck() {
                   "Can't assign to type \"%s\" on left-hand side of "
                   "expression.",
                   type->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
 
         if (type->IsNumericType())
             return this;
 
         const PointerType *pt = CastType<PointerType>(type);
-        if (pt == NULL) {
+        if (pt == nullptr) {
             Error(expr->pos,
                   "Can only pre/post increment numeric and "
                   "pointer types, not \"%s\".",
                   type->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
 
         if (PointerType::IsVoidPointer(type)) {
             Error(expr->pos, "Illegal to pre/post increment \"%s\" type.", type->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
         if (CastType<UndefinedStructType>(pt->GetBaseType())) {
             Error(expr->pos,
                   "Illegal to pre/post increment pointer to "
                   "undefined struct type \"%s\".",
                   type->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
 
         return this;
@@ -1274,27 +1274,27 @@ Expr *UnaryExpr::TypeCheck() {
     if (op == Negate) {
         if (!type->IsNumericType()) {
             Error(expr->pos, "Negate not allowed for non-numeric type \"%s\".", type->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
     } else if (op == LogicalNot) {
         const Type *boolType = lMatchingBoolType(type);
         expr = TypeConvertExpr(expr, boolType, "logical not");
-        if (expr == NULL)
-            return NULL;
+        if (expr == nullptr)
+            return nullptr;
     } else if (op == BitNot) {
         if (!type->IsIntType()) {
             Error(expr->pos,
                   "~ operator can only be used with integer types, "
                   "not \"%s\".",
                   type->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
     }
     return this;
 }
 
 int UnaryExpr::EstimateCost() const {
-    if (llvm::dyn_cast<ConstExpr>(expr) != NULL)
+    if (llvm::dyn_cast<ConstExpr>(expr) != nullptr)
         return 0;
 
     return COST_SIMPLE_ARITH_LOGIC_OP;
@@ -1424,7 +1424,7 @@ static llvm::Value *lEmitBinaryBitOp(BinaryExpr::Op op, llvm::Value *arg0Val, ll
         break;
     default:
         FATAL("logic error in lEmitBinaryBitOp()");
-        return NULL;
+        return nullptr;
     }
 
     return ctx->BinaryOperator(inst, arg0Val, arg1Val, "bitop");
@@ -1434,14 +1434,14 @@ static llvm::Value *lEmitBinaryPointerArith(BinaryExpr::Op op, llvm::Value *valu
                                             const Type *type0, const Type *type1, FunctionEmitContext *ctx,
                                             SourcePos pos) {
     const PointerType *ptrType = CastType<PointerType>(type0);
-    AssertPos(pos, ptrType != NULL);
+    AssertPos(pos, ptrType != nullptr);
     switch (op) {
     case BinaryExpr::Add:
         // ptr + integer
         return ctx->GetElementPtrInst(value0, value1, ptrType, "ptrmath");
         break;
     case BinaryExpr::Sub: {
-        if (CastType<PointerType>(type1) != NULL) {
+        if (CastType<PointerType>(type1) != nullptr) {
             AssertPos(pos, Type::EqualIgnoringConst(type0, type1));
 
             if (ptrType->IsSlice()) {
@@ -1504,7 +1504,7 @@ static llvm::Value *lEmitBinaryPointerArith(BinaryExpr::Op op, llvm::Value *valu
     }
     default:
         FATAL("Logic error in lEmitBinaryArith() for pointer type case");
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -1515,7 +1515,7 @@ static llvm::Value *lEmitBinaryArith(BinaryExpr::Op op, llvm::Value *value0, llv
                                      const Type *type1, FunctionEmitContext *ctx, SourcePos pos) {
     const PointerType *ptrType = CastType<PointerType>(type0);
 
-    if (ptrType != NULL)
+    if (ptrType != nullptr)
         return lEmitBinaryPointerArith(op, value0, value1, type0, type1, ctx, pos);
     else {
         AssertPos(pos, Type::EqualIgnoringConst(type0, type1));
@@ -1524,7 +1524,7 @@ static llvm::Value *lEmitBinaryArith(BinaryExpr::Op op, llvm::Value *value0, llv
         bool isFloatOp = type0->IsFloatType();
         bool isUnsignedOp = type0->IsUnsignedType();
 
-        const char *opName = NULL;
+        const char *opName = nullptr;
         switch (op) {
         case BinaryExpr::Add:
             opName = "add";
@@ -1556,7 +1556,7 @@ static llvm::Value *lEmitBinaryArith(BinaryExpr::Op op, llvm::Value *value0, llv
             break;
         default:
             FATAL("Invalid op type passed to lEmitBinaryArith()");
-            return NULL;
+            return nullptr;
         }
 
         return ctx->BinaryOperator(inst, value0, value1,
@@ -1573,7 +1573,7 @@ static llvm::Value *lEmitBinaryCmp(BinaryExpr::Op op, llvm::Value *e0Val, llvm::
     bool isUnsignedOp = type->IsUnsignedType();
 
     llvm::CmpInst::Predicate pred;
-    const char *opName = NULL;
+    const char *opName = nullptr;
     switch (op) {
     case BinaryExpr::Lt:
         opName = "less";
@@ -1601,7 +1601,7 @@ static llvm::Value *lEmitBinaryCmp(BinaryExpr::Op op, llvm::Value *e0Val, llvm::
         break;
     default:
         FATAL("error in lEmitBinaryCmp()");
-        return NULL;
+        return nullptr;
     }
 
     llvm::Value *cmp = ctx->CmpInst(isFloatOp ? llvm::Instruction::FCmp : llvm::Instruction::ICmp, pred, e0Val, e1Val,
@@ -1622,7 +1622,7 @@ BinaryExpr::BinaryExpr(Op o, Expr *a, Expr *b, SourcePos p) : Expr(p, BinaryExpr
 
 bool lCreateBinaryOperatorCall(const BinaryExpr::Op bop, Expr *a0, Expr *a1, Expr *&op, const SourcePos &sp) {
     bool abort = false;
-    if ((a0 == NULL) || (a1 == NULL)) {
+    if ((a0 == nullptr) || (a1 == nullptr)) {
         return abort;
     }
     Expr *arg0 = a0;
@@ -1632,18 +1632,18 @@ bool lCreateBinaryOperatorCall(const BinaryExpr::Op bop, Expr *a0, Expr *a1, Exp
 
     // If either operand is a reference, dereference it before we move
     // forward
-    if (CastType<ReferenceType>(type0) != NULL) {
+    if (CastType<ReferenceType>(type0) != nullptr) {
         arg0 = new RefDerefExpr(arg0, arg0->pos);
         type0 = arg0->GetType();
     }
-    if (CastType<ReferenceType>(type1) != NULL) {
+    if (CastType<ReferenceType>(type1) != nullptr) {
         arg1 = new RefDerefExpr(arg1, arg1->pos);
         type1 = arg1->GetType();
     }
-    if ((type0 == NULL) || (type1 == NULL)) {
+    if ((type0 == nullptr) || (type1 == nullptr)) {
         return abort;
     }
-    if (CastType<StructType>(type0) != NULL || CastType<StructType>(type1) != NULL) {
+    if (CastType<StructType>(type0) != nullptr || CastType<StructType>(type1) != nullptr) {
         std::string opName = std::string("operator") + lOpString(bop);
         std::vector<Symbol *> funs;
         m->symbolTable->LookupFunction(opName.c_str(), &funs);
@@ -1664,18 +1664,18 @@ bool lCreateBinaryOperatorCall(const BinaryExpr::Op bop, Expr *a0, Expr *a1, Exp
 }
 
 Expr *ispc::MakeBinaryExpr(BinaryExpr::Op o, Expr *a, Expr *b, SourcePos p) {
-    Expr *op = NULL;
+    Expr *op = nullptr;
     bool abort = lCreateBinaryOperatorCall(o, a, b, op, p);
-    if (op != NULL) {
+    if (op != nullptr) {
         return op;
     }
 
-    // lCreateBinaryOperatorCall can return NULL for 2 cases:
+    // lCreateBinaryOperatorCall can return nullptr for 2 cases:
     // 1. When there is an error.
     // 2. We have to create a new BinaryExpr.
     if (abort) {
         AssertPos(p, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     op = new BinaryExpr(o, a, b, p);
@@ -1690,9 +1690,9 @@ Expr *ispc::MakeBinaryExpr(BinaryExpr::Op o, Expr *a, Expr *b, SourcePos p) {
 llvm::Value *lEmitLogicalOp(BinaryExpr::Op op, Expr *arg0, Expr *arg1, FunctionEmitContext *ctx, SourcePos pos) {
 
     const Type *type0 = arg0->GetType(), *type1 = arg1->GetType();
-    if (type0 == NULL || type1 == NULL) {
+    if (type0 == nullptr || type1 == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     // There is overhead (branches, etc.), to short-circuiting, so if the
@@ -1704,23 +1704,23 @@ llvm::Value *lEmitLogicalOp(BinaryExpr::Op op, Expr *arg0, Expr *arg1, FunctionE
     bool shortCircuit = (EstimateCost(arg1) > threshold || SafeToRunWithMaskAllOff(arg1) == false);
 
     // Skip short-circuiting for VectorTypes as well.
-    if ((shortCircuit == false) || CastType<VectorType>(type0) != NULL || CastType<VectorType>(type1) != NULL) {
+    if ((shortCircuit == false) || CastType<VectorType>(type0) != nullptr || CastType<VectorType>(type1) != nullptr) {
         // If one of the operands is uniform but the other is varying,
         // promote the uniform one to varying
         if (type0->IsUniformType() && type1->IsVaryingType()) {
             arg0 = TypeConvertExpr(arg0, AtomicType::VaryingBool, lOpString(op));
-            AssertPos(pos, arg0 != NULL);
+            AssertPos(pos, arg0 != nullptr);
         }
         if (type1->IsUniformType() && type0->IsVaryingType()) {
             arg1 = TypeConvertExpr(arg1, AtomicType::VaryingBool, lOpString(op));
-            AssertPos(pos, arg1 != NULL);
+            AssertPos(pos, arg1 != nullptr);
         }
 
         llvm::Value *value0 = arg0->GetValue(ctx);
         llvm::Value *value1 = arg1->GetValue(ctx);
-        if (value0 == NULL || value1 == NULL) {
+        if (value0 == nullptr || value1 == nullptr) {
             AssertPos(pos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
 
         if (op == BinaryExpr::LogicalAnd)
@@ -1733,9 +1733,9 @@ llvm::Value *lEmitLogicalOp(BinaryExpr::Op op, Expr *arg0, Expr *arg1, FunctionE
 
     // Allocate temporary storage for the return value
     const Type *retType = Type::MoreGeneralType(type0, type1, pos, lOpString(op));
-    if (retType == NULL) {
+    if (retType == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     AddressInfo *retPtrInfo = ctx->AllocaInst(retType, "logical_op_mem");
     llvm::BasicBlock *bbSkipEvalValue1 = ctx->CreateBasicBlock("skip_eval_1", ctx->GetCurrentBasicBlock());
@@ -1744,9 +1744,9 @@ llvm::Value *lEmitLogicalOp(BinaryExpr::Op op, Expr *arg0, Expr *arg1, FunctionE
 
     // Evaluate the first operand
     llvm::Value *value0 = arg0->GetValue(ctx);
-    if (value0 == NULL) {
+    if (value0 == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (type0->IsUniformType()) {
@@ -1786,13 +1786,13 @@ llvm::Value *lEmitLogicalOp(BinaryExpr::Op op, Expr *arg0, Expr *arg1, FunctionE
         ctx->SetCurrentBasicBlock(bbEvalValue1);
         if (type1->IsUniformType() && retType->IsVaryingType()) {
             arg1 = TypeConvertExpr(arg1, AtomicType::VaryingBool, "logical op");
-            AssertPos(pos, arg1 != NULL);
+            AssertPos(pos, arg1 != nullptr);
         }
 
         llvm::Value *value1 = arg1->GetValue(ctx);
-        if (value1 == NULL) {
+        if (value1 == nullptr) {
             AssertPos(pos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
         ctx->StoreInst(value1, retPtrInfo, arg1->GetType());
         ctx->BranchInst(bbLogicalDone);
@@ -1812,7 +1812,7 @@ llvm::Value *lEmitLogicalOp(BinaryExpr::Op op, Expr *arg0, Expr *arg1, FunctionE
         // perform logical vector ops with its value.
         if (type1->IsUniformType()) {
             arg1 = TypeConvertExpr(arg1, AtomicType::VaryingBool, "logical op");
-            AssertPos(pos, arg1 != NULL);
+            AssertPos(pos, arg1 != nullptr);
             type1 = arg1->GetType();
         }
 
@@ -1847,9 +1847,9 @@ llvm::Value *lEmitLogicalOp(BinaryExpr::Op op, Expr *arg0, Expr *arg1, FunctionE
             ctx->SetInternalMaskAndNot(oldMask, value0);
 
             llvm::Value *value1 = arg1->GetValue(ctx);
-            if (value1 == NULL) {
+            if (value1 == nullptr) {
                 AssertPos(pos, m->errorCount > 0);
-                return NULL;
+                return nullptr;
             }
 
             // We need to compute the result carefully, since vector
@@ -1895,9 +1895,9 @@ llvm::Value *lEmitLogicalOp(BinaryExpr::Op op, Expr *arg0, Expr *arg1, FunctionE
             ctx->SetInternalMaskAnd(oldMask, value0);
 
             llvm::Value *value1 = arg1->GetValue(ctx);
-            if (value1 == NULL) {
+            if (value1 == nullptr) {
                 AssertPos(pos, m->errorCount > 0);
-                return NULL;
+                return nullptr;
             }
 
             // And as in the || case, we compute the overall result by
@@ -1959,20 +1959,20 @@ static bool lIsDifficultShiftAmount(Expr *expr) {
 bool BinaryExpr::HasAmbiguousVariability(std::vector<const Expr *> &warn) const {
     bool isArg0Amb = false;
     bool isArg1Amb = false;
-    if (arg0 != NULL) {
+    if (arg0 != nullptr) {
         const Type *type0 = arg0->GetType();
         if (arg0->HasAmbiguousVariability(warn)) {
             isArg0Amb = true;
-        } else if ((type0 != NULL) && (type0->IsVaryingType())) {
+        } else if ((type0 != nullptr) && (type0->IsVaryingType())) {
             // If either arg is varying, then the expression is un-ambiguously varying.
             return false;
         }
     }
-    if (arg1 != NULL) {
+    if (arg1 != nullptr) {
         const Type *type1 = arg1->GetType();
         if (arg1->HasAmbiguousVariability(warn)) {
             isArg1Amb = true;
-        } else if ((type1 != NULL) && (type1->IsVaryingType())) {
+        } else if ((type1 != nullptr) && (type1->IsVaryingType())) {
             // If either arg is varying, then the expression is un-ambiguously varying.
             return false;
         }
@@ -1987,7 +1987,7 @@ bool BinaryExpr::HasAmbiguousVariability(std::vector<const Expr *> &warn) const 
 llvm::Value *BinaryExpr::GetValue(FunctionEmitContext *ctx) const {
     if (!arg0 || !arg1) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     // Handle these specially, since we want to short-circuit their evaluation...
@@ -1996,9 +1996,9 @@ llvm::Value *BinaryExpr::GetValue(FunctionEmitContext *ctx) const {
 
     llvm::Value *value0 = arg0->GetValue(ctx);
     llvm::Value *value1 = arg1->GetValue(ctx);
-    if (value0 == NULL || value1 == NULL) {
+    if (value0 == nullptr || value1 == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     ctx->SetDebugPos(pos);
@@ -2030,17 +2030,17 @@ llvm::Value *BinaryExpr::GetValue(FunctionEmitContext *ctx) const {
         return value1;
     default:
         FATAL("logic error");
-        return NULL;
+        return nullptr;
     }
 }
 
 const Type *BinaryExpr::GetType() const {
-    if (arg0 == NULL || arg1 == NULL)
-        return NULL;
+    if (arg0 == nullptr || arg1 == nullptr)
+        return nullptr;
 
     const Type *type0 = arg0->GetType(), *type1 = arg1->GetType();
-    if (type0 == NULL || type1 == NULL)
-        return NULL;
+    if (type0 == nullptr || type1 == nullptr)
+        return nullptr;
 
     if (type0->IsDependentType() || type1->IsDependentType()) {
         return AtomicType::Dependent;
@@ -2051,17 +2051,17 @@ const Type *BinaryExpr::GetType() const {
     // and will fail type checking and (int + ptr) should be canonicalized
     // into (ptr + int) by type checking.
     if (op == Add)
-        AssertPos(pos, CastType<PointerType>(type1) == NULL);
+        AssertPos(pos, CastType<PointerType>(type1) == nullptr);
 
     if (op == Comma)
         return arg1->GetType();
 
-    if (CastType<PointerType>(type0) != NULL) {
+    if (CastType<PointerType>(type0) != nullptr) {
         if (op == Add)
             // ptr + int -> ptr
             return type0;
         else if (op == Sub) {
-            if (CastType<PointerType>(type1) != NULL) {
+            if (CastType<PointerType>(type1) != nullptr) {
                 // ptr - ptr -> ~ptrdiff_t
                 const Type *diffType = (g->target->is32Bit() || g->opt.force32BitAddressing) ? AtomicType::UniformInt32
                                                                                              : AtomicType::UniformInt64;
@@ -2080,7 +2080,7 @@ const Type *BinaryExpr::GetType() const {
     const Type *exprType = Type::MoreGeneralType(type0, type1, pos, lOpString(op));
     // I don't think that MoreGeneralType should be able to fail after the
     // checks done in BinaryExpr::TypeCheck().
-    AssertPos(pos, exprType != NULL);
+    AssertPos(pos, exprType != nullptr);
 
     switch (op) {
     case Add:
@@ -2109,7 +2109,7 @@ const Type *BinaryExpr::GetType() const {
         // handled above, so fall through here just in case
     default:
         FATAL("logic error in BinaryExpr::GetType()");
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -2183,14 +2183,14 @@ static ConstExpr *lConstFoldBinaryIntOp(BinaryExpr::Op op, const T *v0, const T 
         for (int i = 0; i < count; ++i) {
             if (v1[i] == 0) {
                 Warning(pos, "Remainder by zero is undefined.");
-                return NULL;
+                return nullptr;
             } else {
                 result[i] = (v0[i] % v1[i]);
             }
         }
         break;
     default:
-        return NULL;
+        return nullptr;
     }
 
     return new ConstExpr(carg0->GetType(), result, carg0->pos);
@@ -2213,7 +2213,7 @@ static ConstExpr *lConstFoldBinaryLogicalOp(BinaryExpr::Op op, const T *v0, cons
         FOLD_OP(BinaryExpr::LogicalAnd, &&);
         FOLD_OP(BinaryExpr::LogicalOr, ||);
     default:
-        return NULL;
+        return nullptr;
     }
 
     const Type *rType = carg0->GetType()->IsUniformType() ? AtomicType::UniformBool : AtomicType::VaryingBool;
@@ -2243,7 +2243,7 @@ static ConstExpr *lConstFoldBinaryLogicalFPOp(BinaryExpr::Op op, std::vector<llv
         }
         break;
     default:
-        return NULL;
+        return nullptr;
     }
 
     const Type *rType = carg0->GetType()->IsUniformType() ? AtomicType::UniformBool : AtomicType::VaryingBool;
@@ -2278,7 +2278,7 @@ static ConstExpr *lConstFoldBinaryArithFPOp(BinaryExpr::Op op, std::vector<llvm:
         FOLD_FP_OP(BinaryExpr::Mul, multiply);
         FOLD_FP_OP(BinaryExpr::Div, divide);
     default:
-        return NULL;
+        return nullptr;
     }
 
     return new ConstExpr(carg0->GetType(), result, carg0->pos);
@@ -2300,14 +2300,14 @@ static ConstExpr *lConstFoldBinaryArithOp(BinaryExpr::Op op, const T *v0, const 
         for (int i = 0; i < count; ++i) {
             if (v1[i] == 0) {
                 Warning(pos, "Division by zero is undefined.");
-                return NULL;
+                return nullptr;
             } else {
                 result[i] = (v0[i] / v1[i]);
             }
         }
         break;
     default:
-        return NULL;
+        return nullptr;
     }
 
     return new ConstExpr(carg0->GetType(), result, carg0->pos);
@@ -2332,7 +2332,7 @@ static ConstExpr *lConstFoldBoolBinaryOp(BinaryExpr::Op op, const bool *v0, cons
         FOLD_OP(BinaryExpr::LogicalAnd, &&);
         FOLD_OP(BinaryExpr::LogicalOr, ||);
     default:
-        return NULL;
+        return nullptr;
     }
 
     return new ConstExpr(carg0->GetType(), result, carg0->pos);
@@ -2344,9 +2344,9 @@ static Expr *lConstFoldBinaryFPOp(ConstExpr *constArg0, ConstExpr *constArg1, Bi
     constArg0->GetValues(v0, llvmType);
     constArg1->GetValues(v1, llvmType);
     ConstExpr *ret;
-    if ((ret = lConstFoldBinaryArithFPOp(op, v0, v1, constArg0, pos)) != NULL)
+    if ((ret = lConstFoldBinaryArithFPOp(op, v0, v1, constArg0, pos)) != nullptr)
         return ret;
-    else if ((ret = lConstFoldBinaryLogicalFPOp(op, v0, v1, constArg0)) != NULL)
+    else if ((ret = lConstFoldBinaryLogicalFPOp(op, v0, v1, constArg0)) != nullptr)
         return ret;
     else
         return origExpr;
@@ -2359,19 +2359,19 @@ static Expr *lConstFoldBinaryIntOp(ConstExpr *constArg0, ConstExpr *constArg1, B
     constArg0->GetValues(v0);
     constArg1->GetValues(v1);
     ConstExpr *ret;
-    if ((ret = lConstFoldBinaryArithOp<T, TRef>(op, v0, v1, constArg0, pos)) != NULL)
+    if ((ret = lConstFoldBinaryArithOp<T, TRef>(op, v0, v1, constArg0, pos)) != nullptr)
         return ret;
-    else if ((ret = lConstFoldBinaryIntOp<T, TRef>(op, v0, v1, constArg0, pos)) != NULL)
+    else if ((ret = lConstFoldBinaryIntOp<T, TRef>(op, v0, v1, constArg0, pos)) != nullptr)
         return ret;
-    else if ((ret = lConstFoldBinaryLogicalOp(op, v0, v1, constArg0)) != NULL)
+    else if ((ret = lConstFoldBinaryLogicalOp(op, v0, v1, constArg0)) != nullptr)
         return ret;
     else
         return origExpr;
 }
 
 Expr *BinaryExpr::Optimize() {
-    if (arg0 == NULL || arg1 == NULL)
-        return NULL;
+    if (arg0 == nullptr || arg1 == nullptr)
+        return nullptr;
 
     ConstExpr *constArg0 = llvm::dyn_cast<ConstExpr>(arg0);
     ConstExpr *constArg1 = llvm::dyn_cast<ConstExpr>(arg1);
@@ -2382,7 +2382,7 @@ Expr *BinaryExpr::Optimize() {
         // optimizations related to division by floats..
 
         // transform x / const -> x * (1/const)
-        if (op == Div && constArg1 != NULL) {
+        if (op == Div && constArg1 != nullptr) {
             const Type *type1 = constArg1->GetType();
             if (Type::EqualIgnoringConst(type1, AtomicType::UniformFloat16) ||
                 Type::EqualIgnoringConst(type1, AtomicType::VaryingFloat16) ||
@@ -2402,8 +2402,8 @@ Expr *BinaryExpr::Optimize() {
                 Expr *einv = new ConstExpr(type1, inv, constArg1->pos);
                 Expr *e = new BinaryExpr(Mul, arg0, einv, pos);
                 e = ::TypeCheck(e);
-                if (e == NULL)
-                    return NULL;
+                if (e == nullptr)
+                    return nullptr;
                 return ::Optimize(e);
             }
         }
@@ -2425,13 +2425,13 @@ Expr *BinaryExpr::Optimize() {
                     ExprList *args = new ExprList(arg1, arg1->pos);
                     Expr *rcpCall = new FunctionCallExpr(rcpSymExpr, args, arg1->pos);
                     rcpCall = ::TypeCheck(rcpCall);
-                    if (rcpCall != NULL) {
+                    if (rcpCall != nullptr) {
                         rcpCall = ::Optimize(rcpCall);
-                        if (rcpCall != NULL) {
+                        if (rcpCall != nullptr) {
                             Expr *ret = new BinaryExpr(Mul, arg0, rcpCall, pos);
                             ret = ::TypeCheck(ret);
-                            if (ret == NULL)
-                                return NULL;
+                            if (ret == nullptr)
+                                return nullptr;
                             return ::Optimize(ret);
                         }
                     }
@@ -2447,7 +2447,7 @@ Expr *BinaryExpr::Optimize() {
 
     // From here on out, we're just doing constant folding, so if both args
     // aren't constants then we're done...
-    if (constArg0 == NULL || constArg1 == NULL)
+    if (constArg0 == nullptr || constArg1 == nullptr)
         return this;
 
     AssertPos(pos, Type::EqualIgnoringConst(arg0->GetType(), arg1->GetType()));
@@ -2479,9 +2479,9 @@ Expr *BinaryExpr::Optimize() {
         constArg0->GetValues(v0);
         constArg1->GetValues(v1);
         ConstExpr *ret;
-        if ((ret = lConstFoldBoolBinaryOp(op, v0, v1, constArg0)) != NULL)
+        if ((ret = lConstFoldBoolBinaryOp(op, v0, v1, constArg0)) != nullptr)
             return ret;
-        else if ((ret = lConstFoldBinaryLogicalOp(op, v0, v1, constArg0)) != NULL)
+        else if ((ret = lConstFoldBinaryLogicalOp(op, v0, v1, constArg0)) != nullptr)
             return ret;
         else
             return this;
@@ -2490,12 +2490,12 @@ Expr *BinaryExpr::Optimize() {
 }
 
 Expr *BinaryExpr::TypeCheck() {
-    if (arg0 == NULL || arg1 == NULL)
-        return NULL;
+    if (arg0 == nullptr || arg1 == nullptr)
+        return nullptr;
 
     const Type *type0 = arg0->GetType(), *type1 = arg1->GetType();
-    if (type0 == NULL || type1 == NULL)
-        return NULL;
+    if (type0 == nullptr || type1 == nullptr)
+        return nullptr;
 
     if (type0->IsDependentType() || type1->IsDependentType()) {
         return this;
@@ -2503,23 +2503,23 @@ Expr *BinaryExpr::TypeCheck() {
 
     // If either operand is a reference, dereference it before we move
     // forward
-    if (CastType<ReferenceType>(type0) != NULL) {
+    if (CastType<ReferenceType>(type0) != nullptr) {
         arg0 = new RefDerefExpr(arg0, arg0->pos);
         type0 = arg0->GetType();
-        AssertPos(pos, type0 != NULL);
+        AssertPos(pos, type0 != nullptr);
     }
-    if (CastType<ReferenceType>(type1) != NULL) {
+    if (CastType<ReferenceType>(type1) != nullptr) {
         arg1 = new RefDerefExpr(arg1, arg1->pos);
         type1 = arg1->GetType();
-        AssertPos(pos, type1 != NULL);
+        AssertPos(pos, type1 != nullptr);
     }
 
     // Convert arrays to pointers to their first elements
-    if (CastType<ArrayType>(type0) != NULL) {
+    if (CastType<ArrayType>(type0) != nullptr) {
         arg0 = lArrayToPointer(arg0);
         type0 = arg0->GetType();
     }
-    if (CastType<ArrayType>(type1) != NULL) {
+    if (CastType<ArrayType>(type1) != nullptr) {
         arg1 = lArrayToPointer(arg1);
         type1 = arg1->GetType();
     }
@@ -2530,66 +2530,66 @@ Expr *BinaryExpr::TypeCheck() {
               "Illegal to use binary operator %s with SOA type "
               "\"%s\".",
               lOpString(op), type0->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
     if (type1->GetSOAWidth() > 0) {
         Error(arg1->pos,
               "Illegal to use binary operator %s with SOA type "
               "\"%s\".",
               lOpString(op), type1->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
 
     const PointerType *pt0 = CastType<PointerType>(type0);
     const PointerType *pt1 = CastType<PointerType>(type1);
-    if (pt0 != NULL && pt1 != NULL && op == Sub) {
+    if (pt0 != nullptr && pt1 != nullptr && op == Sub) {
         // Pointer subtraction
         if (PointerType::IsVoidPointer(type0)) {
             Error(pos,
                   "Illegal to perform pointer arithmetic "
                   "on \"%s\" type.",
                   type0->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
         if (PointerType::IsVoidPointer(type1)) {
             Error(pos,
                   "Illegal to perform pointer arithmetic "
                   "on \"%s\" type.",
                   type1->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
         if (CastType<UndefinedStructType>(pt0->GetBaseType())) {
             Error(pos,
                   "Illegal to perform pointer arithmetic "
                   "on undefined struct type \"%s\".",
                   pt0->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
         if (CastType<UndefinedStructType>(pt1->GetBaseType())) {
             Error(pos,
                   "Illegal to perform pointer arithmetic "
                   "on undefined struct type \"%s\".",
                   pt1->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
 
         const Type *t = Type::MoreGeneralType(type0, type1, pos, "-");
-        if (t == NULL)
-            return NULL;
+        if (t == nullptr)
+            return nullptr;
 
         arg0 = TypeConvertExpr(arg0, t, "pointer subtraction");
         arg1 = TypeConvertExpr(arg1, t, "pointer subtraction");
-        if (arg0 == NULL || arg1 == NULL)
-            return NULL;
+        if (arg0 == nullptr || arg1 == nullptr)
+            return nullptr;
 
         return this;
-    } else if (((pt0 != NULL || pt1 != NULL) && op == Add) || (pt0 != NULL && op == Sub)) {
+    } else if (((pt0 != nullptr || pt1 != nullptr) && op == Add) || (pt0 != nullptr && op == Sub)) {
         // Handle ptr + int, int + ptr, ptr - int
-        if (pt0 != NULL && pt1 != NULL) {
+        if (pt0 != nullptr && pt1 != nullptr) {
             Error(pos, "Illegal to add two pointer types \"%s\" and \"%s\".", pt0->GetString().c_str(),
                   pt1->GetString().c_str());
-            return NULL;
-        } else if (pt1 != NULL) {
+            return nullptr;
+        } else if (pt1 != nullptr) {
             // put in canonical order with the pointer as the first operand
             // for GetValue()
             std::swap(arg0, arg1);
@@ -2597,21 +2597,21 @@ Expr *BinaryExpr::TypeCheck() {
             std::swap(pt0, pt1);
         }
 
-        AssertPos(pos, pt0 != NULL);
+        AssertPos(pos, pt0 != nullptr);
 
         if (PointerType::IsVoidPointer(pt0)) {
             Error(pos,
                   "Illegal to perform pointer arithmetic "
                   "on \"%s\" type.",
                   pt0->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
         if (CastType<UndefinedStructType>(pt0->GetBaseType())) {
             Error(pos,
                   "Illegal to perform pointer arithmetic "
                   "on undefined struct type \"%s\".",
                   pt0->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
 
         const Type *offsetType = g->target->is32Bit() ? AtomicType::UniformInt32 : AtomicType::UniformInt64;
@@ -2620,12 +2620,12 @@ Expr *BinaryExpr::TypeCheck() {
         if (type1->IsVaryingType()) {
             arg0 = TypeConvertExpr(arg0, type0->GetAsVaryingType(), "pointer addition");
             offsetType = offsetType->GetAsVaryingType();
-            AssertPos(pos, arg0 != NULL);
+            AssertPos(pos, arg0 != nullptr);
         }
 
         arg1 = TypeConvertExpr(arg1, offsetType, lOpString(op));
-        if (arg1 == NULL)
-            return NULL;
+        if (arg1 == nullptr)
+            return nullptr;
 
         return this;
     }
@@ -2643,36 +2643,36 @@ Expr *BinaryExpr::TypeCheck() {
                   "First operand to binary operator \"%s\" must be "
                   "an integer or bool.",
                   lOpString(op));
-            return NULL;
+            return nullptr;
         }
         if (!type1->IsIntType() && !type1->IsBoolType()) {
             Error(arg1->pos,
                   "Second operand to binary operator \"%s\" must be "
                   "an integer or bool.",
                   lOpString(op));
-            return NULL;
+            return nullptr;
         }
 
         if (op == Shl || op == Shr) {
             bool isVarying = (type0->IsVaryingType() || type1->IsVaryingType());
             if (isVarying) {
                 arg0 = TypeConvertExpr(arg0, type0->GetAsVaryingType(), "shift operator");
-                if (arg0 == NULL)
-                    return NULL;
+                if (arg0 == nullptr)
+                    return nullptr;
                 type0 = arg0->GetType();
             }
             arg1 = TypeConvertExpr(arg1, type0, "shift operator");
-            if (arg1 == NULL)
-                return NULL;
+            if (arg1 == nullptr)
+                return nullptr;
         } else {
             const Type *promotedType = Type::MoreGeneralType(type0, type1, arg0->pos, "binary bit op");
-            if (promotedType == NULL)
-                return NULL;
+            if (promotedType == nullptr)
+                return nullptr;
 
             arg0 = TypeConvertExpr(arg0, promotedType, "binary bit op");
             arg1 = TypeConvertExpr(arg1, promotedType, "binary bit op");
-            if (arg0 == NULL || arg1 == NULL)
-                return NULL;
+            if (arg0 == nullptr || arg1 == nullptr)
+                return nullptr;
         }
         return this;
     }
@@ -2687,24 +2687,24 @@ Expr *BinaryExpr::TypeCheck() {
                   "First operand to binary operator \"%s\" is of "
                   "invalid type \"%s\".",
                   lOpString(op), type0->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
         if (!type1->IsNumericType() || (op == Mod && type1->IsFloatType())) {
             Error(arg1->pos,
                   "First operand to binary operator \"%s\" is of "
                   "invalid type \"%s\".",
                   lOpString(op), type1->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
 
         const Type *promotedType = Type::MoreGeneralType(type0, type1, Union(arg0->pos, arg1->pos), lOpString(op));
-        if (promotedType == NULL)
-            return NULL;
+        if (promotedType == nullptr)
+            return nullptr;
 
         arg0 = TypeConvertExpr(arg0, promotedType, lOpString(op));
         arg1 = TypeConvertExpr(arg1, promotedType, lOpString(op));
-        if (arg0 == NULL || arg1 == NULL)
-            return NULL;
+        if (arg0 == nullptr || arg1 == nullptr)
+            return nullptr;
         return this;
     }
     case Lt:
@@ -2717,42 +2717,42 @@ Expr *BinaryExpr::TypeCheck() {
         const PointerType *pt1 = CastType<PointerType>(type1);
 
         // Convert '0' in expressions where the other expression is a
-        // pointer type to a NULL pointer.
-        if (pt0 != NULL && lIsAllIntZeros(arg1)) {
+        // pointer type to a nullptr pointer.
+        if (pt0 != nullptr && lIsAllIntZeros(arg1)) {
             arg1 = new NullPointerExpr(pos);
             type1 = arg1->GetType();
             pt1 = CastType<PointerType>(type1);
-        } else if (pt1 != NULL && lIsAllIntZeros(arg0)) {
+        } else if (pt1 != nullptr && lIsAllIntZeros(arg0)) {
             arg0 = new NullPointerExpr(pos);
             type0 = arg0->GetType();
             pt0 = CastType<PointerType>(type0);
         }
 
-        if (pt0 == NULL && pt1 == NULL) {
+        if (pt0 == nullptr && pt1 == nullptr) {
             if (!type0->IsBoolType() && !type0->IsNumericType()) {
                 Error(arg0->pos,
                       "First operand to operator \"%s\" is of "
                       "non-comparable type \"%s\".",
                       lOpString(op), type0->GetString().c_str());
-                return NULL;
+                return nullptr;
             }
             if (!type1->IsBoolType() && !type1->IsNumericType()) {
                 Error(arg1->pos,
                       "Second operand to operator \"%s\" is of "
                       "non-comparable type \"%s\".",
                       lOpString(op), type1->GetString().c_str());
-                return NULL;
+                return nullptr;
             }
         }
 
         const Type *promotedType = Type::MoreGeneralType(type0, type1, arg0->pos, lOpString(op));
-        if (promotedType == NULL)
-            return NULL;
+        if (promotedType == nullptr)
+            return nullptr;
 
         arg0 = TypeConvertExpr(arg0, promotedType, lOpString(op));
         arg1 = TypeConvertExpr(arg1, promotedType, lOpString(op));
-        if (arg0 == NULL || arg1 == NULL)
-            return NULL;
+        if (arg0 == nullptr || arg1 == nullptr)
+            return nullptr;
         return this;
     }
     case LogicalAnd:
@@ -2763,7 +2763,7 @@ Expr *BinaryExpr::TypeCheck() {
         const AtomicType *boolType0 = type0->IsUniformType() ? AtomicType::UniformBool : AtomicType::VaryingBool;
         const AtomicType *boolType1 = type1->IsUniformType() ? AtomicType::UniformBool : AtomicType::VaryingBool;
 
-        const Type *destType0 = NULL, *destType1 = NULL;
+        const Type *destType0 = nullptr, *destType1 = nullptr;
         const VectorType *vtype0 = CastType<VectorType>(type0);
         const VectorType *vtype1 = CastType<VectorType>(type1);
         if (vtype0 && vtype1) {
@@ -2773,14 +2773,14 @@ Expr *BinaryExpr::TypeCheck() {
                       "Can't do logical operation \"%s\" between vector types of "
                       "different sizes (%d vs. %d).",
                       lOpString(op), sz0, sz1);
-                return NULL;
+                return nullptr;
             }
             destType0 = new VectorType(boolType0, sz0);
             destType1 = new VectorType(boolType1, sz1);
-        } else if (vtype0 != NULL) {
+        } else if (vtype0 != nullptr) {
             destType0 = new VectorType(boolType0, vtype0->GetElementCount());
             destType1 = new VectorType(boolType1, vtype0->GetElementCount());
-        } else if (vtype1 != NULL) {
+        } else if (vtype1 != nullptr) {
             destType0 = new VectorType(boolType0, vtype1->GetElementCount());
             destType1 = new VectorType(boolType1, vtype1->GetElementCount());
         } else {
@@ -2790,30 +2790,30 @@ Expr *BinaryExpr::TypeCheck() {
 
         arg0 = TypeConvertExpr(arg0, destType0, lOpString(op));
         arg1 = TypeConvertExpr(arg1, destType1, lOpString(op));
-        if (arg0 == NULL || arg1 == NULL)
-            return NULL;
+        if (arg0 == nullptr || arg1 == nullptr)
+            return nullptr;
         return this;
     }
     case Comma:
         return this;
     default:
         FATAL("logic error");
-        return NULL;
+        return nullptr;
     }
 }
 
 const Type *BinaryExpr::GetLValueType() const {
     const Type *t = GetType();
-    if (CastType<PointerType>(t) != NULL) {
+    if (CastType<PointerType>(t) != nullptr) {
         // Are we doing something like (basePtr + offset)[...] = ...
         return t;
     } else {
-        return NULL;
+        return nullptr;
     }
 }
 
 int BinaryExpr::EstimateCost() const {
-    if (llvm::dyn_cast<ConstExpr>(arg0) != NULL && llvm::dyn_cast<ConstExpr>(arg1) != NULL)
+    if (llvm::dyn_cast<ConstExpr>(arg0) != nullptr && llvm::dyn_cast<ConstExpr>(arg1) != nullptr)
         return 0;
 
     return (op == Div || op == Mod) ? COST_COMPLEX_ARITH_OP : COST_SIMPLE_ARITH_LOGIC_OP;
@@ -2852,7 +2852,7 @@ static std::pair<llvm::Constant *, bool> lGetBinaryExprStorageConstant(const Typ
     // Are we doing something like (basePtr + offset)[...] = ... for a Global
     // Variable
     if (!bExpr->GetLValueType())
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
 
     // We are limiting cases to just addition and subtraction involving
     // pointer addresses
@@ -2862,12 +2862,12 @@ static std::pair<llvm::Constant *, bool> lGetBinaryExprStorageConstant(const Typ
     // In this case, it has to be an addition with first argument as
     // a constant value.
     if (!((op == BinaryExpr::Op::Add) || (op == BinaryExpr::Op::Sub)))
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
     if (op == BinaryExpr::Op::Sub) {
         // Ignore cases where subtrahend is a PointerType
         // Eg. b - 5 is valid but 5 - b is not.
         if (CastType<PointerType>(arg1->GetType()))
-            return std::pair<llvm::Constant *, bool>(NULL, false);
+            return std::pair<llvm::Constant *, bool>(nullptr, false);
     }
 
     // 'isNotValidForMultiTargetGlobal' is required to let the caller know
@@ -2888,8 +2888,8 @@ static std::pair<llvm::Constant *, bool> lGetBinaryExprStorageConstant(const Typ
         llvm::Constant *c1 = c1Pair.first;
         isNotValidForMultiTargetGlobal = isNotValidForMultiTargetGlobal || c1Pair.second;
         ConstExpr *cExpr = llvm::dyn_cast<ConstExpr>(arg1);
-        if ((cExpr == NULL) || (c1 == NULL))
-            return std::pair<llvm::Constant *, bool>(NULL, false);
+        if ((cExpr == nullptr) || (c1 == nullptr))
+            return std::pair<llvm::Constant *, bool>(nullptr, false);
         std::pair<llvm::Constant *, bool> c2Pair;
         if (isStorageType)
             c2Pair = cExpr->GetStorageConstant(cExpr->GetType());
@@ -2910,8 +2910,8 @@ static std::pair<llvm::Constant *, bool> lGetBinaryExprStorageConstant(const Typ
         llvm::Constant *c1 = c1Pair.first;
         isNotValidForMultiTargetGlobal = isNotValidForMultiTargetGlobal || c1Pair.second;
         ConstExpr *cExpr = llvm::dyn_cast<ConstExpr>(arg0);
-        if ((cExpr == NULL) || (c1 == NULL))
-            return std::pair<llvm::Constant *, bool>(NULL, false);
+        if ((cExpr == nullptr) || (c1 == nullptr))
+            return std::pair<llvm::Constant *, bool>(nullptr, false);
         std::pair<llvm::Constant *, bool> c2Pair;
         if (isStorageType)
             c2Pair = cExpr->GetStorageConstant(cExpr->GetType());
@@ -2923,7 +2923,7 @@ static std::pair<llvm::Constant *, bool> lGetBinaryExprStorageConstant(const Typ
         return std::pair<llvm::Constant *, bool>(c, isNotValidForMultiTargetGlobal);
     }
 
-    return std::pair<llvm::Constant *, bool>(NULL, false);
+    return std::pair<llvm::Constant *, bool>(nullptr, false);
 }
 
 std::pair<llvm::Constant *, bool> BinaryExpr::GetStorageConstant(const Type *type) const {
@@ -2976,12 +2976,12 @@ static llvm::Value *lEmitOpAssign(AssignExpr::Op op, Expr *arg0, Expr *arg1, con
         // FIXME: I think this test is unnecessary and that this case
         // should be caught during typechecking
         Error(pos, "Can't assign to left-hand side of expression.");
-        return NULL;
+        return nullptr;
     }
     const Type *lvalueType = arg0->GetLValueType();
     const Type *resultType = arg0->GetType();
-    if (lvalueType == NULL || resultType == NULL)
-        return NULL;
+    if (lvalueType == nullptr || resultType == nullptr)
+        return nullptr;
 
     // Get the value on the right-hand side of the assignment+operation
     // operator and load the current value on the left-hand side.
@@ -3026,11 +3026,11 @@ static llvm::Value *lEmitOpAssign(AssignExpr::Op op, Expr *arg0, Expr *arg1, con
         break;
     default:
         FATAL("logic error in lEmitOpAssign()");
-        return NULL;
+        return nullptr;
     }
 
     // Emit the code to compute the new value
-    llvm::Value *newValue = NULL;
+    llvm::Value *newValue = nullptr;
     switch (op) {
     case AssignExpr::MulAssign:
     case AssignExpr::DivAssign:
@@ -3048,7 +3048,7 @@ static llvm::Value *lEmitOpAssign(AssignExpr::Op op, Expr *arg0, Expr *arg1, con
         break;
     default:
         FATAL("logic error in lEmitOpAssign");
-        return NULL;
+        return nullptr;
     }
 
     // And store the result back to the lvalue.
@@ -3064,9 +3064,9 @@ AssignExpr::AssignExpr(AssignExpr::Op o, Expr *a, Expr *b, SourcePos p) : Expr(p
 }
 
 llvm::Value *AssignExpr::GetValue(FunctionEmitContext *ctx) const {
-    const Type *type = NULL;
-    if (lvalue == NULL || rvalue == NULL || (type = GetType()) == NULL)
-        return NULL;
+    const Type *type = nullptr;
+    if (lvalue == nullptr || rvalue == nullptr || (type = GetType()) == nullptr)
+        return nullptr;
     ctx->SetDebugPos(pos);
 
     Symbol *baseSym = lvalue->GetBaseSymbol();
@@ -3074,22 +3074,22 @@ llvm::Value *AssignExpr::GetValue(FunctionEmitContext *ctx) const {
     switch (op) {
     case Assign: {
         llvm::Value *ptr = lvalue->GetLValue(ctx);
-        if (ptr == NULL) {
+        if (ptr == nullptr) {
             Error(lvalue->pos, "Left hand side of assignment expression can't "
                                "be assigned to.");
-            return NULL;
+            return nullptr;
         }
         const Type *ptrType = lvalue->GetLValueType();
         const Type *valueType = rvalue->GetType();
-        if (ptrType == NULL || valueType == NULL) {
+        if (ptrType == nullptr || valueType == nullptr) {
             AssertPos(pos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
 
         llvm::Value *value = rvalue->GetValue(ctx);
-        if (value == NULL) {
+        if (value == nullptr) {
             AssertPos(pos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
 
         ctx->SetDebugPos(lvalue->pos);
@@ -3114,13 +3114,13 @@ llvm::Value *AssignExpr::GetValue(FunctionEmitContext *ctx) const {
     }
     default:
         FATAL("logic error in AssignExpr::GetValue()");
-        return NULL;
+        return nullptr;
     }
 }
 
 Expr *AssignExpr::Optimize() {
-    if (lvalue == NULL || rvalue == NULL)
-        return NULL;
+    if (lvalue == nullptr || rvalue == nullptr)
+        return nullptr;
     return this;
 }
 
@@ -3132,7 +3132,7 @@ const Type *AssignExpr::GetType() const {
         }
         return ltype;
     }
-    return NULL;
+    return nullptr;
 }
 
 /** Recursively checks a structure type to see if it (or any struct type
@@ -3156,15 +3156,15 @@ static bool lCheckForConstStructMember(SourcePos pos, const StructType *structTy
         }
 
         const StructType *st = CastType<StructType>(t);
-        if (st != NULL && lCheckForConstStructMember(pos, st, initialType))
+        if (st != nullptr && lCheckForConstStructMember(pos, st, initialType))
             return true;
     }
     return false;
 }
 
 Expr *AssignExpr::TypeCheck() {
-    if (lvalue == NULL || rvalue == NULL)
-        return NULL;
+    if (lvalue == nullptr || rvalue == nullptr)
+        return nullptr;
 
     const Type *ltype = lvalue->GetType();
     const Type *rtype = rvalue->GetType();
@@ -3172,20 +3172,20 @@ Expr *AssignExpr::TypeCheck() {
         return this;
     }
 
-    bool lvalueIsReference = CastType<ReferenceType>(lvalue->GetType()) != NULL;
+    bool lvalueIsReference = CastType<ReferenceType>(lvalue->GetType()) != nullptr;
     if (lvalueIsReference)
         lvalue = new RefDerefExpr(lvalue, lvalue->pos);
 
     if (PossiblyResolveFunctionOverloads(rvalue, lvalue->GetType()) == false) {
         Error(pos, "Unable to find overloaded function for function "
                    "pointer assignment.");
-        return NULL;
+        return nullptr;
     }
 
     const Type *lhsType = lvalue->GetType();
-    if (lhsType == NULL) {
+    if (lhsType == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (lhsType->IsConstType()) {
@@ -3193,17 +3193,17 @@ Expr *AssignExpr::TypeCheck() {
               "Can't assign to type \"%s\" on left-hand side of "
               "expression.",
               lhsType->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
 
-    if (CastType<PointerType>(lhsType) != NULL) {
+    if (CastType<PointerType>(lhsType) != nullptr) {
         if (op == AddAssign || op == SubAssign) {
             if (PointerType::IsVoidPointer(lhsType)) {
                 Error(pos,
                       "Illegal to perform pointer arithmetic on \"%s\" "
                       "type.",
                       lhsType->GetString().c_str());
-                return NULL;
+                return nullptr;
             }
 
             const Type *deltaType = g->target->is32Bit() ? AtomicType::UniformInt32 : AtomicType::UniformInt64;
@@ -3214,16 +3214,16 @@ Expr *AssignExpr::TypeCheck() {
             rvalue = TypeConvertExpr(rvalue, lhsType, "assignment");
         else {
             Error(lvalue->pos, "Assignment operator \"%s\" is illegal with pointer types.", lOpString(op));
-            return NULL;
+            return nullptr;
         }
-    } else if (CastType<ArrayType>(lhsType) != NULL) {
+    } else if (CastType<ArrayType>(lhsType) != nullptr) {
         Error(lvalue->pos, "Illegal to assign to array type \"%s\".", lhsType->GetString().c_str());
-        return NULL;
+        return nullptr;
     } else
         rvalue = TypeConvertExpr(rvalue, lhsType, lOpString(op));
 
-    if (rvalue == NULL)
-        return NULL;
+    if (rvalue == nullptr)
+        return nullptr;
 
     if (lhsType->IsFloatType() == true &&
         (op == ShlAssign || op == ShrAssign || op == AndAssign || op == XorAssign || op == OrAssign)) {
@@ -3231,21 +3231,21 @@ Expr *AssignExpr::TypeCheck() {
               "Illegal to use %s operator with floating-point "
               "operands.",
               lOpString(op));
-        return NULL;
+        return nullptr;
     }
 
     const StructType *st = CastType<StructType>(lhsType);
-    if (st != NULL) {
+    if (st != nullptr) {
         // Make sure we're not assigning to a struct that has a constant member
         if (lCheckForConstStructMember(pos, st, st))
-            return NULL;
+            return nullptr;
 
         if (op != Assign) {
             Error(lvalue->pos,
                   "Assignment operator \"%s\" is illegal with struct "
                   "type \"%s\".",
                   lOpString(op), st->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
     }
     return this;
@@ -3299,7 +3299,7 @@ static llvm::Value *lEmitVaryingSelect(FunctionEmitContext *ctx, llvm::Value *te
                                        llvm::Value *expr2, const Type *type) {
 
     AddressInfo *resultPtrInfo = ctx->AllocaInst(type, "selectexpr_tmp");
-    Assert(resultPtrInfo != NULL);
+    Assert(resultPtrInfo != nullptr);
     // Don't need to worry about masking here
     ctx->StoreInst(expr2, resultPtrInfo, type);
     // Use masking to conditionally store the expr1 values
@@ -3332,20 +3332,20 @@ static void lEmitSelectExprCode(FunctionEmitContext *ctx, llvm::Value *testVal, 
 bool SelectExpr::HasAmbiguousVariability(std::vector<const Expr *> &warn) const {
     bool isExpr1Amb = false;
     bool isExpr2Amb = false;
-    if (expr1 != NULL) {
+    if (expr1 != nullptr) {
         const Type *type1 = expr1->GetType();
         if (expr1->HasAmbiguousVariability(warn)) {
             isExpr1Amb = true;
-        } else if ((type1 != NULL) && (type1->IsVaryingType())) {
+        } else if ((type1 != nullptr) && (type1->IsVaryingType())) {
             // If either expr is varying, then the expression is un-ambiguously varying.
             return false;
         }
     }
-    if (expr2 != NULL) {
+    if (expr2 != nullptr) {
         const Type *type2 = expr2->GetType();
         if (expr2->HasAmbiguousVariability(warn)) {
             isExpr2Amb = true;
-        } else if ((type2 != NULL) && (type2->IsVaryingType())) {
+        } else if ((type2 != nullptr) && (type2->IsVaryingType())) {
             // If either arg is varying, then the expression is un-ambiguously varying.
             return false;
         }
@@ -3359,7 +3359,7 @@ bool SelectExpr::HasAmbiguousVariability(std::vector<const Expr *> &warn) const 
 
 llvm::Value *SelectExpr::GetValue(FunctionEmitContext *ctx) const {
     if (!expr1 || !expr2 || !test)
-        return NULL;
+        return nullptr;
 
     ctx->SetDebugPos(pos);
 
@@ -3401,7 +3401,7 @@ llvm::Value *SelectExpr::GetValue(FunctionEmitContext *ctx) const {
         ret->addIncoming(expr1Val, truePred);
         ret->addIncoming(expr2Val, falsePred);
         return ret;
-    } else if (CastType<VectorType>(testType) == NULL) {
+    } else if (CastType<VectorType>(testType) == nullptr) {
         // the test is a varying bool type
         llvm::Value *testVal = test->GetValue(ctx);
         AssertPos(pos, testVal->getType() == LLVMTypes::MaskType);
@@ -3457,8 +3457,8 @@ llvm::Value *SelectExpr::GetValue(FunctionEmitContext *ctx) const {
         ctx->SetDebugPos(pos);
         const VectorType *vt = CastType<VectorType>(type);
         // Things that typechecking should have caught
-        AssertPos(pos, vt != NULL);
-        AssertPos(pos, CastType<VectorType>(testType) != NULL &&
+        AssertPos(pos, vt != nullptr);
+        AssertPos(pos, CastType<VectorType>(testType) != nullptr &&
                            (CastType<VectorType>(testType)->GetElementCount() == vt->GetElementCount()));
 
         // Do an element-wise select
@@ -3467,7 +3467,7 @@ llvm::Value *SelectExpr::GetValue(FunctionEmitContext *ctx) const {
             llvm::Value *ti = ctx->ExtractInst(testVal, i);
             llvm::Value *e1i = ctx->ExtractInst(expr1Val, i);
             llvm::Value *e2i = ctx->ExtractInst(expr2Val, i);
-            llvm::Value *sel = NULL;
+            llvm::Value *sel = nullptr;
             if (testType->IsUniformType()) {
                 // Extracting uniform vector bool to uniform bool require
                 // switching from i8 -> i1
@@ -3487,14 +3487,14 @@ llvm::Value *SelectExpr::GetValue(FunctionEmitContext *ctx) const {
 
 const Type *SelectExpr::GetType() const {
     if (!test || !expr1 || !expr2)
-        return NULL;
+        return nullptr;
 
     const Type *testType = test->GetType();
     const Type *expr1Type = expr1->GetType();
     const Type *expr2Type = expr2->GetType();
 
     if (!testType || !expr1Type || !expr2Type)
-        return NULL;
+        return nullptr;
 
     if (testType->IsDependentType() || expr1Type->IsDependentType() || expr2Type->IsDependentType()) {
         return AtomicType::Dependent;
@@ -3502,8 +3502,9 @@ const Type *SelectExpr::GetType() const {
 
     bool becomesVarying = (testType->IsVaryingType() || expr1Type->IsVaryingType() || expr2Type->IsVaryingType());
     // if expr1 and expr2 have different vector sizes, typechecking should fail...
-    int testVecSize = CastType<VectorType>(testType) != NULL ? CastType<VectorType>(testType)->GetElementCount() : 0;
-    int expr1VecSize = CastType<VectorType>(expr1Type) != NULL ? CastType<VectorType>(expr1Type)->GetElementCount() : 0;
+    int testVecSize = CastType<VectorType>(testType) != nullptr ? CastType<VectorType>(testType)->GetElementCount() : 0;
+    int expr1VecSize =
+        CastType<VectorType>(expr1Type) != nullptr ? CastType<VectorType>(expr1Type)->GetElementCount() : 0;
     AssertPos(pos, !(testVecSize != 0 && expr1VecSize != 0 && testVecSize != expr1VecSize));
 
     int vectorSize = std::max(testVecSize, expr1VecSize);
@@ -3535,11 +3536,11 @@ Expr *lConstFoldSelectFP(const bool bv[], ConstExpr *constExpr1, ConstExpr *cons
 }
 
 Expr *SelectExpr::Optimize() {
-    if (test == NULL || expr1 == NULL || expr2 == NULL)
-        return NULL;
+    if (test == nullptr || expr1 == nullptr || expr2 == nullptr)
+        return nullptr;
 
     ConstExpr *constTest = llvm::dyn_cast<ConstExpr>(test);
-    if (constTest == NULL)
+    if (constTest == nullptr)
         return this;
 
     // The test is a constant; see if we can resolve to one of the
@@ -3567,7 +3568,7 @@ Expr *SelectExpr::Optimize() {
         // condition..
         ConstExpr *constExpr1 = llvm::dyn_cast<ConstExpr>(expr1);
         ConstExpr *constExpr2 = llvm::dyn_cast<ConstExpr>(expr2);
-        if (constExpr1 == NULL || constExpr2 == NULL)
+        if (constExpr1 == nullptr || constExpr2 == nullptr)
             return this;
 
         AssertPos(pos, Type::Equal(constExpr1->GetType(), constExpr2->GetType()));
@@ -3605,12 +3606,12 @@ Expr *SelectExpr::Optimize() {
 }
 
 Expr *SelectExpr::TypeCheck() {
-    if (test == NULL || expr1 == NULL || expr2 == NULL)
-        return NULL;
+    if (test == nullptr || expr1 == nullptr || expr2 == nullptr)
+        return nullptr;
 
     const Type *type1 = expr1->GetType(), *type2 = expr2->GetType(), *testType = test->GetType();
     if (!type1 || !type2 || !testType)
-        return NULL;
+        return nullptr;
 
     if (testType->IsDependentType() || type1->IsDependentType() || type2->IsDependentType()) {
         return this;
@@ -3618,20 +3619,20 @@ Expr *SelectExpr::TypeCheck() {
 
     if (const ArrayType *at1 = CastType<ArrayType>(type1)) {
         expr1 = TypeConvertExpr(expr1, PointerType::GetUniform(at1->GetBaseType()), "select");
-        if (expr1 == NULL)
-            return NULL;
+        if (expr1 == nullptr)
+            return nullptr;
         type1 = expr1->GetType();
     }
     if (const ArrayType *at2 = CastType<ArrayType>(type2)) {
         expr2 = TypeConvertExpr(expr2, PointerType::GetUniform(at2->GetBaseType()), "select");
-        if (expr2 == NULL)
-            return NULL;
+        if (expr2 == nullptr)
+            return nullptr;
         type2 = expr2->GetType();
     }
 
     test = TypeConvertExpr(test, lMatchingBoolType(testType), "select");
-    if (test == NULL)
-        return NULL;
+    if (test == nullptr)
+        return nullptr;
     testType = test->GetType();
 
     int testVecSize = CastType<VectorType>(testType) ? CastType<VectorType>(testType)->GetElementCount() : 0;
@@ -3640,16 +3641,16 @@ Expr *SelectExpr::TypeCheck() {
 
     // If the promoted type is a ReferenceType, the expression type will be
     // the reference target type since SelectExpr is always a rvalue.
-    if (CastType<ReferenceType>(promotedType) != NULL)
+    if (CastType<ReferenceType>(promotedType) != nullptr)
         promotedType = promotedType->GetReferenceTarget();
 
-    if (promotedType == NULL)
-        return NULL;
+    if (promotedType == nullptr)
+        return nullptr;
 
     expr1 = TypeConvertExpr(expr1, promotedType, "select");
     expr2 = TypeConvertExpr(expr2, promotedType, "select");
-    if (expr1 == NULL || expr2 == NULL)
-        return NULL;
+    if (expr1 == nullptr || expr2 == nullptr)
+        return nullptr;
 
     return this;
 }
@@ -3695,45 +3696,45 @@ FunctionCallExpr::FunctionCallExpr(Expr *f, ExprList *a, SourcePos p, bool il, E
             tExpr->PrintAmbiguousVariability();
         }
     }
-    if (lce != NULL) {
+    if (lce != nullptr) {
         launchCountExpr[0] = lce[0];
         launchCountExpr[1] = lce[1];
         launchCountExpr[2] = lce[2];
     } else
-        launchCountExpr[0] = launchCountExpr[1] = launchCountExpr[2] = NULL;
+        launchCountExpr[0] = launchCountExpr[1] = launchCountExpr[2] = nullptr;
 }
 
 static const Type *lGetFunctionType(Expr *func) {
-    if (func == NULL)
-        return NULL;
+    if (func == nullptr)
+        return nullptr;
 
     const Type *type = func->GetType();
-    if (type == NULL)
-        return NULL;
+    if (type == nullptr)
+        return nullptr;
 
     if (type->IsDependentType())
         return type;
 
     const FunctionType *ftype = CastType<FunctionType>(type);
-    if (ftype == NULL) {
+    if (ftype == nullptr) {
         // Not a regular function symbol--is it a function pointer?
-        if (CastType<PointerType>(type) != NULL)
+        if (CastType<PointerType>(type) != nullptr)
             ftype = CastType<FunctionType>(type->GetBaseType());
     }
     return ftype;
 }
 
 llvm::Value *FunctionCallExpr::GetValue(FunctionEmitContext *ctx) const {
-    if (func == NULL || args == NULL)
-        return NULL;
+    if (func == nullptr || args == nullptr)
+        return nullptr;
 
     ctx->SetDebugPos(pos);
 
     llvm::Value *callee = func->GetValue(ctx);
 
-    if (callee == NULL) {
+    if (callee == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     const Type *type = lGetFunctionType(func);
@@ -3741,7 +3742,7 @@ llvm::Value *FunctionCallExpr::GetValue(FunctionEmitContext *ctx) const {
         Error(pos, "Can't call function with dependent type.");
     }
     const FunctionType *ft = CastType<FunctionType>(type);
-    AssertPos(pos, ft != NULL);
+    AssertPos(pos, ft != nullptr);
     bool isVoidFunc = ft->GetReturnType()->IsVoidType();
 
     // Automatically convert function call args to references if needed.
@@ -3754,30 +3755,30 @@ llvm::Value *FunctionCallExpr::GetValue(FunctionEmitContext *ctx) const {
     // overload resolution.
     if ((int)callargs.size() > ft->GetNumParameters()) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     for (unsigned int i = 0; i < callargs.size(); ++i) {
         Expr *argExpr = callargs[i];
-        if (argExpr == NULL)
+        if (argExpr == nullptr)
             continue;
 
         const Type *paramType = ft->GetParameterType(i);
 
         const Type *argLValueType = argExpr->GetLValueType();
-        if (argLValueType != NULL && CastType<PointerType>(argLValueType) != NULL && argLValueType->IsVaryingType() &&
-            CastType<ReferenceType>(paramType) != NULL) {
+        if (argLValueType != nullptr && CastType<PointerType>(argLValueType) != nullptr &&
+            argLValueType->IsVaryingType() && CastType<ReferenceType>(paramType) != nullptr) {
             Error(argExpr->pos,
                   "Illegal to pass a \"varying\" lvalue to a "
                   "reference parameter of type \"%s\".",
                   paramType->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
 
         // Do whatever type conversion is needed
         argExpr = TypeConvertExpr(argExpr, paramType, "function call argument");
-        if (argExpr == NULL)
-            return NULL;
+        if (argExpr == nullptr)
+            return nullptr;
         callargs[i] = argExpr;
     }
 
@@ -3789,8 +3790,8 @@ llvm::Value *FunctionCallExpr::GetValue(FunctionEmitContext *ctx) const {
         // FIXME: this type conv should happen when we create the function
         // type!
         Expr *d = TypeConvertExpr(paramDefault, paramType, "function call default argument");
-        if (d == NULL)
-            return NULL;
+        if (d == nullptr)
+            return nullptr;
         callargs.push_back(d);
     }
 
@@ -3798,27 +3799,27 @@ llvm::Value *FunctionCallExpr::GetValue(FunctionEmitContext *ctx) const {
     std::vector<llvm::Value *> argVals;
     for (unsigned int i = 0; i < callargs.size(); ++i) {
         Expr *argExpr = callargs[i];
-        if (argExpr == NULL)
+        if (argExpr == nullptr)
             // give up; we hit an error earlier
-            return NULL;
+            return nullptr;
 
         llvm::Value *argValue = argExpr->GetValue(ctx);
-        if (argValue == NULL)
+        if (argValue == nullptr)
             // something went wrong in evaluating the argument's
             // expression, so give up on this
-            return NULL;
+            return nullptr;
 
         argVals.push_back(argValue);
     }
 
-    llvm::Value *retVal = NULL;
+    llvm::Value *retVal = nullptr;
     ctx->SetDebugPos(pos);
     if (ft->isTask) {
-        AssertPos(pos, launchCountExpr[0] != NULL);
+        AssertPos(pos, launchCountExpr[0] != nullptr);
         llvm::Value *launchCount[3] = {launchCountExpr[0]->GetValue(ctx), launchCountExpr[1]->GetValue(ctx),
                                        launchCountExpr[2]->GetValue(ctx)};
 
-        if (launchCount[0] != NULL)
+        if (launchCount[0] != nullptr)
             ctx->LaunchInst(callee, argVals, launchCount, ft);
     } else {
         if (isInvoke) {
@@ -3829,18 +3830,18 @@ llvm::Value *FunctionCallExpr::GetValue(FunctionEmitContext *ctx) const {
     }
 
     if (isVoidFunc)
-        return NULL;
+        return nullptr;
     else
         return retVal;
 }
 
 llvm::Value *FunctionCallExpr::GetLValue(FunctionEmitContext *ctx) const {
-    if (GetLValueType() != NULL) {
+    if (GetLValueType() != nullptr) {
         return GetValue(ctx);
     } else {
         // Only be a valid LValue type if the function
         // returns a pointer or reference.
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -3848,10 +3849,10 @@ static bool lFullResolveOverloads(Expr *func, ExprList *args, std::vector<const 
                                   std::vector<bool> *argCouldBeNULL, std::vector<bool> *argIsConstant) {
     for (unsigned int i = 0; i < args->exprs.size(); ++i) {
         Expr *expr = args->exprs[i];
-        if (expr == NULL)
+        if (expr == nullptr)
             return false;
         const Type *t = expr->GetType();
-        if (t == NULL)
+        if (t == nullptr)
             return false;
         argTypes->push_back(t);
         argCouldBeNULL->push_back(lIsAllIntZeros(expr) || llvm::dyn_cast<NullPointerExpr>(expr));
@@ -3863,12 +3864,12 @@ static bool lFullResolveOverloads(Expr *func, ExprList *args, std::vector<const 
 const Type *FunctionCallExpr::GetType() const {
     std::vector<const Type *> argTypes;
     std::vector<bool> argCouldBeNULL, argIsConstant;
-    if (func == NULL || args == NULL)
-        return NULL;
+    if (func == nullptr || args == nullptr)
+        return nullptr;
 
     if (lFullResolveOverloads(func, args, &argTypes, &argCouldBeNULL, &argIsConstant) == true) {
         FunctionSymbolExpr *fse = llvm::dyn_cast<FunctionSymbolExpr>(func);
-        if (fse != NULL) {
+        if (fse != nullptr) {
             fse->ResolveOverloads(args->pos, argTypes, &argCouldBeNULL, &argIsConstant);
         }
     }
@@ -3877,13 +3878,13 @@ const Type *FunctionCallExpr::GetType() const {
         return type;
     }
     const FunctionType *ftype = CastType<FunctionType>(type);
-    return ftype ? ftype->GetReturnType() : NULL;
+    return ftype ? ftype->GetReturnType() : nullptr;
 }
 
 const Type *FunctionCallExpr::GetLValueType() const {
     const Type *type = lGetFunctionType(func);
     if (type->IsDependentType()) {
-        return NULL;
+        return nullptr;
     }
     const FunctionType *ftype = CastType<FunctionType>(type);
     if (ftype && (ftype->GetReturnType()->IsPointerType() || ftype->GetReturnType()->IsReferenceType())) {
@@ -3891,60 +3892,60 @@ const Type *FunctionCallExpr::GetLValueType() const {
     } else {
         // Only be a valid LValue type if the function
         // returns a pointer or reference.
-        return NULL;
+        return nullptr;
     }
 }
 
 Expr *FunctionCallExpr::Optimize() {
-    if (func == NULL || args == NULL)
-        return NULL;
+    if (func == nullptr || args == nullptr)
+        return nullptr;
     return this;
 }
 
 Expr *FunctionCallExpr::TypeCheck() {
-    if (func == NULL || args == NULL)
-        return NULL;
+    if (func == nullptr || args == nullptr)
+        return nullptr;
 
     std::vector<const Type *> argTypes;
     std::vector<bool> argCouldBeNULL, argIsConstant;
 
     if (lFullResolveOverloads(func, args, &argTypes, &argCouldBeNULL, &argIsConstant) == false) {
-        return NULL;
+        return nullptr;
     }
 
     FunctionSymbolExpr *fse = llvm::dyn_cast<FunctionSymbolExpr>(func);
     const FunctionType *funcType = nullptr;
-    if (fse != NULL) {
+    if (fse != nullptr) {
         // Regular function call
         if (fse->ResolveOverloads(args->pos, argTypes, &argCouldBeNULL, &argIsConstant) == false)
-            return NULL;
+            return nullptr;
 
         func = ::TypeCheck(fse);
-        if (func == NULL)
-            return NULL;
+        if (func == nullptr)
+            return nullptr;
 
         funcType = CastType<FunctionType>(func->GetType());
-        if (funcType == NULL) {
+        if (funcType == nullptr) {
             const PointerType *pt = CastType<PointerType>(func->GetType());
-            funcType = (pt == NULL) ? NULL : CastType<FunctionType>(pt->GetBaseType());
+            funcType = (pt == nullptr) ? nullptr : CastType<FunctionType>(pt->GetBaseType());
         }
 
-        if (funcType == NULL) {
+        if (funcType == nullptr) {
             Error(pos, "Valid function name must be used for function call.");
-            return NULL;
+            return nullptr;
         }
     } else {
         // Call through a function pointer
         const Type *fptrType = func->GetType();
-        if (fptrType == NULL)
-            return NULL;
+        if (fptrType == nullptr)
+            return nullptr;
 
         // Make sure we do in fact have a function to call
-        if (CastType<PointerType>(fptrType) == NULL ||
-            (funcType = CastType<FunctionType>(fptrType->GetBaseType())) == NULL) {
+        if (CastType<PointerType>(fptrType) == nullptr ||
+            (funcType = CastType<FunctionType>(fptrType->GetBaseType())) == nullptr) {
             Error(func->pos, "Must provide function name or function pointer for "
                              "function call expression.");
-            return NULL;
+            return nullptr;
         }
 
         // Make sure we don't have too many arguments for the function
@@ -3953,18 +3954,18 @@ Expr *FunctionCallExpr::TypeCheck() {
                   "Too many parameter values provided in "
                   "function call (%d provided, %d expected).",
                   (int)argTypes.size(), funcType->GetNumParameters());
-            return NULL;
+            return nullptr;
         }
         // It's ok to have too few arguments, as long as the function's
         // default parameter values have started by the time we run out
         // of arguments
         if ((int)argTypes.size() < funcType->GetNumParameters() &&
-            funcType->GetParameterDefault(argTypes.size()) == NULL) {
+            funcType->GetParameterDefault(argTypes.size()) == nullptr) {
             Error(args->pos,
                   "Too few parameter values provided in "
                   "function call (%d provided, %d expected).",
                   (int)argTypes.size(), funcType->GetNumParameters());
-            return NULL;
+            return nullptr;
         }
 
         // Now make sure they can all type convert to the corresponding
@@ -3974,19 +3975,19 @@ Expr *FunctionCallExpr::TypeCheck() {
                 // make sure it can type convert
                 const Type *paramType = funcType->GetParameterType(i);
                 if (CanConvertTypes(argTypes[i], paramType) == false &&
-                    !(argCouldBeNULL[i] == true && CastType<PointerType>(paramType) != NULL)) {
+                    !(argCouldBeNULL[i] == true && CastType<PointerType>(paramType) != nullptr)) {
                     Error(args->exprs[i]->pos,
                           "Can't convert argument of "
                           "type \"%s\" to type \"%s\" for function call "
                           "argument.",
                           argTypes[i]->GetString().c_str(), paramType->GetString().c_str());
-                    return NULL;
+                    return nullptr;
                 }
             } else
                 // Otherwise the parameter default saves us.  It should
                 // be there for sure, given the check right above the
                 // for loop.
-                AssertPos(pos, funcType->GetParameterDefault(i) != NULL);
+                AssertPos(pos, funcType->GetParameterDefault(i) != nullptr);
         }
 
         if (fptrType->IsVaryingType()) {
@@ -3996,7 +3997,7 @@ Expr *FunctionCallExpr::TypeCheck() {
                       "Illegal to call a varying function pointer that "
                       "points to a function with a uniform return type \"%s\".",
                       funcType->GetReturnType()->GetString().c_str());
-                return NULL;
+                return nullptr;
             }
         }
     }
@@ -4007,39 +4008,39 @@ Expr *FunctionCallExpr::TypeCheck() {
                        "with \"task\" qualifier.");
         for (int k = 0; k < 3; k++) {
             if (!launchCountExpr[k])
-                return NULL;
+                return nullptr;
 
             launchCountExpr[k] = TypeConvertExpr(launchCountExpr[k], AtomicType::UniformInt32, "task launch count");
-            if (launchCountExpr[k] == NULL)
-                return NULL;
+            if (launchCountExpr[k] == nullptr)
+                return nullptr;
         }
     } else {
         if (isLaunch) {
             Error(pos, "\"launch\" expression illegal with non-\"task\"-"
                        "qualified function.");
-            return NULL;
+            return nullptr;
         }
-        AssertPos(pos, launchCountExpr[0] == NULL);
+        AssertPos(pos, launchCountExpr[0] == nullptr);
     }
     if (isInvoke && !funcType->isExternSYCL) {
         Error(pos, "\"invoke_sycl\" expression illegal with non-\'extern \"SYCL\"\'-"
                    "qualified function.");
-        return NULL;
+        return nullptr;
     }
 
     if (isInvoke && !funcType->isRegCall) {
         Error(pos, "\"invoke_sycl\" expression can be only used with \'__regcall\'-"
                    "qualified function.");
-        return NULL;
+        return nullptr;
     }
 
     if (!isInvoke && funcType->isExternSYCL) {
         Error(pos, "Illegal to call \'extern \"SYCL\"\'-qualified function without \"invoke_sycl\" expression.");
-        return NULL;
+        return nullptr;
     }
 
-    if (func == NULL || args == NULL)
-        return NULL;
+    if (func == nullptr || args == nullptr)
+        return nullptr;
     return this;
 }
 
@@ -4050,18 +4051,18 @@ int FunctionCallExpr::EstimateCost() const {
         return COST_INVOKE;
 
     const Type *type = func->GetType();
-    if (type == NULL)
+    if (type == nullptr)
         return 0;
 
     const PointerType *pt = CastType<PointerType>(type);
-    if (pt != NULL)
+    if (pt != nullptr)
         type = type->GetBaseType();
 
     const FunctionType *ftype = CastType<FunctionType>(type);
-    if (ftype != NULL && ftype->costOverride > -1)
+    if (ftype != nullptr && ftype->costOverride > -1)
         return ftype->costOverride;
 
-    if (pt != NULL)
+    if (pt != nullptr)
         return pt->IsUniformType() ? COST_FUNPTR_UNIFORM : COST_FUNPTR_VARYING;
     else
         return COST_FUNCALL;
@@ -4101,7 +4102,7 @@ void FunctionCallExpr::Print(Indent &indent) const {
 bool ExprList::HasAmbiguousVariability(std::vector<const Expr *> &warn) const {
     bool hasAmbiguousVariability = false;
     for (unsigned int i = 0; i < exprs.size(); ++i) {
-        if (exprs[i] != NULL) {
+        if (exprs[i] != nullptr) {
             hasAmbiguousVariability |= exprs[i]->HasAmbiguousVariability(warn);
         }
     }
@@ -4110,12 +4111,12 @@ bool ExprList::HasAmbiguousVariability(std::vector<const Expr *> &warn) const {
 
 llvm::Value *ExprList::GetValue(FunctionEmitContext *ctx) const {
     FATAL("ExprList::GetValue() should never be called");
-    return NULL;
+    return nullptr;
 }
 
 const Type *ExprList::GetType() const {
     FATAL("ExprList::GetType() should never be called");
-    return NULL;
+    return nullptr;
 }
 
 ExprList *ExprList::Optimize() { return this; }
@@ -4128,8 +4129,8 @@ static std::pair<llvm::Constant *, bool> lGetExprListConstant(const Type *type, 
     SourcePos pos = eList->pos;
     bool isVaryingInit = false;
     bool isNotValidForMultiTargetGlobal = false;
-    if (exprs.size() == 1 && (CastType<AtomicType>(type) != NULL || CastType<EnumType>(type) != NULL ||
-                              CastType<PointerType>(type) != NULL)) {
+    if (exprs.size() == 1 && (CastType<AtomicType>(type) != nullptr || CastType<EnumType>(type) != nullptr ||
+                              CastType<PointerType>(type) != nullptr)) {
         if (isStorageType)
             return exprs[0]->GetStorageConstant(type);
         else
@@ -4137,19 +4138,19 @@ static std::pair<llvm::Constant *, bool> lGetExprListConstant(const Type *type, 
     }
 
     const CollectionType *collectionType = CastType<CollectionType>(type);
-    if (collectionType == NULL) {
+    if (collectionType == nullptr) {
         if (type->IsVaryingType() == true) {
             isVaryingInit = true;
         } else
-            return std::pair<llvm::Constant *, bool>(NULL, false);
+            return std::pair<llvm::Constant *, bool>(nullptr, false);
     }
 
     std::string name;
-    if (CastType<StructType>(type) != NULL)
+    if (CastType<StructType>(type) != nullptr)
         name = "struct";
-    else if (CastType<ArrayType>(type) != NULL)
+    else if (CastType<ArrayType>(type) != nullptr)
         name = "array";
-    else if (CastType<VectorType>(type) != NULL)
+    else if (CastType<VectorType>(type) != nullptr)
         name = "vector";
     else if (isVaryingInit == true)
         name = "varying";
@@ -4163,32 +4164,32 @@ static std::pair<llvm::Constant *, bool> lGetExprListConstant(const Type *type, 
               "Initializer list for %s \"%s\" must have no more than %d "
               "elements (has %d).",
               name.c_str(), errType->GetString().c_str(), elementCount, (int)exprs.size());
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
     } else if ((isVaryingInit == true) && ((int)exprs.size() < elementCount)) {
         Error(pos,
               "Initializer list for %s \"%s\" must have %d "
               "elements (has %d).",
               name.c_str(), type->GetString().c_str(), elementCount, (int)exprs.size());
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
     }
 
     std::vector<llvm::Constant *> cv;
     for (unsigned int i = 0; i < exprs.size(); ++i) {
-        if (exprs[i] == NULL)
-            return std::pair<llvm::Constant *, bool>(NULL, false);
+        if (exprs[i] == nullptr)
+            return std::pair<llvm::Constant *, bool>(nullptr, false);
         const Type *elementType =
             (isVaryingInit == true) ? type->GetAsUniformType() : collectionType->GetElementType(i);
 
         Expr *expr = exprs[i];
 
-        if (llvm::dyn_cast<ExprList>(expr) == NULL) {
+        if (llvm::dyn_cast<ExprList>(expr) == nullptr) {
             // If there's a simple type conversion from the type of this
             // expression to the type we need, then let the regular type
             // conversion machinery handle it.
             expr = TypeConvertExpr(exprs[i], elementType, "initializer list");
-            if (expr == NULL) {
+            if (expr == nullptr) {
                 AssertPos(pos, m->errorCount > 0);
-                return std::pair<llvm::Constant *, bool>(NULL, false);
+                return std::pair<llvm::Constant *, bool>(nullptr, false);
             }
             // Re-establish const-ness if possible
             expr = ::Optimize(expr);
@@ -4199,10 +4200,10 @@ static std::pair<llvm::Constant *, bool> lGetExprListConstant(const Type *type, 
         else
             cPair = expr->GetConstant(elementType);
         llvm::Constant *c = cPair.first;
-        if (c == NULL)
+        if (c == nullptr)
             // If this list element couldn't convert to the right constant
             // type for the corresponding collection member, then give up.
-            return std::pair<llvm::Constant *, bool>(NULL, false);
+            return std::pair<llvm::Constant *, bool>(nullptr, false);
         isNotValidForMultiTargetGlobal = isNotValidForMultiTargetGlobal || cPair.second;
         cv.push_back(c);
     }
@@ -4211,14 +4212,14 @@ static std::pair<llvm::Constant *, bool> lGetExprListConstant(const Type *type, 
     if (isVaryingInit == false) {
         for (int i = (int)exprs.size(); i < collectionType->GetElementCount(); ++i) {
             const Type *elementType = collectionType->GetElementType(i);
-            if (elementType == NULL) {
+            if (elementType == nullptr) {
                 AssertPos(pos, m->errorCount > 0);
-                return std::pair<llvm::Constant *, bool>(NULL, false);
+                return std::pair<llvm::Constant *, bool>(nullptr, false);
             }
             llvm::Type *llvmType = elementType->LLVMType(g->ctx);
-            if (llvmType == NULL) {
+            if (llvmType == nullptr) {
                 AssertPos(pos, m->errorCount > 0);
-                return std::pair<llvm::Constant *, bool>(NULL, false);
+                return std::pair<llvm::Constant *, bool>(nullptr, false);
             }
 
             llvm::Constant *c = llvm::Constant::getNullValue(llvmType);
@@ -4226,20 +4227,20 @@ static std::pair<llvm::Constant *, bool> lGetExprListConstant(const Type *type, 
         }
     }
 
-    if (CastType<StructType>(type) != NULL) {
+    if (CastType<StructType>(type) != nullptr) {
         llvm::StructType *llvmStructType = llvm::dyn_cast<llvm::StructType>(collectionType->LLVMType(g->ctx));
-        AssertPos(pos, llvmStructType != NULL);
+        AssertPos(pos, llvmStructType != nullptr);
         return std::pair<llvm::Constant *, bool>(llvm::ConstantStruct::get(llvmStructType, cv),
                                                  isNotValidForMultiTargetGlobal);
     } else {
         llvm::Type *lt = type->LLVMType(g->ctx);
         llvm::ArrayType *lat = llvm::dyn_cast<llvm::ArrayType>(lt);
-        if (lat != NULL)
+        if (lat != nullptr)
             return std::pair<llvm::Constant *, bool>(llvm::ConstantArray::get(lat, cv), isNotValidForMultiTargetGlobal);
         else if (type->IsVaryingType()) {
             // uniform short vector type
             llvm::VectorType *lvt = llvm::dyn_cast<llvm::VectorType>(lt);
-            AssertPos(pos, lvt != NULL);
+            AssertPos(pos, lvt != nullptr);
             int vectorWidth = g->target->getVectorWidth();
 
             while ((cv.size() % vectorWidth) != 0) {
@@ -4249,10 +4250,10 @@ static std::pair<llvm::Constant *, bool> lGetExprListConstant(const Type *type, 
             return std::pair<llvm::Constant *, bool>(llvm::ConstantVector::get(cv), isNotValidForMultiTargetGlobal);
         } else {
             // uniform short vector type
-            AssertPos(pos, type->IsUniformType() && CastType<VectorType>(type) != NULL);
+            AssertPos(pos, type->IsUniformType() && CastType<VectorType>(type) != nullptr);
 
             llvm::VectorType *lvt = llvm::dyn_cast<llvm::VectorType>(lt);
-            AssertPos(pos, lvt != NULL);
+            AssertPos(pos, lvt != nullptr);
 
             // Uniform short vectors are stored as vectors of length
             // rounded up to a power of 2 bits in size but not less then 128 bit.
@@ -4291,10 +4292,10 @@ void ExprList::Print(Indent &indent) const {
 
     indent.pushList(exprs.size());
     for (unsigned int i = 0; i < exprs.size(); ++i) {
-        if (exprs[i] != NULL) {
+        if (exprs[i] != nullptr) {
             exprs[i]->Print(indent);
         } else {
-            indent.Print("<NULL");
+            indent.Print("<NULL>");
             indent.Done();
         }
     }
@@ -4308,7 +4309,7 @@ void ExprList::Print(Indent &indent) const {
 IndexExpr::IndexExpr(Expr *a, Expr *i, SourcePos p) : Expr(p, IndexExprID) {
     baseExpr = a;
     index = i;
-    type = lvalueType = NULL;
+    type = lvalueType = nullptr;
 }
 
 /** When computing pointer values, we need to apply a per-lane offset when
@@ -4332,12 +4333,12 @@ IndexExpr::IndexExpr(Expr *a, Expr *i, SourcePos p) : Expr(p, IndexExprID) {
     needed and then incorporates it in the varying pointer value.
  */
 static llvm::Value *lAddVaryingOffsetsIfNeeded(FunctionEmitContext *ctx, llvm::Value *ptr, const Type *ptrRefType) {
-    if (CastType<ReferenceType>(ptrRefType) != NULL)
+    if (CastType<ReferenceType>(ptrRefType) != nullptr)
         // References are uniform pointers, so no offsetting is needed
         return ptr;
 
     const PointerType *ptrType = CastType<PointerType>(ptrRefType);
-    Assert(ptrType != NULL);
+    Assert(ptrType != nullptr);
     if (ptrType->IsUniformType() || ptrType->IsSlice())
         return ptr;
 
@@ -4366,23 +4367,23 @@ static llvm::Value *lAddVaryingOffsetsIfNeeded(FunctionEmitContext *ctx, llvm::V
     Issue an error and return true if such a member is found.
  */
 static bool lVaryingStructHasUniformMember(const Type *type, SourcePos pos) {
-    if (CastType<VectorType>(type) != NULL || CastType<ReferenceType>(type) != NULL)
+    if (CastType<VectorType>(type) != nullptr || CastType<ReferenceType>(type) != nullptr)
         return false;
 
     const StructType *st = CastType<StructType>(type);
-    if (st == NULL) {
+    if (st == nullptr) {
         const ArrayType *at = CastType<ArrayType>(type);
-        if (at != NULL)
+        if (at != nullptr)
             st = CastType<StructType>(at->GetElementType());
         else {
             const PointerType *pt = CastType<PointerType>(type);
-            if (pt == NULL)
+            if (pt == nullptr)
                 return false;
 
             st = CastType<StructType>(pt->GetBaseType());
         }
 
-        if (st == NULL)
+        if (st == nullptr)
             return false;
     }
 
@@ -4391,12 +4392,12 @@ static bool lVaryingStructHasUniformMember(const Type *type, SourcePos pos) {
 
     for (int i = 0; i < st->GetElementCount(); ++i) {
         const Type *eltType = st->GetElementType(i);
-        if (eltType == NULL) {
+        if (eltType == nullptr) {
             AssertPos(pos, m->errorCount > 0);
             continue;
         }
 
-        if (CastType<StructType>(eltType) != NULL) {
+        if (CastType<StructType>(eltType) != nullptr) {
             // We know that the enclosing struct is varying at this point,
             // so push that down to the enclosed struct before makign the
             // recursive call.
@@ -4418,32 +4419,32 @@ static bool lVaryingStructHasUniformMember(const Type *type, SourcePos pos) {
 
 llvm::Value *IndexExpr::GetValue(FunctionEmitContext *ctx) const {
     const Type *indexType, *returnType;
-    if (baseExpr == NULL || index == NULL || ((indexType = index->GetType()) == NULL) ||
-        ((returnType = GetType()) == NULL)) {
+    if (baseExpr == nullptr || index == nullptr || ((indexType = index->GetType()) == nullptr) ||
+        ((returnType = GetType()) == nullptr)) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     // If this is going to be a gather, make sure that the varying return
     // type can represent the result (i.e. that we don't have a bound
     // 'uniform' member in a varying struct...)
     if (indexType->IsVaryingType() && lVaryingStructHasUniformMember(returnType, pos))
-        return NULL;
+        return nullptr;
 
     ctx->SetDebugPos(pos);
 
     llvm::Value *ptr = GetLValue(ctx);
-    llvm::Value *mask = NULL;
+    llvm::Value *mask = nullptr;
     const Type *lvType = GetLValueType();
-    if (ptr == NULL) {
+    if (ptr == nullptr) {
         // We may be indexing into a temporary that hasn't hit memory, so
         // get the full value and stuff it into temporary alloca'd space so
         // that we can index from there...
         const Type *baseExprType = baseExpr->GetType();
         llvm::Value *val = baseExpr->GetValue(ctx);
-        if (baseExprType == NULL || val == NULL) {
+        if (baseExprType == nullptr || val == nullptr) {
             AssertPos(pos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
         ctx->SetDebugPos(pos);
         AddressInfo *tmpPtrInfo = ctx->AllocaInst(baseExprType, "array_tmp");
@@ -4451,9 +4452,9 @@ llvm::Value *IndexExpr::GetValue(FunctionEmitContext *ctx) const {
 
         // Get a pointer type to the underlying elements
         const SequentialType *st = CastType<SequentialType>(baseExprType);
-        if (st == NULL) {
+        if (st == nullptr) {
             Assert(m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
         lvType = PointerType::GetUniform(st->GetElementType());
 
@@ -4465,9 +4466,9 @@ llvm::Value *IndexExpr::GetValue(FunctionEmitContext *ctx) const {
         mask = LLVMMaskAllOn;
     } else {
         Symbol *baseSym = GetBaseSymbol();
-        if (llvm::dyn_cast<FunctionCallExpr>(baseExpr) == NULL && llvm::dyn_cast<BinaryExpr>(baseExpr) == NULL) {
+        if (llvm::dyn_cast<FunctionCallExpr>(baseExpr) == nullptr && llvm::dyn_cast<BinaryExpr>(baseExpr) == nullptr) {
             // Don't check if we're doing a function call or pointer arith
-            AssertPos(pos, baseSym != NULL);
+            AssertPos(pos, baseSym != nullptr);
         }
         mask = lMaskForSymbol(baseSym, ctx);
     }
@@ -4477,21 +4478,21 @@ llvm::Value *IndexExpr::GetValue(FunctionEmitContext *ctx) const {
 }
 
 const Type *IndexExpr::GetType() const {
-    if (type != NULL)
+    if (type != nullptr)
         return type;
 
     const Type *baseExprType, *indexType;
-    if (!baseExpr || !index || ((baseExprType = baseExpr->GetType()) == NULL) ||
-        ((indexType = index->GetType()) == NULL))
-        return NULL;
+    if (!baseExpr || !index || ((baseExprType = baseExpr->GetType()) == nullptr) ||
+        ((indexType = index->GetType()) == nullptr))
+        return nullptr;
 
     if (baseExprType->IsDependentType() || indexType->IsDependentType()) {
         return AtomicType::Dependent;
     }
 
-    const Type *elementType = NULL;
+    const Type *elementType = nullptr;
     const PointerType *pointerType = CastType<PointerType>(baseExprType);
-    if (pointerType != NULL)
+    if (pointerType != nullptr)
         // ptr[index] -> type that the pointer points to
         elementType = pointerType->GetBaseType();
     else if (const SequentialType *sequentialType = CastType<SequentialType>(baseExprType->GetReferenceTarget()))
@@ -4499,7 +4500,7 @@ const Type *IndexExpr::GetType() const {
         elementType = sequentialType->GetElementType();
     else
         // Not an expression that can be indexed into. Will result in error.
-        return NULL;
+        return nullptr;
 
     // If we're indexing into a sequence of SOA types, the result type is
     // actually the underlying type, as a uniform or varying.  Get the
@@ -4514,7 +4515,7 @@ const Type *IndexExpr::GetType() const {
     // If either the index is varying or we're indexing into a varying
     // pointer, then the result type is the varying variant of the indexed
     // type.
-    if (indexType->IsUniformType() && (pointerType == NULL || pointerType->IsUniformType()))
+    if (indexType->IsUniformType() && (pointerType == nullptr || pointerType->IsUniformType()))
         type = elementType;
     else
         type = elementType->GetAsVaryingType();
@@ -4522,7 +4523,7 @@ const Type *IndexExpr::GetType() const {
     return type;
 }
 
-Symbol *IndexExpr::GetBaseSymbol() const { return baseExpr ? baseExpr->GetBaseSymbol() : NULL; }
+Symbol *IndexExpr::GetBaseSymbol() const { return baseExpr ? baseExpr->GetBaseSymbol() : nullptr; }
 
 /** Utility routine that takes a regualr pointer (either uniform or
     varying) and returns a slice pointer with zero offsets.
@@ -4531,7 +4532,7 @@ static llvm::Value *lConvertToSlicePointer(FunctionEmitContext *ctx, llvm::Value
                                            const PointerType *slicePtrType) {
     llvm::Type *llvmSlicePtrType = slicePtrType->LLVMType(g->ctx);
     llvm::StructType *sliceStructType = llvm::dyn_cast<llvm::StructType>(llvmSlicePtrType);
-    Assert(sliceStructType != NULL && sliceStructType->getElementType(0) == ptr->getType());
+    Assert(sliceStructType != nullptr && sliceStructType->getElementType(0) == ptr->getType());
 
     // Get a null-initialized struct to take care of having zeros for the
     // offsets
@@ -4546,7 +4547,7 @@ static llvm::Value *lConvertToSlicePointer(FunctionEmitContext *ctx, llvm::Value
 */
 static void lCheckIndicesVersusBounds(const Type *baseExprType, Expr *index) {
     const SequentialType *seqType = CastType<SequentialType>(baseExprType);
-    if (seqType == NULL)
+    if (seqType == nullptr)
         return;
 
     int nElements = seqType->GetElementCount();
@@ -4562,7 +4563,7 @@ static void lCheckIndicesVersusBounds(const Type *baseExprType, Expr *index) {
         nElements *= soaWidth;
 
     ConstExpr *ce = llvm::dyn_cast<ConstExpr>(index);
-    if (ce == NULL)
+    if (ce == nullptr)
         return;
 
     int32_t indices[ISPC_MAX_NVEC];
@@ -4580,9 +4581,9 @@ static void lCheckIndicesVersusBounds(const Type *baseExprType, Expr *index) {
     points to SOA'ed data.
 */
 static llvm::Value *lConvertPtrToSliceIfNeeded(FunctionEmitContext *ctx, llvm::Value *ptr, const Type **type) {
-    Assert(*type != NULL);
+    Assert(*type != nullptr);
     const PointerType *ptrType = CastType<PointerType>(*type);
-    Assert(ptrType != NULL);
+    Assert(ptrType != nullptr);
     bool convertToSlice = (ptrType->GetBaseType()->IsSOAType() && ptrType->IsSlice() == false);
     if (convertToSlice == false)
         return ptr;
@@ -4593,25 +4594,25 @@ static llvm::Value *lConvertPtrToSliceIfNeeded(FunctionEmitContext *ctx, llvm::V
 
 llvm::Value *IndexExpr::GetLValue(FunctionEmitContext *ctx) const {
     const Type *baseExprType;
-    if (baseExpr == NULL || index == NULL || ((baseExprType = baseExpr->GetType()) == NULL)) {
+    if (baseExpr == nullptr || index == nullptr || ((baseExprType = baseExpr->GetType()) == nullptr)) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     ctx->SetDebugPos(pos);
     llvm::Value *indexValue = index->GetValue(ctx);
-    if (indexValue == NULL) {
+    if (indexValue == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     ctx->SetDebugPos(pos);
-    if (CastType<PointerType>(baseExprType) != NULL) {
+    if (CastType<PointerType>(baseExprType) != nullptr) {
         // We're indexing off of a pointer
         llvm::Value *basePtrValue = baseExpr->GetValue(ctx);
-        if (basePtrValue == NULL) {
+        if (basePtrValue == nullptr) {
             AssertPos(pos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
         ctx->SetDebugPos(pos);
 
@@ -4625,13 +4626,13 @@ llvm::Value *IndexExpr::GetLValue(FunctionEmitContext *ctx) const {
 
     // Not a pointer: we must be indexing an array or vector (and possibly
     // a reference thereuponfore.)
-    llvm::Value *basePtr = NULL;
-    const PointerType *basePtrType = NULL;
+    llvm::Value *basePtr = nullptr;
+    const PointerType *basePtrType = nullptr;
     if (CastType<ArrayType>(baseExprType) || CastType<VectorType>(baseExprType)) {
         basePtr = baseExpr->GetLValue(ctx);
         basePtrType = CastType<PointerType>(baseExpr->GetLValueType());
         if (baseExpr->GetLValueType())
-            AssertPos(pos, basePtrType != NULL);
+            AssertPos(pos, basePtrType != nullptr);
     } else {
         baseExprType = baseExprType->GetReferenceTarget();
         AssertPos(pos, CastType<ArrayType>(baseExprType) || CastType<VectorType>(baseExprType));
@@ -4639,7 +4640,7 @@ llvm::Value *IndexExpr::GetLValue(FunctionEmitContext *ctx) const {
         basePtrType = PointerType::GetUniform(baseExprType);
     }
     if (!basePtr)
-        return NULL;
+        return nullptr;
 
     // If possible, check the index value(s) against the size of the array
     lCheckIndicesVersusBounds(baseExprType, index);
@@ -4656,33 +4657,33 @@ llvm::Value *IndexExpr::GetLValue(FunctionEmitContext *ctx) const {
 }
 
 const Type *IndexExpr::GetLValueType() const {
-    if (lvalueType != NULL)
+    if (lvalueType != nullptr)
         return lvalueType;
 
     const Type *baseExprType, *baseExprLValueType, *indexType;
-    if (baseExpr == NULL || index == NULL || ((baseExprType = baseExpr->GetType()) == NULL) ||
-        ((baseExprLValueType = baseExpr->GetLValueType()) == NULL) || ((indexType = index->GetType()) == NULL))
-        return NULL;
+    if (baseExpr == nullptr || index == nullptr || ((baseExprType = baseExpr->GetType()) == nullptr) ||
+        ((baseExprLValueType = baseExpr->GetLValueType()) == nullptr) || ((indexType = index->GetType()) == nullptr))
+        return nullptr;
 
     // regularize to a PointerType
-    if (CastType<ReferenceType>(baseExprLValueType) != NULL) {
+    if (CastType<ReferenceType>(baseExprLValueType) != nullptr) {
         const Type *refTarget = baseExprLValueType->GetReferenceTarget();
         baseExprLValueType = PointerType::GetUniform(refTarget);
     }
-    AssertPos(pos, CastType<PointerType>(baseExprLValueType) != NULL);
+    AssertPos(pos, CastType<PointerType>(baseExprLValueType) != nullptr);
 
     // Find the type of thing that we're indexing into
     const Type *elementType;
     const SequentialType *st = CastType<SequentialType>(baseExprLValueType->GetBaseType());
-    if (st != NULL)
+    if (st != nullptr)
         elementType = st->GetElementType();
     else {
         const PointerType *pt = CastType<PointerType>(baseExprLValueType->GetBaseType());
         // This assertion seems overly strict.
         // Why does it need to be a pointer to a pointer?
-        // AssertPos(pos, pt != NULL);
+        // AssertPos(pos, pt != nullptr);
 
-        if (pt != NULL) {
+        if (pt != nullptr) {
             elementType = pt->GetBaseType();
         } else {
             elementType = baseExprLValueType->GetBaseType();
@@ -4692,7 +4693,7 @@ const Type *IndexExpr::GetLValueType() const {
     // Are we indexing into a varying type, or are we indexing with a
     // varying pointer?
     bool baseVarying;
-    if (CastType<PointerType>(baseExprType) != NULL)
+    if (CastType<PointerType>(baseExprType) != nullptr)
         baseVarying = baseExprType->IsVaryingType();
     else
         baseVarying = baseExprLValueType->IsVaryingType();
@@ -4714,22 +4715,22 @@ const Type *IndexExpr::GetLValueType() const {
 }
 
 Expr *IndexExpr::Optimize() {
-    if (baseExpr == NULL || index == NULL)
-        return NULL;
+    if (baseExpr == nullptr || index == nullptr)
+        return nullptr;
     return this;
 }
 
 Expr *IndexExpr::TypeCheck() {
     const Type *indexType;
-    if (baseExpr == NULL || index == NULL || ((indexType = index->GetType()) == NULL)) {
+    if (baseExpr == nullptr || index == nullptr || ((indexType = index->GetType()) == nullptr)) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     const Type *baseExprType = baseExpr->GetType();
-    if (baseExprType == NULL) {
+    if (baseExprType == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (baseExprType->IsDependentType() || indexType->IsDependentType()) {
@@ -4740,14 +4741,14 @@ Expr *IndexExpr::TypeCheck() {
         if (const PointerType *pt = CastType<PointerType>(baseExprType)) {
             if (pt->GetBaseType()->IsVoidType()) {
                 Error(pos, "Illegal to dereference void pointer type \"%s\".", baseExprType->GetString().c_str());
-                return NULL;
+                return nullptr;
             }
         } else {
             Error(pos,
                   "Trying to index into non-array, vector, or pointer "
                   "type \"%s\".",
                   baseExprType->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
     }
 
@@ -4763,8 +4764,8 @@ Expr *IndexExpr::TypeCheck() {
             g->target->is32Bit() || g->opt.force32BitAddressing) {
             const Type *indexType = AtomicType::VaryingInt32;
             index = TypeConvertExpr(index, indexType, "array index");
-            if (index == NULL)
-                return NULL;
+            if (index == nullptr)
+                return nullptr;
         }
     } else { // isUniform
         // For 32-bit target:
@@ -4781,22 +4782,22 @@ Expr *IndexExpr::TypeCheck() {
                                      Type::EqualIgnoringConst(indexType->GetAsUniformType(), AtomicType::UniformInt64));
         const Type *indexType = force_32bit ? AtomicType::UniformInt32 : AtomicType::UniformInt64;
         index = TypeConvertExpr(index, indexType, "array index");
-        if (index == NULL)
-            return NULL;
+        if (index == nullptr)
+            return nullptr;
     }
 
     return this;
 }
 
 int IndexExpr::EstimateCost() const {
-    if (index == NULL || baseExpr == NULL)
+    if (index == nullptr || baseExpr == nullptr)
         return 0;
 
     const Type *indexType = index->GetType();
     const Type *baseExprType = baseExpr->GetType();
 
-    if ((indexType != NULL && indexType->IsVaryingType()) ||
-        (CastType<PointerType>(baseExprType) != NULL && baseExprType->IsVaryingType()))
+    if ((indexType != nullptr && indexType->IsVaryingType()) ||
+        (CastType<PointerType>(baseExprType) != nullptr && baseExprType->IsVaryingType()))
         // be pessimistic; some of these will later turn out to be vector
         // loads/stores, but it's too early for us to know that here.
         return COST_GATHER;
@@ -4861,17 +4862,17 @@ StructMemberExpr::StructMemberExpr(Expr *e, const char *id, SourcePos p, SourceP
     : MemberExpr(e, id, p, idpos, derefLValue, StructMemberExprID) {}
 
 const Type *StructMemberExpr::GetType() const {
-    if (type != NULL)
+    if (type != nullptr)
         return type;
 
     // It's a struct, and the result type is the element type, possibly
     // promoted to varying if the struct type / lvalue is varying.
     const Type *exprType, *lvalueType;
     const StructType *structType;
-    if (expr == NULL || ((exprType = expr->GetType()) == NULL) || ((structType = getStructType()) == NULL) ||
-        ((lvalueType = GetLValueType()) == NULL)) {
+    if (expr == nullptr || ((exprType = expr->GetType()) == nullptr) || ((structType = getStructType()) == nullptr) ||
+        ((lvalueType = GetLValueType()) == nullptr)) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (exprType->IsDependentType() || structType->IsDependentType() || lvalueType->IsDependentType()) {
@@ -4879,10 +4880,10 @@ const Type *StructMemberExpr::GetType() const {
     }
 
     const Type *elementType = structType->GetElementType(identifier);
-    if (elementType == NULL) {
+    if (elementType == nullptr) {
         Error(identifierPos, "Element name \"%s\" not present in struct type \"%s\".%s", identifier.c_str(),
               structType->GetString().c_str(), getCandidateNearMatches().c_str());
-        return NULL;
+        return nullptr;
     }
     AssertPos(pos, Type::Equal(lvalueType->GetBaseType(), elementType));
 
@@ -4910,23 +4911,23 @@ const Type *StructMemberExpr::GetType() const {
 }
 
 const Type *StructMemberExpr::GetLValueType() const {
-    if (lvalueType != NULL)
+    if (lvalueType != nullptr)
         return lvalueType;
 
-    if (expr == NULL) {
+    if (expr == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     const Type *exprLValueType = dereferenceExpr ? expr->GetType() : expr->GetLValueType();
-    if (exprLValueType == NULL) {
+    if (exprLValueType == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     // The pointer type is varying if the lvalue type of the expression is
     // varying (and otherwise uniform)
-    const PointerType *ptrType = (exprLValueType->IsUniformType() || CastType<ReferenceType>(exprLValueType) != NULL)
+    const PointerType *ptrType = (exprLValueType->IsUniformType() || CastType<ReferenceType>(exprLValueType) != nullptr)
                                      ? PointerType::GetUniform(getElementType())
                                      : PointerType::GetVarying(getElementType());
 
@@ -4943,7 +4944,7 @@ const Type *StructMemberExpr::GetLValueType() const {
 
 int StructMemberExpr::getElementNumber() const {
     const StructType *structType = getStructType();
-    if (structType == NULL)
+    if (structType == nullptr)
         return -1;
 
     int elementNumber = structType->GetElementNumber(identifier);
@@ -4956,8 +4957,8 @@ int StructMemberExpr::getElementNumber() const {
 
 const Type *StructMemberExpr::getElementType() const {
     const StructType *structType = getStructType();
-    if (structType == NULL)
-        return NULL;
+    if (structType == nullptr)
+        return nullptr;
 
     return structType->GetElementType(identifier);
 }
@@ -4966,21 +4967,21 @@ const Type *StructMemberExpr::getElementType() const {
     of. */
 const StructType *StructMemberExpr::getStructType() const {
     const Type *type = dereferenceExpr ? expr->GetType() : expr->GetLValueType();
-    if (type == NULL)
-        return NULL;
+    if (type == nullptr)
+        return nullptr;
 
     const Type *structType;
     const ReferenceType *rt = CastType<ReferenceType>(type);
-    if (rt != NULL)
+    if (rt != nullptr)
         structType = rt->GetReferenceTarget();
     else {
         const PointerType *pt = CastType<PointerType>(type);
-        AssertPos(pos, pt != NULL);
+        AssertPos(pos, pt != nullptr);
         structType = pt->GetBaseType();
     }
 
     const StructType *ret = CastType<StructType>(structType);
-    AssertPos(pos, ret != NULL);
+    AssertPos(pos, ret != nullptr);
     return ret;
 }
 
@@ -4991,21 +4992,21 @@ VectorMemberExpr::VectorMemberExpr(Expr *e, const char *id, SourcePos p, SourceP
     : MemberExpr(e, id, p, idpos, derefLValue, VectorMemberExprID) {
     const Type *exprType = e->GetType();
     exprVectorType = CastType<VectorType>(exprType);
-    if (exprVectorType == NULL) {
+    if (exprVectorType == nullptr) {
         const PointerType *pt = CastType<PointerType>(exprType);
-        if (pt != NULL)
+        if (pt != nullptr)
             exprVectorType = CastType<VectorType>(pt->GetBaseType());
         else {
-            AssertPos(pos, CastType<ReferenceType>(exprType) != NULL);
+            AssertPos(pos, CastType<ReferenceType>(exprType) != nullptr);
             exprVectorType = CastType<VectorType>(exprType->GetReferenceTarget());
         }
-        AssertPos(pos, exprVectorType != NULL);
+        AssertPos(pos, exprVectorType != nullptr);
     }
     memberType = new VectorType(exprVectorType->GetElementType(), identifier.length());
 }
 
 const Type *VectorMemberExpr::GetType() const {
-    if (type != NULL)
+    if (type != nullptr)
         return type;
 
     // For 1-element expressions, we have the base vector element
@@ -5022,7 +5023,7 @@ const Type *VectorMemberExpr::GetType() const {
     type = t;
 
     const Type *lvType = GetLValueType();
-    if (lvType != NULL) {
+    if (lvType != nullptr) {
         bool isSlice = (CastType<PointerType>(lvType) && CastType<PointerType>(lvType)->IsSlice());
         if (isSlice) {
             // CO            AssertPos(pos, type->IsSOAType());
@@ -5041,35 +5042,35 @@ llvm::Value *VectorMemberExpr::GetLValue(FunctionEmitContext *ctx) const {
     if (identifier.length() == 1) {
         return MemberExpr::GetLValue(ctx);
     } else {
-        return NULL;
+        return nullptr;
     }
 }
 
 const Type *VectorMemberExpr::GetLValueType() const {
-    if (lvalueType != NULL)
+    if (lvalueType != nullptr)
         return lvalueType;
 
     if (identifier.length() == 1) {
-        if (expr == NULL) {
+        if (expr == nullptr) {
             AssertPos(pos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
 
         const Type *exprLValueType = dereferenceExpr ? expr->GetType() : expr->GetLValueType();
-        if (exprLValueType == NULL)
-            return NULL;
+        if (exprLValueType == nullptr)
+            return nullptr;
 
-        const VectorType *vt = NULL;
-        if (CastType<ReferenceType>(exprLValueType) != NULL)
+        const VectorType *vt = nullptr;
+        if (CastType<ReferenceType>(exprLValueType) != nullptr)
             vt = CastType<VectorType>(exprLValueType->GetReferenceTarget());
         else
             vt = CastType<VectorType>(exprLValueType->GetBaseType());
-        AssertPos(pos, vt != NULL);
+        AssertPos(pos, vt != nullptr);
 
         // we don't want to report that it's e.g. a pointer to a float<1>,
         // but a pointer to a float, etc.
         const Type *elementType = vt->GetElementType();
-        if (CastType<ReferenceType>(exprLValueType) != NULL)
+        if (CastType<ReferenceType>(exprLValueType) != nullptr)
             lvalueType = new ReferenceType(elementType);
         else {
             const PointerType *ptrType = exprLValueType->IsUniformType() ? PointerType::GetUniform(elementType)
@@ -5098,9 +5099,9 @@ llvm::Value *VectorMemberExpr::GetValue(FunctionEmitContext *ctx) const {
             indices.push_back(idx);
         }
 
-        llvm::Value *basePtr = NULL;
-        AddressInfo *basePtrInfo = NULL;
-        const Type *basePtrType = NULL;
+        llvm::Value *basePtr = nullptr;
+        AddressInfo *basePtrInfo = nullptr;
+        const Type *basePtrType = nullptr;
         if (dereferenceExpr) {
             basePtr = expr->GetValue(ctx);
             basePtrType = expr->GetType();
@@ -5109,25 +5110,25 @@ llvm::Value *VectorMemberExpr::GetValue(FunctionEmitContext *ctx) const {
             basePtrType = expr->GetLValueType();
         }
 
-        if (basePtr == NULL || basePtrType == NULL) {
+        if (basePtr == nullptr || basePtrType == nullptr) {
             // Check that expression on the left side is a rvalue expression
             llvm::Value *exprValue = expr->GetValue(ctx);
             basePtrInfo = ctx->AllocaInst(expr->GetType());
             basePtrType = PointerType::GetUniform(exprVectorType);
-            if (basePtrInfo == NULL || basePtrType == NULL) {
+            if (basePtrInfo == nullptr || basePtrType == nullptr) {
                 AssertPos(pos, m->errorCount > 0);
-                return NULL;
+                return nullptr;
             }
             basePtr = basePtrInfo->getPointer();
-            AssertPos(pos, basePtr != NULL);
+            AssertPos(pos, basePtr != nullptr);
             ctx->StoreInst(exprValue, basePtrInfo, expr->GetType());
         }
 
         // Allocate temporary memory to store the result
         AddressInfo *resultPtrInfo = ctx->AllocaInst(memberType, "vector_tmp");
-        if (resultPtrInfo == NULL) {
+        if (resultPtrInfo == nullptr) {
             AssertPos(pos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
 
         // FIXME: we should be able to use the internal mask here according
@@ -5170,8 +5171,8 @@ const Type *VectorMemberExpr::getElementType() const { return memberType; }
 
 DependentMemberExpr::DependentMemberExpr(Expr *e, const char *id, SourcePos p, SourcePos idpos, bool derefLValue)
     : MemberExpr(e, id, p, idpos, derefLValue, DependentMemberExprID) {
-    Assert(e != NULL);
-    Assert(id != NULL);
+    Assert(e != nullptr);
+    Assert(id != nullptr);
 }
 
 int DependentMemberExpr::getElementNumber() const { UNREACHABLE(); };
@@ -5188,27 +5189,27 @@ MemberExpr *MemberExpr::create(Expr *e, const char *id, SourcePos p, SourcePos i
     e = ::TypeCheck(e);
 
     const Type *exprType;
-    if (e == NULL || (exprType = e->GetType()) == NULL)
-        return NULL;
+    if (e == nullptr || (exprType = e->GetType()) == nullptr)
+        return nullptr;
 
     if (exprType->IsDependentType()) {
         return new DependentMemberExpr(e, id, p, idpos, derefLValue);
     }
 
     const ReferenceType *referenceType = CastType<ReferenceType>(exprType);
-    if (referenceType != NULL) {
+    if (referenceType != nullptr) {
         e = new RefDerefExpr(e, e->pos);
         exprType = e->GetType();
-        Assert(exprType != NULL);
+        Assert(exprType != nullptr);
     }
 
     const PointerType *pointerType = CastType<PointerType>(exprType);
-    if (pointerType != NULL)
+    if (pointerType != nullptr)
         exprType = pointerType->GetBaseType();
 
-    if (derefLValue == true && pointerType == NULL) {
+    if (derefLValue == true && pointerType == nullptr) {
         const Type *targetType = exprType->GetReferenceTarget();
-        if (CastType<StructType>(targetType) != NULL)
+        if (CastType<StructType>(targetType) != nullptr)
             Error(p,
                   "Member operator \"->\" can't be applied to non-pointer "
                   "type \"%s\".  Did you mean to use \".\"?",
@@ -5218,20 +5219,20 @@ MemberExpr *MemberExpr::create(Expr *e, const char *id, SourcePos p, SourcePos i
                   "Member operator \"->\" can't be applied to non-struct "
                   "pointer type \"%s\".",
                   exprType->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
     // For struct and short-vector, emit error if elements are accessed
     // incorrectly.
-    if (derefLValue == false && pointerType != NULL &&
-        ((CastType<StructType>(pointerType->GetBaseType()) != NULL) ||
-         (CastType<VectorType>(pointerType->GetBaseType()) != NULL))) {
+    if (derefLValue == false && pointerType != nullptr &&
+        ((CastType<StructType>(pointerType->GetBaseType()) != nullptr) ||
+         (CastType<VectorType>(pointerType->GetBaseType()) != nullptr))) {
         Error(p,
               "Member operator \".\" can't be applied to pointer "
               "type \"%s\".  Did you mean to use \"->\"?",
               exprType->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
-    if (CastType<StructType>(exprType) != NULL) {
+    if (CastType<StructType>(exprType) != nullptr) {
         const StructType *st = CastType<StructType>(exprType);
         if (st->IsDefined()) {
             return new StructMemberExpr(e, id, p, idpos, derefLValue);
@@ -5240,22 +5241,22 @@ MemberExpr *MemberExpr::create(Expr *e, const char *id, SourcePos p, SourcePos i
                   "Member operator \"%s\" can't be applied to declared "
                   "struct \"%s\" containing an undefined struct type.",
                   derefLValue ? "->" : ".", exprType->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
-    } else if (CastType<VectorType>(exprType) != NULL)
+    } else if (CastType<VectorType>(exprType) != nullptr)
         return new VectorMemberExpr(e, id, p, idpos, derefLValue);
     else if (CastType<UndefinedStructType>(exprType)) {
         Error(p,
               "Member operator \"%s\" can't be applied to declared "
               "but not defined struct type \"%s\".",
               derefLValue ? "->" : ".", exprType->GetString().c_str());
-        return NULL;
+        return nullptr;
     } else {
         Error(p,
               "Member operator \"%s\" can't be used with expression of "
               "\"%s\" type.",
               derefLValue ? "->" : ".", exprType->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -5264,20 +5265,20 @@ MemberExpr::MemberExpr(Expr *e, const char *id, SourcePos p, SourcePos idpos, bo
     expr = e;
     identifier = id;
     dereferenceExpr = derefLValue;
-    type = lvalueType = NULL;
+    type = lvalueType = nullptr;
 }
 
 llvm::Value *MemberExpr::GetValue(FunctionEmitContext *ctx) const {
     if (!expr)
-        return NULL;
+        return nullptr;
 
     llvm::Value *lvalue = GetLValue(ctx);
     const Type *lvalueType = GetLValueType();
 
-    llvm::Value *mask = NULL;
-    if (lvalue == NULL) {
+    llvm::Value *mask = nullptr;
+    if (lvalue == nullptr) {
         if (m->errorCount > 0)
-            return NULL;
+            return nullptr;
 
         // As in the array case, this may be a temporary that hasn't hit
         // memory; get the full value and stuff it into a temporary array
@@ -5285,7 +5286,7 @@ llvm::Value *MemberExpr::GetValue(FunctionEmitContext *ctx) const {
         llvm::Value *val = expr->GetValue(ctx);
         if (!val) {
             AssertPos(pos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
         ctx->SetDebugPos(pos);
         const Type *exprType = expr->GetType();
@@ -5294,14 +5295,14 @@ llvm::Value *MemberExpr::GetValue(FunctionEmitContext *ctx) const {
 
         int elementNumber = getElementNumber();
         if (elementNumber == -1)
-            return NULL;
+            return nullptr;
 
         lvalue = ctx->AddElementOffset(ptrInfo, elementNumber);
         lvalueType = PointerType::GetUniform(GetType());
         mask = LLVMMaskAllOn;
     } else {
         Symbol *baseSym = GetBaseSymbol();
-        AssertPos(pos, baseSym != NULL);
+        AssertPos(pos, baseSym != nullptr);
         mask = lMaskForSymbol(baseSym, ctx);
     }
 
@@ -5310,33 +5311,33 @@ llvm::Value *MemberExpr::GetValue(FunctionEmitContext *ctx) const {
     return ctx->LoadInst(lvalue, mask, lvalueType, llvm::Twine(lvalue->getName()) + suffix);
 }
 
-const Type *MemberExpr::GetType() const { return NULL; }
+const Type *MemberExpr::GetType() const { return nullptr; }
 
-Symbol *MemberExpr::GetBaseSymbol() const { return expr ? expr->GetBaseSymbol() : NULL; }
+Symbol *MemberExpr::GetBaseSymbol() const { return expr ? expr->GetBaseSymbol() : nullptr; }
 
 int MemberExpr::getElementNumber() const { return -1; }
 
 llvm::Value *MemberExpr::GetLValue(FunctionEmitContext *ctx) const {
     const Type *exprType;
-    if (!expr || ((exprType = expr->GetType()) == NULL))
-        return NULL;
+    if (!expr || ((exprType = expr->GetType()) == nullptr))
+        return nullptr;
 
     ctx->SetDebugPos(pos);
     llvm::Value *basePtr = dereferenceExpr ? expr->GetValue(ctx) : expr->GetLValue(ctx);
     if (!basePtr)
-        return NULL;
+        return nullptr;
 
     int elementNumber = getElementNumber();
     if (elementNumber == -1)
-        return NULL;
+        return nullptr;
 
     const Type *exprLValueType = dereferenceExpr ? exprType : expr->GetLValueType();
     ctx->SetDebugPos(pos);
     llvm::Value *ptr = ctx->AddElementOffset(new AddressInfo(basePtr, exprLValueType), elementNumber,
                                              basePtr->getName().str().c_str());
-    if (ptr == NULL) {
+    if (ptr == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     ptr = lAddVaryingOffsetsIfNeeded(ctx, ptr, GetLValueType());
@@ -5344,13 +5345,13 @@ llvm::Value *MemberExpr::GetLValue(FunctionEmitContext *ctx) const {
     return ptr;
 }
 
-Expr *MemberExpr::TypeCheck() { return expr ? this : NULL; }
+Expr *MemberExpr::TypeCheck() { return expr ? this : nullptr; }
 
-Expr *MemberExpr::Optimize() { return expr ? this : NULL; }
+Expr *MemberExpr::Optimize() { return expr ? this : nullptr; }
 
 int MemberExpr::EstimateCost() const {
     const Type *lvalueType = GetLValueType();
-    if (lvalueType != NULL && lvalueType->IsVaryingType())
+    if (lvalueType != nullptr && lvalueType->IsVaryingType())
         return COST_GATHER + COST_SIMPLE_ARITH_LOGIC_OP;
     else
         return COST_SIMPLE_ARITH_LOGIC_OP;
@@ -5498,7 +5499,7 @@ ConstExpr::ConstExpr(const Type *t, uint32_t u, SourcePos p) : Expr(p, ConstExpr
     type = t;
     type = type->GetAsConstType();
     AssertPos(pos, Type::Equal(type, AtomicType::UniformUInt32->GetAsConstType()) ||
-                       (CastType<EnumType>(type) != NULL && type->IsUniformType()));
+                       (CastType<EnumType>(type) != nullptr && type->IsUniformType()));
     uint32Val[0] = u;
 }
 
@@ -5507,7 +5508,7 @@ ConstExpr::ConstExpr(const Type *t, uint32_t *u, SourcePos p) : Expr(p, ConstExp
     type = type->GetAsConstType();
     AssertPos(pos, Type::Equal(type, AtomicType::UniformUInt32->GetAsConstType()) ||
                        Type::Equal(type, AtomicType::VaryingUInt32->GetAsConstType()) ||
-                       (CastType<EnumType>(type) != NULL));
+                       (CastType<EnumType>(type) != nullptr));
     for (int j = 0; j < Count(); ++j)
         uint32Val[j] = u[j];
 }
@@ -5632,10 +5633,10 @@ ConstExpr::ConstExpr(const ConstExpr *old, SourcePos p) : Expr(p, ConstExprID) {
 
 AtomicType::BasicType ConstExpr::getBasicType() const {
     const AtomicType *at = CastType<AtomicType>(type);
-    if (at != NULL)
+    if (at != nullptr)
         return at->basicType;
     else {
-        AssertPos(pos, CastType<EnumType>(type) != NULL);
+        AssertPos(pos, CastType<EnumType>(type) != nullptr);
         return AtomicType::TYPE_UINT32;
     }
 }
@@ -5678,7 +5679,7 @@ llvm::Value *ConstExpr::GetValue(FunctionEmitContext *ctx) const {
         return isVarying ? LLVMDoubleVector(fpVal) : LLVMDouble(fpVal[0]);
     default:
         FATAL("unimplemented const type");
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -5923,7 +5924,7 @@ static std::pair<llvm::Constant *, bool> lGetConstExprConstant(const Type *const
         else
             return std::pair<llvm::Constant *, bool>(LLVMInt32Vector(iv), isNotValidForMultiTargetGlobal);
     } else if (Type::Equal(constType, AtomicType::UniformUInt32) || Type::Equal(constType, AtomicType::VaryingUInt32) ||
-               CastType<EnumType>(constType) != NULL) {
+               CastType<EnumType>(constType) != nullptr) {
         uint32_t uiv[ISPC_MAX_NVEC];
         cExpr->GetValues(uiv, constType->IsVaryingType());
         if (constType->IsUniformType())
@@ -5966,14 +5967,14 @@ static std::pair<llvm::Constant *, bool> lGetConstExprConstant(const Type *const
             return std::pair<llvm::Constant *, bool>(LLVMDouble(dv[0]), isNotValidForMultiTargetGlobal);
         else
             return std::pair<llvm::Constant *, bool>(LLVMDoubleVector(dv), isNotValidForMultiTargetGlobal);
-    } else if (CastType<PointerType>(constType) != NULL) {
+    } else if (CastType<PointerType>(constType) != nullptr) {
         // The only time we should get here is if we have an integer '0'
-        // constant that should be turned into a NULL pointer of the
+        // constant that should be turned into a nullptr pointer of the
         // appropriate type.
         llvm::Type *llvmType = constType->LLVMType(g->ctx);
-        if (llvmType == NULL) {
+        if (llvmType == nullptr) {
             AssertPos(pos, m->errorCount > 0);
-            return std::pair<llvm::Constant *, bool>(NULL, false);
+            return std::pair<llvm::Constant *, bool>(nullptr, false);
         }
 
         int64_t iv[ISPC_MAX_NVEC];
@@ -5982,13 +5983,13 @@ static std::pair<llvm::Constant *, bool> lGetConstExprConstant(const Type *const
             if (iv[i] != 0)
                 // We'll issue an error about this later--trying to assign
                 // a constant int to a pointer, without a typecast.
-                return std::pair<llvm::Constant *, bool>(NULL, false);
+                return std::pair<llvm::Constant *, bool>(nullptr, false);
 
         return std::pair<llvm::Constant *, bool>(llvm::Constant::getNullValue(llvmType),
                                                  isNotValidForMultiTargetGlobal);
     } else {
         Debug(pos, "Unable to handle type \"%s\" in ConstExpr::GetConstant().", constType->GetString().c_str());
-        return std::pair<llvm::Constant *, bool>(NULL, isNotValidForMultiTargetGlobal);
+        return std::pair<llvm::Constant *, bool>(nullptr, isNotValidForMultiTargetGlobal);
     }
 }
 
@@ -6081,7 +6082,7 @@ TypeCastExpr::TypeCastExpr(const Type *t, Expr *e, SourcePos p) : Expr(p, TypeCa
  */
 static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprVal, const AtomicType *toType,
                                     const AtomicType *fromType, SourcePos pos) {
-    llvm::Value *cast = NULL;
+    llvm::Value *cast = nullptr;
 
     std::string opName = exprVal->getName().str();
     switch (toType->basicType) {
@@ -6696,7 +6697,7 @@ static llvm::Value *lUniformValueToVarying(FunctionEmitContext *ctx, llvm::Value
     // for structs/arrays/vectors, just recursively make their elements
     // varying (if needed) and populate the return value.
     const CollectionType *collectionType = CastType<CollectionType>(type);
-    if (collectionType != NULL) {
+    if (collectionType != nullptr) {
         llvm::Type *llvmType = type->GetAsVaryingType()->LLVMStorageType(g->ctx);
         llvm::Value *retValue = llvm::UndefValue::get(llvmType);
 
@@ -6705,18 +6706,18 @@ static llvm::Value *lUniformValueToVarying(FunctionEmitContext *ctx, llvm::Value
         for (int i = 0; i < collectionType->GetElementCount(); ++i) {
             llvm::Value *v = ctx->ExtractInst(value, i, "get_element");
             // If struct has "bound uniform" member, we don't need to cast it to varying
-            if (!(structType != NULL && structType->GetElementType(i)->IsUniformType())) {
+            if (!(structType != nullptr && structType->GetElementType(i)->IsUniformType())) {
                 const Type *elemType = collectionType->GetElementType(i);
                 // If member is a uniform bool, it needs to be truncated to i1 since
                 // uniform  bool in IR is i1 and i8 in struct
                 // Consider switching to just a broadcast for bool
-                if ((elemType->IsBoolType()) && (CastType<AtomicType>(elemType) != NULL)) {
+                if ((elemType->IsBoolType()) && (CastType<AtomicType>(elemType) != nullptr)) {
                     v = ctx->TruncInst(v, LLVMTypes::BoolType);
                 }
                 v = lUniformValueToVarying(ctx, v, elemType, pos);
                 // If the extracted element if bool and varying needs to be
                 // converted back to i8 vector to insert into varying struct.
-                if ((elemType->IsBoolType()) && (CastType<AtomicType>(elemType) != NULL)) {
+                if ((elemType->IsBoolType()) && (CastType<AtomicType>(elemType) != nullptr)) {
                     v = ctx->SwitchBoolSize(v, LLVMTypes::BoolVectorStorageType);
                 }
             }
@@ -6732,17 +6733,17 @@ static llvm::Value *lUniformValueToVarying(FunctionEmitContext *ctx, llvm::Value
                                pos);
     }
 
-    Assert(CastType<PointerType>(type) != NULL);
+    Assert(CastType<PointerType>(type) != nullptr);
     return ctx->SmearUniform(value);
 }
 
 bool TypeCastExpr::HasAmbiguousVariability(std::vector<const Expr *> &warn) const {
 
-    if (expr == NULL)
+    if (expr == nullptr)
         return false;
 
     const Type *toType = type, *fromType = expr->GetType();
-    if (toType == NULL || fromType == NULL)
+    if (toType == nullptr || fromType == nullptr)
         return false;
 
     if (toType->HasUnboundVariability() && fromType->IsUniformType()) {
@@ -6767,33 +6768,33 @@ void TypeCastExpr::PrintAmbiguousVariability() const {
 
 llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
     if (!expr)
-        return NULL;
+        return nullptr;
 
     ctx->SetDebugPos(pos);
     const Type *toType = GetType(), *fromType = expr->GetType();
-    if (toType == NULL || fromType == NULL) {
+    if (toType == nullptr || fromType == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (toType->IsVoidType()) {
         // emit the code for the expression in case it has side-effects but
         // then we're done.
         (void)expr->GetValue(ctx);
-        return NULL;
+        return nullptr;
     }
 
     const PointerType *fromPointerType = CastType<PointerType>(fromType);
     const PointerType *toPointerType = CastType<PointerType>(toType);
     const ArrayType *toArrayType = CastType<ArrayType>(toType);
     const ArrayType *fromArrayType = CastType<ArrayType>(fromType);
-    if (fromPointerType != NULL) {
-        if (toArrayType != NULL) {
+    if (fromPointerType != nullptr) {
+        if (toArrayType != nullptr) {
             return expr->GetValue(ctx);
-        } else if (toPointerType != NULL) {
+        } else if (toPointerType != nullptr) {
             llvm::Value *value = expr->GetValue(ctx);
-            if (value == NULL)
-                return NULL;
+            if (value == nullptr)
+                return nullptr;
 
             if (fromPointerType->IsSlice() == false && toPointerType->IsSlice() == true) {
                 // Convert from a non-slice pointer to a slice pointer by
@@ -6839,7 +6840,7 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
                 }
             }
         } else {
-            AssertPos(pos, CastType<AtomicType>(toType) != NULL);
+            AssertPos(pos, CastType<AtomicType>(toType) != nullptr);
             if (toType->IsBoolType()) {
                 // convert pointer to bool
                 llvm::Type *lfu = fromType->GetAsUniformType()->LLVMType(g->ctx);
@@ -6851,7 +6852,7 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
 
                 llvm::Value *exprVal = expr->GetValue(ctx);
                 llvm::Value *cmp =
-                    ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_NE, exprVal, nullPtrValue, "ptr_ne_NULL");
+                    ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_NE, exprVal, nullPtrValue, "ptr_ne_null");
 
                 if (toType->IsVaryingType()) {
                     if (fromType->IsUniformType())
@@ -6863,15 +6864,15 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
             } else {
                 // ptr -> int
                 llvm::Value *value = expr->GetValue(ctx);
-                if (value == NULL)
-                    return NULL;
+                if (value == nullptr)
+                    return nullptr;
 
                 if (toType->IsVaryingType() && fromType->IsUniformType())
                     value = ctx->SmearUniform(value);
 
                 llvm::Type *llvmToType = toType->LLVMType(g->ctx);
-                if (llvmToType == NULL)
-                    return NULL;
+                if (llvmToType == nullptr)
+                    return nullptr;
                 return ctx->PtrToIntInst(value, llvmToType, "ptr_typecast");
             }
         }
@@ -6882,7 +6883,7 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
         // system doesn't worry about constiness.)
         return expr->GetValue(ctx);
 
-    if (fromArrayType != NULL && toPointerType != NULL) {
+    if (fromArrayType != nullptr && toPointerType != nullptr) {
         // implicit array to pointer to first element
         Expr *arrayAsPtr = lArrayToPointer(expr);
         const Type *arrayType = arrayAsPtr->GetType();
@@ -6892,9 +6893,9 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
                                Type::EqualIgnoringConst(arrayType->GetAsVaryingType(), toPointerType) == true);
             arrayAsPtr = new TypeCastExpr(toPointerType, arrayAsPtr, pos);
             arrayAsPtr = ::TypeCheck(arrayAsPtr);
-            AssertPos(pos, arrayAsPtr != NULL);
+            AssertPos(pos, arrayAsPtr != nullptr);
             arrayAsPtr = ::Optimize(arrayAsPtr);
-            AssertPos(pos, arrayAsPtr != NULL);
+            AssertPos(pos, arrayAsPtr != nullptr);
             arrayType = arrayAsPtr->GetType();
         }
         Assert(arrayType);
@@ -6905,7 +6906,7 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
     // This also should be caught during typechecking
     AssertPos(pos, !(toType->IsUniformType() && fromType->IsVaryingType()));
 
-    if (toArrayType != NULL && fromArrayType != NULL) {
+    if (toArrayType != nullptr && fromArrayType != nullptr) {
         // cast array pointer from [n x foo] to [0 x foo] if needed to be able
         // to pass to a function that takes an unsized array as a parameter
         if (toArrayType->GetElementCount() != 0 && (toArrayType->GetElementCount() != fromArrayType->GetElementCount()))
@@ -6952,7 +6953,7 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
 
         llvm::Value *origValue = expr->GetValue(ctx);
         if (!origValue)
-            return NULL;
+            return nullptr;
         return lUniformValueToVarying(ctx, origValue, fromType, pos);
     }
 
@@ -6964,7 +6965,7 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
 
         llvm::Value *exprVal = expr->GetValue(ctx);
         if (!exprVal)
-            return NULL;
+            return nullptr;
 
         // Emit instructions to do type conversion of each of the elements
         // of the vector.
@@ -6977,9 +6978,9 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
             llvm::Value *ei = ctx->ExtractInst(exprVal, i);
             llvm::Value *conv = lTypeConvAtomic(ctx, ei, toVector->GetElementType(), fromVector->GetElementType(), pos);
             if (!conv)
-                return NULL;
+                return nullptr;
             if ((toVector->GetElementType()->IsBoolType()) &&
-                (CastType<AtomicType>(toVector->GetElementType()) != NULL)) {
+                (CastType<AtomicType>(toVector->GetElementType()) != nullptr)) {
                 conv = ctx->SwitchBoolSize(conv, toVector->GetElementType()->LLVMStorageType(g->ctx));
             }
 
@@ -6990,7 +6991,7 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
 
     llvm::Value *exprVal = expr->GetValue(ctx);
     if (!exprVal)
-        return NULL;
+        return nullptr;
 
     const EnumType *fromEnum = CastType<EnumType>(fromType);
     const EnumType *toEnum = CastType<EnumType>(toType);
@@ -7003,15 +7004,15 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
 
     const AtomicType *fromAtomic = CastType<AtomicType>(fromType);
     // at this point, coming from an atomic type is all that's left...
-    AssertPos(pos, fromAtomic != NULL);
+    AssertPos(pos, fromAtomic != nullptr);
 
     if (toVector) {
         // scalar -> short vector conversion
         llvm::Value *conv = lTypeConvAtomic(ctx, exprVal, toVector->GetElementType(), fromAtomic, pos);
         if (!conv)
-            return NULL;
+            return nullptr;
 
-        llvm::Value *cast = NULL;
+        llvm::Value *cast = nullptr;
         llvm::Type *toTypeLLVM = toType->LLVMStorageType(g->ctx);
         if (llvm::isa<llvm::VectorType>(toTypeLLVM)) {
             // Example uniform float => uniform float<3>
@@ -7021,7 +7022,7 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
             cast = llvm::UndefValue::get(toType->LLVMStorageType(g->ctx));
             for (int i = 0; i < toVector->GetElementCount(); ++i) {
                 if ((toVector->GetElementType()->IsBoolType()) &&
-                    (CastType<AtomicType>(toVector->GetElementType()) != NULL)) {
+                    (CastType<AtomicType>(toVector->GetElementType()) != nullptr)) {
                     conv = ctx->SwitchBoolSize(conv, toVector->GetElementType()->LLVMStorageType(g->ctx));
                 }
                 // Here's InsertInst produces InsertValueInst.
@@ -7032,30 +7033,30 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
         }
 
         return cast;
-    } else if (toPointerType != NULL) {
+    } else if (toPointerType != nullptr) {
         // int -> ptr
         if (toType->IsVaryingType() && fromType->IsUniformType())
             exprVal = ctx->SmearUniform(exprVal);
 
         llvm::Type *llvmToType = toType->LLVMType(g->ctx);
-        if (llvmToType == NULL)
-            return NULL;
+        if (llvmToType == nullptr)
+            return nullptr;
 
         return ctx->IntToPtrInst(exprVal, llvmToType, "int_to_ptr");
     } else {
         const AtomicType *toAtomic = CastType<AtomicType>(toType);
         // typechecking should ensure this is the case
-        AssertPos(pos, toAtomic != NULL);
+        AssertPos(pos, toAtomic != nullptr);
 
         return lTypeConvAtomic(ctx, exprVal, toAtomic, fromAtomic, pos);
     }
 }
 
 llvm::Value *TypeCastExpr::GetLValue(FunctionEmitContext *ctx) const {
-    if (GetLValueType() != NULL) {
+    if (GetLValueType() != nullptr) {
         return GetValue(ctx);
     } else {
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -7064,11 +7065,11 @@ const Type *TypeCastExpr::GetType() const {
     // (uniform base_type) of (varying base_type). This is a part of function
     // TypeCastExpr::TypeCheck. After implementation of operators we
     // have to have this functionality here.
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
     const Type *toType = type, *fromType = expr->GetType();
-    if (toType == NULL || fromType == NULL)
-        return NULL;
+    if (toType == nullptr || fromType == nullptr)
+        return nullptr;
 
     if (toType->IsDependentType()) {
         return toType;
@@ -7087,28 +7088,28 @@ const Type *TypeCastExpr::GetType() const {
 
 const Type *TypeCastExpr::GetLValueType() const {
     AssertPos(pos, type->HasUnboundVariability() == false);
-    if (CastType<PointerType>(GetType()) != NULL) {
+    if (CastType<PointerType>(GetType()) != nullptr) {
         return type;
     } else {
-        return NULL;
+        return nullptr;
     }
 }
 
 static const Type *lDeconstifyType(const Type *t) {
     const PointerType *pt = CastType<PointerType>(t);
-    if (pt != NULL)
+    if (pt != nullptr)
         return new PointerType(lDeconstifyType(pt->GetBaseType()), pt->GetVariability(), false);
     else
         return t->GetAsNonConstType();
 }
 
 Expr *TypeCastExpr::TypeCheck() {
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
 
     const Type *toType = type, *fromType = expr->GetType();
-    if (toType == NULL || fromType == NULL)
-        return NULL;
+    if (toType == nullptr || fromType == nullptr)
+        return nullptr;
 
     if (toType->IsDependentType() || fromType->IsDependentType()) {
         return this;
@@ -7130,19 +7131,19 @@ Expr *TypeCastExpr::TypeCheck() {
     if (fromType->IsVoidType() || (fromType->IsVaryingType() && toType->IsUniformType())) {
         Error(pos, "Can't type cast from type \"%s\" to type \"%s\"", fromType->GetString().c_str(),
               toType->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
 
     // First some special cases that we allow only with an explicit type cast
     const PointerType *fromPtr = CastType<PointerType>(fromType);
     const PointerType *toPtr = CastType<PointerType>(toType);
-    if (fromPtr != NULL && toPtr != NULL)
+    if (fromPtr != nullptr && toPtr != nullptr)
         // allow explicit typecasts between any two different pointer types
         return this;
 
     const ReferenceType *fromRef = CastType<ReferenceType>(fromType);
     const ReferenceType *toRef = CastType<ReferenceType>(toType);
-    if (fromRef != NULL && toRef != NULL) {
+    if (fromRef != nullptr && toRef != nullptr) {
         // allow explicit typecasts between any two different reference types
         // Issues #721
         return this;
@@ -7157,7 +7158,7 @@ Expr *TypeCastExpr::TypeCheck() {
         return this;
 
     // ptr -> int type casts
-    if (fromPtr != NULL && toAtomic != NULL && toAtomic->IsIntType()) {
+    if (fromPtr != nullptr && toAtomic != nullptr && toAtomic->IsIntType()) {
         bool safeCast =
             (toAtomic->basicType == AtomicType::TYPE_INT64 || toAtomic->basicType == AtomicType::TYPE_UINT64);
         if (g->target->is32Bit())
@@ -7172,21 +7173,21 @@ Expr *TypeCastExpr::TypeCheck() {
     }
 
     // int -> ptr
-    if (fromAtomic != NULL && fromAtomic->IsIntType() && toPtr != NULL)
+    if (fromAtomic != nullptr && fromAtomic->IsIntType() && toPtr != nullptr)
         return this;
 
     // And otherwise see if it's one of the conversions allowed to happen
     // implicitly.
     Expr *e = TypeConvertExpr(expr, toType, "type cast expression");
-    if (e == NULL)
-        return NULL;
+    if (e == nullptr)
+        return nullptr;
     else
         return e;
 }
 
 Expr *TypeCastExpr::Optimize() {
     ConstExpr *constExpr = llvm::dyn_cast<ConstExpr>(expr);
-    if (constExpr == NULL)
+    if (constExpr == nullptr)
         // We can't do anything if this isn't a const expr
         return this;
 
@@ -7196,7 +7197,7 @@ Expr *TypeCastExpr::Optimize() {
     // If we're not casting to an atomic or enum type, we can't do anything
     // here, since ConstExprs can only represent those two types.  (So
     // e.g. we're casting from an int to an int<4>.)
-    if (toAtomic == NULL && toEnum == NULL)
+    if (toAtomic == nullptr && toEnum == nullptr)
         return this;
 
     bool forceVarying = toType->IsVaryingType();
@@ -7273,7 +7274,7 @@ Expr *TypeCastExpr::Optimize() {
 }
 
 int TypeCastExpr::EstimateCost() const {
-    if (llvm::dyn_cast<ConstExpr>(expr) != NULL)
+    if (llvm::dyn_cast<ConstExpr>(expr) != nullptr)
         return 0;
 
     // FIXME: return COST_TYPECAST_COMPLEX when appropriate
@@ -7294,10 +7295,10 @@ void TypeCastExpr::Print(Indent &indent) const {
     indent.Done();
 }
 
-Symbol *TypeCastExpr::GetBaseSymbol() const { return expr ? expr->GetBaseSymbol() : NULL; }
+Symbol *TypeCastExpr::GetBaseSymbol() const { return expr ? expr->GetBaseSymbol() : nullptr; }
 
 static llvm::Constant *lConvertPointerConstant(llvm::Constant *c, const Type *constType) {
-    if (c == NULL || constType->IsUniformType())
+    if (c == nullptr || constType->IsUniformType())
         return c;
 
     // Handle conversion to int and then to vector of int or array of int
@@ -7327,17 +7328,17 @@ std::pair<llvm::Constant *, bool> TypeCastExpr::GetConstant(const Type *constTyp
     // can't represent pointer values, we have to handle a few cases
     // related to pointers here:
     //
-    // 1. Null pointer (NULL, 0) valued initializers
+    // 1. Null pointer (nullptr, 0) valued initializers
     // 2. Converting function types to pointer-to-function types
     // 3. And converting these from uniform to the varying/soa equivalents.
     //
 
-    if ((CastType<PointerType>(constType) == NULL) && (llvm::dyn_cast<SizeOfExpr>(expr) == NULL))
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+    if ((CastType<PointerType>(constType) == nullptr) && (llvm::dyn_cast<SizeOfExpr>(expr) == nullptr))
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
 
-    llvm::Value *ptr = NULL;
+    llvm::Value *ptr = nullptr;
     if (GetBaseSymbol())
-        ptr = GetBaseSymbol()->storageInfo ? GetBaseSymbol()->storageInfo->getPointer() : NULL;
+        ptr = GetBaseSymbol()->storageInfo ? GetBaseSymbol()->storageInfo->getPointer() : nullptr;
 
     if (ptr && llvm::dyn_cast<llvm::GlobalVariable>(ptr)) {
         if (CastType<ArrayType>(expr->GetType())) {
@@ -7366,27 +7367,27 @@ ReferenceExpr::ReferenceExpr(Expr *e, SourcePos p) : Expr(p, ReferenceExprID) { 
 
 llvm::Value *ReferenceExpr::GetValue(FunctionEmitContext *ctx) const {
     ctx->SetDebugPos(pos);
-    if (expr == NULL) {
+    if (expr == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::Value *value = expr->GetLValue(ctx);
-    if (value != NULL)
+    if (value != nullptr)
         return value;
 
-    // value is NULL if the expression is a temporary; in this case, we'll
+    // value is nullptr if the expression is a temporary; in this case, we'll
     // allocate storage for it so that we can return the pointer to that...
     const Type *type;
-    if ((type = expr->GetType()) == NULL || type->LLVMType(g->ctx) == NULL) {
+    if ((type = expr->GetType()) == nullptr || type->LLVMType(g->ctx) == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     value = expr->GetValue(ctx);
-    if (value == NULL) {
+    if (value == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     AddressInfo *ptrInfo = ctx->AllocaInst(type);
@@ -7394,15 +7395,15 @@ llvm::Value *ReferenceExpr::GetValue(FunctionEmitContext *ctx) const {
     return ptrInfo->getPointer();
 }
 
-Symbol *ReferenceExpr::GetBaseSymbol() const { return expr ? expr->GetBaseSymbol() : NULL; }
+Symbol *ReferenceExpr::GetBaseSymbol() const { return expr ? expr->GetBaseSymbol() : nullptr; }
 
 const Type *ReferenceExpr::GetType() const {
     if (!expr)
-        return NULL;
+        return nullptr;
 
     const Type *type = expr->GetType();
     if (!type)
-        return NULL;
+        return nullptr;
 
     if (type->IsDependentType()) {
         return AtomicType::Dependent;
@@ -7413,24 +7414,24 @@ const Type *ReferenceExpr::GetType() const {
 
 const Type *ReferenceExpr::GetLValueType() const {
     if (!expr)
-        return NULL;
+        return nullptr;
 
     const Type *type = expr->GetType();
     if (!type)
-        return NULL;
+        return nullptr;
 
     return PointerType::GetUniform(type);
 }
 
 Expr *ReferenceExpr::Optimize() {
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
     return this;
 }
 
 Expr *ReferenceExpr::TypeCheck() {
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
     return this;
 }
 
@@ -7442,7 +7443,7 @@ ReferenceExpr *ReferenceExpr::Instantiate(TemplateInstantiation &templInst) cons
 }
 
 void ReferenceExpr::Print(Indent &indent) const {
-    if (expr == NULL || GetType() == NULL) {
+    if (expr == nullptr || GetType() == nullptr) {
         indent.Print("ReferenceExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -7463,17 +7464,17 @@ void ReferenceExpr::Print(Indent &indent) const {
 DerefExpr::DerefExpr(Expr *e, SourcePos p, unsigned scid) : Expr(p, scid) { expr = e; }
 
 llvm::Value *DerefExpr::GetValue(FunctionEmitContext *ctx) const {
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
     llvm::Value *ptr = expr->GetValue(ctx);
-    if (ptr == NULL)
-        return NULL;
+    if (ptr == nullptr)
+        return nullptr;
     const Type *type = expr->GetType();
-    if (type == NULL)
-        return NULL;
+    if (type == nullptr)
+        return nullptr;
 
     if (lVaryingStructHasUniformMember(type, pos))
-        return NULL;
+        return nullptr;
 
     // If dealing with 'varying * varying' add required offsets.
     ptr = lAddVaryingOffsetsIfNeeded(ctx, ptr, type);
@@ -7486,22 +7487,22 @@ llvm::Value *DerefExpr::GetValue(FunctionEmitContext *ctx) const {
 }
 
 llvm::Value *DerefExpr::GetLValue(FunctionEmitContext *ctx) const {
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
     return expr->GetValue(ctx);
 }
 
 const Type *DerefExpr::GetLValueType() const {
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
     return expr->GetType();
 }
 
-Symbol *DerefExpr::GetBaseSymbol() const { return expr ? expr->GetBaseSymbol() : NULL; }
+Symbol *DerefExpr::GetBaseSymbol() const { return expr ? expr->GetBaseSymbol() : nullptr; }
 
 Expr *DerefExpr::Optimize() {
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
     return this;
 }
 
@@ -7512,11 +7513,11 @@ PtrDerefExpr::PtrDerefExpr(Expr *e, SourcePos p) : DerefExpr(e, p, PtrDerefExprI
 
 const Type *PtrDerefExpr::GetType() const {
     const Type *type;
-    if (expr == NULL || (type = expr->GetType()) == NULL) {
+    if (expr == nullptr || (type = expr->GetType()) == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
-    AssertPos(pos, CastType<PointerType>(type) != NULL);
+    AssertPos(pos, CastType<PointerType>(type) != nullptr);
 
     if (type->IsDependentType()) {
         return AtomicType::Dependent;
@@ -7530,9 +7531,9 @@ const Type *PtrDerefExpr::GetType() const {
 
 Expr *PtrDerefExpr::TypeCheck() {
     const Type *type;
-    if (expr == NULL || (type = expr->GetType()) == NULL) {
+    if (expr == nullptr || (type = expr->GetType()) == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (type->IsDependentType()) {
@@ -7542,11 +7543,11 @@ Expr *PtrDerefExpr::TypeCheck() {
     if (const PointerType *pt = CastType<PointerType>(type)) {
         if (pt->GetBaseType()->IsVoidType()) {
             Error(pos, "Illegal to dereference void pointer type \"%s\".", type->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
     } else {
         Error(pos, "Illegal to dereference non-pointer type \"%s\".", type->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
 
     return this;
@@ -7554,7 +7555,7 @@ Expr *PtrDerefExpr::TypeCheck() {
 
 int PtrDerefExpr::EstimateCost() const {
     const Type *type;
-    if (expr == NULL || (type = expr->GetType()) == NULL) {
+    if (expr == nullptr || (type = expr->GetType()) == nullptr) {
         AssertPos(pos, m->errorCount > 0);
         return 0;
     }
@@ -7573,7 +7574,7 @@ PtrDerefExpr *PtrDerefExpr::Instantiate(TemplateInstantiation &templInst) const 
 }
 
 void PtrDerefExpr::Print(Indent &indent) const {
-    if (expr == NULL || GetType() == NULL) {
+    if (expr == nullptr || GetType() == nullptr) {
         indent.Print("PtrDerefExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -7595,24 +7596,24 @@ RefDerefExpr::RefDerefExpr(Expr *e, SourcePos p) : DerefExpr(e, p, RefDerefExprI
 
 const Type *RefDerefExpr::GetType() const {
     const Type *type;
-    if (expr == NULL || (type = expr->GetType()) == NULL) {
+    if (expr == nullptr || (type = expr->GetType()) == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (type->IsDependentType()) {
         return AtomicType::Dependent;
     }
 
-    AssertPos(pos, CastType<ReferenceType>(type) != NULL);
+    AssertPos(pos, CastType<ReferenceType>(type) != nullptr);
     return type->GetReferenceTarget();
 }
 
 Expr *RefDerefExpr::TypeCheck() {
     const Type *type;
-    if (expr == NULL || (type = expr->GetType()) == NULL) {
+    if (expr == nullptr || (type = expr->GetType()) == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (type->IsDependentType()) {
@@ -7622,13 +7623,13 @@ Expr *RefDerefExpr::TypeCheck() {
     // We only create RefDerefExprs internally for references in
     // expressions, so we should never create one with a non-reference
     // expression...
-    AssertPos(pos, CastType<ReferenceType>(type) != NULL);
+    AssertPos(pos, CastType<ReferenceType>(type) != nullptr);
 
     return this;
 }
 
 int RefDerefExpr::EstimateCost() const {
-    if (expr == NULL)
+    if (expr == nullptr)
         return 0;
 
     return COST_DEREF;
@@ -7640,7 +7641,7 @@ RefDerefExpr *RefDerefExpr::Instantiate(TemplateInstantiation &templInst) const 
 }
 
 void RefDerefExpr::Print(Indent &indent) const {
-    if (expr == NULL || GetType() == NULL) {
+    if (expr == nullptr || GetType() == nullptr) {
         indent.Print("RefDerefExpr: <NULL EXPR>\n");
         return;
     }
@@ -7661,36 +7662,36 @@ AddressOfExpr::AddressOfExpr(Expr *e, SourcePos p) : Expr(p, AddressOfExprID), e
 
 llvm::Value *AddressOfExpr::GetValue(FunctionEmitContext *ctx) const {
     ctx->SetDebugPos(pos);
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
 
     const Type *exprType = expr->GetType();
-    if (CastType<ReferenceType>(exprType) != NULL || CastType<FunctionType>(exprType) != NULL)
+    if (CastType<ReferenceType>(exprType) != nullptr || CastType<FunctionType>(exprType) != nullptr)
         return expr->GetValue(ctx);
     else
         return expr->GetLValue(ctx);
 }
 
 const Type *AddressOfExpr::GetType() const {
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
 
     const Type *exprType = expr->GetType();
     if (exprType && exprType->IsDependentType()) {
         return AtomicType::Dependent;
     }
 
-    if (CastType<ReferenceType>(exprType) != NULL)
+    if (CastType<ReferenceType>(exprType) != nullptr)
         return PointerType::GetUniform(exprType->GetReferenceTarget());
 
     const Type *t = expr->GetLValueType();
-    if (t != NULL)
+    if (t != nullptr)
         return t;
     else {
         t = expr->GetType();
-        if (t == NULL) {
+        if (t == nullptr) {
             AssertPos(pos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
         return PointerType::GetUniform(t);
     }
@@ -7698,19 +7699,19 @@ const Type *AddressOfExpr::GetType() const {
 
 const Type *AddressOfExpr::GetLValueType() const {
     if (!expr)
-        return NULL;
+        return nullptr;
 
     const Type *type = expr->GetType();
     if (!type)
-        return NULL;
+        return nullptr;
 
     return PointerType::GetUniform(type);
 }
 
-Symbol *AddressOfExpr::GetBaseSymbol() const { return expr ? expr->GetBaseSymbol() : NULL; }
+Symbol *AddressOfExpr::GetBaseSymbol() const { return expr ? expr->GetBaseSymbol() : nullptr; }
 
 void AddressOfExpr::Print(Indent &indent) const {
-    if (expr == NULL || GetType() == NULL) {
+    if (expr == nullptr || GetType() == nullptr) {
         indent.Print("AddressOfExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -7727,24 +7728,24 @@ void AddressOfExpr::Print(Indent &indent) const {
 
 Expr *AddressOfExpr::TypeCheck() {
     const Type *exprType;
-    if (expr == NULL || (exprType = expr->GetType()) == NULL) {
+    if (expr == nullptr || (exprType = expr->GetType()) == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (exprType->IsDependentType()) {
         return this;
     }
 
-    if (CastType<ReferenceType>(exprType) != NULL || CastType<FunctionType>(exprType) != NULL) {
+    if (CastType<ReferenceType>(exprType) != nullptr || CastType<FunctionType>(exprType) != nullptr) {
         return this;
     }
 
-    if (expr->GetLValueType() != NULL)
+    if (expr->GetLValueType() != nullptr)
         return this;
 
     Error(expr->pos, "Illegal to take address of non-lvalue or function.");
-    return NULL;
+    return nullptr;
 }
 
 Expr *AddressOfExpr::Optimize() { return this; }
@@ -7757,40 +7758,40 @@ AddressOfExpr *AddressOfExpr::Instantiate(TemplateInstantiation &templInst) cons
 }
 
 std::pair<llvm::Constant *, bool> AddressOfExpr::GetConstant(const Type *type) const {
-    if (expr == NULL || expr->GetType() == NULL) {
+    if (expr == nullptr || expr->GetType() == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
     }
 
     const PointerType *pt = CastType<PointerType>(type);
-    if (pt == NULL)
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+    if (pt == nullptr)
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
 
     bool isNotValidForMultiTargetGlobal = false;
     const FunctionType *ft = CastType<FunctionType>(pt->GetBaseType());
-    if (ft != NULL) {
+    if (ft != nullptr) {
         std::pair<llvm::Constant *, bool> cPair = expr->GetConstant(ft);
         llvm::Constant *c = cPair.first;
         return std::pair<llvm::Constant *, bool>(lConvertPointerConstant(c, type), cPair.second);
     }
-    llvm::Value *ptr = NULL;
+    llvm::Value *ptr = nullptr;
     if (GetBaseSymbol())
-        ptr = GetBaseSymbol()->storageInfo ? GetBaseSymbol()->storageInfo->getPointer() : NULL;
+        ptr = GetBaseSymbol()->storageInfo ? GetBaseSymbol()->storageInfo->getPointer() : nullptr;
     if (ptr && llvm::dyn_cast<llvm::GlobalVariable>(ptr)) {
         const Type *eTYPE = GetType();
         if (type->LLVMType(g->ctx) == eTYPE->LLVMType(g->ctx)) {
-            if (llvm::dyn_cast<SymbolExpr>(expr) != NULL) {
+            if (llvm::dyn_cast<SymbolExpr>(expr) != nullptr) {
                 return std::pair<llvm::Constant *, bool>(llvm::cast<llvm::Constant>(ptr),
                                                          isNotValidForMultiTargetGlobal);
 
             } else if (IndexExpr *IExpr = llvm::dyn_cast<IndexExpr>(expr)) {
                 std::vector<llvm::Value *> gepIndex;
-                Expr *mBaseExpr = NULL;
+                Expr *mBaseExpr = nullptr;
                 while (IExpr) {
                     std::pair<llvm::Constant *, bool> cIndexPair = IExpr->index->GetConstant(IExpr->index->GetType());
                     llvm::Constant *cIndex = cIndexPair.first;
-                    if (cIndex == NULL)
-                        return std::pair<llvm::Constant *, bool>(NULL, false);
+                    if (cIndex == nullptr)
+                        return std::pair<llvm::Constant *, bool>(nullptr, false);
                     gepIndex.insert(gepIndex.begin(), cIndex);
                     mBaseExpr = IExpr->baseExpr;
                     IExpr = llvm::dyn_cast<IndexExpr>(mBaseExpr);
@@ -7798,8 +7799,8 @@ std::pair<llvm::Constant *, bool> AddressOfExpr::GetConstant(const Type *type) c
                 }
                 // The base expression needs to be a global symbol so that the
                 // address is a constant.
-                if (llvm::dyn_cast<SymbolExpr>(mBaseExpr) == NULL)
-                    return std::pair<llvm::Constant *, bool>(NULL, false);
+                if (llvm::dyn_cast<SymbolExpr>(mBaseExpr) == nullptr)
+                    return std::pair<llvm::Constant *, bool>(nullptr, false);
                 gepIndex.insert(gepIndex.begin(), LLVMInt64(0));
                 llvm::Constant *c = llvm::cast<llvm::Constant>(ptr);
                 llvm::Constant *c1 = llvm::ConstantExpr::getGetElementPtr(
@@ -7808,27 +7809,27 @@ std::pair<llvm::Constant *, bool> AddressOfExpr::GetConstant(const Type *type) c
             }
         }
     }
-    return std::pair<llvm::Constant *, bool>(NULL, false);
+    return std::pair<llvm::Constant *, bool>(nullptr, false);
 }
 
 ///////////////////////////////////////////////////////////////////////////
 // SizeOfExpr
 
-SizeOfExpr::SizeOfExpr(Expr *e, SourcePos p) : Expr(p, SizeOfExprID), expr(e), type(NULL) {}
+SizeOfExpr::SizeOfExpr(Expr *e, SourcePos p) : Expr(p, SizeOfExprID), expr(e), type(nullptr) {}
 
-SizeOfExpr::SizeOfExpr(const Type *t, SourcePos p) : Expr(p, SizeOfExprID), expr(NULL), type(t) {
+SizeOfExpr::SizeOfExpr(const Type *t, SourcePos p) : Expr(p, SizeOfExprID), expr(nullptr), type(t) {
     type = type->ResolveUnboundVariability(Variability::Varying);
 }
 
 llvm::Value *SizeOfExpr::GetValue(FunctionEmitContext *ctx) const {
     ctx->SetDebugPos(pos);
     const Type *t = expr ? expr->GetType() : type;
-    if (t == NULL)
-        return NULL;
+    if (t == nullptr)
+        return nullptr;
 
     llvm::Type *llvmType = t->LLVMType(g->ctx);
-    if (llvmType == NULL)
-        return NULL;
+    if (llvmType == nullptr)
+        return nullptr;
 
     return g->target->SizeOf(llvmType, ctx->GetCurrentBasicBlock());
 }
@@ -7860,12 +7861,12 @@ Expr *SizeOfExpr::TypeCheck() {
     }
 
     // Can't compute the size of a struct without a definition
-    if (type != NULL && CastType<UndefinedStructType>(type) != NULL) {
+    if (type != nullptr && CastType<UndefinedStructType>(type) != nullptr) {
         Error(pos,
               "Can't compute the size of declared but not defined "
               "struct type \"%s\".",
               type->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
 
     return this;
@@ -7885,16 +7886,16 @@ SizeOfExpr *SizeOfExpr::Instantiate(TemplateInstantiation &templInst) const {
 
 std::pair<llvm::Constant *, bool> SizeOfExpr::GetConstant(const Type *rtype) const {
     const Type *t = expr ? expr->GetType() : type;
-    if (t == NULL)
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+    if (t == nullptr)
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
 
     bool isNotValidForMultiTargetGlobal = false;
     if (t->IsVaryingType())
         isNotValidForMultiTargetGlobal = true;
 
     llvm::Type *llvmType = t->LLVMType(g->ctx);
-    if (llvmType == NULL)
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+    if (llvmType == nullptr)
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
 
     uint64_t byteSize = g->target->getDataLayout()->getTypeStoreSize(llvmType);
     return std::pair<llvm::Constant *, bool>(llvm::ConstantInt::get(rtype->LLVMType(g->ctx), byteSize),
@@ -7908,11 +7909,11 @@ AllocaExpr::AllocaExpr(Expr *e, SourcePos p) : Expr(p, AllocaExprID), expr(e) {}
 
 llvm::Value *AllocaExpr::GetValue(FunctionEmitContext *ctx) const {
     ctx->SetDebugPos(pos);
-    if (expr == NULL)
-        return NULL;
+    if (expr == nullptr)
+        return nullptr;
     llvm::Value *llvmValue = expr->GetValue(ctx);
-    if (llvmValue == NULL)
-        return NULL;
+    if (llvmValue == nullptr)
+        return nullptr;
     llvm::Value *resultPtr = ctx->AllocaInst(LLVMTypes::Int8Type, llvmValue, "allocaExpr", 16,
                                              false)
                                  ->getPointer(); // 16 byte stack alignment.
@@ -7937,24 +7938,24 @@ void AllocaExpr::Print(Indent &indent) const {
 }
 
 Expr *AllocaExpr::TypeCheck() {
-    if (expr == NULL) {
-        return NULL;
+    if (expr == nullptr) {
+        return nullptr;
     }
 
-    const Type *argType = expr ? expr->GetType() : NULL;
+    const Type *argType = expr ? expr->GetType() : nullptr;
     if (argType && argType->IsDependentType()) {
         return this;
     }
 
     const Type *sizeType = m->symbolTable->LookupType("size_t");
-    Assert(sizeType != NULL);
+    Assert(sizeType != nullptr);
     if (!Type::Equal(sizeType->GetAsUniformType(), expr->GetType())) {
         expr = TypeConvertExpr(expr, sizeType->GetAsUniformType(), "Alloca_arg");
     }
-    if (expr == NULL) {
+    if (expr == nullptr) {
         Assert(argType);
         Error(pos, "\"alloca()\" cannot have an argument of type \"%s\".", argType->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
 
     return this;
@@ -7975,9 +7976,9 @@ AllocaExpr *AllocaExpr::Instantiate(TemplateInstantiation &templInst) const {
 SymbolExpr::SymbolExpr(Symbol *s, SourcePos p) : Expr(p, SymbolExprID) { symbol = s; }
 
 llvm::Value *SymbolExpr::GetValue(FunctionEmitContext *ctx) const {
-    // storageInfo may be NULL due to an earlier compilation error
+    // storageInfo may be nullptr due to an earlier compilation error
     if (!symbol || !symbol->storageInfo)
-        return NULL;
+        return nullptr;
     ctx->SetDebugPos(pos);
 
     std::string loadName = symbol->name + std::string("_load");
@@ -7992,17 +7993,17 @@ llvm::Value *SymbolExpr::GetValue(FunctionEmitContext *ctx) const {
 }
 
 llvm::Value *SymbolExpr::GetLValue(FunctionEmitContext *ctx) const {
-    if (symbol == NULL)
-        return NULL;
+    if (symbol == nullptr)
+        return nullptr;
     ctx->SetDebugPos(pos);
     return symbol->storageInfo->getPointer();
 }
 
 const Type *SymbolExpr::GetLValueType() const {
-    if (symbol == NULL)
-        return NULL;
+    if (symbol == nullptr)
+        return nullptr;
 
-    if (CastType<ReferenceType>(symbol->type) != NULL)
+    if (CastType<ReferenceType>(symbol->type) != nullptr)
         return PointerType::GetUniform(symbol->type->GetReferenceTarget());
     else
         return PointerType::GetUniform(symbol->type);
@@ -8010,14 +8011,14 @@ const Type *SymbolExpr::GetLValueType() const {
 
 Symbol *SymbolExpr::GetBaseSymbol() const { return symbol; }
 
-const Type *SymbolExpr::GetType() const { return symbol ? symbol->type : NULL; }
+const Type *SymbolExpr::GetType() const { return symbol ? symbol->type : nullptr; }
 
 Expr *SymbolExpr::TypeCheck() { return this; }
 
 Expr *SymbolExpr::Optimize() {
-    if (symbol == NULL)
-        return NULL;
-    else if (symbol->constValue != NULL) {
+    if (symbol == nullptr)
+        return nullptr;
+    else if (symbol->constValue != nullptr) {
         AssertPos(pos, GetType()->IsConstType());
         return new ConstExpr(symbol->constValue, pos);
     } else
@@ -8036,7 +8037,7 @@ SymbolExpr *SymbolExpr::Instantiate(TemplateInstantiation &templInst) const {
 }
 
 void SymbolExpr::Print(Indent &indent) const {
-    if (symbol == NULL || GetType() == NULL) {
+    if (symbol == nullptr || GetType() == nullptr) {
         indent.Print("SymbolExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -8078,16 +8079,16 @@ const Type *FunctionSymbolExpr::GetType() const {
         return AtomicType::Dependent;
     }
 
-    if (triedToResolve == false && matchingFunc == NULL) {
+    if (triedToResolve == false && matchingFunc == nullptr) {
         Error(pos, "Ambiguous use of overloaded function \"%s\".", name.c_str());
-        return NULL;
+        return nullptr;
     }
 
-    return matchingFunc ? matchingFunc->type : NULL;
+    return matchingFunc ? matchingFunc->type : nullptr;
 }
 
 llvm::Value *FunctionSymbolExpr::GetValue(FunctionEmitContext *ctx) const {
-    return matchingFunc ? matchingFunc->function : NULL;
+    return matchingFunc ? matchingFunc->function : nullptr;
 }
 
 Symbol *FunctionSymbolExpr::GetBaseSymbol() const { return matchingFunc; }
@@ -8129,19 +8130,19 @@ void FunctionSymbolExpr::Print(Indent &indent) const {
 }
 
 std::pair<llvm::Constant *, bool> FunctionSymbolExpr::GetConstant(const Type *type) const {
-    if (matchingFunc == NULL || matchingFunc->function == NULL)
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+    if (matchingFunc == nullptr || matchingFunc->function == nullptr)
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
 
     const FunctionType *ft = CastType<FunctionType>(type);
-    if (ft == NULL)
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+    if (ft == nullptr)
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
 
     if (Type::Equal(type, matchingFunc->type) == false) {
         Error(pos,
               "Type of function symbol \"%s\" doesn't match expected type "
               "\"%s\".",
               matchingFunc->type->GetString().c_str(), type->GetString().c_str());
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
     }
 
     return std::pair<llvm::Constant *, bool>(matchingFunc->function, false);
@@ -8152,7 +8153,7 @@ static std::string lGetOverloadCandidateMessage(const std::vector<Symbol *> &fun
                                                 const std::vector<bool> *argCouldBeNULL) {
     std::string message = "Passed types: (";
     for (unsigned int i = 0; i < argTypes.size(); ++i) {
-        if (argTypes[i] != NULL)
+        if (argTypes[i] != nullptr)
             message += argTypes[i]->GetString();
         else
             message += "(unknown type)";
@@ -8161,7 +8162,7 @@ static std::string lGetOverloadCandidateMessage(const std::vector<Symbol *> &fun
 
     for (unsigned int i = 0; i < funcs.size(); ++i) {
         const FunctionType *ft = CastType<FunctionType>(funcs[i]->type);
-        Assert(ft != NULL);
+        Assert(ft != nullptr);
         message += "Candidate: ";
         message += ft->GetString();
         if (i < funcs.size() - 1)
@@ -8177,7 +8178,7 @@ static std::string lGetOverloadCandidateMessage(const std::vector<Symbol *> &fun
 static bool lIsMatchWithTypeWidening(const Type *callType, const Type *funcArgType) {
     const AtomicType *callAt = CastType<AtomicType>(callType);
     const AtomicType *funcAt = CastType<AtomicType>(funcArgType);
-    if (callAt == NULL || funcAt == NULL)
+    if (callAt == nullptr || funcAt == nullptr)
         return false;
 
     if (callAt->IsUniformType() != funcAt->IsUniformType())
@@ -8220,7 +8221,7 @@ std::vector<Symbol *> FunctionSymbolExpr::getCandidateFunctions(int argCount) co
     for (Symbol *sym : candidateFunctions) {
         AssertPos(pos, sym != nullptr);
         const FunctionType *ft = CastType<FunctionType>(sym->type);
-        AssertPos(pos, ft != NULL);
+        AssertPos(pos, ft != nullptr);
 
         // There's no way to match if the caller is passing more arguments
         // than this function instance takes.
@@ -8416,7 +8417,7 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
                     const ArrayType *at = CastType<ArrayType>(argType);
                     if (at) {
                         const Type *targetType = at->GetElementType();
-                        if (targetType == NULL) {
+                        if (targetType == nullptr) {
                             deductionFailed = true;
                             break;
                         }
@@ -8499,15 +8500,15 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
 }
 
 static bool lArgIsPointerType(const Type *type) {
-    if (CastType<PointerType>(type) != NULL)
+    if (CastType<PointerType>(type) != nullptr)
         return true;
 
     const ReferenceType *rt = CastType<ReferenceType>(type);
-    if (rt == NULL)
+    if (rt == nullptr)
         return false;
 
     const Type *t = rt->GetReferenceTarget();
-    return (CastType<PointerType>(t) != NULL);
+    return (CastType<PointerType>(t) != nullptr);
 }
 
 /** This function computes the value of a cost function that represents the
@@ -8540,7 +8541,7 @@ int FunctionSymbolExpr::computeOverloadCost(const FunctionType *ftype, const std
             // Step "1" from documentation
             cost[i] += 0;
         else if (argCouldBeNULL && (*argCouldBeNULL)[i] && lArgIsPointerType(fargType))
-            // Passing NULL to a pointer-typed parameter is also a no-cost operation
+            // Passing nullptr to a pointer-typed parameter is also a no-cost operation
             // Step "1" from documentation
             cost[i] += 0;
         else {
@@ -8548,7 +8549,7 @@ int FunctionSymbolExpr::computeOverloadCost(const FunctionType *ftype, const std
             // count the cost of various conversions as much lower than the
             // cost if it wasn't--so scale up the cost when this isn't the
             // case..
-            if (argIsConstant == NULL || (*argIsConstant)[i] == false)
+            if (argIsConstant == nullptr || (*argIsConstant)[i] == false)
                 costScale *= 512;
 
             if (CastType<ReferenceType>(fargType)) {
@@ -8677,7 +8678,7 @@ bool FunctionSymbolExpr::ResolveOverloads(SourcePos argPos, const std::vector<co
     // Compute the cost for calling each of the candidate functions
     for (int i = 0; i < (int)actualCandidates.size(); ++i) {
         const FunctionType *ft = CastType<FunctionType>(actualCandidates[i]->type);
-        AssertPos(pos, ft != NULL);
+        AssertPos(pos, ft != nullptr);
         int *cost = new int[argTypes.size()];
         candidateCosts.push_back(computeOverloadCost(ft, argTypes, argCouldBeNULL, argIsConstant, cost));
         candidateExpandCosts.push_back(cost);
@@ -8745,7 +8746,7 @@ const Type *SyncExpr::GetType() const { return AtomicType::Void; }
 llvm::Value *SyncExpr::GetValue(FunctionEmitContext *ctx) const {
     ctx->SetDebugPos(pos);
     ctx->SyncInst();
-    return NULL;
+    return nullptr;
 }
 
 int SyncExpr::EstimateCost() const { return COST_SYNC; }
@@ -8776,13 +8777,13 @@ Expr *NullPointerExpr::Optimize() { return this; }
 
 std::pair<llvm::Constant *, bool> NullPointerExpr::GetConstant(const Type *type) const {
     const PointerType *pt = CastType<PointerType>(type);
-    if (pt == NULL)
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+    if (pt == nullptr)
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
 
     llvm::Type *llvmType = type->LLVMType(g->ctx);
-    if (llvmType == NULL) {
+    if (llvmType == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return std::pair<llvm::Constant *, bool>(NULL, false);
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
     }
 
     return std::pair<llvm::Constant *, bool>(llvm::Constant::getNullValue(llvmType), false);
@@ -8824,7 +8825,7 @@ NewExpr::NewExpr(int typeQual, const Type *t, Expr *init, Expr *count, SourcePos
         // varying new.
         isVarying = (typeQual == 0) || (typeQual & TYPEQUAL_VARYING);
 
-    if (allocType != NULL)
+    if (allocType != nullptr)
         allocType = allocType->ResolveUnboundVariability(Variability::Uniform);
 }
 
@@ -8838,11 +8839,11 @@ llvm::Value *NewExpr::GetValue(FunctionEmitContext *ctx) const {
     // Determine how many elements we need to allocate.  Note that this
     // will be a varying value if this is a varying new.
     llvm::Value *countValue;
-    if (countExpr != NULL) {
+    if (countExpr != nullptr) {
         countValue = countExpr->GetValue(ctx);
-        if (countValue == NULL) {
+        if (countValue == nullptr) {
             AssertPos(pos, m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
     } else {
         if (isVarying) {
@@ -8889,27 +8890,27 @@ llvm::Value *NewExpr::GetValue(FunctionEmitContext *ctx) const {
             func = m->module->getFunction("__new_uniform_64rt");
         }
     }
-    AssertPos(pos, func != NULL);
+    AssertPos(pos, func != nullptr);
 
     // Make the call for the the actual allocation.
-    llvm::Value *ptrValue = ctx->CallInst(func, NULL, allocSize, "new");
+    llvm::Value *ptrValue = ctx->CallInst(func, nullptr, allocSize, "new");
 
     // Now handle initializers and returning the right type for the result.
     const Type *retType = GetType();
-    if (retType == NULL)
-        return NULL;
+    if (retType == nullptr)
+        return nullptr;
     if (isVarying) {
         if (g->target->is32Bit())
             // Convert i64 vector values to i32 if we are compiling to a
             // 32-bit target.
             ptrValue = ctx->TruncInst(ptrValue, LLVMTypes::VoidPointerVectorType, "ptr_to_32bit");
 
-        if (initExpr != NULL) {
+        if (initExpr != nullptr) {
             // If we have an initializer expression, emit code that checks
             // to see if each lane is active and if so, runs the code to do
             // the initialization.  Note that we're we're taking advantage
             // of the fact that the __new_varying*() functions are
-            // implemented to return NULL for program instances that aren't
+            // implemented to return nullptr for program instances that aren't
             // executing; more generally, we should be using the current
             // execution mask for this...
             for (int i = 0; i < g->target->getVectorWidth(); ++i) {
@@ -8942,7 +8943,7 @@ llvm::Value *NewExpr::GetValue(FunctionEmitContext *ctx) const {
         llvm::Type *ptrType = retType->LLVMType(g->ctx);
         ptrValue = ctx->BitCastInst(ptrValue, ptrType, llvm::Twine(ptrValue->getName()) + "_cast_ptr");
 
-        if (initExpr != NULL)
+        if (initExpr != nullptr)
             InitSymbol(new AddressInfo(ptrValue, ptrType), allocType, initExpr, ctx, pos);
 
         return ptrValue;
@@ -8950,8 +8951,8 @@ llvm::Value *NewExpr::GetValue(FunctionEmitContext *ctx) const {
 }
 
 const Type *NewExpr::GetType() const {
-    if (allocType == NULL)
-        return NULL;
+    if (allocType == nullptr)
+        return nullptr;
 
     if (allocType->IsDependentType()) {
         return AtomicType::Dependent;
@@ -8962,9 +8963,9 @@ const Type *NewExpr::GetType() const {
 
 Expr *NewExpr::TypeCheck() {
     // It's illegal to call new with an undefined struct type
-    if (allocType == NULL) {
+    if (allocType == nullptr) {
         AssertPos(pos, m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (allocType->IsDependentType()) {
@@ -8973,39 +8974,39 @@ Expr *NewExpr::TypeCheck() {
 
     if (g->target->isXeTarget()) {
         Error(pos, "\"new\" is not supported for Xe targets yet.");
-        return NULL;
+        return nullptr;
     }
 
-    if (CastType<UndefinedStructType>(allocType) != NULL) {
+    if (CastType<UndefinedStructType>(allocType) != nullptr) {
         Error(pos,
               "Can't dynamically allocate storage for declared "
               "but not defined type \"%s\".",
               allocType->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
     const StructType *st = CastType<StructType>(allocType);
-    if (st != NULL && !st->IsDefined()) {
+    if (st != nullptr && !st->IsDefined()) {
         Error(pos,
               "Can't dynamically allocate storage for declared "
               "type \"%s\" containing undefined member type.",
               allocType->GetString().c_str());
-        return NULL;
+        return nullptr;
     }
 
     // Otherwise we only need to make sure that if we have an expression
     // giving a number of elements to allocate that it can be converted to
     // an integer of the appropriate variability.
-    if (countExpr == NULL)
+    if (countExpr == nullptr)
         return this;
 
     const Type *countType;
-    if ((countType = countExpr->GetType()) == NULL)
-        return NULL;
+    if ((countType = countExpr->GetType()) == nullptr)
+        return nullptr;
 
     if (isVarying == false && countType->IsVaryingType()) {
         Error(pos, "Illegal to provide \"varying\" allocation count with "
                    "\"uniform new\" expression.");
-        return NULL;
+        return nullptr;
     }
 
     // Figure out the type that the allocation count should be
@@ -9015,8 +9016,8 @@ Expr *NewExpr::TypeCheck() {
         t = t->GetAsVaryingType();
 
     countExpr = TypeConvertExpr(countExpr, t, "item count");
-    if (countExpr == NULL)
-        return NULL;
+    if (countExpr == nullptr)
+        return nullptr;
 
     return this;
 }

--- a/src/expr.h
+++ b/src/expr.h
@@ -37,7 +37,7 @@ class Expr : public ASTNode {
         this function should emit IR that computes the expression's lvalue
         and returns the corresponding llvm::Value.  Expressions that can't
         provide an lvalue should leave this unimplemented; the default
-        implementation returns NULL.  */
+        implementation returns nullptr.  */
     virtual llvm::Value *GetLValue(FunctionEmitContext *ctx) const;
 
     /** Returns the Type of the expression. */
@@ -57,7 +57,7 @@ class Expr : public ASTNode {
         corresponding llvm::Constant value and a flag denoting if it's
         valid for multi-target compilation for use as an initializer of
         a global variable. Otherwise it should return the llvm::constant
-        value as NULL. */
+        value as nullptr. */
     virtual std::pair<llvm::Constant *, bool> GetStorageConstant(const Type *type) const;
 
     /** If this is a constant expression that can be converted to a
@@ -65,18 +65,18 @@ class Expr : public ASTNode {
         corresponding llvm::Constant value and a flag denoting if it's
         valid for multi-target compilation for use as an initializer of
         a global variable. Otherwise it should return the llvm::constant
-        value as NULL. */
+        value as nullptr. */
     virtual std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
     /** This method should perform early optimizations of the expression
         (constant folding, etc.) and return a pointer to the resulting
-        expression.  If an error is encountered during optimization, NULL
+        expression.  If an error is encountered during optimization, nullptr
         should be returned. */
     virtual Expr *Optimize() = 0;
 
     /** This method should perform type checking of the expression and
         return a pointer to the resulting expression.  If an error is
-        encountered, NULL should be returned. */
+        encountered, nullptr should be returned. */
     virtual Expr *TypeCheck() = 0;
 
     virtual Expr *Instantiate(TemplateInstantiation &templInst) const = 0;
@@ -255,7 +255,7 @@ class ExprList : public Expr {
  */
 class FunctionCallExpr : public Expr {
   public:
-    FunctionCallExpr(Expr *func, ExprList *args, SourcePos p, bool isLaunch = false, Expr *launchCountExpr[3] = NULL,
+    FunctionCallExpr(Expr *func, ExprList *args, SourcePos p, bool isLaunch = false, Expr *launchCountExpr[3] = nullptr,
                      bool isInvoke = false);
 
     static inline bool classof(FunctionCallExpr const *) { return true; }
@@ -658,8 +658,8 @@ class SizeOfExpr : public Expr {
     SizeOfExpr *Instantiate(TemplateInstantiation &templInst) const;
     std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
 
-    /* One of expr or type should be non-NULL (but not both of them).  The
-       SizeOfExpr returns the size of whichever one of them isn't NULL. */
+    /* One of expr or type should be non-nullptr (but not both of them).  The
+       SizeOfExpr returns the size of whichever one of them isn't nullptr. */
     Expr *expr;
     const Type *type;
 };
@@ -734,18 +734,18 @@ class FunctionSymbolExpr : public Expr {
     /** Given the types of the function arguments, in the presence of
         function overloading, this method resolves which actual function
         the arguments match best.  If the argCouldBeNULL parameter is
-        non-NULL, each element indicates whether the corresponding argument
-        is the number zero, indicating that it could be a NULL pointer, and
-        if argIsConstant is non-NULL, each element indicates whether the
+        non-nullptr, each element indicates whether the corresponding argument
+        is the number zero, indicating that it could be a nullptr pointer, and
+        if argIsConstant is non-nullptr, each element indicates whether the
         corresponding argument is a compile-time constant value.  Both of
-        these parameters may be NULL (for cases where overload resolution
+        these parameters may be nullptr (for cases where overload resolution
         is being done just given type information without the parameter
         argument expressions being available.  This function returns true
         on success.
      */
     bool ResolveOverloads(SourcePos argPos, const std::vector<const Type *> &argTypes,
-                          const std::vector<bool> *argCouldBeNULL = NULL,
-                          const std::vector<bool> *argIsConstant = NULL);
+                          const std::vector<bool> *argCouldBeNULL = nullptr,
+                          const std::vector<bool> *argIsConstant = nullptr);
 
   private:
     std::vector<Symbol *> getCandidateFunctions(int argCount) const;
@@ -789,7 +789,7 @@ class SyncExpr : public Expr {
     SyncExpr *Instantiate(TemplateInstantiation &templInst) const;
 };
 
-/** @brief An expression that represents a NULL pointer. */
+/** @brief An expression that represents a nullptr pointer. */
 class NullPointerExpr : public Expr {
   public:
     NullPointerExpr(SourcePos p) : Expr(p, NullPointerExprID) {}
@@ -828,7 +828,7 @@ class NewExpr : public Expr {
     /** Type of object to allocate storage for. */
     const Type *allocType;
     /** Expression giving the number of elements to allocate, when the
-        "new Foo[expr]" form is used.  This may be NULL, in which case a
+        "new Foo[expr]" form is used.  This may be nullptr, in which case a
         single element of the given type will be allocated. */
     Expr *countExpr;
     /** Optional initializer expression used to initialize the allocated
@@ -849,12 +849,12 @@ class NewExpr : public Expr {
     are provided, then an error message is issued if the type conversion
     isn't possible.
  */
-bool CanConvertTypes(const Type *fromType, const Type *toType, const char *errorMsgBase = NULL,
+bool CanConvertTypes(const Type *fromType, const Type *toType, const char *errorMsgBase = nullptr,
                      SourcePos pos = SourcePos());
 
 /** This function attempts to convert the given expression to the given
     type, returning a pointer to a new expression that is the result.  If
-    the required type conversion is illegal, it returns NULL and prints an
+    the required type conversion is illegal, it returns nullptr and prints an
     error message using the provided string to indicate the context for
     which type conversion was being applied (e.g. "function call
     parameter").

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -138,20 +138,20 @@ void Function::Print(Indent &indent) const {
 // Type checking and optimization is also done here.
 Function::Function(Symbol *s, Stmt *c) : sym(s), code(c) {
     maskSymbol = m->symbolTable->LookupVariable("__mask");
-    Assert(maskSymbol != NULL);
+    Assert(maskSymbol != nullptr);
 
     const FunctionType *type = CastType<FunctionType>(sym->type);
-    Assert(type != NULL);
+    Assert(type != nullptr);
 
     for (int i = 0; i < type->GetNumParameters(); ++i) {
         const char *paramName = type->GetParameterName(i).c_str();
         Symbol *paramSym = m->symbolTable->LookupVariable(paramName);
-        if (paramSym == NULL)
+        if (paramSym == nullptr)
             Assert(strncmp(paramName, "__anon_parameter_", 17) == 0);
         args.push_back(paramSym);
 
         const Type *t = type->GetParameterType(i);
-        if (paramSym != NULL && CastType<ReferenceType>(t) == NULL)
+        if (paramSym != nullptr && CastType<ReferenceType>(t) == nullptr)
             paramSym->parentFunction = this;
     }
 
@@ -179,9 +179,9 @@ Function::Function(Symbol *s, Stmt *c) : sym(s), code(c) {
         taskCountSym2 = m->symbolTable->LookupVariable("taskCount2");
         Assert(taskCountSym2);
     } else {
-        threadIndexSym = threadCountSym = taskIndexSym = taskCountSym = NULL;
-        taskIndexSym0 = taskIndexSym1 = taskIndexSym2 = NULL;
-        taskCountSym0 = taskCountSym1 = taskCountSym2 = NULL;
+        threadIndexSym = threadCountSym = taskIndexSym = taskCountSym = nullptr;
+        taskIndexSym0 = taskIndexSym1 = taskIndexSym2 = nullptr;
+        taskCountSym0 = taskCountSym1 = taskCountSym2 = nullptr;
     }
 
     typeCheckAndOptimize();
@@ -197,14 +197,14 @@ Function::Function(Symbol *s, Stmt *c, Symbol *ms, std::vector<Symbol *> &a)
 }
 
 void Function::typeCheckAndOptimize() {
-    if (code != NULL) {
+    if (code != nullptr) {
         debugPrintHelper(DebugPrintPoint::Initial);
 
         code = TypeCheck(code);
 
         debugPrintHelper(DebugPrintPoint::AfterTypeChecking);
 
-        if (code != NULL) {
+        if (code != nullptr) {
             code = Optimize(code);
 
             debugPrintHelper(DebugPrintPoint::AfterOptimization);
@@ -214,13 +214,13 @@ void Function::typeCheckAndOptimize() {
 
 const Type *Function::GetReturnType() const {
     const FunctionType *type = CastType<FunctionType>(sym->type);
-    Assert(type != NULL);
+    Assert(type != nullptr);
     return type->GetReturnType();
 }
 
 const FunctionType *Function::GetType() const {
     const FunctionType *type = CastType<FunctionType>(sym->type);
-    Assert(type != NULL);
+    Assert(type != nullptr);
     return type;
 }
 
@@ -242,7 +242,7 @@ static void lCopyInTaskParameter(int i, AddressInfo *structArgPtrInfo, const std
     // Get the type of the argument we're copying in and its Symbol pointer
     Symbol *sym = args[i];
 
-    if (sym == NULL)
+    if (sym == nullptr)
         // anonymous parameter, so don't worry about it
         return;
 
@@ -264,8 +264,8 @@ static void lCopyInTaskParameter(int i, AddressInfo *structArgPtrInfo, const std
 static llvm::Value *lXeGetTaskVariableValue(FunctionEmitContext *ctx, std::string taskFunc) {
     std::vector<llvm::Value *> args;
     llvm::Function *task_func = m->module->getFunction(taskFunc);
-    Assert(task_func != NULL);
-    return ctx->CallInst(task_func, NULL, args, taskFunc + "_call");
+    Assert(task_func != nullptr);
+    return ctx->CallInst(task_func, nullptr, args, taskFunc + "_call");
 }
 
 /** Given the statements implementing a function, emit the code that
@@ -292,7 +292,7 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
     llvm::BasicBlock *entryBBlock = ctx->GetCurrentBasicBlock();
 #endif
     const FunctionType *type = CastType<FunctionType>(sym->type);
-    Assert(type != NULL);
+    Assert(type != nullptr);
 
     // CPU tasks
     if (type->isTask == true && !g->target->isXeTarget()) {
@@ -327,7 +327,7 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
             int nArgs = (int)args.size();
             // The mask is the last parameter in the argument structure
             llvm::Value *ptr = ctx->AddElementOffset(stInfo, nArgs, "task_struct_mask");
-            llvm::Value *ptrval = ctx->LoadInst(new AddressInfo(ptr, LLVMTypes::MaskType), NULL, "mask");
+            llvm::Value *ptrval = ctx->LoadInst(new AddressInfo(ptr, LLVMTypes::MaskType), nullptr, "mask");
             ctx->SetFunctionMask(ptrval);
         }
 
@@ -367,7 +367,7 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
         Assert(fType->getFunctionNumParams() >= args.size());
         for (unsigned int i = 0; i < args.size(); ++i, ++argIter) {
             Symbol *argSym = args[i];
-            if (argSym == NULL)
+            if (argSym == nullptr)
                 // anonymous function parameter
                 continue;
 
@@ -459,7 +459,7 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
     ctx->SetFunctionFTZ_DAZFlags();
 
     // Finally, we can generate code for the function
-    if (code != NULL) {
+    if (code != nullptr) {
         ctx->SetDebugPos(code->pos);
         ctx->AddInstrumentationPoint("function entry");
 
@@ -549,7 +549,7 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
         // FIXME: would like to set the context's current position to
         // e.g. the end of the function code
 
-        // if bblock is non-NULL, it hasn't been terminated by e.g. a
+        // if bblock is non-nullptr, it hasn't been terminated by e.g. a
         // return instruction.  Need to add a return instruction.
         ctx->ReturnInst();
     }
@@ -627,12 +627,12 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
 }
 
 void Function::GenerateIR() {
-    if (sym == NULL)
-        // May be NULL due to error earlier in compilation
+    if (sym == nullptr)
+        // May be nullptr due to error earlier in compilation
         return;
 
     llvm::Function *function = sym->function;
-    Assert(function != NULL);
+    Assert(function != nullptr);
 
     // But if that function has a definition, we don't want to redefine it.
     if (function->empty() == false) {
@@ -641,7 +641,7 @@ void Function::GenerateIR() {
     }
 
     const FunctionType *type = CastType<FunctionType>(sym->type);
-    Assert(type != NULL);
+    Assert(type != nullptr);
 
     if (type->isExternSYCL) {
         Error(sym->pos, "\n\'extern \"SYCL\"\' function \"%s\" cannot be defined in ISPC.", sym->name.c_str());
@@ -654,7 +654,7 @@ void Function::GenerateIR() {
     SourcePos firstStmtPos = sym->pos;
     if (code) {
         StmtList *sl = llvm::dyn_cast<StmtList>(code);
-        if (sl && sl->stmts.size() > 0 && sl->stmts[0] != NULL)
+        if (sl && sl->stmts.size() > 0 && sl->stmts[0] != nullptr)
             firstStmtPos = sl->stmts[0]->pos;
         else
             firstStmtPos = code->pos;
@@ -815,15 +815,15 @@ bool TemplateArgs::IsEqual(TemplateArgs &otherArgs) const {
 
 FunctionTemplate::FunctionTemplate(TemplateSymbol *s, Stmt *c) : sym(s), code(c) {
     maskSymbol = m->symbolTable->LookupVariable("__mask");
-    Assert(maskSymbol != NULL);
+    Assert(maskSymbol != nullptr);
 
     const FunctionType *type = GetFunctionType();
-    Assert(type != NULL);
+    Assert(type != nullptr);
 
     for (int i = 0; i < type->GetNumParameters(); ++i) {
         const char *paramName = type->GetParameterName(i).c_str();
         Symbol *paramSym = m->symbolTable->LookupVariable(paramName);
-        if (paramSym == NULL) {
+        if (paramSym == nullptr) {
             Assert(strncmp(paramName, "__anon_parameter_", 17) == 0);
         }
         args.push_back(paramSym);
@@ -1091,12 +1091,12 @@ llvm::Function *TemplateInstantiation::createLLVMFunction(Symbol *functionSym, b
         // default.)  Set parameter attributes accordingly.  (Only for
         // uniform pointers, since varying pointers are int vectors...)
         if (!functionType->isTask && !functionType->isExternSYCL &&
-            ((CastType<PointerType>(argType) != NULL && argType->IsUniformType() &&
+            ((CastType<PointerType>(argType) != nullptr && argType->IsUniformType() &&
               // Exclude SOA argument because it is a pair {struct *, int}
               // instead of pointer
               !CastType<PointerType>(argType)->IsSlice()) ||
 
-             CastType<ReferenceType>(argType) != NULL)) {
+             CastType<ReferenceType>(argType) != nullptr)) {
 
             function->addParamAttr(i, llvm::Attribute::NoAlias);
         }

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -644,8 +644,8 @@ class AllCPUs {
 };
 
 Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, bool printTarget)
-    : m_target(NULL), m_targetMachine(NULL), m_dataLayout(NULL), m_valid(false), m_ispc_target(ispc_target),
-      m_isa(SSE2), m_arch(Arch::none), m_is32Bit(true), m_cpu(""), m_attributes(""), m_tf_attributes(NULL),
+    : m_target(nullptr), m_targetMachine(nullptr), m_dataLayout(nullptr), m_valid(false), m_ispc_target(ispc_target),
+      m_isa(SSE2), m_arch(Arch::none), m_is32Bit(true), m_cpu(""), m_attributes(""), m_tf_attributes(nullptr),
       m_nativeVectorWidth(-1), m_nativeVectorAlignment(-1), m_dataTypeWidth(-1), m_vectorWidth(-1), m_generatePIC(pic),
       m_maskingIsFree(false), m_maskBitCount(-1), m_hasHalfConverts(false), m_hasHalfFullSupport(false),
       m_hasRand(false), m_hasGather(false), m_hasScatter(false), m_hasTranscendentals(false), m_hasTrigonometry(false),
@@ -805,7 +805,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         }
     }
     // For Xe target we do not need to create target/targetMachine
-    if (this->m_target == NULL && !ISPCTargetIsGen(m_ispc_target)) {
+    if (this->m_target == nullptr && !ISPCTargetIsGen(m_ispc_target)) {
         std::string error_message;
         error_message = "Invalid architecture \"";
         error_message += ArchToString(arch);
@@ -1632,7 +1632,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         // For Xe target we do not need to create target/targetMachine
         if (!isXeTarget()) {
             m_targetMachine = m_target->createTargetMachine(triple, m_cpu, featuresString, options, relocModel);
-            Assert(m_targetMachine != NULL);
+            Assert(m_targetMachine != nullptr);
 
             // Set Optimization level for llvm codegen based on Optimization level
             // requested by user via ISPC Optimization Flag. Mapping is :
@@ -1660,7 +1660,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, boo
         // Initialize TargetData/DataLayout in 3 steps.
         // 1. Get default data layout first
         std::string dl_string;
-        if (m_targetMachine != NULL)
+        if (m_targetMachine != nullptr)
             dl_string = m_targetMachine->createDataLayout().getStringRepresentation();
         if (isXeTarget())
             dl_string = m_arch == Arch::xe64 ? "e-p:64:64-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:"
@@ -2020,13 +2020,13 @@ llvm::Value *Target::SizeOf(llvm::Type *type, llvm::BasicBlock *insertAtEnd) {
 
 llvm::Value *Target::StructOffset(llvm::Type *type, int element, llvm::BasicBlock *insertAtEnd) {
     llvm::StructType *structType = llvm::dyn_cast<llvm::StructType>(type);
-    if (structType == NULL || structType->isSized() == false) {
+    if (structType == nullptr || structType->isSized() == false) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     const llvm::StructLayout *sl = getDataLayout()->getStructLayout(structType);
-    Assert(sl != NULL);
+    Assert(sl != nullptr);
 
     uint64_t offset = sl->getElementOffset(element);
     if (m_is32Bit || g->opt.force32BitAddressing)
@@ -2094,7 +2094,7 @@ void Target::markFuncWithCallingConv(llvm::Function *func) {
                     argIter->addAttr(llvm::Attribute::InReg);
                     continue;
                 }
-                if (((llvm::dyn_cast<llvm::VectorType>(argType) != NULL) || argType->isFloatTy() ||
+                if (((llvm::dyn_cast<llvm::VectorType>(argType) != nullptr) || argType->isFloatTy() ||
                      argType->isDoubleTy())) {
                     numArgsVecInReg++;
                     argIter->addAttr(llvm::Attribute::InReg);
@@ -2226,7 +2226,7 @@ Globals::Globals() {
     enableTimeTrace = false;
     // set default granularity to 500.
     timeTraceGranularity = 500;
-    target = NULL;
+    target = nullptr;
     ctx = new llvm::LLVMContext;
 
 // Opaque pointers mode is supported starting from LLVM 14,
@@ -2254,7 +2254,7 @@ Globals::Globals() {
 #ifdef ISPC_HOST_IS_WINDOWS
     _getcwd(currentDirectory, sizeof(currentDirectory));
 #else
-    if (getcwd(currentDirectory, sizeof(currentDirectory)) == NULL)
+    if (getcwd(currentDirectory, sizeof(currentDirectory)) == nullptr)
         FATAL("Current directory path is too long!");
 #endif
     forceAlignment = -1;
@@ -2273,8 +2273,8 @@ Globals::Globals() {
 
 SourcePos::SourcePos(const char *n, int fl, int fc, int ll, int lc) {
     name = n;
-    if (name == NULL) {
-        if (m != NULL)
+    if (name == nullptr) {
+        if (m != nullptr)
             name = m->module->getModuleIdentifier().c_str();
         else
             name = "(unknown)";

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -111,7 +111,7 @@ enum class AddressSpace {
     lexing code).  Both lines and columns are counted starting from one.
  */
 struct SourcePos {
-    SourcePos(const char *n = NULL, int fl = 0, int fc = 0, int ll = 0, int lc = 0);
+    SourcePos(const char *n = nullptr, int fl = 0, int fc = 0, int ll = 0, int lc = 0);
 
     const char *name;
     int first_line;

--- a/src/lex.ll
+++ b/src/lex.ll
@@ -335,7 +335,7 @@ inline int ispcRand() {
         } \
         else if (r == 2) { \
             Symbol *sym = m->symbolTable->RandomSymbol(); \
-            if (sym != NULL) { \
+            if (sym != nullptr) { \
                 yylval.stringVal = new std::string(sym->name); \
                 Warning(yylloc, "Fuzz test replaced with identifier \"%s\".", sym->name.c_str()); \
                 return TOKEN_IDENTIFIER; \
@@ -468,7 +468,7 @@ L?\"(\\.|[^\\"])*\" { lStringConst(&yylval, &yylloc); return TOKEN_STRING_LITERA
     /* We have an identifier--is it a type name or an identifier?
        The symbol table will straighten us out... */
     yylval.stringVal = new std::string(yytext);
-    if (m->symbolTable->LookupType(yytext) != NULL)
+    if (m->symbolTable->LookupType(yytext) != nullptr)
         return TOKEN_TYPE_NAME;
     else if (m->symbolTable->LookupFunctionTemplate(yytext))
         return TOKEN_TEMPLATE_NAME;
@@ -643,7 +643,7 @@ static int
 lParseInteger(bool dotdotdot) {
     int ls = 0, us = 0;
 
-    char *endPtr = NULL;
+    char *endPtr = nullptr;
     if (yytext[0] == '0' && yytext[1] == 'b')
         yylval.intVal = lParseBinary(yytext+2, yylloc, &endPtr);
     else {
@@ -819,7 +819,7 @@ static void lPragmaUnroll(YYSTYPE *yylval, SourcePos *pos, std::string fromUserR
         ++pos->last_column;
     }
 
-    char *endPtr = NULL;
+    char *endPtr = nullptr;
 #if defined(ISPC_HOST_IS_WINDOWS) && !defined(__MINGW32__)
     count = _strtoui64(currChar, &endPtr, 0);
 #else
@@ -1067,7 +1067,7 @@ lStringConst(YYSTYPE *yylval, SourcePos *pos)
     char *p;
     std::string str;
     p = strchr(yytext, '"') + 1;
-    if (p == NULL)
+    if (p == nullptr)
        return;
 
     while (*p != '\"') {
@@ -1105,7 +1105,7 @@ ipow2(int exponent) {
 */
 static double
 lParseHexFloat(const char *ptr) {
-    Assert(ptr != NULL);
+    Assert(ptr != nullptr);
 
     Assert(ptr[0] == '0' && (ptr[1] == 'x' || ptr[1] == 'X'));
     ptr += 2;
@@ -1149,7 +1149,7 @@ lParseHexFloat(const char *ptr) {
     ++ptr; // skip the 'p'/'P'
 
     // interestingly enough, the exponent is provided base 10..
-    char* endptr = NULL;
+    char* endptr = nullptr;
     int exponent = (int)strtol(ptr, &endptr, 10);
     Assert(ptr != endptr);
 

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -26,57 +26,57 @@
 
 namespace ispc {
 
-llvm::Type *LLVMTypes::VoidType = NULL;
-llvm::PointerType *LLVMTypes::VoidPointerType = NULL;
-llvm::Type *LLVMTypes::PointerIntType = NULL;
-llvm::Type *LLVMTypes::BoolType = NULL;
-llvm::Type *LLVMTypes::BoolStorageType = NULL;
+llvm::Type *LLVMTypes::VoidType = nullptr;
+llvm::PointerType *LLVMTypes::VoidPointerType = nullptr;
+llvm::Type *LLVMTypes::PointerIntType = nullptr;
+llvm::Type *LLVMTypes::BoolType = nullptr;
+llvm::Type *LLVMTypes::BoolStorageType = nullptr;
 
-llvm::Type *LLVMTypes::Int8Type = NULL;
-llvm::Type *LLVMTypes::Int16Type = NULL;
-llvm::Type *LLVMTypes::Int32Type = NULL;
-llvm::Type *LLVMTypes::Int64Type = NULL;
-llvm::Type *LLVMTypes::Float16Type = NULL;
-llvm::Type *LLVMTypes::FloatType = NULL;
-llvm::Type *LLVMTypes::DoubleType = NULL;
+llvm::Type *LLVMTypes::Int8Type = nullptr;
+llvm::Type *LLVMTypes::Int16Type = nullptr;
+llvm::Type *LLVMTypes::Int32Type = nullptr;
+llvm::Type *LLVMTypes::Int64Type = nullptr;
+llvm::Type *LLVMTypes::Float16Type = nullptr;
+llvm::Type *LLVMTypes::FloatType = nullptr;
+llvm::Type *LLVMTypes::DoubleType = nullptr;
 
-llvm::Type *LLVMTypes::Int8PointerType = NULL;
-llvm::Type *LLVMTypes::Int16PointerType = NULL;
-llvm::Type *LLVMTypes::Int32PointerType = NULL;
-llvm::Type *LLVMTypes::Int64PointerType = NULL;
-llvm::Type *LLVMTypes::Float16PointerType = NULL;
-llvm::Type *LLVMTypes::FloatPointerType = NULL;
-llvm::Type *LLVMTypes::DoublePointerType = NULL;
+llvm::Type *LLVMTypes::Int8PointerType = nullptr;
+llvm::Type *LLVMTypes::Int16PointerType = nullptr;
+llvm::Type *LLVMTypes::Int32PointerType = nullptr;
+llvm::Type *LLVMTypes::Int64PointerType = nullptr;
+llvm::Type *LLVMTypes::Float16PointerType = nullptr;
+llvm::Type *LLVMTypes::FloatPointerType = nullptr;
+llvm::Type *LLVMTypes::DoublePointerType = nullptr;
 
-llvm::VectorType *LLVMTypes::MaskType = NULL;
-llvm::VectorType *LLVMTypes::BoolVectorType = NULL;
-llvm::VectorType *LLVMTypes::BoolVectorStorageType = NULL;
+llvm::VectorType *LLVMTypes::MaskType = nullptr;
+llvm::VectorType *LLVMTypes::BoolVectorType = nullptr;
+llvm::VectorType *LLVMTypes::BoolVectorStorageType = nullptr;
 
-llvm::VectorType *LLVMTypes::Int1VectorType = NULL;
-llvm::VectorType *LLVMTypes::Int8VectorType = NULL;
-llvm::VectorType *LLVMTypes::Int16VectorType = NULL;
-llvm::VectorType *LLVMTypes::Int32VectorType = NULL;
-llvm::VectorType *LLVMTypes::Int64VectorType = NULL;
-llvm::VectorType *LLVMTypes::Float16VectorType = NULL;
-llvm::VectorType *LLVMTypes::FloatVectorType = NULL;
-llvm::VectorType *LLVMTypes::DoubleVectorType = NULL;
+llvm::VectorType *LLVMTypes::Int1VectorType = nullptr;
+llvm::VectorType *LLVMTypes::Int8VectorType = nullptr;
+llvm::VectorType *LLVMTypes::Int16VectorType = nullptr;
+llvm::VectorType *LLVMTypes::Int32VectorType = nullptr;
+llvm::VectorType *LLVMTypes::Int64VectorType = nullptr;
+llvm::VectorType *LLVMTypes::Float16VectorType = nullptr;
+llvm::VectorType *LLVMTypes::FloatVectorType = nullptr;
+llvm::VectorType *LLVMTypes::DoubleVectorType = nullptr;
 
-llvm::Type *LLVMTypes::Int8VectorPointerType = NULL;
-llvm::Type *LLVMTypes::Int16VectorPointerType = NULL;
-llvm::Type *LLVMTypes::Int32VectorPointerType = NULL;
-llvm::Type *LLVMTypes::Int64VectorPointerType = NULL;
-llvm::Type *LLVMTypes::Float16VectorPointerType = NULL;
-llvm::Type *LLVMTypes::FloatVectorPointerType = NULL;
-llvm::Type *LLVMTypes::DoubleVectorPointerType = NULL;
+llvm::Type *LLVMTypes::Int8VectorPointerType = nullptr;
+llvm::Type *LLVMTypes::Int16VectorPointerType = nullptr;
+llvm::Type *LLVMTypes::Int32VectorPointerType = nullptr;
+llvm::Type *LLVMTypes::Int64VectorPointerType = nullptr;
+llvm::Type *LLVMTypes::Float16VectorPointerType = nullptr;
+llvm::Type *LLVMTypes::FloatVectorPointerType = nullptr;
+llvm::Type *LLVMTypes::DoubleVectorPointerType = nullptr;
 
-llvm::VectorType *LLVMTypes::VoidPointerVectorType = NULL;
+llvm::VectorType *LLVMTypes::VoidPointerVectorType = nullptr;
 
-llvm::Constant *LLVMTrue = NULL;
-llvm::Constant *LLVMFalse = NULL;
-llvm::Constant *LLVMTrueInStorage = NULL;
-llvm::Constant *LLVMFalseInStorage = NULL;
-llvm::Constant *LLVMMaskAllOn = NULL;
-llvm::Constant *LLVMMaskAllOff = NULL;
+llvm::Constant *LLVMTrue = nullptr;
+llvm::Constant *LLVMFalse = nullptr;
+llvm::Constant *LLVMTrueInStorage = nullptr;
+llvm::Constant *LLVMFalseInStorage = nullptr;
+llvm::Constant *LLVMMaskAllOn = nullptr;
+llvm::Constant *LLVMMaskAllOff = nullptr;
 
 void InitLLVMUtil(llvm::LLVMContext *ctx, Target &target) {
     LLVMTypes::VoidType = llvm::Type::getVoidTy(*ctx);
@@ -151,7 +151,7 @@ void InitLLVMUtil(llvm::LLVMContext *ctx, Target &target) {
     LLVMFalseInStorage = llvm::ConstantInt::get(LLVMTypes::Int8Type, 0x00, false /*unsigned*/);
 
     std::vector<llvm::Constant *> maskOnes;
-    llvm::Constant *onMask = NULL;
+    llvm::Constant *onMask = nullptr;
     switch (target.getMaskBitCount()) {
     case 1:
         onMask = llvm::ConstantInt::get(llvm::Type::getInt1Ty(*ctx), 1, false /*unsigned*/); // 0x1
@@ -177,7 +177,7 @@ void InitLLVMUtil(llvm::LLVMContext *ctx, Target &target) {
     LLVMMaskAllOn = llvm::ConstantVector::get(maskOnes);
 
     std::vector<llvm::Constant *> maskZeros;
-    llvm::Constant *offMask = NULL;
+    llvm::Constant *offMask = nullptr;
     switch (target.getMaskBitCount()) {
     case 1:
         offMask = llvm::ConstantInt::get(llvm::Type::getInt1Ty(*ctx), 0, true /*signed*/);
@@ -468,7 +468,7 @@ llvm::Constant *LLVMBoolVectorInStorage(const bool *bvec) {
 llvm::Constant *LLVMIntAsType(int64_t val, llvm::Type *type) {
     llvm::FixedVectorType *vecType = llvm::dyn_cast<llvm::FixedVectorType>(type);
 
-    if (vecType != NULL) {
+    if (vecType != nullptr) {
         llvm::Constant *v = llvm::ConstantInt::get(vecType->getElementType(), val, true /* signed */);
         std::vector<llvm::Constant *> vals;
         for (int i = 0; i < (int)vecType->getNumElements(); ++i)
@@ -481,7 +481,7 @@ llvm::Constant *LLVMIntAsType(int64_t val, llvm::Type *type) {
 llvm::Constant *LLVMUIntAsType(uint64_t val, llvm::Type *type) {
     llvm::FixedVectorType *vecType = llvm::dyn_cast<llvm::FixedVectorType>(type);
 
-    if (vecType != NULL) {
+    if (vecType != nullptr) {
         llvm::Constant *v = llvm::ConstantInt::get(vecType->getElementType(), val, false /* unsigned */);
         std::vector<llvm::Constant *> vals;
         for (int i = 0; i < (int)vecType->getNumElements(); ++i)
@@ -512,7 +512,7 @@ static bool lValuesAreEqual(llvm::Value *v0, llvm::Value *v1, std::vector<llvm::
 
     llvm::BinaryOperator *bo0 = llvm::dyn_cast<llvm::BinaryOperator>(v0);
     llvm::BinaryOperator *bo1 = llvm::dyn_cast<llvm::BinaryOperator>(v1);
-    if (bo0 != NULL && bo1 != NULL) {
+    if (bo0 != nullptr && bo1 != nullptr) {
         if (bo0->getOpcode() != bo1->getOpcode())
             return false;
         return (lValuesAreEqual(bo0->getOperand(0), bo1->getOperand(0), seenPhi0, seenPhi1) &&
@@ -521,7 +521,7 @@ static bool lValuesAreEqual(llvm::Value *v0, llvm::Value *v1, std::vector<llvm::
 
     llvm::CastInst *cast0 = llvm::dyn_cast<llvm::CastInst>(v0);
     llvm::CastInst *cast1 = llvm::dyn_cast<llvm::CastInst>(v1);
-    if (cast0 != NULL && cast1 != NULL) {
+    if (cast0 != nullptr && cast1 != nullptr) {
         if (cast0->getOpcode() != cast1->getOpcode())
             return false;
         return lValuesAreEqual(cast0->getOperand(0), cast1->getOperand(0), seenPhi0, seenPhi1);
@@ -529,7 +529,7 @@ static bool lValuesAreEqual(llvm::Value *v0, llvm::Value *v1, std::vector<llvm::
 
     llvm::PHINode *phi0 = llvm::dyn_cast<llvm::PHINode>(v0);
     llvm::PHINode *phi1 = llvm::dyn_cast<llvm::PHINode>(v1);
-    if (phi0 != NULL && phi1 != NULL) {
+    if (phi0 != nullptr && phi1 != nullptr) {
         if (phi0->getNumIncomingValues() != phi1->getNumIncomingValues())
             return false;
 
@@ -578,15 +578,15 @@ static bool lIsFirstElementConstVector(llvm::Value *v) {
     // Need to understand what initial intent was here (what instruction supposed to be handled).
     // TODO: after fixing FIXME above isXeTarget() needs to be removed.
     if (g->target->isXeTarget()) {
-        if (cv == NULL && llvm::isa<llvm::Instruction>(v)) {
+        if (cv == nullptr && llvm::isa<llvm::Instruction>(v)) {
             llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(v);
             Assert(inst);
             cv = llvm::dyn_cast<llvm::ConstantVector>(inst->getOperand(1));
         }
     }
-    if (cv != NULL) {
+    if (cv != nullptr) {
         llvm::Constant *c = llvm::dyn_cast<llvm::Constant>(cv->getOperand(0));
-        if (c == NULL) {
+        if (c == nullptr) {
             return false;
         }
 
@@ -607,19 +607,19 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
     // Catch a pattern of InsertElement chain.
     if (llvm::InsertElementInst *ie = llvm::dyn_cast<llvm::InsertElementInst>(inst)) {
         // Gather elements of vector
-        while (ie != NULL) {
+        while (ie != nullptr) {
             int64_t iOffset = lGetIntValue(ie->getOperand(2));
             Assert(iOffset >= 0 && iOffset < vectorWidth);
 
             // Get the scalar value from this insert
-            if (elements[iOffset] == NULL) {
+            if (elements[iOffset] == nullptr) {
                 elements[iOffset] = ie->getOperand(1);
             }
 
             // Do we have another insert?
             llvm::Value *insertBase = ie->getOperand(0);
             ie = llvm::dyn_cast<llvm::InsertElementInst>(insertBase);
-            if (ie != NULL) {
+            if (ie != nullptr) {
                 continue;
             }
 
@@ -631,18 +631,18 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
                 llvm::Constant *cv = llvm::dyn_cast<llvm::Constant>(insertBase);
                 Assert(vectorWidth == (int)(cv->getNumOperands()));
                 for (int i = 0; i < vectorWidth; i++) {
-                    if (elements[i] == NULL) {
+                    if (elements[i] == nullptr) {
                         elements[i] = cv->getOperand(i);
                     }
                 }
                 break;
             } else {
                 // Here chain ends in llvm::LoadInst or some other.
-                // They are not equal to each other so we should return NULL if compare
+                // They are not equal to each other so we should return nullptr if compare
                 // and first element if we have it.
-                Assert(compare == true || elements[0] != NULL);
+                Assert(compare == true || elements[0] != nullptr);
                 if (compare) {
-                    return NULL;
+                    return nullptr;
                 } else {
                     return elements[0];
                 }
@@ -658,31 +658,31 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
         int null_number = 0;
         int NonNull = 0;
         for (int i = 0; i < vectorWidth; i++) {
-            if (elements[i] == NULL) {
+            if (elements[i] == nullptr) {
                 null_number++;
             } else {
                 NonNull = i;
             }
         }
         if (null_number == vectorWidth) {
-            // All of elements are NULLs
-            return NULL;
+            // All of elements are nullptrs
+            return nullptr;
         }
         if ((undef == false) && (null_number != 0)) {
-            // We don't want NULLs in chain, but we have them
-            return NULL;
+            // We don't want nullptrs in chain, but we have them
+            return nullptr;
         }
 
         // Compare elements of vector
         for (int i = 0; i < vectorWidth; i++) {
-            if (elements[i] == NULL) {
+            if (elements[i] == nullptr) {
                 continue;
             }
 
             std::vector<llvm::PHINode *> seenPhi0;
             std::vector<llvm::PHINode *> seenPhi1;
             if (lValuesAreEqual(elements[NonNull], elements[i], seenPhi0, seenPhi1) == false) {
-                return NULL;
+                return nullptr;
             }
         }
         return elements[NonNull];
@@ -703,10 +703,10 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
         if (llvm::isa<llvm::ConstantAggregateZero>(indices)) {
             llvm::Value *op = shuf->getOperand(0);
             llvm::InsertElementInst *ie = llvm::dyn_cast<llvm::InsertElementInst>(op);
-            if (ie == NULL && searchFirstUndef) {
+            if (ie == nullptr && searchFirstUndef) {
                 // Trying to recognize 2nd pattern
                 llvm::BinaryOperator *bop = llvm::dyn_cast<llvm::BinaryOperator>(op);
-                if (bop != NULL && ((bop->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop))) {
+                if (bop != nullptr && ((bop->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop))) {
                     if (lIsFirstElementConstVector(bop->getOperand(1))) {
                         ie = llvm::dyn_cast<llvm::InsertElementInst>(bop->getOperand(0));
                     } else if (llvm::isa<llvm::InsertElementInst>(bop->getOperand(1))) {
@@ -715,7 +715,7 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
                     }
                 }
             }
-            if (ie != NULL && llvm::isa<llvm::UndefValue>(ie->getOperand(0))) {
+            if (ie != nullptr && llvm::isa<llvm::UndefValue>(ie->getOperand(0))) {
                 llvm::ConstantInt *ci = llvm::dyn_cast<llvm::ConstantInt>(ie->getOperand(2));
                 Assert(ci);
                 if (ci->isZero()) {
@@ -724,13 +724,13 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
             }
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 bool LLVMExtractVectorInts(llvm::Value *v, int64_t ret[], int *nElts) {
     // Make sure we do in fact have a vector of integer values here
     llvm::FixedVectorType *vt = llvm::dyn_cast<llvm::FixedVectorType>(v->getType());
-    Assert(vt != NULL);
+    Assert(vt != nullptr);
     Assert(llvm::isa<llvm::IntegerType>(vt->getElementType()));
 
     *nElts = (int)vt->getNumElements();
@@ -742,7 +742,7 @@ bool LLVMExtractVectorInts(llvm::Value *v, int64_t ret[], int *nElts) {
     }
 
     llvm::ConstantDataVector *cv = llvm::dyn_cast<llvm::ConstantDataVector>(v);
-    if (cv == NULL)
+    if (cv == nullptr)
         return false;
 
     for (int i = 0; i < (int)cv->getNumElements(); ++i)
@@ -751,7 +751,7 @@ bool LLVMExtractVectorInts(llvm::Value *v, int64_t ret[], int *nElts) {
 }
 
 static bool lVectorValuesAllEqual(llvm::Value *v, int vectorLength, std::vector<llvm::PHINode *> &seenPhis,
-                                  llvm::Value **splatValue = NULL);
+                                  llvm::Value **splatValue = nullptr);
 
 /** This function checks to see if the given (scalar or vector) value is an
     exact multiple of baseValue.  It returns true if so, and false if not
@@ -765,7 +765,7 @@ static bool lIsExactMultiple(llvm::Value *val, int baseValue, int vectorLength,
         // If we've worked down to a constant int, then the moment of truth
         // has arrived...
         llvm::ConstantInt *ci = llvm::dyn_cast<llvm::ConstantInt>(val);
-        if (ci != NULL)
+        if (ci != nullptr)
             return (ci->getZExtValue() % baseValue) == 0;
     } else
         Assert(LLVMVectorValuesAllEqual(val));
@@ -778,7 +778,7 @@ static bool lIsExactMultiple(llvm::Value *val, int baseValue, int vectorLength,
     }
 
     llvm::PHINode *phi = llvm::dyn_cast<llvm::PHINode>(val);
-    if (phi != NULL) {
+    if (phi != nullptr) {
         for (unsigned int i = 0; i < seenPhis.size(); ++i)
             if (phi == seenPhis[i])
                 return true;
@@ -801,7 +801,7 @@ static bool lIsExactMultiple(llvm::Value *val, int baseValue, int vectorLength,
     }
 
     llvm::BinaryOperator *bop = llvm::dyn_cast<llvm::BinaryOperator>(val);
-    if (bop != NULL && ((bop->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop))) {
+    if (bop != nullptr && ((bop->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop))) {
         llvm::Value *op0 = bop->getOperand(0);
         llvm::Value *op1 = bop->getOperand(1);
 
@@ -857,7 +857,7 @@ static bool lAllDivBaseEqual(llvm::Value *val, int64_t baseValue, int vectorLeng
     }
 
     llvm::PHINode *phi = llvm::dyn_cast<llvm::PHINode>(val);
-    if (phi != NULL) {
+    if (phi != nullptr) {
         for (unsigned int i = 0; i < seenPhis.size(); ++i)
             if (phi == seenPhis[i])
                 return true;
@@ -881,7 +881,8 @@ static bool lAllDivBaseEqual(llvm::Value *val, int64_t baseValue, int vectorLeng
     }
 
     llvm::BinaryOperator *bop = llvm::dyn_cast<llvm::BinaryOperator>(val);
-    if (bop != NULL && ((bop->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop)) && canAdd == true) {
+    if (bop != nullptr && ((bop->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop)) &&
+        canAdd == true) {
         llvm::Value *op0 = bop->getOperand(0);
         llvm::Value *op1 = bop->getOperand(1);
 
@@ -995,25 +996,25 @@ static bool lVectorValuesAllEqual(llvm::Value *v, int vectorLength, std::vector<
     }
 
     llvm::ConstantVector *cv = llvm::dyn_cast<llvm::ConstantVector>(v);
-    if (cv != NULL) {
+    if (cv != nullptr) {
         llvm::Value *splat = cv->getSplatValue();
-        if (splat != NULL && splatValue) {
+        if (splat != nullptr && splatValue) {
             *splatValue = splat;
         }
-        return (splat != NULL);
+        return (splat != nullptr);
     }
 
     llvm::ConstantDataVector *cdv = llvm::dyn_cast<llvm::ConstantDataVector>(v);
-    if (cdv != NULL) {
+    if (cdv != nullptr) {
         llvm::Value *splat = cdv->getSplatValue();
-        if (splat != NULL && splatValue) {
+        if (splat != nullptr && splatValue) {
             *splatValue = splat;
         }
-        return (splat != NULL);
+        return (splat != nullptr);
     }
 
     llvm::BinaryOperator *bop = llvm::dyn_cast<llvm::BinaryOperator>(v);
-    if (bop != NULL) {
+    if (bop != nullptr) {
         // Easy case: both operands are all equal -> return true
         if (lVectorValuesAllEqual(bop->getOperand(0), vectorLength, seenPhis) &&
             lVectorValuesAllEqual(bop->getOperand(1), vectorLength, seenPhis))
@@ -1028,12 +1029,12 @@ static bool lVectorValuesAllEqual(llvm::Value *v, int vectorLength, std::vector<
     }
 
     llvm::CastInst *cast = llvm::dyn_cast<llvm::CastInst>(v);
-    if (cast != NULL)
+    if (cast != nullptr)
         return lVectorValuesAllEqual(cast->getOperand(0), vectorLength, seenPhis);
 
     llvm::InsertElementInst *ie = llvm::dyn_cast<llvm::InsertElementInst>(v);
-    if (ie != NULL) {
-        return (LLVMFlattenInsertChain(ie, vectorLength) != NULL);
+    if (ie != nullptr) {
+        return (LLVMFlattenInsertChain(ie, vectorLength) != nullptr);
     }
 
     llvm::PHINode *phi = llvm::dyn_cast<llvm::PHINode>(v);
@@ -1068,7 +1069,7 @@ static bool lVectorValuesAllEqual(llvm::Value *v, int vectorLength, std::vector<
         return false;
 
     llvm::ShuffleVectorInst *shuffle = llvm::dyn_cast<llvm::ShuffleVectorInst>(v);
-    if (shuffle != NULL) {
+    if (shuffle != nullptr) {
         llvm::Value *indices = shuffle->getShuffleMaskForBitcode();
 
         if (lVectorValuesAllEqual(indices, vectorLength, seenPhis))
@@ -1101,7 +1102,7 @@ static bool lVectorValuesAllEqual(llvm::Value *v, int vectorLength, std::vector<
 */
 bool LLVMVectorValuesAllEqual(llvm::Value *v, llvm::Value **splat) {
     llvm::FixedVectorType *vt = llvm::dyn_cast<llvm::FixedVectorType>(v->getType());
-    Assert(vt != NULL);
+    Assert(vt != nullptr);
     int vectorLength = vt->getNumElements();
 
     std::vector<llvm::PHINode *> seenPhis;
@@ -1118,7 +1119,7 @@ bool LLVMVectorValuesAllEqual(llvm::Value *v, llvm::Value **splat) {
 bool IsOrEquivalentToAdd(llvm::Value *op) {
     bool isEq = false;
     llvm::BinaryOperator *bop = llvm::dyn_cast<llvm::BinaryOperator>(op);
-    if (bop != NULL && bop->getOpcode() == llvm::Instruction::Or) {
+    if (bop != nullptr && bop->getOpcode() == llvm::Instruction::Or) {
         // Special case when A+B --> A|B transformation is triggered
         // We need to prove that A|B == A+B
         llvm::Module *module = bop->getParent()->getParent()->getParent();
@@ -1146,7 +1147,7 @@ static bool lVectorIsLinearConstantInts(llvm::ConstantDataVector *cv, int vector
     Assert((int)elements.size() == vectorLength);
 
     llvm::ConstantInt *ci = llvm::dyn_cast<llvm::ConstantInt>(elements[0]);
-    if (ci == NULL)
+    if (ci == nullptr)
         // Not a vector of integers
         return false;
 
@@ -1157,7 +1158,7 @@ static bool lVectorIsLinearConstantInts(llvm::ConstantDataVector *cv, int vector
     // is stride.  If not, fail.
     for (int i = 1; i < vectorLength; ++i) {
         ci = llvm::dyn_cast<llvm::ConstantInt>(elements[i]);
-        if (ci == NULL)
+        if (ci == nullptr)
             return false;
 
         int64_t nextVal = ci->getSExtValue();
@@ -1177,15 +1178,15 @@ static bool lCheckMulForLinear(llvm::Value *op0, llvm::Value *op1, int vectorLen
     // Is the first operand a constant integer value splatted across all of
     // the lanes?
     llvm::ConstantDataVector *cv = llvm::dyn_cast<llvm::ConstantDataVector>(op0);
-    if (cv == NULL)
+    if (cv == nullptr)
         return false;
 
     llvm::Constant *csplat = cv->getSplatValue();
-    if (csplat == NULL)
+    if (csplat == nullptr)
         return false;
 
     llvm::ConstantInt *splat = llvm::dyn_cast<llvm::ConstantInt>(csplat);
-    if (splat == NULL)
+    if (splat == nullptr)
         return false;
 
     // If the splat value doesn't evenly divide the stride we're looking
@@ -1208,15 +1209,15 @@ static bool lCheckShlForLinear(llvm::Value *op0, llvm::Value *op1, int vectorLen
     // Is the second operand a constant integer value splatted across all of
     // the lanes?
     llvm::ConstantDataVector *cv = llvm::dyn_cast<llvm::ConstantDataVector>(op1);
-    if (cv == NULL)
+    if (cv == nullptr)
         return false;
 
     llvm::Constant *csplat = cv->getSplatValue();
-    if (csplat == NULL)
+    if (csplat == nullptr)
         return false;
 
     llvm::ConstantInt *splat = llvm::dyn_cast<llvm::ConstantInt>(csplat);
-    if (splat == NULL)
+    if (splat == nullptr)
         return false;
 
     // If (1 << the splat value) doesn't evenly divide the stride we're
@@ -1271,11 +1272,11 @@ static bool lVectorIsLinear(llvm::Value *v, int vectorLength, int stride, std::v
     // First try the easy case: if the values are all just constant
     // integers and have the expected stride between them, then we're done.
     llvm::ConstantDataVector *cv = llvm::dyn_cast<llvm::ConstantDataVector>(v);
-    if (cv != NULL)
+    if (cv != nullptr)
         return lVectorIsLinearConstantInts(cv, vectorLength, stride);
 
     llvm::BinaryOperator *bop = llvm::dyn_cast<llvm::BinaryOperator>(v);
-    if (bop != NULL) {
+    if (bop != nullptr) {
         // FIXME: is it right to pass the seenPhis to the all equal check as well??
         llvm::Value *op0 = bop->getOperand(0), *op1 = bop->getOperand(1);
         if ((bop->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop)) {
@@ -1319,14 +1320,14 @@ static bool lVectorIsLinear(llvm::Value *v, int vectorLength, int stride, std::v
     }
 
     llvm::CastInst *ci = llvm::dyn_cast<llvm::CastInst>(v);
-    if (ci != NULL)
+    if (ci != nullptr)
         return lVectorIsLinear(ci->getOperand(0), vectorLength, stride, seenPhis);
 
     if (llvm::isa<llvm::CallInst>(v) || llvm::isa<llvm::LoadInst>(v))
         return false;
 
     llvm::PHINode *phi = llvm::dyn_cast<llvm::PHINode>(v);
-    if (phi != NULL) {
+    if (phi != nullptr) {
         for (unsigned int i = 0; i < seenPhis.size(); ++i)
             if (seenPhis[i] == phi)
                 return true;
@@ -1355,7 +1356,7 @@ static bool lVectorIsLinear(llvm::Value *v, int vectorLength, int stride, std::v
     // cases where doing so would detect cases where actually have a linear
     // vector.
     llvm::ShuffleVectorInst *shuffle = llvm::dyn_cast<llvm::ShuffleVectorInst>(v);
-    if (shuffle != NULL)
+    if (shuffle != nullptr)
         return false;
 
 #if 0
@@ -1380,7 +1381,7 @@ static bool lVectorIsLinear(llvm::Value *v, int vectorLength, int stride, std::v
 */
 bool LLVMVectorIsLinear(llvm::Value *v, int stride) {
     llvm::FixedVectorType *vt = llvm::dyn_cast<llvm::FixedVectorType>(v->getType());
-    Assert(vt != NULL);
+    Assert(vt != nullptr);
     int vectorLength = vt->getNumElements();
 
     std::vector<llvm::PHINode *> seenPhis;
@@ -1397,14 +1398,14 @@ static void lDumpValue(llvm::Value *v, std::set<llvm::Value *> &done) {
         return;
 
     llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(v);
-    if (done.size() > 0 && inst == NULL)
+    if (done.size() > 0 && inst == nullptr)
         return;
 
     fprintf(stderr, "  ");
     v->print(llvm::errs());
     done.insert(v);
 
-    if (inst == NULL)
+    if (inst == nullptr)
         return;
 
     for (unsigned i = 0; i < inst->getNumOperands(); ++i)
@@ -1419,7 +1420,7 @@ void LLVMDumpValue(llvm::Value *v) {
 
 static llvm::Value *lExtractFirstVectorElement(llvm::Value *v, std::map<llvm::PHINode *, llvm::PHINode *> &phiMap) {
     llvm::FixedVectorType *vt = llvm::dyn_cast<llvm::FixedVectorType>(v->getType());
-    Assert(vt != NULL);
+    Assert(vt != nullptr);
 
     // First, handle various constant types; do the extraction manually, as
     // appropriate.
@@ -1436,7 +1437,7 @@ static llvm::Value *lExtractFirstVectorElement(llvm::Value *v, std::map<llvm::PH
     // extractelement %value, 0 in the start of function.
     if (llvm::Argument *arg = llvm::dyn_cast<llvm::Argument>(v)) {
         llvm::Function *func = arg->getParent();
-        Assert(func != NULL);
+        Assert(func != nullptr);
         llvm::BasicBlock &bb = func->getEntryBlock();
         llvm::Instruction *insertPoint = &*bb.getFirstInsertionPt();
         return llvm::ExtractElementInst::Create(v, LLVMInt32(0), "first_elt", insertPoint);
@@ -1452,18 +1453,18 @@ static llvm::Value *lExtractFirstVectorElement(llvm::Value *v, std::map<llvm::PH
     // Rewrite regular binary operators and casts to the scalarized
     // equivalent.
     llvm::BinaryOperator *bop = llvm::dyn_cast<llvm::BinaryOperator>(v);
-    if (bop != NULL) {
+    if (bop != nullptr) {
         llvm::Value *v0 = lExtractFirstVectorElement(bop->getOperand(0), phiMap);
         llvm::Value *v1 = lExtractFirstVectorElement(bop->getOperand(1), phiMap);
-        Assert(v0 != NULL);
-        Assert(v1 != NULL);
+        Assert(v0 != nullptr);
+        Assert(v1 != nullptr);
         // Note that the new binary operator is inserted immediately before
         // the previous vector one
         return llvm::BinaryOperator::Create(bop->getOpcode(), v0, v1, newName, bop);
     }
 
     llvm::CastInst *cast = llvm::dyn_cast<llvm::CastInst>(v);
-    if (cast != NULL) {
+    if (cast != nullptr) {
         llvm::Value *v = lExtractFirstVectorElement(cast->getOperand(0), phiMap);
         // Similarly, the equivalent scalar cast instruction goes right
         // before the vector cast
@@ -1471,7 +1472,7 @@ static llvm::Value *lExtractFirstVectorElement(llvm::Value *v, std::map<llvm::PH
     }
 
     llvm::PHINode *phi = llvm::dyn_cast<llvm::PHINode>(v);
-    if (phi != NULL) {
+    if (phi != nullptr) {
         // For PHI notes, recursively scalarize them.
         if (phiMap.find(phi) != phiMap.end())
             return phiMap[phi];
@@ -1521,8 +1522,9 @@ static llvm::Value *lExtractFirstVectorElement(llvm::Value *v, std::map<llvm::PH
     // instruction, which we insert immediately after the instruction we
     // have here.
     llvm::Instruction *insertAfter = llvm::dyn_cast<llvm::Instruction>(v);
-    Assert(insertAfter != NULL);
-    llvm::Instruction *ee = llvm::ExtractElementInst::Create(v, LLVMInt32(0), "first_elt", (llvm::Instruction *)NULL);
+    Assert(insertAfter != nullptr);
+    llvm::Instruction *ee =
+        llvm::ExtractElementInst::Create(v, LLVMInt32(0), "first_elt", (llvm::Instruction *)nullptr);
     ee->insertAfter(insertAfter);
     return ee;
 }
@@ -1541,7 +1543,7 @@ llvm::Value *LLVMExtractFirstVectorElement(llvm::Value *v) {
 llvm::Value *LLVMConcatVectors(llvm::Value *v1, llvm::Value *v2, llvm::Instruction *insertBefore) {
     Assert(v1->getType() == v2->getType());
     llvm::FixedVectorType *vt = llvm::dyn_cast<llvm::FixedVectorType>(v1->getType());
-    Assert(vt != NULL);
+    Assert(vt != nullptr);
 
     int32_t identity[ISPC_MAX_NVEC];
     int resultSize = 2 * vt->getNumElements();
@@ -1705,7 +1707,7 @@ static uint64_t lConstElementsToMask(const llvm::SmallVector<llvm::Constant *, I
             // We create a separate 'undef mask' with all undef bits set.
             // This mask will have no bits set if there are no 'undef' elements.
             llvm::UndefValue *uv = llvm::dyn_cast<llvm::UndefValue>(elements[i]);
-            Assert(uv != NULL); // vs return -1 if NULL?
+            Assert(uv != nullptr); // vs return -1 if nullptr?
             undefSetMask |= (1ull << i);
             continue;
         }
@@ -1733,7 +1735,7 @@ static uint64_t lConstElementsToMask(const llvm::SmallVector<llvm::Constant *, I
  */
 bool GetMaskFromValue(llvm::Value *factor, uint64_t *mask) {
     llvm::ConstantDataVector *cdv = llvm::dyn_cast<llvm::ConstantDataVector>(factor);
-    if (cdv != NULL) {
+    if (cdv != nullptr) {
         llvm::SmallVector<llvm::Constant *, ISPC_MAX_NVEC> elements;
         for (int i = 0; i < (int)cdv->getNumElements(); ++i)
             elements.push_back(cdv->getElementAsConstant(i));
@@ -1742,11 +1744,11 @@ bool GetMaskFromValue(llvm::Value *factor, uint64_t *mask) {
     }
 
     llvm::ConstantVector *cv = llvm::dyn_cast<llvm::ConstantVector>(factor);
-    if (cv != NULL) {
+    if (cv != nullptr) {
         llvm::SmallVector<llvm::Constant *, ISPC_MAX_NVEC> elements;
         for (int i = 0; i < (int)cv->getNumOperands(); ++i) {
             llvm::Constant *c = llvm::dyn_cast<llvm::Constant>(cv->getOperand(i));
-            if (c == NULL)
+            if (c == nullptr)
                 return false;
             if (llvm::isa<llvm::ConstantExpr>(cv->getOperand(i)))
                 return false; // We can not handle constant expressions here
@@ -1760,7 +1762,7 @@ bool GetMaskFromValue(llvm::Value *factor, uint64_t *mask) {
     } else {
 #if 0
         llvm::ConstantExpr *ce = llvm::dyn_cast<llvm::ConstantExpr>(factor);
-        if (ce != NULL) {
+        if (ce != nullptr) {
             llvm::TargetMachine *targetMachine = g->target->GetTargetMachine();
             const llvm::TargetData *td = targetMachine->getTargetData();
             llvm::Constant *c = llvm::ConstantFoldConstantExpression(ce, td);
@@ -1824,7 +1826,7 @@ static void lGetAddressSpace(llvm::Value *v, std::set<llvm::Value *> &done, std:
 
     llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(v);
     bool isConstExpr = false;
-    if (inst == NULL) {
+    if (inst == nullptr) {
         // Case when GEP is constant expression
         if (llvm::ConstantExpr *constExpr = llvm::dyn_cast<llvm::ConstantExpr>(v)) {
             // This instruction isn't inserted anywhere, so delete it when done
@@ -1833,7 +1835,7 @@ static void lGetAddressSpace(llvm::Value *v, std::set<llvm::Value *> &done, std:
         }
     }
 
-    if (done.size() > 0 && inst == NULL) {
+    if (done.size() > 0 && inst == nullptr) {
         // Found external pointer like "float* %aFOO"
         if (llvm::isa<llvm::PointerType>(v->getType()))
             addrSpaceVec.insert(AddressSpace::ispc_global);
@@ -1848,7 +1850,7 @@ static void lGetAddressSpace(llvm::Value *v, std::set<llvm::Value *> &done, std:
         return;
     }
 
-    if (inst == NULL || llvm::isa<llvm::CallInst>(v)) {
+    if (inst == nullptr || llvm::isa<llvm::CallInst>(v)) {
         if (llvm::isa<llvm::PointerType>(v->getType()) || (inst && lIsSVMLoad(inst)))
             addrSpaceVec.insert(AddressSpace::ispc_global);
         return;

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -235,7 +235,7 @@ extern llvm::Constant *LLVMMaskAllOff;
 /** Tests to see if all of the elements of the vector in the 'v' parameter
     are equal.  Like lValuesAreEqual(), this is a conservative test and may
     return false for arrays where the values are actually all equal.  */
-extern bool LLVMVectorValuesAllEqual(llvm::Value *v, llvm::Value **splat = NULL);
+extern bool LLVMVectorValuesAllEqual(llvm::Value *v, llvm::Value **splat = nullptr);
 
 /** Tests to see if OR is actually an ADD.  */
 extern bool IsOrEquivalentToAdd(llvm::Value *op);
@@ -284,11 +284,11 @@ extern bool LLVMExtractVectorInts(llvm::Value *v, int64_t ret[], int *nElts);
                   <i64 4, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef>
          %gep_offset = shufflevector <8 x i64> %0, <8 x i64> undef, <8 x i32> zeroinitializer
     Function returns:
-    Compare all elements and return one of them if all are equal, otherwise NULL.
+    Compare all elements and return one of them if all are equal, otherwise nullptr.
     If searchFirstUndef argument is true, look for the vector with the first not-undef element, like:
          <i64 4, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef>
     If compare argument is false, don't do compare and return first element instead.
-    If undef argument is true, ignore undef elements (but all undef yields NULL anyway).
+    If undef argument is true, ignore undef elements (but all undef yields nullptr anyway).
 
  */
 extern llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool compare = true, bool undef = true,
@@ -367,21 +367,22 @@ extern bool LLVMIsValueUndef(llvm::Value *value);
 
 /** Below are helper functions to construct LLVM instructions. */
 extern llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, const llvm::Twine &name,
-                                    llvm::Instruction *insertBefore = NULL);
+                                    llvm::Instruction *insertBefore = nullptr);
 
 extern llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
-                                    const llvm::Twine &name, llvm::Instruction *insertBefore = NULL);
+                                    const llvm::Twine &name, llvm::Instruction *insertBefore = nullptr);
 
 extern llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
-                                    llvm::Value *arg3, const llvm::Twine &name, llvm::Instruction *insertBefore = NULL);
+                                    llvm::Value *arg3, const llvm::Twine &name,
+                                    llvm::Instruction *insertBefore = nullptr);
 
 extern llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
                                     llvm::Value *arg3, llvm::Value *arg4, const llvm::Twine &name,
-                                    llvm::Instruction *insertBefore = NULL);
+                                    llvm::Instruction *insertBefore = nullptr);
 
 extern llvm::CallInst *LLVMCallInst(llvm::Function *func, llvm::Value *arg0, llvm::Value *arg1, llvm::Value *arg2,
                                     llvm::Value *arg3, llvm::Value *arg4, llvm::Value *arg5, const llvm::Twine &name,
-                                    llvm::Instruction *insertBefore = NULL);
+                                    llvm::Instruction *insertBefore = nullptr);
 
 extern llvm::GetElementPtrInst *LLVMGEPInst(llvm::Value *ptr, llvm::Type *ptrElType, llvm::Value *offset,
                                             const char *name, llvm::Instruction *insertBefore);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -262,7 +262,7 @@ class ArgFactory {
 
         if (c == '\0')
             // Reached the end so no more arguments
-            return NULL;
+            return nullptr;
 
         // c now has the first character of the next argument, so collect the rest
         while (c != '\0' && !(isspace(c) && !insideDQ && !insideSQ)) {
@@ -329,7 +329,7 @@ static void lAddSingleArg(char *arg, std::vector<char *> &argv);
 static void lAddArgsFromFactory(ArgFactory &Args, std::vector<char *> &argv) {
     while (true) {
         char *NextArg = Args.GetNextArg();
-        if (NextArg == NULL)
+        if (NextArg == nullptr)
             break;
         lAddSingleArg(NextArg, argv);
     }
@@ -355,13 +355,13 @@ static void lAddSingleArg(char *arg, std::vector<char *> &argv) {
     if (arg[0] == '@') {
         char *filename = &arg[1];
         FILE *file = fopen(filename, "r");
-        if (file != NULL) {
+        if (file != nullptr) {
             lAddArgsFromFile(file, argv);
             fclose(file);
-            arg = NULL;
+            arg = nullptr;
         }
     }
-    if (arg != NULL) {
+    if (arg != nullptr) {
         argv.push_back(arg);
     }
 }
@@ -545,7 +545,7 @@ int main(int Argc, char *Argv[]) {
     lGetAllArgs(Argc, Argv, argv);
     int argc = argv.size();
 
-    llvm::sys::AddSignalHandler(lSignal, NULL);
+    llvm::sys::AddSignalHandler(lSignal, nullptr);
 
     // initialize available LLVM targets
 #ifdef ISPC_X86_ENABLED
@@ -581,13 +581,13 @@ int main(int Argc, char *Argv[]) {
     LLVMInitializeWebAssemblyTargetInfo();
     LLVMInitializeWebAssemblyTargetMC();
 #endif
-    char *file = NULL;
-    const char *headerFileName = NULL;
-    const char *outFileName = NULL;
-    const char *depsFileName = NULL;
-    const char *depsTargetName = NULL;
-    const char *hostStubFileName = NULL;
-    const char *devStubFileName = NULL;
+    char *file = nullptr;
+    const char *headerFileName = nullptr;
+    const char *outFileName = nullptr;
+    const char *depsFileName = nullptr;
+    const char *depsTargetName = nullptr;
+    const char *hostStubFileName = nullptr;
+    const char *devStubFileName = nullptr;
 
     std::vector<std::string> linkFileNames;
     // Initiailize globals early so that we can set various option values
@@ -598,7 +598,7 @@ int main(int Argc, char *Argv[]) {
     Module::OutputFlags flags = Module::NoFlags;
     Arch arch = Arch::none;
     std::vector<ISPCTarget> targets;
-    const char *cpu = NULL, *intelAsmSyntax = NULL;
+    const char *cpu = nullptr, *intelAsmSyntax = nullptr;
     BooleanOptValue vectorCall = BooleanOptValue::none;
     BooleanOptValue discardValueNames = BooleanOptValue::none;
 
@@ -648,7 +648,7 @@ int main(int Argc, char *Argv[]) {
             exit(1);
         }
 
-        if (outFileName == NULL) {
+        if (outFileName == nullptr) {
             Warning(SourcePos(), "No output file name specified. "
                                  "The inputs will be linked and warnings/errors will "
                                  "be issued, but no output will be generated.");
@@ -710,7 +710,7 @@ int main(int Argc, char *Argv[]) {
         } else if (!strncmp(argv[i], "--x86-asm-syntax=", 17)) {
             intelAsmSyntax = argv[i] + 17;
             if (!((std::string(intelAsmSyntax) == "intel") || (std::string(intelAsmSyntax) == "att"))) {
-                intelAsmSyntax = NULL;
+                intelAsmSyntax = nullptr;
                 errorHandler.AddError("Invalid value for --x86-asm-syntax: \"%s\" -- "
                                       "only intel and att are allowed.",
                                       argv[i] + 17);
@@ -1013,7 +1013,7 @@ int main(int Argc, char *Argv[]) {
         } else if (argv[i][0] == '-') {
             errorHandler.AddError("Unknown option \"%s\".", argv[i]);
         } else {
-            if (file != NULL) {
+            if (file != nullptr) {
                 errorHandler.AddError("Multiple input files specified on command "
                                       "line: \"%s\" and \"%s\".",
                                       file, argv[i]);
@@ -1027,7 +1027,7 @@ int main(int Argc, char *Argv[]) {
     // All the rest of errors and warnigns will be processed in regullar way.
     errorHandler.Emit();
 
-    if (file == NULL) {
+    if (file == nullptr) {
         Error(SourcePos(), "No input file were specified. To read text from stdin use \"-\" as file name.");
         exit(1);
     }
@@ -1084,7 +1084,7 @@ int main(int Argc, char *Argv[]) {
     if (g->enableFuzzTest) {
         if (g->fuzzTestSeed == -1) {
 #ifdef ISPC_HOST_IS_WINDOWS
-            int seed = (unsigned)time(NULL);
+            int seed = (unsigned)time(nullptr);
 #else
             int seed = getpid();
 #endif
@@ -1098,14 +1098,14 @@ int main(int Argc, char *Argv[]) {
 #endif
     }
 
-    if (depsFileName != NULL)
+    if (depsFileName != nullptr)
         flags &= ~Module::OutputDepsToStdout;
 
-    if (depsFileName != NULL && 0 == (flags & (Module::GenerateFlatDeps | Module::GenerateMakeRuleForDeps))) {
+    if (depsFileName != nullptr && 0 == (flags & (Module::GenerateFlatDeps | Module::GenerateMakeRuleForDeps))) {
         Warning(SourcePos(), "Dependency file name specified with -MF, but no "
                              "mode specified; did you forget to specify -M or -MMM? "
                              "No dependency output will be generated.");
-        depsFileName = NULL;
+        depsFileName = nullptr;
     }
 
     if ((Module::GenerateFlatDeps | Module::GenerateMakeRuleForDeps) ==
@@ -1119,9 +1119,9 @@ int main(int Argc, char *Argv[]) {
         outFileName = "-"; // Assume stdout by default (-E mode)
     }
 
-    if (outFileName == NULL && headerFileName == NULL &&
-        (depsFileName == NULL && 0 == (flags & Module::OutputDepsToStdout)) && hostStubFileName == NULL &&
-        devStubFileName == NULL) {
+    if (outFileName == nullptr && headerFileName == nullptr &&
+        (depsFileName == nullptr && 0 == (flags & Module::OutputDepsToStdout)) && hostStubFileName == nullptr &&
+        devStubFileName == nullptr) {
         Warning(SourcePos(), "No output file or header file name specified. "
                              "Program will be compiled and warnings/errors will "
                              "be issued, but no output will be generated.");
@@ -1146,7 +1146,7 @@ int main(int Argc, char *Argv[]) {
     if (targets.size() > 1)
         g->isMultiTargetCompilation = true;
 
-    if ((ot == Module::Asm) && (intelAsmSyntax != NULL)) {
+    if ((ot == Module::Asm) && (intelAsmSyntax != nullptr)) {
         std::vector<const char *> Args(3);
         Args[0] = "ispc (LLVM option parsing)";
         Args[2] = nullptr;
@@ -1189,7 +1189,7 @@ int main(int Argc, char *Argv[]) {
 
     if (g->enableTimeTrace) {
         // Write to file only if compilation is successfull.
-        if ((ret == 0) && (outFileName != NULL)) {
+        if ((ret == 0) && (outFileName != nullptr)) {
             writeCompileTimeFile(outFileName);
         }
         llvm::timeTraceProfilerCleanup();

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -226,7 +226,7 @@ Module::Module(const char *fn) : filename(fn) {
             Error(SourcePos(), "Can't emit debugging information with no source file on disk.\n");
             ++errorCount;
             delete diBuilder;
-            diBuilder = NULL;
+            diBuilder = nullptr;
         } else {
             std::string directory, name;
             GetDirectoryAndFileName(g->currentDirectory, filename, &directory, &name);
@@ -318,12 +318,12 @@ int Module::CompileFile() {
     } else {
         llvm::TimeTraceScope TimeScope("Frontend parser");
         // No preprocessor, just open up the file if it's not stdin..
-        FILE *f = NULL;
+        FILE *f = nullptr;
         if (IsStdin(filename)) {
             f = stdin;
         } else {
             f = fopen(filename, "r");
-            if (f == NULL) {
+            if (f == nullptr) {
                 perror(filename);
                 return 1;
             }
@@ -421,9 +421,9 @@ void Module::AddTypeDef(const std::string &name, const Type *type, SourcePos pos
 
 void Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *initExpr, bool isConst,
                                StorageClass storageClass, SourcePos pos) {
-    // These may be NULL due to errors in parsing; just gracefully return
+    // These may be nullptr due to errors in parsing; just gracefully return
     // here if so.
-    if (name == "" || type == NULL) {
+    if (name == "" || type == nullptr) {
         Assert(errorCount > 0);
         return;
     }
@@ -454,11 +454,11 @@ void Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *
     }
 
     type = ArrayType::SizeUnsizedArrays(type, initExpr);
-    if (type == NULL)
+    if (type == nullptr)
         return;
 
     const ArrayType *at = CastType<ArrayType>(type);
-    if (at != NULL && at->TotalElementCount() == 0) {
+    if (at != nullptr && at->TotalElementCount() == 0) {
         Error(pos, "Illegal to declare a global variable with unsized "
                    "array dimensions that aren't set with an initializer "
                    "expression.");
@@ -466,28 +466,28 @@ void Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *
     }
 
     llvm::Type *llvmType = type->LLVMStorageType(g->ctx);
-    if (llvmType == NULL)
+    if (llvmType == nullptr)
         return;
 
     // See if we have an initializer expression for the global.  If so,
     // make sure it's a compile-time constant!
-    llvm::Constant *llvmInitializer = NULL;
-    ConstExpr *constValue = NULL;
+    llvm::Constant *llvmInitializer = nullptr;
+    ConstExpr *constValue = nullptr;
     if (storageClass == SC_EXTERN) {
-        if (initExpr != NULL)
+        if (initExpr != nullptr)
             Error(pos, "Initializer can't be provided with \"extern\" global variable \"%s\".", name.c_str());
     } else {
-        if (initExpr != NULL) {
+        if (initExpr != nullptr) {
             initExpr = TypeCheck(initExpr);
-            if (initExpr != NULL) {
+            if (initExpr != nullptr) {
                 // We need to make sure the initializer expression is
                 // the same type as the global.  (But not if it's an
                 // ExprList; they don't have types per se / can't type
                 // convert themselves anyway.)
-                if (llvm::dyn_cast<ExprList>(initExpr) == NULL)
+                if (llvm::dyn_cast<ExprList>(initExpr) == nullptr)
                     initExpr = TypeConvertExpr(initExpr, type, "initializer");
 
-                if (initExpr != NULL) {
+                if (initExpr != nullptr) {
                     initExpr = Optimize(initExpr);
                     // Fingers crossed, now let's see if we've got a
                     // constant value..
@@ -496,7 +496,7 @@ void Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *
 
                     // If compiling for multitarget, skip initialization for
                     // indentified scenarios unless it's static
-                    if (llvmInitializer != NULL) {
+                    if (llvmInitializer != nullptr) {
                         if ((storageClass != SC_STATIC) && (initPair.second == true)) {
                             if (g->isMultiTargetCompilation == true) {
                                 Error(initExpr->pos,
@@ -528,13 +528,13 @@ void Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *
 
         // If no initializer was provided or if we couldn't get a value
         // above, initialize it with zeros..
-        if (llvmInitializer == NULL)
+        if (llvmInitializer == nullptr)
             llvmInitializer = llvm::Constant::getNullValue(llvmType);
     }
 
     Symbol *sym = symbolTable->LookupVariable(name.c_str());
-    llvm::GlobalVariable *oldGV = NULL;
-    if (sym != NULL) {
+    llvm::GlobalVariable *oldGV = nullptr;
+    if (sym != nullptr) {
         // We've already seen either a declaration or a definition of this
         // global.
 
@@ -548,7 +548,7 @@ void Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *
         }
 
         llvm::GlobalVariable *gv = llvm::dyn_cast<llvm::GlobalVariable>(sym->storageInfo->getPointer());
-        Assert(gv != NULL);
+        Assert(gv != nullptr);
 
         // And issue an error if this is a redefinition of a variable
         if (gv->hasInitializer() && sym->storageClass != SC_EXTERN && sym->storageClass != SC_EXTERN_C &&
@@ -571,7 +571,7 @@ void Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *
     llvm::GlobalValue::LinkageTypes linkage =
         (sym->storageClass == SC_STATIC) ? llvm::GlobalValue::InternalLinkage : llvm::GlobalValue::ExternalLinkage;
 
-    // Note that the NULL llvmInitializer is what leads to "extern"
+    // Note that the nullptr llvmInitializer is what leads to "extern"
     // declarations coming up extern and not defining storage (a bit
     // subtle)...
     sym->storageInfo = new AddressInfo(
@@ -579,7 +579,7 @@ void Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *
 
     // Patch up any references to the previous GlobalVariable (e.g. from a
     // declaration of a global that was later defined.)
-    if (oldGV != NULL) {
+    if (oldGV != nullptr) {
         oldGV->replaceAllUsesWith(sym->storageInfo->getPointer());
         oldGV->removeFromParent();
         sym->storageInfo->getPointer()->setName(sym->name.c_str());
@@ -616,7 +616,7 @@ void Module::AddGlobalVariable(const std::string &name, const Type *type, Expr *
 static bool lRecursiveCheckValidParamType(const Type *t, bool vectorOk, bool soaOk, const std::string &name,
                                           SourcePos pos) {
     const StructType *st = CastType<StructType>(t);
-    if (st != NULL) {
+    if (st != nullptr) {
         for (int i = 0; i < st->GetElementCount(); ++i)
             if (!lRecursiveCheckValidParamType(st->GetElementType(i), soaOk, vectorOk, name, pos))
                 return false;
@@ -626,15 +626,15 @@ static bool lRecursiveCheckValidParamType(const Type *t, bool vectorOk, bool soa
     // Vector types are also not supported, pending ispc properly
     // supporting the platform ABI.  (Pointers to vector types are ok,
     // though.)  (https://github.com/ispc/ispc/issues/363)...
-    if (vectorOk == false && CastType<VectorType>(t) != NULL)
+    if (vectorOk == false && CastType<VectorType>(t) != nullptr)
         return false;
 
     const SequentialType *seqt = CastType<SequentialType>(t);
-    if (seqt != NULL)
+    if (seqt != nullptr)
         return lRecursiveCheckValidParamType(seqt->GetElementType(), soaOk, vectorOk, name, pos);
 
     const PointerType *pt = CastType<PointerType>(t);
-    if (pt != NULL) {
+    if (pt != nullptr) {
         // Only allow exported uniform pointers
         // Uniform pointers to varying data, however, are ok.
         if (pt->IsVaryingType())
@@ -715,7 +715,7 @@ static void lCheckTaskParameterTypes(const Type *type, const std::string &name, 
 static void lCheckForStructParameters(const FunctionType *ftype, SourcePos pos) {
     for (int i = 0; i < ftype->GetNumParameters(); ++i) {
         const Type *type = ftype->GetParameterType(i);
-        if (CastType<StructType>(type) != NULL) {
+        if (CastType<StructType>(type) != nullptr) {
             Error(pos, "Passing structs to/from application functions by value "
                        "is currently not supported. Use a reference, a const reference, "
                        "a pointer, or a const pointer to the struct instead.");
@@ -733,11 +733,11 @@ static void lCheckForStructParameters(const FunctionType *ftype, SourcePos pos) 
 void Module::AddFunctionDeclaration(const std::string &name, const FunctionType *functionType,
                                     StorageClass storageClass, bool isInline, bool isNoInline, bool isVectorCall,
                                     bool isRegCall, SourcePos pos) {
-    Assert(functionType != NULL);
+    Assert(functionType != nullptr);
 
     // If a global variable with the same name has already been declared
     // issue an error.
-    if (symbolTable->LookupVariable(name.c_str()) != NULL) {
+    if (symbolTable->LookupVariable(name.c_str()) != nullptr) {
         Error(pos, "Function \"%s\" shadows previously-declared global variable. Ignoring this definition.",
               name.c_str());
         return;
@@ -750,7 +750,7 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
             Symbol *overloadFunc = overloadFuncs[i];
 
             const FunctionType *overloadType = CastType<FunctionType>(overloadFunc->type);
-            if (overloadType == NULL) {
+            if (overloadType == nullptr) {
                 Assert(m->errorCount == 0);
                 continue;
             }
@@ -772,7 +772,7 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
             // different, return an error--overloading by return type isn't
             // allowed.
             const FunctionType *ofType = CastType<FunctionType>(overloadFunc->type);
-            Assert(ofType != NULL);
+            Assert(ofType != nullptr);
             if (ofType->GetNumParameters() == functionType->GetNumParameters()) {
                 int i;
                 for (i = 0; i < functionType->GetNumParameters(); ++i) {
@@ -830,7 +830,7 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
     // Get the LLVM FunctionType
     bool disableMask = (storageClass == SC_EXTERN_C || storageClass == SC_EXTERN_SYCL);
     llvm::FunctionType *llvmFunctionType = functionType->LLVMFunctionType(g->ctx, disableMask);
-    if (llvmFunctionType == NULL)
+    if (llvmFunctionType == nullptr)
         return;
 
     // And create the llvm::Function
@@ -943,12 +943,12 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
         // default.)  Set parameter attributes accordingly.  (Only for
         // uniform pointers, since varying pointers are int vectors...)
         if (!functionType->isTask && !functionType->isExternSYCL &&
-            ((CastType<PointerType>(argType) != NULL && argType->IsUniformType() &&
+            ((CastType<PointerType>(argType) != nullptr && argType->IsUniformType() &&
               // Exclude SOA argument because it is a pair {struct *, int}
               // instead of pointer
               !CastType<PointerType>(argType)->IsSlice()) ||
 
-             CastType<ReferenceType>(argType) != NULL)) {
+             CastType<ReferenceType>(argType) != nullptr)) {
 
             function->addParamAttr(i, llvm::Attribute::NoAlias);
 #if 0
@@ -966,7 +966,7 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
                     argName.c_str());
         }
 
-        if (defaultValue != NULL)
+        if (defaultValue != nullptr)
             seenDefaultArg = true;
         else if (seenDefaultArg) {
             // Once one parameter has provided a default value, then all of
@@ -998,7 +998,7 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
 
 void Module::AddFunctionDefinition(const std::string &name, const FunctionType *type, Stmt *code) {
     Symbol *sym = symbolTable->LookupFunction(name.c_str(), type);
-    if (sym == NULL || code == NULL) {
+    if (sym == nullptr || code == nullptr) {
         Assert(m->errorCount > 0);
         return;
     }
@@ -1019,12 +1019,12 @@ void Module::AddFunctionDefinition(const std::string &name, const FunctionType *
 void Module::AddFunctionTemplateDeclaration(const TemplateParms *templateParmList, const std::string &name,
                                             const FunctionType *ftype, StorageClass sc, bool isInline, bool isNoInline,
                                             bool isVectorCall, SourcePos pos) {
-    Assert(ftype != NULL);
-    Assert(templateParmList != NULL);
+    Assert(ftype != nullptr);
+    Assert(templateParmList != nullptr);
 
     // If a global variable with the same name has already been declared
     // issue an error.
-    if (symbolTable->LookupVariable(name.c_str()) != NULL) {
+    if (symbolTable->LookupVariable(name.c_str()) != nullptr) {
         Error(pos,
               "Function template \"%s\" shadows previously-declared global variable. "
               "Ignoring this definition.",
@@ -1079,7 +1079,7 @@ void Module::AddFunctionTemplateDefinition(const TemplateParms *templateParmList
     }
 
     TemplateSymbol *sym = symbolTable->LookupFunctionTemplate(templateParmList, name, ftype);
-    if (sym == NULL || code == NULL) {
+    if (sym == nullptr || code == nullptr) {
         Assert(m->errorCount > 0);
         return;
     }
@@ -1154,8 +1154,8 @@ void Module::AddFunctionTemplateInstantiation(const std::string &name,
 
 void Module::AddExportedTypes(const std::vector<std::pair<const Type *, SourcePos>> &types) {
     for (int i = 0; i < (int)types.size(); ++i) {
-        if (CastType<StructType>(types[i].first) == NULL && CastType<VectorType>(types[i].first) == NULL &&
-            CastType<EnumType>(types[i].first) == NULL)
+        if (CastType<StructType>(types[i].first) == nullptr && CastType<VectorType>(types[i].first) == nullptr &&
+            CastType<EnumType>(types[i].first) == nullptr)
             Error(types[i].second, "Only struct, vector, and enum types, not \"%s\", are allowed in type export lists.",
                   types[i].first->GetString().c_str());
         else
@@ -1188,9 +1188,9 @@ bool Module::writeOutput(OutputType outputType, OutputFlags flags, const char *o
         // file being created seem to mismatch.  This can help catch missing
         // command-line arguments specifying the output file type.
         const char *suffix = strrchr(outFileName, '.');
-        if (suffix != NULL) {
+        if (suffix != nullptr) {
             ++suffix;
-            const char *fileType = NULL;
+            const char *fileType = nullptr;
             switch (outputType) {
             case Asm:
                 if (strcasecmp(suffix, "s"))
@@ -1242,7 +1242,7 @@ bool Module::writeOutput(OutputType outputType, OutputFlags flags, const char *o
                 Assert(0 /* swtich case not handled */);
                 return 1;
             }
-            if (fileType != NULL)
+            if (fileType != nullptr)
                 Warning(SourcePos(), "Emitting %s file, but filename \"%s\" has suffix \"%s\"?", fileType, outFileName,
                         suffix);
         }
@@ -1533,14 +1533,14 @@ bool Module::writeObjectFileOrAssembly(llvm::TargetMachine *targetMachine, llvm:
     underlying struct type. */
 static const StructType *lGetElementStructType(const Type *t) {
     const StructType *st = CastType<StructType>(t);
-    if (st != NULL)
+    if (st != nullptr)
         return st;
 
     const ArrayType *at = CastType<ArrayType>(t);
-    if (at != NULL)
+    if (at != nullptr)
         return lGetElementStructType(at->GetElementType());
 
-    return NULL;
+    return nullptr;
 }
 
 static bool lContainsPtrToVarying(const StructType *st) {
@@ -1579,7 +1579,7 @@ static void lEmitStructDecl(const StructType *st, std::vector<const StructType *
     // Otherwise first make sure any contained structs have been declared.
     for (int i = 0; i < st->GetElementCount(); ++i) {
         const StructType *elementStructType = lGetElementStructType(st->GetElementType(i));
-        if (elementStructType != NULL)
+        if (elementStructType != nullptr)
             lEmitStructDecl(elementStructType, emittedStructs, file, emitUnifs);
     }
 
@@ -1599,7 +1599,7 @@ static void lEmitStructDecl(const StructType *st, std::vector<const StructType *
     if (!(pack = stypeStructType->isPacked())) {
         for (int i = 0; !needsAlign && (i < st->GetElementCount()); ++i) {
             const Type *ftype = st->GetElementType(i)->GetAsNonConstType();
-            needsAlign |= ftype->IsVaryingType() && (CastType<StructType>(ftype) == NULL);
+            needsAlign |= ftype->IsVaryingType() && (CastType<StructType>(ftype) == nullptr);
         }
     }
     if (st->GetSOAWidth() > 0) {
@@ -1620,14 +1620,14 @@ static void lEmitStructDecl(const StructType *st, std::vector<const StructType *
         std::string d = ftype->GetCDeclaration(st->GetElementName(i));
 
         fprintf(file, "    ");
-        if (needsAlign && ftype->IsVaryingType() && (CastType<StructType>(ftype) == NULL)) {
+        if (needsAlign && ftype->IsVaryingType() && (CastType<StructType>(ftype) == nullptr)) {
             unsigned uABI = DL->getABITypeAlign(ftype->LLVMStorageType(g->ctx)).value();
             fprintf(file, "__ISPC_ALIGN__(%u) ", uABI);
         }
         // Don't expand arrays, pointers and structures:
         // their insides will be expanded automatically.
         if (!ftype->IsArrayType() && !ftype->IsPointerType() && ftype->IsVaryingType() &&
-            (CastType<StructType>(ftype) == NULL)) {
+            (CastType<StructType>(ftype) == nullptr)) {
             fprintf(file, "%s[%d];\n", d.c_str(), g->target->getVectorWidth());
         } else {
             fprintf(file, "%s;\n", d.c_str());
@@ -1678,7 +1678,7 @@ static void lEmitEnumDecls(const std::vector<const EnumType *> &enumTypes, FILE 
         // Print the individual enumerators
         for (int j = 0; j < enumTypes[i]->GetEnumeratorCount(); ++j) {
             const Symbol *e = enumTypes[i]->GetEnumerator(j);
-            Assert(e->constValue != NULL);
+            Assert(e->constValue != nullptr);
             unsigned int enumValue[1];
             int count = e->constValue->GetValues(enumValue);
             Assert(count == 1);
@@ -1746,7 +1746,7 @@ template <typename T> static void lAddTypeIfNew(const Type *type, std::vector<co
             return;
 
     const T *castType = CastType<T>(type);
-    Assert(castType != NULL);
+    Assert(castType != nullptr);
     exportedTypes->push_back(castType);
 }
 
@@ -1761,25 +1761,25 @@ static void lGetExportedTypes(const Type *type, std::vector<const StructType *> 
     const StructType *structType = CastType<StructType>(type);
     const FunctionType *ftype = CastType<FunctionType>(type);
 
-    if (CastType<ReferenceType>(type) != NULL)
+    if (CastType<ReferenceType>(type) != nullptr)
         lGetExportedTypes(type->GetReferenceTarget(), exportedStructTypes, exportedEnumTypes, exportedVectorTypes);
-    else if (CastType<PointerType>(type) != NULL)
+    else if (CastType<PointerType>(type) != nullptr)
         lGetExportedTypes(type->GetBaseType(), exportedStructTypes, exportedEnumTypes, exportedVectorTypes);
-    else if (arrayType != NULL)
+    else if (arrayType != nullptr)
         lGetExportedTypes(arrayType->GetElementType(), exportedStructTypes, exportedEnumTypes, exportedVectorTypes);
-    else if (structType != NULL) {
+    else if (structType != nullptr) {
         lAddTypeIfNew(type, exportedStructTypes);
         for (int i = 0; i < structType->GetElementCount(); ++i)
             lGetExportedTypes(structType->GetElementType(i), exportedStructTypes, exportedEnumTypes,
                               exportedVectorTypes);
-    } else if (CastType<UndefinedStructType>(type) != NULL)
+    } else if (CastType<UndefinedStructType>(type) != nullptr)
         // do nothing
         ;
-    else if (CastType<EnumType>(type) != NULL)
+    else if (CastType<EnumType>(type) != nullptr)
         lAddTypeIfNew(type, exportedEnumTypes);
-    else if (CastType<VectorType>(type) != NULL)
+    else if (CastType<VectorType>(type) != nullptr)
         lAddTypeIfNew(type, exportedVectorTypes);
-    else if (ftype != NULL) {
+    else if (ftype != nullptr) {
         // Handle Return Types
         lGetExportedTypes(ftype->GetReturnType(), exportedStructTypes, exportedEnumTypes, exportedVectorTypes);
 
@@ -1787,7 +1787,7 @@ static void lGetExportedTypes(const Type *type, std::vector<const StructType *> 
         for (int j = 0; j < ftype->GetNumParameters(); ++j)
             lGetExportedTypes(ftype->GetParameterType(j), exportedStructTypes, exportedEnumTypes, exportedVectorTypes);
     } else
-        Assert(CastType<AtomicType>(type) != NULL);
+        Assert(CastType<AtomicType>(type) != nullptr);
 }
 
 /** Given a set of functions, return the set of structure and vector types
@@ -1799,7 +1799,7 @@ static void lGetExportedParamTypes(const std::vector<Symbol *> &funcs,
                                    std::vector<const VectorType *> *exportedVectorTypes) {
     for (unsigned int i = 0; i < funcs.size(); ++i) {
         const FunctionType *ftype = CastType<FunctionType>(funcs[i]->type);
-        Assert(ftype != NULL);
+        Assert(ftype != nullptr);
 
         // Handle the return type
         lGetExportedTypes(ftype->GetReturnType(), exportedStructTypes, exportedEnumTypes, exportedVectorTypes);
@@ -2743,19 +2743,19 @@ static std::string lGetTargetFileName(const char *outFileName, const std::string
     return targetOutFileName;
 }
 
-static bool lSymbolIsExported(const Symbol *s) { return s->exportedFunction != NULL; }
+static bool lSymbolIsExported(const Symbol *s) { return s->exportedFunction != nullptr; }
 
 // Small structure to hold pointers to the various different versions of a
 // llvm::Function that were compiled for different compilation target ISAs.
 struct FunctionTargetVariants {
     FunctionTargetVariants() {
         for (int i = 0; i < Target::NUM_ISAS; ++i) {
-            func[i] = NULL;
-            FTs[i] = NULL;
+            func[i] = nullptr;
+            FTs[i] = nullptr;
         }
     }
     // The func array is indexed with the Target::ISA enumerant.  Some
-    // values may be NULL, indicating that the original function wasn't
+    // values may be nullptr, indicating that the original function wasn't
     // compiled to the corresponding target ISA.
     llvm::Function *func[Target::NUM_ISAS];
     const FunctionType *FTs[Target::NUM_ISAS];
@@ -2776,10 +2776,10 @@ static void lGetExportedFunctions(SymbolTable *symbolTable, std::map<std::string
 
 static llvm::FunctionType *lGetVaryingDispatchType(FunctionTargetVariants &funcs) {
     llvm::Type *ptrToInt8Ty = llvm::Type::getInt8PtrTy(*g->ctx);
-    llvm::FunctionType *resultFuncTy = NULL;
+    llvm::FunctionType *resultFuncTy = nullptr;
 
     for (int i = 0; i < Target::NUM_ISAS; ++i) {
-        if (funcs.func[i] == NULL) {
+        if (funcs.func[i] == nullptr) {
             continue;
         } else {
             bool foundVarying = false;
@@ -2864,7 +2864,7 @@ static void lCreateDispatchFunction(llvm::Module *module, llvm::Function *setISA
             targetFuncs[i]->setCallingConv(callingConv);
 
         } else
-            targetFuncs[i] = NULL;
+            targetFuncs[i] = nullptr;
     }
 
     bool voidReturn = ftype->getReturnType()->isVoidTy();
@@ -2899,7 +2899,7 @@ static void lCreateDispatchFunction(llvm::Module *module, llvm::Function *setISA
     // the expectation that they are ordered in the Target::ISA enumerant
     // from least to most capable.
     for (int i = Target::NUM_ISAS - 1; i >= 0; --i) {
-        if (targetFuncs[i] == NULL)
+        if (targetFuncs[i] == nullptr)
             continue;
 
         // Emit code to see if the system can run the current candidate
@@ -2990,9 +2990,9 @@ static llvm::Module *lInitDispatchModule() {
 static void lEmitDispatchModule(llvm::Module *module, std::map<std::string, FunctionTargetVariants> &functions) {
     // Get pointers to things we need below
     llvm::Function *setFunc = module->getFunction("__set_system_isa");
-    Assert(setFunc != NULL);
+    Assert(setFunc != nullptr);
     llvm::Value *systemBestISAPtr = module->getGlobalVariable("__system_best_isa", true);
-    Assert(systemBestISAPtr != NULL);
+    Assert(systemBestISAPtr != nullptr);
 
     // For each exported function, create the dispatch function
     std::map<std::string, FunctionTargetVariants>::iterator iter;
@@ -3050,12 +3050,12 @@ static void lExtractOrCheckGlobals(llvm::Module *msrc, llvm::Module *mdst, bool 
         if (gv->getLinkage() == llvm::GlobalValue::ExternalLinkage && gv->hasInitializer()) {
             llvm::Type *type = gv->getValueType();
             Symbol *sym = m->symbolTable->LookupVariable(gv->getName().str().c_str());
-            Assert(sym != NULL);
+            Assert(sym != nullptr);
 
             // Check presence and compatibility for the current global
             if (check) {
                 llvm::GlobalVariable *exist = mdst->getGlobalVariable(gv->getName());
-                Assert(exist != NULL);
+                Assert(exist != nullptr);
 
                 // It is possible that the types may not match: for
                 // example, this happens with varying globals if we
@@ -3082,7 +3082,7 @@ static void lExtractOrCheckGlobals(llvm::Module *msrc, llvm::Module *mdst, bool 
             }
             // Turn this into an 'extern' declaration by clearing its
             // initializer.
-            gv->setInitializer(NULL);
+            gv->setInitializer(nullptr);
         }
     }
 }
@@ -3124,13 +3124,13 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
                 return 1;
             }
 #endif
-            if (outFileName != NULL)
+            if (outFileName != nullptr)
                 if (!m->writeOutput(outputType, outputFlags, outFileName))
                     return 1;
-            if (headerFileName != NULL)
+            if (headerFileName != nullptr)
                 if (!m->writeOutput(Module::Header, outputFlags, headerFileName))
                     return 1;
-            if (depsFileName != NULL || (outputFlags & Module::OutputDepsToStdout)) {
+            if (depsFileName != nullptr || (outputFlags & Module::OutputDepsToStdout)) {
                 std::string targetName;
                 if (depsTargetName)
                     targetName = depsTargetName;
@@ -3147,10 +3147,10 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
                 if (!m->writeOutput(Module::Deps, outputFlags, depsFileName, targetName.c_str(), srcFile))
                     return 1;
             }
-            if (hostStubFileName != NULL)
+            if (hostStubFileName != nullptr)
                 if (!m->writeOutput(Module::HostStub, outputFlags, hostStubFileName))
                     return 1;
-            if (devStubFileName != NULL)
+            if (devStubFileName != nullptr)
                 if (!m->writeOutput(Module::DevStub, outputFlags, devStubFileName))
                     return 1;
         } else {
@@ -3159,10 +3159,10 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
 
         int errorCount = m->errorCount;
         delete m;
-        m = NULL;
+        m = nullptr;
 
         delete g->target;
-        g->target = NULL;
+        g->target = nullptr;
 
         return errorCount > 0;
     } else {
@@ -3172,7 +3172,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
                                "an intermediate temporary file.");
             return 1;
         }
-        if (cpu != NULL) {
+        if (cpu != nullptr) {
             Error(SourcePos(), "Illegal to specify cpu type when compiling for multiple targets.");
             return 1;
         }
@@ -3180,7 +3180,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
         // The user supplied multiple targets
         Assert(targets.size() > 1);
 
-        if (outFileName != NULL && strcmp(outFileName, "-") == 0) {
+        if (outFileName != nullptr && strcmp(outFileName, "-") == 0) {
             Error(SourcePos(), "Multi-target compilation can't generate output "
                                "to stdout.  Please provide an output filename.\n");
             return 1;
@@ -3192,9 +3192,9 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
 
         llvm::TargetMachine *targetMachines[Target::NUM_ISAS];
         for (int i = 0; i < Target::NUM_ISAS; ++i)
-            targetMachines[i] = NULL;
+            targetMachines[i] = nullptr;
 
-        llvm::Module *dispatchModule = NULL;
+        llvm::Module *dispatchModule = nullptr;
 
         std::map<std::string, FunctionTargetVariants> exportedFunctions;
         int errorCount = 0;
@@ -3202,7 +3202,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
         // Handle creating a "generic" header file for multiple targets
         // that use exported varyings
         DispatchHeaderInfo DHI;
-        if (headerFileName != NULL) {
+        if (headerFileName != nullptr) {
             DHI.file = fopen(headerFileName, "w");
             if (!DHI.file) {
                 perror("fopen");
@@ -3228,7 +3228,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             // Issue an error if we've already compiled to a variant of
             // this target ISA.  (It doesn't make sense to compile to both
             // avx and avx-x2, for example.)
-            if (targetMachines[g->target->getISA()] != NULL) {
+            if (targetMachines[g->target->getISA()] != nullptr) {
                 Error(SourcePos(), "Can't compile to multiple variants of %s target!\n", g->target->GetISAString());
                 return 1;
             }
@@ -3243,7 +3243,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             if (compileResult == 0) {
                 // Create the dispatch module, unless already created;
                 // in the latter case, just do the checking
-                bool check = (dispatchModule != NULL);
+                bool check = (dispatchModule != nullptr);
                 if (!check)
                     dispatchModule = lInitDispatchModule();
                 lExtractOrCheckGlobals(m->module, dispatchModule, check);
@@ -3253,7 +3253,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
                 // later.
                 lGetExportedFunctions(m->symbolTable, exportedFunctions);
 
-                if (outFileName != NULL) {
+                if (outFileName != nullptr) {
                     std::string targetOutFileName;
                     std::string isaName{g->target->GetISAString()};
                     targetOutFileName = lGetTargetFileName(outFileName, isaName);
@@ -3272,7 +3272,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
 
             // Only write the generate header file, if desired, the first
             // time through the loop here.
-            if (headerFileName != NULL) {
+            if (headerFileName != nullptr) {
                 if (i == targets.size() - 1) {
                     // only print backmatter on the last target.
                     DHI.EmitBackMatter = true;
@@ -3294,43 +3294,43 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             }
 
             delete g->target;
-            g->target = NULL;
+            g->target = nullptr;
 
             // Important: Don't delete the llvm::Module *m here; we need to
             // keep it around so the llvm::Functions *s stay valid for when
             // we generate the dispatch module's functions...
         }
 
-        // Find the first non-NULL target machine from the targets we
+        // Find the first non-nullptr target machine from the targets we
         // compiled to above.  We'll use this as the target machine for
         // compiling the dispatch module--this is safe in that it is the
         // least-common-denominator of all of the targets we compiled to.
-        llvm::TargetMachine *firstTargetMachine = NULL;
+        llvm::TargetMachine *firstTargetMachine = nullptr;
         int i = 0;
         const char *firstISA = "";
         ISPCTarget firstTarget = ISPCTarget::none;
-        while (i < Target::NUM_ISAS && firstTargetMachine == NULL) {
+        while (i < Target::NUM_ISAS && firstTargetMachine == nullptr) {
             firstISA = Target::ISAToTargetString((Target::ISA)i);
             firstTarget = ParseISPCTarget(firstISA);
             firstTargetMachine = targetMachines[i++];
         }
         Assert(strcmp(firstISA, "") != 0);
         Assert(firstTarget != ISPCTarget::none);
-        Assert(firstTargetMachine != NULL);
+        Assert(firstTargetMachine != nullptr);
 
         g->target = new Target(arch, cpu, firstTarget, 0 != (outputFlags & GeneratePIC), false);
         if (!g->target->isValid()) {
             return 1;
         }
 
-        if (dispatchModule == NULL) {
+        if (dispatchModule == nullptr) {
             Error(SourcePos(), "Failed to create dispatch module.\n");
             return 1;
         }
 
         lEmitDispatchModule(dispatchModule, exportedFunctions);
 
-        if (outFileName != NULL) {
+        if (outFileName != nullptr) {
             switch (outputType) {
             case CPPStub:
                 // No preprocessor output for dispatch module.
@@ -3353,7 +3353,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             }
         }
 
-        if (depsFileName != NULL || (outputFlags & Module::OutputDepsToStdout)) {
+        if (depsFileName != nullptr || (outputFlags & Module::OutputDepsToStdout)) {
             std::string targetName;
             if (depsTargetName)
                 targetName = depsTargetName;
@@ -3376,7 +3376,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
         }
 
         delete g->target;
-        g->target = NULL;
+        g->target = nullptr;
         return errorCount > 0;
     }
 }
@@ -3407,7 +3407,7 @@ int Module::LinkAndOutput(std::vector<std::string> linkFiles, OutputType outputT
         }
         inputStream.close();
     }
-    if (outFileName != NULL) {
+    if (outFileName != nullptr) {
         if ((outputType == Bitcode) || (outputType == BitcodeText))
             writeBitcode(llvmLink.get(), outFileName, outputType);
 #ifdef ISPC_XE_ENABLED

--- a/src/module.h
+++ b/src/module.h
@@ -55,7 +55,7 @@ class Module {
     void AddTypeDef(const std::string &name, const Type *type, SourcePos pos);
 
     /** Add a new global variable corresponding to the given Symbol to the
-        module.  If non-NULL, initExpr gives the initiailizer expression
+        module.  If non-nullptr, initExpr gives the initiailizer expression
         for the global's inital value. */
     void AddGlobalVariable(const std::string &name, const Type *type, Expr *initExpr, bool isConst,
                            StorageClass storageClass, SourcePos pos);
@@ -139,7 +139,7 @@ class Module {
                             are specified in the "targets" parameter and if this
                             parameter is "foo.o", then we'll generate multiple
                             output files, like "foo.o", "foo_sse2.o", "foo_avx.o".
-        @param headerFileName If non-NULL, emit a header file suitable for
+        @param headerFileName If non-nullptr, emit a header file suitable for
                               inclusion from C/C++ code with declarations of
                               types and functions exported from the given ispc
                               source file.
@@ -195,14 +195,14 @@ class Module {
 
     /** Write the corresponding output type to the given file.  Returns
         true on success, false if there has been an error.  The given
-        filename may be NULL, indicating that output should go to standard
+        filename may be nullptr, indicating that output should go to standard
         output. */
-    bool writeOutput(OutputType ot, OutputFlags flags, const char *filename, const char *depTargetFileName = NULL,
-                     const char *sourceFileName = NULL, DispatchHeaderInfo *DHI = 0);
+    bool writeOutput(OutputType ot, OutputFlags flags, const char *filename, const char *depTargetFileName = nullptr,
+                     const char *sourceFileName = nullptr, DispatchHeaderInfo *DHI = 0);
     bool writeHeader(const char *filename);
     bool writeDispatchHeader(DispatchHeaderInfo *DHI);
-    bool writeDeps(const char *filename, bool generateMakeRule, const char *targetName = NULL,
-                   const char *srcFilename = NULL);
+    bool writeDeps(const char *filename, bool generateMakeRule, const char *targetName = nullptr,
+                   const char *srcFilename = nullptr);
     bool writeDevStub(const char *filename);
     bool writeHostStub(const char *filename);
     bool writeCPPStub(const char *outFileName);

--- a/src/opt/GatherCoalescePass.cpp
+++ b/src/opt/GatherCoalescePass.cpp
@@ -17,7 +17,7 @@ struct CoalescedLoadOp {
     CoalescedLoadOp(int64_t s, int c) {
         start = s;
         count = c;
-        load = element0 = element1 = NULL;
+        load = element0 = element1 = nullptr;
     }
 
     /** Starting offset of the load from the common base pointer (in terms
@@ -516,7 +516,7 @@ static llvm::Value *lAssemble4Vector(const std::vector<CoalescedLoadOp> &loadOps
 static llvm::Value *lApplyLoad4s(llvm::Value *result, const std::vector<CoalescedLoadOp> &loadOps,
                                  const int64_t offsets[4], bool set[4], llvm::Instruction *insertBefore) {
     int32_t firstMatchElements[4] = {-1, -1, -1, -1};
-    const CoalescedLoadOp *firstMatch = NULL;
+    const CoalescedLoadOp *firstMatch = nullptr;
 
     Assert(llvm::isa<llvm::UndefValue>(result));
 
@@ -542,7 +542,7 @@ static llvm::Value *lApplyLoad4s(llvm::Value *result, const std::vector<Coalesce
 
         if (anyMatched) {
             if (llvm::isa<llvm::UndefValue>(result)) {
-                if (firstMatch == NULL) {
+                if (firstMatch == nullptr) {
                     firstMatch = &loadop;
                     for (int i = 0; i < 4; ++i)
                         firstMatchElements[i] = matchElements[i];
@@ -555,7 +555,7 @@ static llvm::Value *lApplyLoad4s(llvm::Value *result, const std::vector<Coalesce
                             shuffle[i] = 4 + matchElements[i];
                     }
                     result = LLVMShuffleVectors(firstMatch->load, loadop.load, shuffle, 4, insertBefore);
-                    firstMatch = NULL;
+                    firstMatch = nullptr;
                 }
             } else {
                 int32_t shuffle[4] = {-1, -1, -1, -1};
@@ -570,7 +570,7 @@ static llvm::Value *lApplyLoad4s(llvm::Value *result, const std::vector<Coalesce
         }
     }
 
-    if (firstMatch != NULL && llvm::isa<llvm::UndefValue>(result))
+    if (firstMatch != nullptr && llvm::isa<llvm::UndefValue>(result))
         return LLVMShuffleVectors(firstMatch->load, result, firstMatchElements, 4, insertBefore);
     else
         return result;
@@ -642,7 +642,7 @@ static void lAssembleResultVectors(const std::vector<CoalescedLoadOp> &loadOps,
     // into 4, 8, or 16-wide final result vectors.
     int numGathers = constOffsets.size() / g->target->getVectorWidth();
     for (int i = 0; i < numGathers; ++i) {
-        llvm::Value *result = NULL;
+        llvm::Value *result = nullptr;
         switch (g->target->getVectorWidth()) {
         case 4:
             result = vec4s[i];
@@ -678,7 +678,7 @@ static llvm::Value *lComputeBasePtr(llvm::CallInst *gatherInst, llvm::Type *base
     // checking for this in GatherCoalescePass::runOnBasicBlock().  Thus,
     // extract the first value and use that as a scalar.
     llvm::Value *variable = LLVMExtractFirstVectorElement(variableOffsets);
-    Assert(variable != NULL);
+    Assert(variable != nullptr);
     if (variable->getType() == LLVMTypes::Int64Type)
         offsetScale = new llvm::ZExtInst(offsetScale, LLVMTypes::Int64Type, "scale_to64", insertBefore);
     llvm::Value *offset =
@@ -770,7 +770,7 @@ static bool lCoalesceGathers(const std::vector<llvm::CallInst *> &coalesceGroup,
     Assert(results.size() == coalesceGroup.size());
     for (int i = 0; i < (int)results.size(); ++i) {
         llvm::Instruction *ir = llvm::dyn_cast<llvm::Instruction>(results[i]);
-        Assert(ir != NULL);
+        Assert(ir != nullptr);
 
         llvm::Type *origType = coalesceGroup[i]->getType();
         if (origType != ir->getType())
@@ -806,9 +806,9 @@ static bool lInstructionMayWriteToMemory(llvm::Instruction *inst) {
     // indicating it won't write to memory has to be treated as a potential
     // store.
     llvm::CallInst *ci = llvm::dyn_cast<llvm::CallInst>(inst);
-    if (ci != NULL) {
+    if (ci != nullptr) {
         llvm::Function *calledFunc = ci->getCalledFunction();
-        if (calledFunc == NULL)
+        if (calledFunc == nullptr)
             return true;
 
         if (calledFunc->onlyReadsMemory() || calledFunc->doesNotAccessMemory())
@@ -839,16 +839,16 @@ bool GatherCoalescePass::coalesceGathersFactored(llvm::BasicBlock &bb) {
         // Iterate over all of the instructions and look for calls to
         // __pseudo_gather_factored_base_offsets{32,64}_{i32,float} calls.
         llvm::CallInst *callInst = llvm::dyn_cast<llvm::CallInst>(&*curIter);
-        if (callInst == NULL)
+        if (callInst == nullptr)
             continue;
 
         llvm::Function *calledFunc = callInst->getCalledFunction();
-        if (calledFunc == NULL)
+        if (calledFunc == nullptr)
             continue;
 
         int i;
         for (i = 0; i < nGatherFuncs; ++i)
-            if (gatherFuncs[i] != NULL && calledFunc == gatherFuncs[i])
+            if (gatherFuncs[i] != nullptr && calledFunc == gatherFuncs[i])
                 break;
         if (i == nGatherFuncs)
             // Doesn't match any of the types of gathers we care about
@@ -900,7 +900,7 @@ bool GatherCoalescePass::coalesceGathersFactored(llvm::BasicBlock &bb) {
                 break;
 
             llvm::CallInst *fwdCall = llvm::dyn_cast<llvm::CallInst>(&*fwdIter);
-            if (fwdCall == NULL || fwdCall->getCalledFunction() != calledFunc)
+            if (fwdCall == nullptr || fwdCall->getCalledFunction() != calledFunc)
                 continue;
 
             SourcePos fwdPos;

--- a/src/opt/ISPCPass.h
+++ b/src/opt/ISPCPass.h
@@ -57,9 +57,9 @@ namespace ispc {
 enum { BYTE = 1, WORD = 2, DWORD = 4, QWORD = 8, OWORD = 16, GRF = 32 };
 
 #define DEBUG_START_BB(NAME)                                                                                           \
-    if (g->debugPrint &&                                                                                               \
-        (getenv("FUNC") == NULL || (getenv("FUNC") != NULL && !strncmp(bb.getParent()->getName().str().c_str(),        \
-                                                                       getenv("FUNC"), strlen(getenv("FUNC")))))) {    \
+    if (g->debugPrint && (getenv("FUNC") == nullptr ||                                                                 \
+                          (getenv("FUNC") != nullptr && !strncmp(bb.getParent()->getName().str().c_str(),              \
+                                                                 getenv("FUNC"), strlen(getenv("FUNC")))))) {          \
         fprintf(stderr, "Start of " NAME "\n");                                                                        \
         fprintf(stderr, "---------------\n");                                                                          \
         bb.print(llvm::errs());                                                                                        \
@@ -67,9 +67,9 @@ enum { BYTE = 1, WORD = 2, DWORD = 4, QWORD = 8, OWORD = 16, GRF = 32 };
     } else /* eat semicolon */
 
 #define DEBUG_END_BB(NAME)                                                                                             \
-    if (g->debugPrint &&                                                                                               \
-        (getenv("FUNC") == NULL || (getenv("FUNC") != NULL && !strncmp(bb.getParent()->getName().str().c_str(),        \
-                                                                       getenv("FUNC"), strlen(getenv("FUNC")))))) {    \
+    if (g->debugPrint && (getenv("FUNC") == nullptr ||                                                                 \
+                          (getenv("FUNC") != nullptr && !strncmp(bb.getParent()->getName().str().c_str(),              \
+                                                                 getenv("FUNC"), strlen(getenv("FUNC")))))) {          \
         fprintf(stderr, "End of " NAME " %s\n", modifiedAny ? "** CHANGES **" : "");                                   \
         fprintf(stderr, "---------------\n");                                                                          \
         bb.print(llvm::errs());                                                                                        \

--- a/src/opt/InstructionSimplify.cpp
+++ b/src/opt/InstructionSimplify.cpp
@@ -12,7 +12,7 @@ char InstructionSimplifyPass::ID = 0;
 
 static llvm::Value *lSimplifyBoolVec(llvm::Value *value) {
     llvm::TruncInst *trunc = llvm::dyn_cast<llvm::TruncInst>(value);
-    if (trunc != NULL) {
+    if (trunc != nullptr) {
         // Convert trunc({sext,zext}(i1 vector)) -> (i1 vector)
         llvm::SExtInst *sext = llvm::dyn_cast<llvm::SExtInst>(value);
         if (sext && sext->getOperand(0)->getType() == LLVMTypes::Int1VectorType)
@@ -28,7 +28,7 @@ static llvm::Value *lSimplifyBoolVec(llvm::Value *value) {
       // On 3.4+ (maybe even older), it can result in illegal
       // operations, so it's being disabled.
     llvm::ICmpInst *icmp = llvm::dyn_cast<llvm::ICmpInst>(value);
-    if (icmp != NULL) {
+    if (icmp != nullptr) {
         // icmp(ne, {sext,zext}(foo), zeroinitializer) -> foo
         if (icmp->getSignedPredicate() == llvm::CmpInst::ICMP_NE) {
             llvm::Value *op1 = icmp->getOperand(1);
@@ -45,26 +45,26 @@ static llvm::Value *lSimplifyBoolVec(llvm::Value *value) {
 
     }
     */
-    return NULL;
+    return nullptr;
 }
 
 static bool lSimplifySelect(llvm::SelectInst *selectInst, llvm::BasicBlock::iterator iter) {
     if (selectInst->getType()->isVectorTy() == false)
         return false;
-    Assert(selectInst->getOperand(1) != NULL);
-    Assert(selectInst->getOperand(2) != NULL);
+    Assert(selectInst->getOperand(1) != nullptr);
+    Assert(selectInst->getOperand(2) != nullptr);
     llvm::Value *factor = selectInst->getOperand(0);
 
     // Simplify all-on or all-off mask values
     MaskStatus maskStatus = GetMaskStatusFromValue(factor);
-    llvm::Value *value = NULL;
+    llvm::Value *value = nullptr;
     if (maskStatus == MaskStatus::all_on)
         // Mask all on -> replace with the first select value
         value = selectInst->getOperand(1);
     else if (maskStatus == MaskStatus::all_off)
         // Mask all off -> replace with the second select value
         value = selectInst->getOperand(2);
-    if (value != NULL) {
+    if (value != nullptr) {
         ReplaceInstWithValueWrapper(iter, value);
         return true;
     }
@@ -74,7 +74,7 @@ static bool lSimplifySelect(llvm::SelectInst *selectInst, llvm::BasicBlock::iter
     // the code generators and leads to sub-optimal code (particularly for
     // 8 and 16-bit masks).  We'll try to simplify them out here so that
     // the code generator patterns match..
-    if ((factor = lSimplifyBoolVec(factor)) != NULL) {
+    if ((factor = lSimplifyBoolVec(factor)) != nullptr) {
         llvm::Instruction *newSelect = llvm::SelectInst::Create(factor, selectInst->getOperand(1),
                                                                 selectInst->getOperand(2), selectInst->getName());
         llvm::ReplaceInstWithInst(selectInst, newSelect);
@@ -89,7 +89,7 @@ static bool lSimplifyCall(llvm::CallInst *callInst, llvm::BasicBlock::iterator i
 
     // Turn a __movmsk call with a compile-time constant vector into the
     // equivalent scalar value.
-    if (calledFunc == NULL || calledFunc != m->module->getFunction("__movmsk"))
+    if (calledFunc == nullptr || calledFunc != m->module->getFunction("__movmsk"))
         return false;
 
     uint64_t mask;

--- a/src/opt/IntrinsicsOptPass.cpp
+++ b/src/opt/IntrinsicsOptPass.cpp
@@ -57,11 +57,11 @@ bool IntrinsicsOpt::optimizeIntrinsics(llvm::BasicBlock &bb) {
     for (llvm::BasicBlock::iterator iter = bb.begin(), e = bb.end(); iter != e;) {
         llvm::BasicBlock::iterator curIter = iter++;
         llvm::CallInst *callInst = llvm::dyn_cast<llvm::CallInst>(&*(curIter));
-        if (callInst == NULL || callInst->getCalledFunction() == NULL)
+        if (callInst == nullptr || callInst->getCalledFunction() == nullptr)
             continue;
 
         BlendInstruction *blend = matchingBlendInstruction(callInst->getCalledFunction());
-        if (blend != NULL) {
+        if (blend != nullptr) {
             llvm::Value *v[2] = {callInst->getArgOperand(blend->op0), callInst->getArgOperand(blend->op1)};
             llvm::Value *factor = callInst->getArgOperand(blend->opFactor);
 
@@ -90,7 +90,7 @@ bool IntrinsicsOpt::optimizeIntrinsics(llvm::BasicBlock &bb) {
             }
 
             MaskStatus maskStatus = GetMaskStatusFromValue(factor);
-            llvm::Value *value = NULL;
+            llvm::Value *value = nullptr;
             if (maskStatus == MaskStatus::all_off) {
                 // Mask all off -> replace with the first blend value
                 value = v[0];
@@ -99,7 +99,7 @@ bool IntrinsicsOpt::optimizeIntrinsics(llvm::BasicBlock &bb) {
                 value = v[1];
             }
 
-            if (value != NULL) {
+            if (value != nullptr) {
                 ReplaceInstWithValueWrapper(curIter, value);
                 modifiedAny = true;
                 continue;
@@ -144,7 +144,7 @@ bool IntrinsicsOpt::optimizeIntrinsics(llvm::BasicBlock &bb) {
                     align = callInst->getCalledFunction() == avxMaskedLoad32 ? 4 : 8;
                 llvm::Instruction *loadInst = new llvm::LoadInst(
                     returnType, castPtr, llvm::Twine(callInst->getArgOperand(0)->getName()) + "_load",
-                    false /* not volatile */, llvm::MaybeAlign(align).valueOrOne(), (llvm::Instruction *)NULL);
+                    false /* not volatile */, llvm::MaybeAlign(align).valueOrOne(), (llvm::Instruction *)nullptr);
                 LLVMCopyMetadata(loadInst, callInst);
                 llvm::ReplaceInstWithInst(callInst, loadInst);
                 modifiedAny = true;
@@ -174,7 +174,7 @@ bool IntrinsicsOpt::optimizeIntrinsics(llvm::BasicBlock &bb) {
                     align = g->target->getNativeVectorAlignment();
                 else
                     align = callInst->getCalledFunction() == avxMaskedStore32 ? 4 : 8;
-                llvm::StoreInst *storeInst = new llvm::StoreInst(rvalue, castPtr, (llvm::Instruction *)NULL,
+                llvm::StoreInst *storeInst = new llvm::StoreInst(rvalue, castPtr, (llvm::Instruction *)nullptr,
                                                                  llvm::MaybeAlign(align).valueOrOne());
                 LLVMCopyMetadata(storeInst, callInst);
                 llvm::ReplaceInstWithInst(callInst, storeInst);
@@ -202,7 +202,7 @@ bool IntrinsicsOpt::runOnFunction(llvm::Function &F) {
 
 bool IntrinsicsOpt::matchesMaskInstruction(llvm::Function *function) {
     for (unsigned int i = 0; i < maskInstructions.size(); ++i) {
-        if (maskInstructions[i].function != NULL && function == maskInstructions[i].function) {
+        if (maskInstructions[i].function != nullptr && function == maskInstructions[i].function) {
             return true;
         }
     }
@@ -211,11 +211,11 @@ bool IntrinsicsOpt::matchesMaskInstruction(llvm::Function *function) {
 
 IntrinsicsOpt::BlendInstruction *IntrinsicsOpt::matchingBlendInstruction(llvm::Function *function) {
     for (unsigned int i = 0; i < blendInstructions.size(); ++i) {
-        if (blendInstructions[i].function != NULL && function == blendInstructions[i].function) {
+        if (blendInstructions[i].function != nullptr && function == blendInstructions[i].function) {
             return &blendInstructions[i];
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 llvm::Pass *CreateIntrinsicsOptPass() { return new IntrinsicsOpt; }

--- a/src/opt/IsCompileTimeConstant.cpp
+++ b/src/opt/IsCompileTimeConstant.cpp
@@ -26,13 +26,13 @@ bool IsCompileTimeConstantPass::lowerCompileTimeConstant(llvm::BasicBlock &bb) {
         // Iterate through the instructions looking for calls to the
         // __is_compile_time_constant_*() functions
         llvm::CallInst *callInst = llvm::dyn_cast<llvm::CallInst>(&*(curIter));
-        if (callInst == NULL)
+        if (callInst == nullptr)
             continue;
 
         int j;
         int nFuncs = sizeof(funcs) / sizeof(funcs[0]);
         for (j = 0; j < nFuncs; ++j) {
-            if (funcs[j] != NULL && callInst->getCalledFunction() == funcs[j])
+            if (funcs[j] != nullptr && callInst->getCalledFunction() == funcs[j])
                 break;
         }
         if (j == nFuncs)

--- a/src/opt/MakeInternalFuncsStatic.cpp
+++ b/src/opt/MakeInternalFuncsStatic.cpp
@@ -177,7 +177,7 @@ bool MakeInternalFuncsStaticPass::runOnModule(llvm::Module &module) {
     int count = sizeof(names) / sizeof(names[0]);
     for (int i = 0; i < count; ++i) {
         llvm::Function *f = m->module->getFunction(names[i]);
-        if (f != NULL && f->empty() == false) {
+        if (f != nullptr && f->empty() == false) {
             f->setLinkage(llvm::GlobalValue::InternalLinkage);
             modifiedAny = true;
         }

--- a/src/opt/MangleOpenCLBuiltins.cpp
+++ b/src/opt/MangleOpenCLBuiltins.cpp
@@ -94,7 +94,7 @@ bool MangleOpenCLBuiltins::mangleOpenCLBuiltins(llvm::BasicBlock &bb) {
         llvm::Instruction *inst = &*I;
         if (llvm::CallInst *ci = llvm::dyn_cast<llvm::CallInst>(inst)) {
             llvm::Function *func = ci->getCalledFunction();
-            if (func == NULL)
+            if (func == nullptr)
                 continue;
             if (func->getName().startswith("__spirv_")) {
                 std::string mangledName;

--- a/src/opt/PeepholePass.cpp
+++ b/src/opt/PeepholePass.cpp
@@ -66,7 +66,7 @@ template <typename Op_t> struct UDiv2_match {
         llvm::BinaryOperator *bop;
         llvm::ConstantDataVector *cdv;
         if ((bop = llvm::dyn_cast<llvm::BinaryOperator>(V)) &&
-            (cdv = llvm::dyn_cast<llvm::ConstantDataVector>(bop->getOperand(1))) && cdv->getSplatValue() != NULL) {
+            (cdv = llvm::dyn_cast<llvm::ConstantDataVector>(bop->getOperand(1))) && cdv->getSplatValue() != nullptr) {
             const llvm::APInt &apInt = cdv->getUniqueInteger();
 
             switch (bop->getOpcode()) {
@@ -95,7 +95,7 @@ template <typename Op_t> struct SDiv2_match {
         llvm::BinaryOperator *bop;
         llvm::ConstantDataVector *cdv;
         if ((bop = llvm::dyn_cast<llvm::BinaryOperator>(V)) &&
-            (cdv = llvm::dyn_cast<llvm::ConstantDataVector>(bop->getOperand(1))) && cdv->getSplatValue() != NULL) {
+            (cdv = llvm::dyn_cast<llvm::ConstantDataVector>(bop->getOperand(1))) && cdv->getSplatValue() != nullptr) {
             const llvm::APInt &apInt = cdv->getUniqueInteger();
 
             switch (bop->getOpcode()) {
@@ -130,7 +130,7 @@ static bool lHasIntrinsicInDefinition(llvm::Function *func) {
 
 static llvm::Instruction *lGetBinaryIntrinsic(const char *name, llvm::Value *opa, llvm::Value *opb) {
     llvm::Function *func = m->module->getFunction(name);
-    Assert(func != NULL);
+    Assert(func != nullptr);
 
     // Make sure that the definition of the llvm::Function has a call to an
     // intrinsic function in its instructions; otherwise we will generate
@@ -140,7 +140,7 @@ static llvm::Instruction *lGetBinaryIntrinsic(const char *name, llvm::Value *opa
     if (lHasIntrinsicInDefinition(func))
         return LLVMCallInst(func, opa, opb, name);
     else
-        return NULL;
+        return nullptr;
 }
 
 //////////////////////////////////////////////////
@@ -154,11 +154,11 @@ static llvm::Instruction *lMatchAvgUpUInt8(llvm::Value *inst) {
                                     m_Add(m_Add(m_ZExt8To16(m_Value(opa)), m_APInt(delta)), m_ZExt8To16(m_Value(opb)))),
                         m_Add(m_Add(m_ZExt8To16(m_Value(opa)), m_ZExt8To16(m_Value(opb))), m_APInt(delta))))))) {
         if (delta->isIntN(1) == false)
-            return NULL;
+            return nullptr;
 
         return lGetBinaryIntrinsic("__avg_up_uint8", opa, opb);
     }
-    return NULL;
+    return nullptr;
 }
 
 static llvm::Instruction *lMatchAvgDownUInt8(llvm::Value *inst) {
@@ -167,7 +167,7 @@ static llvm::Instruction *lMatchAvgDownUInt8(llvm::Value *inst) {
     if (match(inst, m_Trunc16To8(m_UDiv2(m_Add(m_ZExt8To16(m_Value(opa)), m_ZExt8To16(m_Value(opb))))))) {
         return lGetBinaryIntrinsic("__avg_down_uint8", opa, opb);
     }
-    return NULL;
+    return nullptr;
 }
 
 static llvm::Instruction *lMatchAvgUpUInt16(llvm::Value *inst) {
@@ -180,11 +180,11 @@ static llvm::Instruction *lMatchAvgUpUInt16(llvm::Value *inst) {
                               m_Add(m_Add(m_ZExt16To32(m_Value(opa)), m_APInt(delta)), m_ZExt16To32(m_Value(opb)))),
                   m_Add(m_Add(m_ZExt16To32(m_Value(opa)), m_ZExt16To32(m_Value(opb))), m_APInt(delta))))))) {
         if (delta->isIntN(1) == false)
-            return NULL;
+            return nullptr;
 
         return lGetBinaryIntrinsic("__avg_up_uint16", opa, opb);
     }
-    return NULL;
+    return nullptr;
 }
 
 static llvm::Instruction *lMatchAvgDownUInt16(llvm::Value *inst) {
@@ -193,7 +193,7 @@ static llvm::Instruction *lMatchAvgDownUInt16(llvm::Value *inst) {
     if (match(inst, m_Trunc32To16(m_UDiv2(m_Add(m_ZExt16To32(m_Value(opa)), m_ZExt16To32(m_Value(opb))))))) {
         return lGetBinaryIntrinsic("__avg_down_uint16", opa, opb);
     }
-    return NULL;
+    return nullptr;
 }
 
 static llvm::Instruction *lMatchAvgUpInt8(llvm::Value *inst) {
@@ -205,11 +205,11 @@ static llvm::Instruction *lMatchAvgUpInt8(llvm::Value *inst) {
                                     m_Add(m_Add(m_SExt8To16(m_Value(opa)), m_APInt(delta)), m_SExt8To16(m_Value(opb)))),
                         m_Add(m_Add(m_SExt8To16(m_Value(opa)), m_SExt8To16(m_Value(opb))), m_APInt(delta))))))) {
         if (delta->isIntN(1) == false)
-            return NULL;
+            return nullptr;
 
         return lGetBinaryIntrinsic("__avg_up_int8", opa, opb);
     }
-    return NULL;
+    return nullptr;
 }
 
 static llvm::Instruction *lMatchAvgDownInt8(llvm::Value *inst) {
@@ -218,7 +218,7 @@ static llvm::Instruction *lMatchAvgDownInt8(llvm::Value *inst) {
     if (match(inst, m_Trunc16To8(m_SDiv2(m_Add(m_SExt8To16(m_Value(opa)), m_SExt8To16(m_Value(opb))))))) {
         return lGetBinaryIntrinsic("__avg_down_int8", opa, opb);
     }
-    return NULL;
+    return nullptr;
 }
 
 static llvm::Instruction *lMatchAvgUpInt16(llvm::Value *inst) {
@@ -231,11 +231,11 @@ static llvm::Instruction *lMatchAvgUpInt16(llvm::Value *inst) {
                               m_Add(m_Add(m_SExt16To32(m_Value(opa)), m_APInt(delta)), m_SExt16To32(m_Value(opb)))),
                   m_Add(m_Add(m_SExt16To32(m_Value(opa)), m_SExt16To32(m_Value(opb))), m_APInt(delta))))))) {
         if (delta->isIntN(1) == false)
-            return NULL;
+            return nullptr;
 
         return lGetBinaryIntrinsic("__avg_up_int16", opa, opb);
     }
-    return NULL;
+    return nullptr;
 }
 
 static llvm::Instruction *lMatchAvgDownInt16(llvm::Value *inst) {
@@ -244,7 +244,7 @@ static llvm::Instruction *lMatchAvgDownInt16(llvm::Value *inst) {
     if (match(inst, m_Trunc32To16(m_SDiv2(m_Add(m_SExt16To32(m_Value(opa)), m_SExt16To32(m_Value(opb))))))) {
         return lGetBinaryIntrinsic("__avg_down_int16", opa, opb);
     }
-    return NULL;
+    return nullptr;
 }
 
 bool PeepholePass::matchAndReplace(llvm::BasicBlock &bb) {
@@ -272,7 +272,7 @@ bool PeepholePass::matchAndReplace(llvm::BasicBlock &bb) {
             builtinCall = lMatchAvgDownInt8(inst);
         if (!builtinCall)
             builtinCall = lMatchAvgDownInt16(inst);
-        if (builtinCall != NULL) {
+        if (builtinCall != nullptr) {
             llvm::ReplaceInstWithInst(inst, builtinCall);
             modifiedAny = true;
         }

--- a/src/opt/ReplacePseudoMemoryOps.cpp
+++ b/src/opt/ReplacePseudoMemoryOps.cpp
@@ -19,7 +19,7 @@ char ReplacePseudoMemoryOpsPass::ID = 0;
 */
 static bool lIsSafeToBlend(llvm::Value *lvalue) {
     llvm::BitCastInst *bc = llvm::dyn_cast<llvm::BitCastInst>(lvalue);
-    if (bc != NULL)
+    if (bc != nullptr)
         return lIsSafeToBlend(bc->getOperand(0));
     else {
         llvm::AllocaInst *ai = llvm::dyn_cast<llvm::AllocaInst>(lvalue);
@@ -30,10 +30,10 @@ static bool lIsSafeToBlend(llvm::Value *lvalue) {
                 type = at->getElementType();
             }
             llvm::FixedVectorType *vt = llvm::dyn_cast<llvm::FixedVectorType>(type);
-            return (vt != NULL && (int)vt->getNumElements() == g->target->getVectorWidth());
+            return (vt != nullptr && (int)vt->getNumElements() == g->target->getVectorWidth());
         } else {
             llvm::GetElementPtrInst *gep = llvm::dyn_cast<llvm::GetElementPtrInst>(lvalue);
-            if (gep != NULL)
+            if (gep != nullptr)
                 return lIsSafeToBlend(gep->getOperand(0));
             else
                 return false;
@@ -47,7 +47,7 @@ static bool lReplacePseudoMaskedStore(llvm::CallInst *callInst) {
             pseudoFunc = m->module->getFunction(pname);
             blendFunc = m->module->getFunction(bname);
             maskedStoreFunc = m->module->getFunction(msname);
-            Assert(pseudoFunc != NULL && blendFunc != NULL && maskedStoreFunc != NULL);
+            Assert(pseudoFunc != nullptr && blendFunc != nullptr && maskedStoreFunc != nullptr);
         }
         llvm::Function *pseudoFunc;
         llvm::Function *blendFunc;
@@ -62,14 +62,14 @@ static bool lReplacePseudoMaskedStore(llvm::CallInst *callInst) {
         LMSInfo("__pseudo_masked_store_float", "__masked_store_blend_float", "__masked_store_float"),
         LMSInfo("__pseudo_masked_store_i64", "__masked_store_blend_i64", "__masked_store_i64"),
         LMSInfo("__pseudo_masked_store_double", "__masked_store_blend_double", "__masked_store_double")};
-    LMSInfo *info = NULL;
+    LMSInfo *info = nullptr;
     for (unsigned int i = 0; i < sizeof(msInfo) / sizeof(msInfo[0]); ++i) {
-        if (msInfo[i].pseudoFunc != NULL && callInst->getCalledFunction() == msInfo[i].pseudoFunc) {
+        if (msInfo[i].pseudoFunc != nullptr && callInst->getCalledFunction() == msInfo[i].pseudoFunc) {
             info = &msInfo[i];
             break;
         }
     }
-    if (info == NULL)
+    if (info == nullptr)
         return false;
 
     llvm::Value *lvalue = callInst->getArgOperand(0);
@@ -245,17 +245,17 @@ static bool lReplacePseudoGS(llvm::CallInst *callInst) {
 
     llvm::Function *calledFunc = callInst->getCalledFunction();
 
-    LowerGSInfo *info = NULL;
+    LowerGSInfo *info = nullptr;
     for (unsigned int i = 0; i < sizeof(lgsInfo) / sizeof(lgsInfo[0]); ++i) {
-        if (lgsInfo[i].pseudoFunc != NULL && calledFunc == lgsInfo[i].pseudoFunc) {
+        if (lgsInfo[i].pseudoFunc != nullptr && calledFunc == lgsInfo[i].pseudoFunc) {
             info = &lgsInfo[i];
             break;
         }
     }
-    if (info == NULL)
+    if (info == nullptr)
         return false;
 
-    Assert(info->actualFunc != NULL);
+    Assert(info->actualFunc != nullptr);
 
     // Get the source position from the metadata attached to the call
     // instruction so that we can issue PerformanceWarning()s below.
@@ -282,7 +282,7 @@ bool ReplacePseudoMemoryOpsPass::replacePseudoMemoryOps(llvm::BasicBlock &bb) {
     // is moved forward before the instruction is processed.
     for (llvm::BasicBlock::iterator iter = bb.begin(), e = bb.end(); iter != e;) {
         llvm::CallInst *callInst = llvm::dyn_cast<llvm::CallInst>(&*(iter++));
-        if (callInst == NULL || callInst->getCalledFunction() == NULL)
+        if (callInst == nullptr || callInst->getCalledFunction() == nullptr)
             continue;
 
         if (lReplacePseudoGS(callInst)) {

--- a/src/opt/XeGatherCoalescePass.cpp
+++ b/src/opt/XeGatherCoalescePass.cpp
@@ -179,7 +179,7 @@ void MemoryCoalescing::analyseInsts(llvm::BasicBlock &BB) {
     Assert(OptType == MemType::OPT_LOAD || OptType == MemType::OPT_STORE);
     OptBlock CurrentBlock;
     for (; (OptType == MemType::OPT_LOAD) ? (bi != be) : (rbi != rbe);) {
-        llvm::Instruction *Inst = NULL;
+        llvm::Instruction *Inst = nullptr;
         if (OptType == MemType::OPT_LOAD) {
             Inst = &*bi;
             ++bi;

--- a/src/opt/XeReplaceLLVMIntrinsics.cpp
+++ b/src/opt/XeReplaceLLVMIntrinsics.cpp
@@ -23,7 +23,7 @@ restart:
         llvm::Instruction *inst = &*I;
         if (llvm::CallInst *ci = llvm::dyn_cast<llvm::CallInst>(inst)) {
             llvm::Function *func = ci->getCalledFunction();
-            if (func == NULL || !func->isIntrinsic())
+            if (func == nullptr || !func->isIntrinsic())
                 continue;
 
             if (func->getName().equals("llvm.trap")) {
@@ -45,7 +45,7 @@ restart:
                 Args.push_back(zeroMask);
 
                 llvm::Instruction *newInst = llvm::CallInst::Create(Fn, Args, ci->getName());
-                if (newInst != NULL) {
+                if (newInst != nullptr) {
                     llvm::ReplaceInstWithInst(ci, newInst);
                     modifiedAny = true;
                     goto restart;
@@ -69,7 +69,7 @@ restart:
                 auto Fn = llvm::GenXIntrinsic::getGenXDeclaration(m->module, xeAbsID, Tys);
                 Assert(Fn);
                 llvm::Instruction *newInst = llvm::CallInst::Create(Fn, ci->getOperand(0), "");
-                if (newInst != NULL) {
+                if (newInst != nullptr) {
                     LLVMCopyMetadata(newInst, ci);
                     llvm::ReplaceInstWithInst(ci, newInst);
                     modifiedAny = true;

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -35,7 +35,7 @@
             YYRHSLOC (Rhs, 0).last_line;                               \
           (Current).first_column = (Current).last_column =             \
             YYRHSLOC (Rhs, 0).last_column;                             \
-          (Current).name = NULL;                        /* new */ \
+          (Current).name = nullptr;                        /* new */ \
         }                                                              \
     while (0)
 
@@ -123,7 +123,7 @@ static const char *lParamListTokens[] = {
 };
 
 struct ForeachDimension {
-    ForeachDimension(Symbol *s = NULL, Expr *b = NULL, Expr *e = NULL) {
+    ForeachDimension(Symbol *s = nullptr, Expr *b = nullptr, Expr *e = nullptr) {
         sym = s;
         beginExpr = b;
         endExpr = e;
@@ -281,7 +281,7 @@ primary_expression
     : TOKEN_IDENTIFIER {
         const char *name = yylval.stringVal->c_str();
         Symbol *s = m->symbolTable->LookupVariable(name);
-        $$ = NULL;
+        $$ = nullptr;
         if (s)
             $$ = new SymbolExpr(s, @1);
         else {
@@ -290,7 +290,7 @@ primary_expression
             if (funs.size() > 0)
                 $$ = new FunctionSymbolExpr(name, funs, @1);
         }
-        if ($$ == NULL) {
+        if ($$ == nullptr) {
             std::vector<std::string> alternates =
                 m->symbolTable->ClosestVariableOrFunctionMatch(name);
             std::string alts = lGetAlternates(alternates);
@@ -359,7 +359,7 @@ primary_expression
 /*    | TOKEN_STRING_LITERAL
        { UNIMPLEMENTED }*/
     | '(' expression ')' { $$ = $2; }
-    | '(' error ')' { $$ = NULL; }
+    | '(' error ')' { $$ = nullptr; }
     ;
 
 launch_expression
@@ -440,39 +440,39 @@ launch_expression
        {
           Error(Union(@2, @7), "\"launch\" expressions no longer take '<' '>' "
                 "around function call expression.");
-          $$ = NULL;
+          $$ = nullptr;
        }
     | TOKEN_LAUNCH '<' postfix_expression '(' ')' '>'
        {
           Error(Union(@2, @6), "\"launch\" expressions no longer take '<' '>' "
                 "around function call expression.");
-          $$ = NULL;
+          $$ = nullptr;
        }
     | TOKEN_LAUNCH '[' assignment_expression ']' '<' postfix_expression '(' argument_expression_list ')' '>'
        {
           Error(Union(@5, @10), "\"launch\" expressions no longer take '<' '>' "
                 "around function call expression.");
-          $$ = NULL;
+          $$ = nullptr;
        }
     | TOKEN_LAUNCH '[' assignment_expression ']' '<' postfix_expression '(' ')' '>'
        {
           Error(Union(@5, @9), "\"launch\" expressions no longer take '<' '>' "
                 "around function call expression.");
-          $$ = NULL;
+          $$ = nullptr;
        }
     ;
 
 invoke_sycl_expression
     : TOKEN_INVOKE_SYCL '(' postfix_expression ')'
       {
-          $$ = new FunctionCallExpr($3, new ExprList(@4), Union(@1,@4), false, NULL, true);
+          $$ = new FunctionCallExpr($3, new ExprList(@4), Union(@1,@4), false, nullptr, true);
       }
     | TOKEN_INVOKE_SYCL '(' postfix_expression ',' argument_expression_list ')'
       {
-          $$ = new FunctionCallExpr($3, $5, Union(@1,@6), false, NULL, true);
+          $$ = new FunctionCallExpr($3, $5, Union(@1,@6), false, nullptr, true);
       }
     | TOKEN_INVOKE_SYCL '(' error ')'
-      { $$ = NULL; }
+      { $$ = nullptr; }
     ;
 
 postfix_expression
@@ -480,7 +480,7 @@ postfix_expression
     | postfix_expression '[' expression ']'
       { $$ = new IndexExpr($1, $3, Union(@1,@4)); }
     | postfix_expression '[' error ']'
-      { $$ = NULL; }
+      { $$ = nullptr; }
     | launch_expression
     | postfix_expression '.' TOKEN_IDENTIFIER
       { $$ = MemberExpr::create($1, yytext, Union(@1,@3), @3, false); }
@@ -507,8 +507,8 @@ intrincall_expression
           Symbol* sym = m->AddLLVMIntrinsicDecl(*name, $3, Union(@1,@4));
           const char *fname = name->c_str();
           const std::vector<Symbol *> funcs{sym};
-          FunctionSymbolExpr *fSym = NULL;
-          if (sym != NULL)
+          FunctionSymbolExpr *fSym = nullptr;
+          if (sym != nullptr)
               fSym = new FunctionSymbolExpr(fname, funcs, @1);
           $$ = new FunctionCallExpr(fSym, $3, Union(@1,@4));
 
@@ -522,7 +522,7 @@ funcall_expression
     | postfix_expression '(' argument_expression_list ')'
       { $$ = new FunctionCallExpr($1, $3, Union(@1,@4)); }
     | postfix_expression '(' error ')'
-      { $$ = NULL; }
+      { $$ = nullptr; }
     | simple_template_id '(' ')'
       {
           // Create FunctionSymbolExpr with a candidate functions list
@@ -558,7 +558,7 @@ funcall_expression
           }
       }
     | simple_template_id '(' error ')'
-      { $$ = NULL; }
+      { $$ = nullptr; }
     ;
 
 argument_expression_list
@@ -566,7 +566,7 @@ argument_expression_list
     | argument_expression_list ',' assignment_expression
       {
           ExprList *argList = llvm::dyn_cast<ExprList>($1);
-          if (argList == NULL) {
+          if (argList == nullptr) {
               AssertPos(@1, m->errorCount > 0);
               argList = new ExprList(@3);
           }
@@ -706,42 +706,42 @@ rate_qualified_type_specifier
     : type_specifier { $$ = $1; }
     | TOKEN_UNIFORM type_specifier
     {
-        if ($2 == NULL)
-            $$ = NULL;
+        if ($2 == nullptr)
+            $$ = nullptr;
         else if ($2->IsVoidType()) {
             Error(@1, "\"uniform\" qualifier is illegal with \"void\" type.");
-            $$ = NULL;
+            $$ = nullptr;
         }
         else
             $$ = $2->GetAsUniformType();
     }
     | TOKEN_VARYING type_specifier
     {
-        if ($2 == NULL)
-            $$ = NULL;
+        if ($2 == nullptr)
+            $$ = nullptr;
         else if ($2->IsVoidType()) {
             Error(@1, "\"varying\" qualifier is illegal with \"void\" type.");
-            $$ = NULL;
+            $$ = nullptr;
         }
         else
             $$ = $2->GetAsVaryingType();
     }
     | soa_width_specifier type_specifier
     {
-        if ($2 == NULL)
-            $$ = NULL;
+        if ($2 == nullptr)
+            $$ = nullptr;
         else {
             int soaWidth = (int)$1;
             const StructType *st = CastType<StructType>($2);
-            if (st == NULL) {
+            if (st == nullptr) {
                 Error(@1, "\"soa\" qualifier is illegal with non-struct type \"%s\".",
                       $2->GetString().c_str());
-                $$ = NULL;
+                $$ = nullptr;
             }
             else if (soaWidth <= 0 || (soaWidth & (soaWidth - 1)) != 0) {
                 Error(@1, "soa<%d> width illegal. Value must be positive power "
                       "of two.", soaWidth);
-                $$ = NULL;
+                $$ = nullptr;
             }
             else
                 $$ = st->GetAsSOAType(soaWidth);
@@ -753,15 +753,15 @@ new_expression
     : conditional_expression
     | rate_qualified_new rate_qualified_type_specifier
     {
-        $$ = new NewExpr((int32_t)$1, $2, NULL, NULL, @1, Union(@1, @2));
+        $$ = new NewExpr((int32_t)$1, $2, nullptr, nullptr, @1, Union(@1, @2));
     }
     | rate_qualified_new rate_qualified_type_specifier '(' initializer_list ')'
     {
-        $$ = new NewExpr((int32_t)$1, $2, $4, NULL, @1, Union(@1, @2));
+        $$ = new NewExpr((int32_t)$1, $2, $4, nullptr, @1, Union(@1, @2));
     }
     | rate_qualified_new rate_qualified_type_specifier '[' expression ']'
     {
-        $$ = new NewExpr((int32_t)$1, $2, NULL, $4, @1, Union(@1, @4));
+        $$ = new NewExpr((int32_t)$1, $2, nullptr, $4, @1, Union(@1, @4));
     }
     ;
 
@@ -804,20 +804,20 @@ constant_expression
 declaration_statement
     : declaration
     {
-        if ($1 == NULL) {
+        if ($1 == nullptr) {
             AssertPos(@1, m->errorCount > 0);
-            $$ = NULL;
+            $$ = nullptr;
         }
         else if ($1->declSpecs->storageClass == SC_TYPEDEF) {
             for (unsigned int i = 0; i < $1->declarators.size(); ++i) {
-                if ($1->declarators[i] == NULL)
+                if ($1->declarators[i] == nullptr)
                     AssertPos(@1, m->errorCount > 0);
                 else
                     m->AddTypeDef($1->declarators[i]->name,
                                   $1->declarators[i]->type,
                                   $1->declarators[i]->pos);
             }
-            $$ = NULL;
+            $$ = nullptr;
         }
         else {
             $1->DeclareFunctions();
@@ -861,7 +861,7 @@ declspec_list
     }
     | declspec_list ',' declspec_item
     {
-        if ($1 != NULL)
+        if ($1 != nullptr)
             $1->push_back(*$3);
         $$ = $1;
     }
@@ -877,12 +877,12 @@ declspec_specifier
 declaration_specifiers
     : storage_class_specifier
       {
-          $$ = new DeclSpecs(NULL, $1);
+          $$ = new DeclSpecs(nullptr, $1);
       }
     | storage_class_specifier declaration_specifiers
       {
           DeclSpecs *ds = (DeclSpecs *)$2;
-          if (ds != NULL) {
+          if (ds != nullptr) {
               if (ds->storageClass != SC_NONE)
                   Error(@1, "Multiple storage class specifiers in a declaration are illegal. "
                         "(Have provided both \"%s\" and \"%s\".)",
@@ -896,14 +896,14 @@ declaration_specifiers
     | declspec_specifier
       {
           $$ = new DeclSpecs;
-          if ($1 != NULL)
+          if ($1 != nullptr)
               $$->declSpecList = *$1;
       }
     | declspec_specifier declaration_specifiers
       {
           DeclSpecs *ds = (DeclSpecs *)$2;
           std::vector<std::pair<std::string, SourcePos> > *declSpecList = $1;
-          if (ds != NULL && declSpecList != NULL) {
+          if (ds != nullptr && declSpecList != nullptr) {
               for (int i = 0; i < (int)declSpecList->size(); ++i)
                   ds->declSpecList.push_back((*declSpecList)[i]);
           }
@@ -918,7 +918,7 @@ declaration_specifiers
     | soa_width_specifier declaration_specifiers
       {
           DeclSpecs *ds = (DeclSpecs *)$2;
-          if (ds != NULL) {
+          if (ds != nullptr) {
               if (ds->soaWidth != 0)
                   Error(@1, "soa<> qualifier supplied multiple times in declaration.");
               else
@@ -939,8 +939,8 @@ declaration_specifiers
     | type_specifier declaration_specifiers
       {
           DeclSpecs *ds = (DeclSpecs *)$2;
-          if (ds != NULL) {
-              if (ds->baseType != NULL) {
+          if (ds != nullptr) {
+              if (ds->baseType != nullptr) {
                   if( ds->baseType->IsUnsignedType()) {
                       Error(@1, "Redefining uint8/uint16/uint32/uint64 type "
                       "which is part of ISPC language since version 1.13. "
@@ -956,12 +956,12 @@ declaration_specifiers
       }
     | type_qualifier
       {
-          $$ = new DeclSpecs(NULL, SC_NONE, $1);
+          $$ = new DeclSpecs(nullptr, SC_NONE, $1);
       }
     | type_qualifier declaration_specifiers
       {
           DeclSpecs *ds = (DeclSpecs *)$2;
-          if (ds != NULL)
+          if (ds != nullptr)
               ds->typeQualifiers |= $1;
           $$ = ds;
       }
@@ -971,18 +971,18 @@ init_declarator_list
     : init_declarator
       {
           std::vector<Declarator *> *dl = new std::vector<Declarator *>;
-          if ($1 != NULL)
+          if ($1 != nullptr)
               dl->push_back($1);
           $$ = dl;
       }
     | init_declarator_list ',' init_declarator
       {
           std::vector<Declarator *> *dl = (std::vector<Declarator *> *)$1;
-          if (dl == NULL) {
+          if (dl == nullptr) {
               AssertPos(@1, m->errorCount > 0);
               dl = new std::vector<Declarator *>;
           }
-          if ($3 != NULL)
+          if ($3 != nullptr)
               dl->push_back($3);
           $$ = dl;
       }
@@ -992,7 +992,7 @@ init_declarator
     : declarator
     | declarator '=' initializer
       {
-          if ($1 != NULL)
+          if ($1 != nullptr)
               $1->initExpr = $3;
           $$ = $1;
       }
@@ -1020,8 +1020,8 @@ type_specifier
 type_specifier_list
     : type_specifier
     {
-        if ($1 == NULL)
-            $$ = NULL;
+        if ($1 == nullptr)
+            $$ = nullptr;
         else {
             std::vector<std::pair<const Type *, SourcePos> > *vec =
                 new std::vector<std::pair<const Type *, SourcePos> >;
@@ -1032,7 +1032,7 @@ type_specifier_list
     | type_specifier_list ',' type_specifier
     {
         $$ = $1;
-        if ($1 == NULL)
+        if ($1 == nullptr)
             Assert(m->errorCount > 0);
         else
             $$->push_back(std::make_pair($3, @3));
@@ -1058,7 +1058,7 @@ atomic_var_type_specifier
 short_vec_specifier
     : atomic_var_type_specifier '<' int_constant '>'
     {
-        $$ = $1 ? new VectorType($1, (int32_t)$3) : NULL;
+        $$ = $1 ? new VectorType($1, (int32_t)$3) : nullptr;
     }
     ;
 
@@ -1071,17 +1071,17 @@ struct_or_union_and_name
     : struct_or_union struct_or_union_name
       {
           const Type *st = m->symbolTable->LookupType($2);
-          if (st == NULL) {
+          if (st == nullptr) {
               st = new UndefinedStructType($2, Variability::Unbound, false, @2);
               m->symbolTable->AddType($2, st, @2);
               $$ = st;
           }
           else {
-              if (CastType<StructType>(st) == NULL &&
-                  CastType<UndefinedStructType>(st) == NULL) {
+              if (CastType<StructType>(st) == nullptr &&
+                  CastType<UndefinedStructType>(st) == nullptr) {
                   Error(@2, "Type \"%s\" is not a struct type! (%s)", $2,
                         st->GetString().c_str());
-                  $$ = NULL;
+                  $$ = nullptr;
               }
               else
                   $$ = st;
@@ -1093,7 +1093,7 @@ struct_or_union_specifier
     : struct_or_union_and_name
     | struct_or_union_and_name '{' struct_declaration_list '}'
       {
-          if ($3 != NULL) {
+          if ($3 != nullptr) {
               llvm::SmallVector<const Type *, 8> elementTypes;
               llvm::SmallVector<std::string, 8> elementNames;
               llvm::SmallVector<SourcePos, 8> elementPositions;
@@ -1109,11 +1109,11 @@ struct_or_union_specifier
               $$ = st;
           }
           else
-              $$ = NULL;
+              $$ = nullptr;
       }
     | struct_or_union '{' struct_declaration_list '}'
       {
-          if ($3 != NULL) {
+          if ($3 != nullptr) {
               llvm::SmallVector<const Type *, 8> elementTypes;
               llvm::SmallVector<std::string, 8> elementNames;
               llvm::SmallVector<SourcePos, 8> elementPositions;
@@ -1123,7 +1123,7 @@ struct_or_union_specifier
                                   false, Variability::Unbound, true, @1);
           }
           else
-              $$ = NULL;
+              $$ = nullptr;
       }
     | struct_or_union '{' '}'
       {
@@ -1157,18 +1157,18 @@ struct_declaration_list
     : struct_declaration
       {
           std::vector<StructDeclaration *> *sdl = new std::vector<StructDeclaration *>;
-          if ($1 != NULL)
+          if ($1 != nullptr)
               sdl->push_back($1);
           $$ = sdl;
       }
     | struct_declaration_list struct_declaration
       {
           std::vector<StructDeclaration *> *sdl = (std::vector<StructDeclaration *> *)$1;
-          if (sdl == NULL) {
+          if (sdl == nullptr) {
               AssertPos(@1, m->errorCount > 0);
               sdl = new std::vector<StructDeclaration *>;
           }
-          if ($2 != NULL)
+          if ($2 != nullptr)
               sdl->push_back($2);
           $$ = sdl;
       }
@@ -1176,7 +1176,7 @@ struct_declaration_list
 
 struct_declaration
     : specifier_qualifier_list struct_declarator_list ';'
-      { $$ = ($1 != NULL && $2 != NULL) ? new StructDeclaration($1, $2) : NULL; }
+      { $$ = ($1 != nullptr && $2 != nullptr) ? new StructDeclaration($1, $2) : nullptr; }
     ;
 
 specifier_qualifier_list
@@ -1185,11 +1185,11 @@ specifier_qualifier_list
     | short_vec_specifier
     | type_qualifier specifier_qualifier_list
     {
-        if ($2 != NULL) {
+        if ($2 != nullptr) {
             if ($1 == TYPEQUAL_UNIFORM) {
                 if ($2->IsVoidType()) {
                     Error(@1, "\"uniform\" qualifier is illegal with \"void\" type.");
-                    $$ = NULL;
+                    $$ = nullptr;
                 }
                 else
                     $$ = $2->GetAsUniformType();
@@ -1197,7 +1197,7 @@ specifier_qualifier_list
             else if ($1 == TYPEQUAL_VARYING) {
                 if ($2->IsVoidType()) {
                     Error(@1, "\"varying\" qualifier is illegal with \"void\" type.");
-                    $$ = NULL;
+                    $$ = nullptr;
                 }
                 else
                     $$ = $2->GetAsVaryingType();
@@ -1262,7 +1262,7 @@ specifier_qualifier_list
         else {
             if (m->errorCount == 0)
                 Error(@1, "Lost type qualifier in parser.");
-            $$ = NULL;
+            $$ = nullptr;
         }
     }
     ;
@@ -1272,18 +1272,18 @@ struct_declarator_list
     : struct_declarator
       {
           std::vector<Declarator *> *sdl = new std::vector<Declarator *>;
-          if ($1 != NULL)
+          if ($1 != nullptr)
               sdl->push_back($1);
           $$ = sdl;
       }
     | struct_declarator_list ',' struct_declarator
       {
           std::vector<Declarator *> *sdl = (std::vector<Declarator *> *)$1;
-          if (sdl == NULL) {
+          if (sdl == nullptr) {
               AssertPos(@1, m->errorCount > 0);
               sdl = new std::vector<Declarator *>;
           }
-          if ($3 != NULL)
+          if ($3 != nullptr)
               sdl->push_back($3);
           $$ = sdl;
       }
@@ -1303,7 +1303,7 @@ enum_identifier
 enum_specifier
     : TOKEN_ENUM '{' enumerator_list '}'
       {
-          $$ = lCreateEnumType(NULL, $3, @1);
+          $$ = lCreateEnumType(nullptr, $3, @1);
       }
     | TOKEN_ENUM enum_identifier '{' enumerator_list '}'
       {
@@ -1311,7 +1311,7 @@ enum_specifier
       }
     | TOKEN_ENUM '{' enumerator_list ',' '}'
       {
-          $$ = lCreateEnumType(NULL, $3, @1);
+          $$ = lCreateEnumType(nullptr, $3, @1);
       }
     | TOKEN_ENUM enum_identifier '{' enumerator_list ',' '}'
       {
@@ -1320,18 +1320,18 @@ enum_specifier
     | TOKEN_ENUM enum_identifier
       {
           const Type *type = m->symbolTable->LookupType($2);
-          if (type == NULL) {
+          if (type == nullptr) {
               std::vector<std::string> alternates = m->symbolTable->ClosestEnumTypeMatch($2);
               std::string alts = lGetAlternates(alternates);
               Error(@2, "Enum type \"%s\" unknown.%s", $2, alts.c_str());
-              $$ = NULL;
+              $$ = nullptr;
           }
           else {
               const EnumType *enumType = CastType<EnumType>(type);
-              if (enumType == NULL) {
+              if (enumType == nullptr) {
                   Error(@2, "Type \"%s\" is not an enum type (%s).", $2,
                         type->GetString().c_str());
-                  $$ = NULL;
+                  $$ = nullptr;
               }
               else
                   $$ = enumType;
@@ -1342,8 +1342,8 @@ enum_specifier
 enumerator_list
     : enumerator
       {
-          if ($1 == NULL)
-              $$ = NULL;
+          if ($1 == nullptr)
+              $$ = nullptr;
           else {
               std::vector<Symbol *> *el = new std::vector<Symbol *>;
               el->push_back($1);
@@ -1353,11 +1353,11 @@ enumerator_list
     | enumerator_list ',' enumerator
       {
           std::vector<Symbol *> *symList = $1;
-          if (symList == NULL) {
+          if (symList == nullptr) {
               AssertPos(@1, m->errorCount > 0);
               symList = new std::vector<Symbol *>;
           }
-          if ($3 != NULL)
+          if ($3 != nullptr)
               symList->push_back($3);
           $$ = symList;
       }
@@ -1371,7 +1371,7 @@ enumerator
     | enum_identifier '=' constant_expression
       {
           int value;
-          if ($1 != NULL && $3 != NULL &&
+          if ($1 != nullptr && $3 != nullptr &&
               lGetConstantInt($3, &value, @3, "Enumerator value")) {
               Symbol *sym = new Symbol($1, @1);
               sym->constValue = new ConstExpr(AtomicType::UniformUInt32->GetAsConstType(),
@@ -1379,7 +1379,7 @@ enumerator
               $$ = sym;
           }
           else
-              $$ = NULL;
+              $$ = nullptr;
       }
     ;
 
@@ -1412,27 +1412,27 @@ type_qualifier_list
 declarator
     : pointer direct_declarator
     {
-        if ($1 != NULL) {
+        if ($1 != nullptr) {
             Declarator *tail = $1;
-            while (tail->child != NULL)
+            while (tail->child != nullptr)
                tail = tail->child;
             tail->child = $2;
             $$ = $1;
         }
         else
-            $$ = NULL;
+            $$ = nullptr;
     }
     | reference direct_declarator
     {
-        if ($1 != NULL) {
+        if ($1 != nullptr) {
             Declarator *tail = $1;
-            while (tail->child != NULL)
+            while (tail->child != nullptr)
                tail = tail->child;
             tail->child = $2;
             $$ = $1;
         }
         else
-            $$ = NULL;
+            $$ = nullptr;
     }
     | direct_declarator
     ;
@@ -1466,10 +1466,10 @@ direct_declarator
     | direct_declarator '[' constant_expression ']'
     {
         int size;
-        if ($1 != NULL && lGetConstantInt($3, &size, @3, "Array dimension")) {
+        if ($1 != nullptr && lGetConstantInt($3, &size, @3, "Array dimension")) {
             if (size < 0) {
                 Error(@3, "Array dimension must be non-negative.");
-                $$ = NULL;
+                $$ = nullptr;
             }
             else {
                 Declarator *d = new Declarator(DK_ARRAY, Union(@1, @4));
@@ -1479,48 +1479,48 @@ direct_declarator
             }
         }
         else
-            $$ = NULL;
+            $$ = nullptr;
     }
     | direct_declarator '[' ']'
     {
-        if ($1 != NULL) {
+        if ($1 != nullptr) {
             Declarator *d = new Declarator(DK_ARRAY, Union(@1, @3));
             d->arraySize = 0; // unsize
             d->child = $1;
             $$ = d;
         }
         else
-            $$ = NULL;
+            $$ = nullptr;
     }
     | direct_declarator '[' error ']'
     {
-         $$ = NULL;
+         $$ = nullptr;
     }
     | direct_declarator '(' parameter_type_list ')'
       {
-          if ($1 != NULL) {
+          if ($1 != nullptr) {
               Declarator *d = new Declarator(DK_FUNCTION, Union(@1, @4));
               d->child = $1;
-              if ($3 != NULL)
+              if ($3 != nullptr)
                   d->functionParams = *$3;
               $$ = d;
           }
           else
-              $$ = NULL;
+              $$ = nullptr;
       }
     | direct_declarator '(' ')'
       {
-          if ($1 != NULL) {
+          if ($1 != nullptr) {
               Declarator *d = new Declarator(DK_FUNCTION, Union(@1, @3));
               d->child = $1;
               $$ = d;
           }
           else
-              $$ = NULL;
+              $$ = nullptr;
       }
     | direct_declarator '(' error ')'
     {
-        $$ = NULL;
+        $$ = nullptr;
     }
     ;
 
@@ -1568,23 +1568,23 @@ parameter_list
     : parameter_declaration
     {
         std::vector<Declaration *> *dl = new std::vector<Declaration *>;
-        if ($1 != NULL)
+        if ($1 != nullptr)
             dl->push_back($1);
         $$ = dl;
     }
     | parameter_list ',' parameter_declaration
     {
         std::vector<Declaration *> *dl = (std::vector<Declaration *> *)$1;
-        if (dl == NULL)
+        if (dl == nullptr)
             dl = new std::vector<Declaration *>;
-        if ($3 != NULL)
+        if ($3 != nullptr)
             dl->push_back($3);
         $$ = dl;
     }
     | error ','
     {
         lSuggestParamListAlternates();
-        $$ = NULL;
+        $$ = nullptr;
     }
     ;
 
@@ -1595,24 +1595,24 @@ parameter_declaration
     }
     | declaration_specifiers declarator '=' initializer
     {
-        if ($1 != NULL && $2 != NULL) {
+        if ($1 != nullptr && $2 != nullptr) {
             $2->initExpr = $4;
             $$ = new Declaration($1, $2);
         }
         else
-            $$ = NULL;
+            $$ = nullptr;
     }
     | declaration_specifiers abstract_declarator
     {
-        if ($1 != NULL && $2 != NULL)
+        if ($1 != nullptr && $2 != nullptr)
             $$ = new Declaration($1, $2);
         else
-            $$ = NULL;
+            $$ = nullptr;
     }
     | declaration_specifiers
     {
-        if ($1 == NULL)
-            $$ = NULL;
+        if ($1 == nullptr)
+            $$ = nullptr;
         else
             $$ = new Declaration($1);
     }
@@ -1629,10 +1629,10 @@ type_name
     : specifier_qualifier_list
     | specifier_qualifier_list abstract_declarator
     {
-        if ($1 == NULL || $2 == NULL)
-            $$ = NULL;
+        if ($1 == nullptr || $2 == nullptr)
+            $$ = nullptr;
         else {
-            $2->InitFromType($1, NULL);
+            $2->InitFromType($1, nullptr);
             $$ = $2->type;
         }
     }
@@ -1646,8 +1646,8 @@ abstract_declarator
     | direct_abstract_declarator
     | pointer direct_abstract_declarator
       {
-          if ($2 == NULL)
-              $$ = NULL;
+          if ($2 == nullptr)
+              $$ = nullptr;
           else {
               Declarator *d = new Declarator(DK_POINTER, Union(@1, @2));
               d->child = $2;
@@ -1660,8 +1660,8 @@ abstract_declarator
       }
     | reference direct_abstract_declarator
       {
-          if ($2 == NULL)
-              $$ = NULL;
+          if ($2 == nullptr)
+              $$ = nullptr;
           else {
               Declarator *d = new Declarator(DK_REFERENCE, Union(@1, @2));
               d->child = $2;
@@ -1682,10 +1682,10 @@ direct_abstract_declarator
     | '[' constant_expression ']'
       {
         int size;
-        if ($2 != NULL && lGetConstantInt($2, &size, @2, "Array dimension")) {
+        if ($2 != nullptr && lGetConstantInt($2, &size, @2, "Array dimension")) {
             if (size < 0) {
                 Error(@2, "Array dimension must be non-negative.");
-                $$ = NULL;
+                $$ = nullptr;
             }
             else {
                 Declarator *d = new Declarator(DK_ARRAY, Union(@1, @3));
@@ -1694,12 +1694,12 @@ direct_abstract_declarator
             }
         }
         else
-            $$ = NULL;
+            $$ = nullptr;
       }
     | direct_abstract_declarator '[' ']'
       {
-          if ($1 == NULL)
-              $$ = NULL;
+          if ($1 == nullptr)
+              $$ = nullptr;
           else {
               Declarator *d = new Declarator(DK_ARRAY, Union(@1, @3));
               d->arraySize = 0;
@@ -1710,10 +1710,10 @@ direct_abstract_declarator
     | direct_abstract_declarator '[' constant_expression ']'
       {
           int size;
-          if ($1 != NULL && $3 != NULL && lGetConstantInt($3, &size, @3, "Array dimension")) {
+          if ($1 != nullptr && $3 != nullptr && lGetConstantInt($3, &size, @3, "Array dimension")) {
               if (size < 0) {
                   Error(@3, "Array dimension must be non-negative.");
-                  $$ = NULL;
+                  $$ = nullptr;
               }
               else {
                   Declarator *d = new Declarator(DK_ARRAY, Union(@1, @4));
@@ -1723,20 +1723,20 @@ direct_abstract_declarator
               }
           }
           else
-              $$ = NULL;
+              $$ = nullptr;
       }
     | '(' ')'
       { $$ = new Declarator(DK_FUNCTION, Union(@1, @2)); }
     | '(' parameter_type_list ')'
       {
           Declarator *d = new Declarator(DK_FUNCTION, Union(@1, @3));
-          if ($2 != NULL) d->functionParams = *$2;
+          if ($2 != nullptr) d->functionParams = *$2;
           $$ = d;
       }
     | direct_abstract_declarator '(' ')'
       {
-          if ($1 == NULL)
-              $$ = NULL;
+          if ($1 == nullptr)
+              $$ = nullptr;
           else {
               Declarator *d = new Declarator(DK_FUNCTION, Union(@1, @3));
               d->child = $1;
@@ -1745,12 +1745,12 @@ direct_abstract_declarator
       }
     | direct_abstract_declarator '(' parameter_type_list ')'
       {
-          if ($1 == NULL)
-              $$ = NULL;
+          if ($1 == nullptr)
+              $$ = nullptr;
           else {
               Declarator *d = new Declarator(DK_FUNCTION, Union(@1, @4));
               d->child = $1;
-              if ($3 != NULL) d->functionParams = *$3;
+              if ($3 != nullptr) d->functionParams = *$3;
               $$ = d;
           }
       }
@@ -1768,7 +1768,7 @@ initializer_list
     | initializer_list ',' initializer
       {
           ExprList *exprList = $1;
-          if (exprList == NULL) {
+          if (exprList == nullptr) {
               AssertPos(@1, m->errorCount > 0);
               exprList = new ExprList(@3);
           }
@@ -1788,7 +1788,7 @@ pragma
 attributed_statement
     : pragma attributed_statement
     {
-        if (($1->aType == PragmaAttributes::AttributeType::pragmaloop) && ($2 != NULL)) {
+        if (($1->aType == PragmaAttributes::AttributeType::pragmaloop) && ($2 != nullptr)) {
             std::pair<Globals::pragmaUnrollType, int> unrollVal = std::pair<Globals::pragmaUnrollType, int>($1->unrollType, $1->count);
             $2->SetLoopAttribute(unrollVal);
         }
@@ -1813,7 +1813,7 @@ statement
     | error ';'
     {
         lSuggestBuiltinAlternates();
-        $$ = NULL;
+        $$ = nullptr;
     }
     ;
 
@@ -1825,12 +1825,12 @@ labeled_statement
     | TOKEN_CASE constant_expression ':' attributed_statement
       {
           int value;
-          if ($2 != NULL &&
+          if ($2 != nullptr &&
               lGetConstantInt($2, &value, @2, "Case statement value")) {
               $$ = new CaseStmt(value, $4, Union(@1, @2));
           }
           else
-              $$ = NULL;
+              $$ = nullptr;
       }
     | TOKEN_DEFAULT ':' attributed_statement
       { $$ = new DefaultStmt($3, @1); }
@@ -1845,7 +1845,7 @@ end_scope
     ;
 
 compound_statement
-    : '{' '}' { $$ = NULL; }
+    : '{' '}' { $$ = nullptr; }
     | start_scope statement_list end_scope { $$ = $2; }
     ;
 
@@ -1859,7 +1859,7 @@ statement_list
     | statement_list attributed_statement
       {
           StmtList *sl = (StmtList *)$1;
-          if (sl == NULL) {
+          if (sl == nullptr) {
               AssertPos(@1, m->errorCount > 0);
               sl = new StmtList(@2);
           }
@@ -1869,17 +1869,17 @@ statement_list
     ;
 
 expression_statement
-    : ';' { $$ = NULL; }
-    | expression ';' { $$ = $1 ? new ExprStmt($1, @1) : NULL; }
+    : ';' { $$ = nullptr; }
+    | expression ';' { $$ = $1 ? new ExprStmt($1, @1) : nullptr; }
     ;
 
 selection_statement
     : TOKEN_IF '(' expression ')' attributed_statement
-      { $$ = new IfStmt($3, $5, NULL, false, @1); }
+      { $$ = new IfStmt($3, $5, nullptr, false, @1); }
     | TOKEN_IF '(' expression ')' attributed_statement TOKEN_ELSE attributed_statement
       { $$ = new IfStmt($3, $5, $7, false, @1); }
     | TOKEN_CIF '(' expression ')' attributed_statement
-      { $$ = new IfStmt($3, $5, NULL, true, @1); }
+      { $$ = new IfStmt($3, $5, nullptr, true, @1); }
     | TOKEN_CIF '(' expression ')' attributed_statement TOKEN_ELSE attributed_statement
       { $$ = new IfStmt($3, $5, $7, true, @1); }
     | TOKEN_SWITCH '(' expression ')' attributed_statement
@@ -1888,7 +1888,7 @@ selection_statement
 
 for_test
     : ';'
-      { $$ = NULL; }
+      { $$ = nullptr; }
     | expression ';'
       { $$ = $1; }
     ;
@@ -1971,11 +1971,11 @@ foreach_dimension_list
     | foreach_dimension_list ',' foreach_dimension_specifier
     {
         std::vector<ForeachDimension *> *dv = $1;
-        if (dv == NULL) {
+        if (dv == nullptr) {
             AssertPos(@1, m->errorCount > 0);
             dv = new std::vector<ForeachDimension *>;
         }
-        if ($3 != NULL)
+        if ($3 != nullptr)
             dv->push_back($3);
         $$ = dv;
     }
@@ -1991,15 +1991,15 @@ foreach_unique_identifier
 
 iteration_statement
     : TOKEN_WHILE '(' expression ')' attributed_statement
-      { $$ = new ForStmt(NULL, $3, NULL, $5, false, @1); }
+      { $$ = new ForStmt(nullptr, $3, nullptr, $5, false, @1); }
     | TOKEN_CWHILE '(' expression ')' attributed_statement
-      { $$ = new ForStmt(NULL, $3, NULL, $5, true, @1); }
+      { $$ = new ForStmt(nullptr, $3, nullptr, $5, true, @1); }
     | TOKEN_DO attributed_statement TOKEN_WHILE '(' expression ')' ';'
       { $$ = new DoStmt($5, $2, false, @1); }
     | TOKEN_CDO attributed_statement TOKEN_WHILE '(' expression ')' ';'
       { $$ = new DoStmt($5, $2, true, @1); }
     | for_scope '(' for_init_statement for_test ')' attributed_statement
-      { $$ = new ForStmt($3, $4, NULL, $6, false, @1);
+      { $$ = new ForStmt($3, $4, nullptr, $6, false, @1);
         m->symbolTable->PopScope();
       }
     | for_scope '(' for_init_statement for_test expression ')' attributed_statement
@@ -2007,7 +2007,7 @@ iteration_statement
         m->symbolTable->PopScope();
       }
     | cfor_scope '(' for_init_statement for_test ')' attributed_statement
-      { $$ = new ForStmt($3, $4, NULL, $6, true, @1);
+      { $$ = new ForStmt($3, $4, nullptr, $6, true, @1);
         m->symbolTable->PopScope();
       }
     | cfor_scope '(' for_init_statement for_test expression ')' attributed_statement
@@ -2017,7 +2017,7 @@ iteration_statement
     | foreach_scope '(' foreach_dimension_list ')'
      {
          std::vector<ForeachDimension *> *dims = $3;
-         if (dims == NULL) {
+         if (dims == nullptr) {
              AssertPos(@3, m->errorCount > 0);
              dims = new std::vector<ForeachDimension *>;
          }
@@ -2027,7 +2027,7 @@ iteration_statement
      attributed_statement
      {
          std::vector<ForeachDimension *> *dims = $3;
-         if (dims == NULL) {
+         if (dims == nullptr) {
              AssertPos(@3, m->errorCount > 0);
              dims = new std::vector<ForeachDimension *>;
          }
@@ -2045,7 +2045,7 @@ iteration_statement
     | foreach_tiled_scope '(' foreach_dimension_list ')'
      {
          std::vector<ForeachDimension *> *dims = $3;
-         if (dims == NULL) {
+         if (dims == nullptr) {
              AssertPos(@3, m->errorCount > 0);
              dims = new std::vector<ForeachDimension *>;
          }
@@ -2056,7 +2056,7 @@ iteration_statement
      attributed_statement
      {
          std::vector<ForeachDimension *> *dims = $3;
-         if (dims == NULL) {
+         if (dims == nullptr) {
              AssertPos(@1, m->errorCount > 0);
              dims = new std::vector<ForeachDimension *>;
          }
@@ -2073,7 +2073,7 @@ iteration_statement
      }
     | foreach_active_scope '(' foreach_active_identifier ')'
      {
-         if ($3 != NULL)
+         if ($3 != nullptr)
              m->symbolTable->AddVariable($3);
      }
      attributed_statement
@@ -2086,9 +2086,9 @@ iteration_statement
      {
          Expr *expr = $5;
          const Type *type;
-         if (expr != NULL &&
-             (expr = TypeCheck(expr)) != NULL &&
-             (type = expr->GetType()) != NULL) {
+         if (expr != nullptr &&
+             (expr = TypeCheck(expr)) != nullptr &&
+             (type = expr->GetType()) != nullptr) {
              const Type *iterType = type->GetAsUniformType()->GetAsConstType();
              Symbol *sym = new Symbol($3, @3, iterType);
              m->symbolTable->AddVariable(sym);
@@ -2113,7 +2113,7 @@ jump_statement
     | TOKEN_BREAK ';'
       { $$ = new BreakStmt(@1); }
     | TOKEN_RETURN ';'
-      { $$ = new ReturnStmt(NULL, @1); }
+      { $$ = new ReturnStmt(nullptr, @1); }
     | TOKEN_RETURN expression ';'
       { $$ = new ReturnStmt($2, @1); }
     ;
@@ -2140,7 +2140,7 @@ unmasked_statement
 print_statement
     : TOKEN_PRINT '(' string_constant ')' ';'
       {
-           $$ = new PrintStmt(*$3, NULL, @1);
+           $$ = new PrintStmt(*$3, nullptr, @1);
       }
     | TOKEN_PRINT '(' string_constant ',' argument_expression_list ')' ';'
       {
@@ -2170,12 +2170,12 @@ external_declaration
     | TOKEN_EXTERN TOKEN_STRING_SYCL_LITERAL '{' declaration '}'
     | TOKEN_EXPORT '{' type_specifier_list '}' ';'
     {
-        if ($3 != NULL)
+        if ($3 != nullptr)
             m->AddExportedTypes(*$3);
     }
     | declaration
     {
-        if ($1 != NULL)
+        if ($1 != nullptr)
             for (unsigned int i = 0; i < $1->declarators.size(); ++i)
                 lAddDeclaration($1->declSpecs, $1->declarators[i]);
     }
@@ -2194,17 +2194,17 @@ function_definition
     }
     compound_statement
     {
-        if ($2 != NULL) {
+        if ($2 != nullptr) {
             // FIXME: Next list is redundant, as it's done in lAddDeclaration()
             $2->InitFromDeclSpecs($1);
             const FunctionType *funcType = CastType<FunctionType>($2->type);
-            if (funcType == NULL)
+            if (funcType == nullptr)
                 AssertPos(@1, m->errorCount > 0);
             else if ($1->storageClass == SC_TYPEDEF)
                 Error(@1, "Illegal \"typedef\" provided with function definition.");
             else {
                 Stmt *code = $4;
-                if (code == NULL) code = new StmtList(@4);
+                if (code == nullptr) code = new StmtList(@4);
                 m->AddFunctionDefinition($2->name, funcType, code);
             }
         }
@@ -2259,11 +2259,11 @@ template_parameter_list
     | template_parameter_list ',' template_parameter
       {
           TemplateParms *list = (TemplateParms *) $1;
-          if (list == NULL) {
+          if (list == nullptr) {
               AssertPos(@1, m->errorCount > 0);
               list = new TemplateParms();
           }
-          if ($3 != NULL) {
+          if ($3 != nullptr) {
               list->Add($3);
           }
           $$ = list;
@@ -2314,9 +2314,9 @@ template_function_declaration_or_definition
       }
     | template_declaration compound_statement
       {
-          if ($1 != NULL) {
+          if ($1 != nullptr) {
               Stmt *code = $2;
-              if (code == NULL) code = new StmtList(@2);
+              if (code == nullptr) code = new StmtList(@2);
               m->AddFunctionTemplateDefinition($1->templateParms, $1->name, $1->type, code);
           }
 
@@ -2377,7 +2377,7 @@ template_function_instantiation
           // Function declarator
           Declarator *d = new Declarator(DK_FUNCTION, Union(@1, @6));
           d->child = simpleTemplID->first;
-          if ($5 != NULL) {
+          if ($5 != nullptr) {
               d->functionParams = *$5;
           }
 
@@ -2433,7 +2433,7 @@ lYYTNameErr (char *yyres, const char *yystr)
   Assert(tokenNameRemap.size() > 0);
   if (tokenNameRemap.find(yystr) != tokenNameRemap.end()) {
       std::string n = tokenNameRemap[yystr];
-      if (yyres == NULL)
+      if (yyres == nullptr)
           return n.size();
       else
           return yystpcpy(yyres, n.c_str()) - yyres;
@@ -2507,7 +2507,7 @@ lSuggestParamListAlternates() {
 
 static void
 lAddDeclaration(DeclSpecs *ds, Declarator *decl) {
-    if (ds == NULL || decl == NULL)
+    if (ds == nullptr || decl == nullptr)
         // Error happened earlier during parsing
         return;
 
@@ -2515,7 +2515,7 @@ lAddDeclaration(DeclSpecs *ds, Declarator *decl) {
     if (ds->storageClass == SC_TYPEDEF)
         m->AddTypeDef(decl->name, decl->type, decl->pos);
     else {
-        if (decl->type == NULL) {
+        if (decl->type == nullptr) {
             Assert(m->errorCount > 0);
             return;
         }
@@ -2523,7 +2523,7 @@ lAddDeclaration(DeclSpecs *ds, Declarator *decl) {
         decl->type = decl->type->ResolveUnboundVariability(Variability::Varying);
 
         const FunctionType *ft = CastType<FunctionType>(decl->type);
-        if (ft != NULL) {
+        if (ft != nullptr) {
             bool isInline = (ds->typeQualifiers & TYPEQUAL_INLINE);
             bool isNoInline = (ds->typeQualifiers & TYPEQUAL_NOINLINE);
             bool isVectorCall = (ds->typeQualifiers & TYPEQUAL_VECTORCALL);
@@ -2541,7 +2541,7 @@ lAddDeclaration(DeclSpecs *ds, Declarator *decl) {
 
 static void
 lAddTemplateDeclaration(TemplateParms *templateParmList, DeclSpecs *ds, Declarator *decl) {
-    if (ds == NULL || decl == NULL)
+    if (ds == nullptr || decl == nullptr)
         // Error happened earlier during parsing
         return;
 
@@ -2551,7 +2551,7 @@ lAddTemplateDeclaration(TemplateParms *templateParmList, DeclSpecs *ds, Declarat
         Error(decl->pos, "Illegal \"typedef\" provided with function template.");
         return;
     } else {
-        if (decl->type == NULL) {
+        if (decl->type == nullptr) {
             Assert(m->errorCount > 0);
             return;
         }
@@ -2559,7 +2559,7 @@ lAddTemplateDeclaration(TemplateParms *templateParmList, DeclSpecs *ds, Declarat
         //decl->type = decl->type->ResolveUnboundVariability(Variability::Varying);
 
         const FunctionType *ft = CastType<FunctionType>(decl->type);
-        if (ft != NULL) {
+        if (ft != nullptr) {
             bool isInline = (ds->typeQualifiers & TYPEQUAL_INLINE);
             bool isNoInline = (ds->typeQualifiers & TYPEQUAL_NOINLINE);
             bool isVectorCall = (ds->typeQualifiers & TYPEQUAL_VECTORCALL);
@@ -2581,12 +2581,12 @@ lAddFunctionParams(Declarator *decl) {
     // It's responsibility of the caller to create a new symbol table scope.
     // For regular functions, the scope starts before function parameters.
     // For template functions, the scope starts before template parameters.
-    if (decl == NULL) {
+    if (decl == nullptr) {
         return;
     }
 
     // walk down to the declarator for the function itself
-    while (decl->kind != DK_FUNCTION && decl->child != NULL)
+    while (decl->kind != DK_FUNCTION && decl->child != nullptr)
         decl = decl->child;
     if (decl->kind != DK_FUNCTION) {
         AssertPos(decl->pos, m->errorCount > 0);
@@ -2596,9 +2596,9 @@ lAddFunctionParams(Declarator *decl) {
     // now loop over its parameters and add them to the symbol table
     for (unsigned int i = 0; i < decl->functionParams.size(); ++i) {
         Declaration *pdecl = decl->functionParams[i];
-        Assert(pdecl != NULL && pdecl->declarators.size() == 1);
+        Assert(pdecl != nullptr && pdecl->declarators.size() == 1);
         Declarator *declarator = pdecl->declarators[0];
-        if (declarator == NULL)
+        if (declarator == nullptr)
             AssertPos(decl->pos, m->errorCount > 0);
         else {
             Symbol *sym = new Symbol(declarator->name, declarator->pos,
@@ -2620,7 +2620,7 @@ lAddFunctionParams(Declarator *decl) {
 
 /** Add a symbol for the built-in mask variable to the symbol table */
 static void lAddMaskToSymbolTable(SourcePos pos) {
-    const Type *t = NULL;
+    const Type *t = nullptr;
     switch (g->target->getMaskBitCount()) {
     case 1:
         t = AtomicType::VaryingBool;
@@ -2725,24 +2725,24 @@ lGetStorageClassString(StorageClass sc) {
 */
 static bool
 lGetConstantInt(Expr *expr, int *value, SourcePos pos, const char *usage) {
-    if (expr == NULL)
+    if (expr == nullptr)
         return false;
     expr = TypeCheck(expr);
-    if (expr == NULL)
+    if (expr == nullptr)
         return false;
     expr = Optimize(expr);
-    if (expr == NULL)
+    if (expr == nullptr)
         return false;
 
     std::pair<llvm::Constant *, bool> cValPair = expr->GetConstant(expr->GetType());
     llvm::Constant *cval = cValPair.first;
-    if (cval == NULL) {
+    if (cval == nullptr) {
         Error(pos, "%s must be a compile-time constant.", usage);
         return false;
     }
     else {
         llvm::ConstantInt *ci = llvm::dyn_cast<llvm::ConstantInt>(cval);
-        if (ci == NULL) {
+        if (ci == nullptr) {
             Error(pos, "%s must be a compile-time integer constant.", usage);
             return false;
         }
@@ -2762,11 +2762,11 @@ lGetConstantInt(Expr *expr, int *value, SourcePos pos, const char *usage) {
 
 static EnumType *
 lCreateEnumType(const char *name, std::vector<Symbol *> *enums, SourcePos pos) {
-    if (enums == NULL)
-        return NULL;
+    if (enums == nullptr)
+        return nullptr;
 
     EnumType *enumType = name ? new EnumType(name, pos) : new EnumType(pos);
-    if (name != NULL)
+    if (name != nullptr)
         m->symbolTable->AddType(name, enumType, pos);
 
     lFinalizeEnumeratorSymbols(*enums, enumType);
@@ -2798,7 +2798,7 @@ lFinalizeEnumeratorSymbols(std::vector<Symbol *> &enums,
 
     for (unsigned int i = 0; i < enums.size(); ++i) {
         enums[i]->type = enumType;
-        if (enums[i]->constValue != NULL) {
+        if (enums[i]->constValue != nullptr) {
             /* Already has a value, so first update nextVal with it. */
             int count = enums[i]->constValue->GetValues(&nextVal);
             AssertPos(enums[i]->pos, count == 1);
@@ -2814,7 +2814,7 @@ lFinalizeEnumeratorSymbols(std::vector<Symbol *> &enums,
                                               enums[i]->pos);
             castExpr = Optimize(castExpr);
             enums[i]->constValue = llvm::dyn_cast<ConstExpr>(castExpr);
-            AssertPos(enums[i]->pos, enums[i]->constValue != NULL);
+            AssertPos(enums[i]->pos, enums[i]->constValue != nullptr);
         }
         else {
             enums[i]->constValue = new ConstExpr(enumType, nextVal++,

--- a/src/stmt.h
+++ b/src/stmt.h
@@ -62,7 +62,7 @@ class ExprStmt : public Stmt {
 };
 
 struct VariableDeclaration {
-    VariableDeclaration(Symbol *s = NULL, Expr *i = NULL) {
+    VariableDeclaration(Symbol *s = nullptr, Expr *i = nullptr) {
         sym = s;
         init = i;
     }
@@ -177,7 +177,7 @@ class ForStmt : public Stmt {
     int EstimateCost() const;
     ForStmt *Instantiate(TemplateInstantiation &templInst) const;
 
-    /** 'for' statment initializer; may be NULL, indicating no intitializer */
+    /** 'for' statment initializer; may be nullptr, indicating no intitializer */
     Stmt *init;
     /** expression that returns a value indicating whether the loop should
         continue for the next iteration */

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -25,8 +25,8 @@ using namespace ispc;
 // Symbol
 
 Symbol::Symbol(const std::string &n, SourcePos p, const Type *t, StorageClass sc)
-    : pos(p), name(n), storageInfo(NULL), function(NULL), exportedFunction(NULL), type(t), constValue(NULL),
-      storageClass(sc), varyingCFDepth(0), parentFunction(NULL) {}
+    : pos(p), name(n), storageInfo(nullptr), function(nullptr), exportedFunction(nullptr), type(t), constValue(nullptr),
+      storageClass(sc), varyingCFDepth(0), parentFunction(nullptr) {}
 
 ///////////////////////////////////////////////////////////////////////////
 // TemplateSymbol
@@ -68,7 +68,7 @@ void SymbolTable::PopScope() {
 }
 
 bool SymbolTable::AddVariable(Symbol *symbol) {
-    Assert(symbol != NULL);
+    Assert(symbol != nullptr);
 
     // Check to see if a symbol of the same name has already been declared.
     for (int i = (int)variables.size() - 1; i >= 0; --i) {
@@ -105,13 +105,13 @@ Symbol *SymbolTable::LookupVariable(const char *name) {
         if (iter != sm.end())
             return iter->second;
     }
-    return NULL;
+    return nullptr;
 }
 
 bool SymbolTable::AddFunction(Symbol *symbol) {
     const FunctionType *ft = CastType<FunctionType>(symbol->type);
-    Assert(ft != NULL);
-    if (LookupFunction(symbol->name.c_str(), ft) != NULL)
+    Assert(ft != nullptr);
+    if (LookupFunction(symbol->name.c_str(), ft) != nullptr)
         // A function of the same name and type has already been added to
         // the symbol table
         return false;
@@ -124,7 +124,7 @@ bool SymbolTable::AddFunction(Symbol *symbol) {
 bool SymbolTable::LookupFunction(const char *name, std::vector<Symbol *> *matches) {
     FunctionMapType::iterator iter = functions.find(name);
     if (iter != functions.end()) {
-        if (matches == NULL)
+        if (matches == nullptr)
             return true;
         else {
             const std::vector<Symbol *> &funcs = iter->second;
@@ -144,11 +144,11 @@ Symbol *SymbolTable::LookupFunction(const char *name, const FunctionType *type) 
                 return funcs[j];
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 bool SymbolTable::AddIntrinsics(Symbol *symbol) {
-    if (LookupIntrinsics(symbol->function) != NULL) {
+    if (LookupIntrinsics(symbol->function) != nullptr) {
         // A function of the same type has already been added to
         // the symbol table
         return false;
@@ -212,7 +212,7 @@ TemplateSymbol *SymbolTable::LookupFunctionTemplate(const TemplateParms *templat
 
 bool SymbolTable::AddType(const char *name, const Type *type, SourcePos pos) {
     const Type *t = LookupLocalType(name);
-    if (t != NULL && CastType<UndefinedStructType>(t) == NULL) {
+    if (t != nullptr && CastType<UndefinedStructType>(t) == nullptr) {
         // If we have a previous declaration of anything other than an
         // UndefinedStructType with this struct name, issue an error.  If
         // we have an UndefinedStructType, then we'll fall through to the
@@ -382,7 +382,7 @@ inline int ispcRand() {
 Symbol *SymbolTable::RandomSymbol() {
     int v = ispcRand() % variables.size();
     if (variables[v]->size() == 0)
-        return NULL;
+        return nullptr;
     int count = ispcRand() % variables[v]->size();
     SymbolMapType::iterator iter = variables[v]->begin();
     while (count-- > 0) {

--- a/src/sym.h
+++ b/src/sym.h
@@ -40,7 +40,7 @@ class Symbol {
   public:
     /** The Symbol constructor takes the name of the symbol, its
         position in a source file, and its type (if known). */
-    Symbol(const std::string &name, SourcePos pos, const Type *t = NULL, StorageClass sc = SC_NONE);
+    Symbol(const std::string &name, SourcePos pos, const Type *t = nullptr, StorageClass sc = SC_NONE);
 
     SourcePos pos;            /*!< Source file position where the symbol was defined */
     std::string name;         /*!< Symbol's name */
@@ -61,9 +61,9 @@ class Symbol {
                                     declaration around the symbol has been parsed.  */
     ConstExpr *constValue;     /*!< For symbols with const-qualified types, this may store
                                     the symbol's compile-time constant value.  This value may
-                                    validly be NULL for a const-qualified type, however; for
+                                    validly be nullptr for a const-qualified type, however; for
                                     example, the ConstExpr class can't currently represent
-                                    struct types.  For cases like these, ConstExpr is NULL,
+                                    struct types.  For cases like these, ConstExpr is nullptr,
                                     though for all const symbols, the value pointed to by the
                                     storageInfo pointer member will be its constant value.  (This
                                     messiness is due to needing an ispc ConstExpr for the early
@@ -148,7 +148,7 @@ class SymbolTable {
         returning the first match found.
 
         @param  name The name of the variable to be searched for.
-        @return A pointer to the Symbol, if a match is found.  NULL if no
+        @return A pointer to the Symbol, if a match is found.  nullptr if no
         Symbol with the given name is in the symbol table. */
     Symbol *LookupVariable(const char *name);
 
@@ -166,7 +166,7 @@ class SymbolTable {
         be returned in the provided vector and it's up the the caller to
         resolve which one (if any) to use.  Returns true if any matches
         were found. */
-    bool LookupFunction(const char *name, std::vector<Symbol *> *matches = NULL);
+    bool LookupFunction(const char *name, std::vector<Symbol *> *matches = nullptr);
 
     /** Adds the given function symbol for LLVM intrinsic to the symbol table.
         @param symbol The function symbol to be added.
@@ -178,13 +178,13 @@ class SymbolTable {
 
     /** Looks for a LLVM intrinsic function in the symbol table.
 
-        @return pointer to matching Symbol; NULL if none is found. */
+        @return pointer to matching Symbol; nullptr if none is found. */
     Symbol *LookupIntrinsics(llvm::Function *func);
 
     /** Looks for a function with the given name and type
         in the symbol table.
 
-        @return pointer to matching Symbol; NULL if none is found. */
+        @return pointer to matching Symbol; nullptr if none is found. */
     Symbol *LookupFunction(const char *name, const FunctionType *type);
 
     /** Adds the given function template to the symbol table.
@@ -206,7 +206,7 @@ class SymbolTable {
     /** Looks for a function template with the given name and type
         in the symbol table.
 
-        @return pointer to matching FunctionTemplate; NULL if none is found. */
+        @return pointer to matching FunctionTemplate; nullptr if none is found. */
     TemplateSymbol *LookupFunctionTemplate(const TemplateParms *templateParmList, const std::string &name,
                                            const FunctionType *type);
 
@@ -248,7 +248,7 @@ class SymbolTable {
 
     /** Looks for a type of the given name in the symbol table.
 
-        @return Pointer to the Type, if found; otherwise NULL is returned.
+        @return Pointer to the Type, if found; otherwise nullptr is returned.
     */
     const Type *LookupType(const char *name) const;
 

--- a/src/target_enums.cpp
+++ b/src/target_enums.cpp
@@ -175,7 +175,7 @@ std::pair<std::vector<ISPCTarget>, std::string> ParseISPCTargets(const char *tar
     bool done = false;
     while (!done) {
         const char *tend = strchr(tstart, ',');
-        if (tend == NULL) {
+        if (tend == nullptr) {
             done = true;
             tend = strchr(tstart, '\0');
         }

--- a/src/target_registry.cpp
+++ b/src/target_registry.cpp
@@ -63,8 +63,8 @@ std::vector<const BitcodeLib *> *TargetLibRegistry::libs = nullptr;
 TargetLibRegistry::TargetLibRegistry() {
     // TODO: sort before adding - to canonicalize.
     // TODO: check for conflicts / duplicates.
-    m_dispatch = NULL;
-    m_dispatch_macos = NULL;
+    m_dispatch = nullptr;
+    m_dispatch_macos = nullptr;
     for (auto lib : *libs) {
         switch (lib->getType()) {
         case BitcodeLib::BitcodeLibType::Dispatch:

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -140,17 +140,17 @@ const AtomicType *AtomicType::Void = new AtomicType(TYPE_VOID, Variability::Unif
 
 AtomicType::AtomicType(BasicType bt, Variability v, bool ic)
     : Type(ATOMIC_TYPE), basicType(bt), variability(v), isConst(ic) {
-    asOtherConstType = NULL;
-    asUniformType = asVaryingType = NULL;
+    asOtherConstType = nullptr;
+    asUniformType = asVaryingType = nullptr;
 }
 
 Variability AtomicType::GetVariability() const { return variability; }
 
-bool Type::IsPointerType() const { return (CastType<PointerType>(this) != NULL); }
+bool Type::IsPointerType() const { return (CastType<PointerType>(this) != nullptr); }
 
-bool Type::IsArrayType() const { return (CastType<ArrayType>(this) != NULL); }
+bool Type::IsArrayType() const { return (CastType<ArrayType>(this) != nullptr); }
 
-bool Type::IsReferenceType() const { return (CastType<ReferenceType>(this) != NULL); }
+bool Type::IsReferenceType() const { return (CastType<ReferenceType>(this) != nullptr); }
 
 bool Type::IsVoidType() const { return EqualIgnoringConst(this, AtomicType::Void); }
 
@@ -220,7 +220,7 @@ const AtomicType *AtomicType::GetAsUnsignedType() const {
         return this;
 
     if (IsIntType() == false)
-        return NULL;
+        return nullptr;
 
     switch (basicType) {
     case TYPE_INT8:
@@ -233,7 +233,7 @@ const AtomicType *AtomicType::GetAsUnsignedType() const {
         return new AtomicType(TYPE_UINT64, variability, isConst);
     default:
         FATAL("Unexpected basicType in GetAsUnsignedType()");
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -242,7 +242,7 @@ const AtomicType *AtomicType::GetAsConstType() const {
     if (isConst == true)
         return this;
 
-    if (asOtherConstType == NULL) {
+    if (asOtherConstType == nullptr) {
         asOtherConstType = new AtomicType(basicType, variability, true);
         asOtherConstType->asOtherConstType = this;
     }
@@ -254,7 +254,7 @@ const AtomicType *AtomicType::GetAsNonConstType() const {
     if (isConst == false)
         return this;
 
-    if (asOtherConstType == NULL) {
+    if (asOtherConstType == nullptr) {
         asOtherConstType = new AtomicType(basicType, variability, false);
         asOtherConstType->asOtherConstType = this;
     }
@@ -268,7 +268,7 @@ const AtomicType *AtomicType::GetAsVaryingType() const {
     if (variability == Variability::Varying)
         return this;
 
-    if (asVaryingType == NULL) {
+    if (asVaryingType == nullptr) {
         asVaryingType = new AtomicType(basicType, Variability::Varying, isConst);
         if (variability == Variability::Uniform)
             asVaryingType->asUniformType = this;
@@ -281,7 +281,7 @@ const AtomicType *AtomicType::GetAsUniformType() const {
     if (variability == Variability::Uniform)
         return this;
 
-    if (asUniformType == NULL) {
+    if (asUniformType == nullptr) {
         asUniformType = new AtomicType(basicType, Variability::Uniform, isConst);
         if (variability == Variability::Varying)
             asUniformType->asVaryingType = this;
@@ -533,7 +533,7 @@ static llvm::Type *lGetAtomicLLVMType(llvm::LLVMContext *ctx, const AtomicType *
         case AtomicType::TYPE_DEPENDENT:
         default:
             FATAL("logic error in lGetAtomicLLVMType");
-            return NULL;
+            return nullptr;
         }
     } else {
         ArrayType at(aType->GetAsUniformType(), variability.soaWidth);
@@ -557,7 +557,7 @@ llvm::DIType *AtomicType::GetDIType(llvm::DIScope *scope) const {
     if (variability.type == Variability::Uniform) {
         switch (basicType) {
         case TYPE_VOID:
-            return NULL;
+            return nullptr;
 
         case TYPE_BOOL:
             return m->diBuilder->createBasicType("bool", 32 /* size */, llvm::dwarf::DW_ATE_unsigned);
@@ -599,7 +599,7 @@ llvm::DIType *AtomicType::GetDIType(llvm::DIScope *scope) const {
         default:
             FATAL("unhandled basic type in AtomicType::GetDIType()");
 
-            return NULL;
+            return nullptr;
         }
     } else if (variability == Variability::Varying) {
 
@@ -623,8 +623,8 @@ llvm::DIType *AtomicType::GetDIType(llvm::DIScope *scope) const {
 
 TemplateTypeParmType::TemplateTypeParmType(std::string n, Variability v, bool ic, SourcePos p)
     : Type(TEMPLATE_TYPE_PARM_TYPE), name(n), variability(v), isConst(ic), pos(p) {
-    asOtherConstType = NULL;
-    asUniformType = asVaryingType = NULL;
+    asOtherConstType = nullptr;
+    asUniformType = asVaryingType = nullptr;
 }
 
 Variability TemplateTypeParmType::GetVariability() const { return variability; }
@@ -644,7 +644,7 @@ const Type *TemplateTypeParmType::GetBaseType() const { return this; }
 const Type *TemplateTypeParmType::GetAsVaryingType() const {
     if (variability == Variability::Varying)
         return this;
-    if (asVaryingType == NULL) {
+    if (asVaryingType == nullptr) {
         asVaryingType = new TemplateTypeParmType(name, Variability::Varying, isConst, pos);
         if (variability == Variability::Uniform)
             asVaryingType->asUniformType = this;
@@ -655,7 +655,7 @@ const Type *TemplateTypeParmType::GetAsVaryingType() const {
 const Type *TemplateTypeParmType::GetAsUniformType() const {
     if (variability == Variability::Uniform)
         return this;
-    if (asUniformType == NULL) {
+    if (asUniformType == nullptr) {
         asUniformType = new TemplateTypeParmType(name, Variability::Uniform, isConst, pos);
         if (variability == Variability::Varying)
             asUniformType->asVaryingType = this;
@@ -677,7 +677,7 @@ const Type *TemplateTypeParmType::GetAsSOAType(int width) const {
 
 const Type *TemplateTypeParmType::ResolveDependence(TemplateInstantiation &templInst) const {
     const Type *resolvedType = templInst.InstantiateType(GetName());
-    if (resolvedType == NULL) {
+    if (resolvedType == nullptr) {
         // Failed to resolve the type, return
         return this;
     }
@@ -711,7 +711,7 @@ const Type *TemplateTypeParmType::GetAsConstType() const {
     if (isConst == true)
         return this;
 
-    if (asOtherConstType == NULL) {
+    if (asOtherConstType == nullptr) {
         asOtherConstType = new TemplateTypeParmType(name, variability, true, pos);
         asOtherConstType->asOtherConstType = this;
     }
@@ -722,7 +722,7 @@ const Type *TemplateTypeParmType::GetAsNonConstType() const {
     if (isConst == false)
         return this;
 
-    if (asOtherConstType == NULL) {
+    if (asOtherConstType == nullptr) {
         asOtherConstType = new TemplateTypeParmType(name, variability, false, pos);
         asOtherConstType->asOtherConstType = this;
     }
@@ -941,7 +941,7 @@ llvm::Type *EnumType::LLVMType(llvm::LLVMContext *ctx) const {
     }
     default:
         FATAL("Unexpected variability in EnumType::LLVMType()");
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -950,7 +950,7 @@ llvm::DIType *EnumType::GetDIType(llvm::DIScope *scope) const {
     std::vector<llvm::Metadata *> enumeratorDescriptors;
     for (unsigned int i = 0; i < enumerators.size(); ++i) {
         unsigned int enumeratorValue[1];
-        Assert(enumerators[i]->constValue != NULL);
+        Assert(enumerators[i]->constValue != nullptr);
         int count = enumerators[i]->constValue->GetValues(enumeratorValue);
         Assert(count == 1);
 
@@ -983,7 +983,7 @@ llvm::DIType *EnumType::GetDIType(llvm::DIScope *scope) const {
     }
     default:
         FATAL("Unexpected variability in EnumType::GetDIType()");
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -1082,9 +1082,9 @@ const PointerType *PointerType::GetWithAddrSpace(AddressSpace as) const {
 }
 
 const PointerType *PointerType::ResolveDependence(TemplateInstantiation &templInst) const {
-    if (baseType == NULL) {
+    if (baseType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     const Type *resType = baseType->ResolveDependence(templInst);
@@ -1097,9 +1097,9 @@ const PointerType *PointerType::ResolveDependence(TemplateInstantiation &templIn
 }
 
 const PointerType *PointerType::ResolveUnboundVariability(Variability v) const {
-    if (baseType == NULL) {
+    if (baseType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     Assert(v != Variability::Unbound);
@@ -1123,7 +1123,7 @@ const PointerType *PointerType::GetAsNonConstType() const {
 }
 
 std::string PointerType::GetString() const {
-    if (baseType == NULL) {
+    if (baseType == nullptr) {
         Assert(m->errorCount > 0);
         return "";
     }
@@ -1144,7 +1144,7 @@ std::string PointerType::GetString() const {
 
 std::string PointerType::Mangle() const {
     Assert(variability != Variability::Unbound);
-    if (baseType == NULL) {
+    if (baseType == nullptr) {
         Assert(m->errorCount > 0);
         return "";
     }
@@ -1167,13 +1167,13 @@ std::string PointerType::GetCDeclaration(const std::string &name) const {
         return "";
     }
 
-    if (baseType == NULL) {
+    if (baseType == nullptr) {
         Assert(m->errorCount > 0);
         return "";
     }
 
     bool baseIsBasicVarying = (IsBasicType(baseType)) && (baseType->IsVaryingType());
-    bool baseIsFunction = (CastType<FunctionType>(baseType) != NULL);
+    bool baseIsFunction = (CastType<FunctionType>(baseType) != nullptr);
 
     std::string tempName;
     if (baseIsBasicVarying || baseIsFunction)
@@ -1209,9 +1209,9 @@ std::string PointerType::GetCDeclaration(const std::string &name) const {
 }
 
 llvm::Type *PointerType::LLVMType(llvm::LLVMContext *ctx) const {
-    if (baseType == NULL) {
+    if (baseType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     if (isSlice) {
@@ -1239,9 +1239,9 @@ llvm::Type *PointerType::LLVMType(llvm::LLVMContext *ctx) const {
 
     switch (variability.type) {
     case Variability::Uniform: {
-        llvm::Type *ptype = NULL;
+        llvm::Type *ptype = nullptr;
         const FunctionType *ftype = CastType<FunctionType>(baseType);
-        if (ftype != NULL)
+        if (ftype != nullptr)
             ptype = llvm::PointerType::get(ftype->LLVMFunctionType(ctx), (unsigned)addrSpace);
         else {
             if (baseType->IsVoidType())
@@ -1261,14 +1261,14 @@ llvm::Type *PointerType::LLVMType(llvm::LLVMContext *ctx) const {
     }
     default:
         FATAL("Unexpected variability in PointerType::LLVMType()");
-        return NULL;
+        return nullptr;
     }
 }
 
 llvm::DIType *PointerType::GetDIType(llvm::DIScope *scope) const {
-    if (baseType == NULL) {
+    if (baseType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     llvm::DIType *diTargetType = baseType->GetDIType(scope);
     int bitsSize = g->target->is32Bit() ? 32 : 64;
@@ -1298,7 +1298,7 @@ llvm::DIType *PointerType::GetDIType(llvm::DIScope *scope) const {
     }
     default:
         FATAL("Unexpected variability in PointerType::GetDIType()");
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -1317,15 +1317,15 @@ ArrayType::ArrayType(const Type *c, int a) : SequentialType(ARRAY_TYPE), child(c
 }
 
 llvm::ArrayType *ArrayType::LLVMType(llvm::LLVMContext *ctx) const {
-    if (child == NULL) {
+    if (child == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::Type *ct = child->LLVMStorageType(ctx);
-    if (ct == NULL) {
+    if (ct == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return llvm::ArrayType::get(ct, numElements);
 }
@@ -1356,41 +1356,41 @@ const Type *ArrayType::GetBaseType() const {
 }
 
 const ArrayType *ArrayType::GetAsVaryingType() const {
-    if (child == NULL) {
+    if (child == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return new ArrayType(child->GetAsVaryingType(), numElements);
 }
 
 const ArrayType *ArrayType::GetAsUniformType() const {
-    if (child == NULL) {
+    if (child == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return new ArrayType(child->GetAsUniformType(), numElements);
 }
 
 const ArrayType *ArrayType::GetAsUnboundVariabilityType() const {
-    if (child == NULL) {
+    if (child == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return new ArrayType(child->GetAsUnboundVariabilityType(), numElements);
 }
 
 const ArrayType *ArrayType::GetAsSOAType(int width) const {
-    if (child == NULL) {
+    if (child == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return new ArrayType(child->GetAsSOAType(width), numElements);
 }
 
 const ArrayType *ArrayType::ResolveDependence(TemplateInstantiation &templInst) const {
-    if (child == NULL) {
+    if (child == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     const Type *resType = child->ResolveDependence(templInst);
@@ -1401,33 +1401,33 @@ const ArrayType *ArrayType::ResolveDependence(TemplateInstantiation &templInst) 
 }
 
 const ArrayType *ArrayType::ResolveUnboundVariability(Variability v) const {
-    if (child == NULL) {
+    if (child == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return new ArrayType(child->ResolveUnboundVariability(v), numElements);
 }
 
 const ArrayType *ArrayType::GetAsUnsignedType() const {
-    if (child == NULL) {
+    if (child == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return new ArrayType(child->GetAsUnsignedType(), numElements);
 }
 
 const ArrayType *ArrayType::GetAsConstType() const {
-    if (child == NULL) {
+    if (child == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return new ArrayType(child->GetAsConstType(), numElements);
 }
 
 const ArrayType *ArrayType::GetAsNonConstType() const {
-    if (child == NULL) {
+    if (child == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return new ArrayType(child->GetAsNonConstType(), numElements);
 }
@@ -1438,7 +1438,7 @@ const Type *ArrayType::GetElementType() const { return child; }
 
 std::string ArrayType::GetString() const {
     const Type *base = GetBaseType();
-    if (base == NULL) {
+    if (base == nullptr) {
         Assert(m->errorCount > 0);
         return "";
     }
@@ -1461,7 +1461,7 @@ std::string ArrayType::GetString() const {
 }
 
 std::string ArrayType::Mangle() const {
-    if (child == NULL) {
+    if (child == nullptr) {
         Assert(m->errorCount > 0);
         return "(error)";
     }
@@ -1477,7 +1477,7 @@ std::string ArrayType::Mangle() const {
 
 std::string ArrayType::GetCDeclaration(const std::string &name) const {
     const Type *base = GetBaseType();
-    if (base == NULL) {
+    if (base == nullptr) {
         Assert(m->errorCount > 0);
         return "";
     }
@@ -1517,16 +1517,16 @@ std::string ArrayType::GetCDeclaration(const std::string &name) const {
 
 int ArrayType::TotalElementCount() const {
     const ArrayType *ct = CastType<ArrayType>(child);
-    if (ct != NULL)
+    if (ct != nullptr)
         return numElements * ct->TotalElementCount();
     else
         return numElements;
 }
 
 llvm::DIType *ArrayType::GetDIType(llvm::DIScope *scope) const {
-    if (child == NULL) {
+    if (child == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     llvm::DIType *eltType = child->GetDIType(scope);
     return lCreateDIArray(eltType, numElements);
@@ -1539,11 +1539,11 @@ ArrayType *ArrayType::GetSizedArray(int sz) const {
 
 const Type *ArrayType::SizeUnsizedArrays(const Type *type, Expr *initExpr) {
     const ArrayType *at = CastType<ArrayType>(type);
-    if (at == NULL)
+    if (at == nullptr)
         return type;
 
     ExprList *exprList = llvm::dyn_cast_or_null<ExprList>(initExpr);
-    if (exprList == NULL || exprList->exprs.size() == 0)
+    if (exprList == nullptr || exprList->exprs.size() == 0)
         return type;
 
     // If the current dimension is unsized, then size it according to the
@@ -1558,13 +1558,13 @@ const Type *ArrayType::SizeUnsizedArrays(const Type *type, Expr *initExpr) {
     // (after checking below that it has the same length as all of the
     // other ones.
     ExprList *nextList = llvm::dyn_cast_or_null<ExprList>(exprList->exprs[0]);
-    if (nextList == NULL)
+    if (nextList == nullptr)
         return type;
 
     Assert(at);
     const Type *nextType = at->GetElementType();
     const ArrayType *nextArrayType = CastType<ArrayType>(nextType);
-    if (nextArrayType != NULL && nextArrayType->GetElementCount() == 0) {
+    if (nextArrayType != nullptr && nextArrayType->GetElementCount() == 0) {
         // If the recursive call to SizeUnsizedArrays at the bottom of the
         // function is going to size an unsized dimension, make sure that
         // all of the sub-expression lists are the same length--i.e. issue
@@ -1572,18 +1572,18 @@ const Type *ArrayType::SizeUnsizedArrays(const Type *type, Expr *initExpr) {
         // int x[][] = { { 1 }, { 1, 2, 3, 4 } };
         unsigned int nextSize = nextList->exprs.size();
         for (unsigned int i = 1; i < exprList->exprs.size(); ++i) {
-            if (exprList->exprs[i] == NULL) {
+            if (exprList->exprs[i] == nullptr) {
                 // We should have seen an error earlier in this case.
                 Assert(m->errorCount > 0);
                 continue;
             }
 
             ExprList *el = llvm::dyn_cast_or_null<ExprList>(exprList->exprs[i]);
-            if (el == NULL || el->exprs.size() != nextSize) {
+            if (el == nullptr || el->exprs.size() != nextSize) {
                 Error(Union(exprList->exprs[0]->pos, exprList->exprs[i]->pos),
                       "Inconsistent initializer expression list lengths "
                       "make it impossible to size unsized array dimensions.");
-                return NULL;
+                return nullptr;
             }
         }
     }
@@ -1598,7 +1598,7 @@ const Type *ArrayType::SizeUnsizedArrays(const Type *type, Expr *initExpr) {
 
 VectorType::VectorType(const AtomicType *b, int a) : SequentialType(VECTOR_TYPE), base(b), numElements(a) {
     Assert(numElements > 0);
-    Assert(base != NULL);
+    Assert(base != nullptr);
 }
 
 Variability VectorType::GetVariability() const { return base->GetVariability(); }
@@ -1634,9 +1634,9 @@ const VectorType *VectorType::ResolveUnboundVariability(Variability v) const {
 }
 
 const VectorType *VectorType::GetAsUnsignedType() const {
-    if (base == NULL) {
+    if (base == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return new VectorType(base->GetAsUnsignedType(), numElements);
 }
@@ -1677,9 +1677,9 @@ static llvm::Type *lGetVectorLLVMType(llvm::LLVMContext *ctx, const VectorType *
     const Type *base = vType->GetBaseType();
     int numElements = vType->GetElementCount();
 
-    if (base == NULL) {
+    if (base == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::Type *bt;
@@ -1690,7 +1690,7 @@ static llvm::Type *lGetVectorLLVMType(llvm::LLVMContext *ctx, const VectorType *
     else
         bt = base->LLVMType(ctx);
     if (!bt)
-        return NULL;
+        return nullptr;
 
     if (base->IsUniformType())
         // Vectors of uniform types are laid out across LLVM vectors, with
@@ -1708,7 +1708,7 @@ static llvm::Type *lGetVectorLLVMType(llvm::LLVMContext *ctx, const VectorType *
         return llvm::ArrayType::get(bt, numElements);
     else {
         FATAL("Unexpected variability in lGetVectorLLVMType()");
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -1741,7 +1741,7 @@ llvm::DIType *VectorType::GetDIType(llvm::DIScope *scope) const {
         return at.GetDIType(scope);
     } else {
         FATAL("Unexpected variability in VectorType::GetDIType()");
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -1814,8 +1814,8 @@ StructType::StructType(const std::string &n, const llvm::SmallVector<const Type 
                        Variability v, bool ia, SourcePos p)
     : CollectionType(STRUCT_TYPE), name(n), elementTypes(elts), elementNames(en), elementPositions(ep), variability(v),
       isConst(ic), isAnonymous(ia), pos(p) {
-    oppositeConstStructType = NULL;
-    finalElementTypes.resize(elts.size(), NULL);
+    oppositeConstStructType = nullptr;
+    finalElementTypes.resize(elts.size(), nullptr);
 
     static int count = 0;
     if (variability != Variability::Unbound) {
@@ -1847,10 +1847,10 @@ StructType::StructType(const std::string &n, const llvm::SmallVector<const Type 
         } else {
             for (int i = 0; i < nElements; ++i) {
                 const Type *type = GetElementType(i);
-                if (type == NULL) {
+                if (type == nullptr) {
                     Assert(m->errorCount > 0);
                     return;
-                } else if (CastType<FunctionType>(type) != NULL) {
+                } else if (CastType<FunctionType>(type) != nullptr) {
                     Error(elementPositions[i], "Method declarations are not "
                                                "supported.");
                     return;
@@ -1906,11 +1906,11 @@ bool StructType::IsDefined() const {
     for (int i = 0; i < GetElementCount(); i++) {
         const Type *t = GetElementType(i);
         const UndefinedStructType *ust = CastType<UndefinedStructType>(t);
-        if (ust != NULL) {
+        if (ust != nullptr) {
             return false;
         }
         const StructType *st = CastType<StructType>(t);
-        if (st != NULL) {
+        if (st != nullptr) {
             if (!st->IsDefined()) {
                 return false;
             }
@@ -1950,7 +1950,7 @@ const StructType *StructType::GetAsSOAType(int width) const {
         return this;
 
     if (checkIfCanBeSOA(this) == false)
-        return NULL;
+        return nullptr;
 
     return new StructType(name, elementTypes, elementNames, elementPositions, isConst,
                           Variability(Variability::SOA, width), isAnonymous, pos);
@@ -1974,7 +1974,7 @@ const StructType *StructType::ResolveUnboundVariability(Variability v) const {
 const StructType *StructType::GetAsConstType() const {
     if (isConst == true)
         return this;
-    else if (oppositeConstStructType != NULL)
+    else if (oppositeConstStructType != nullptr)
         return oppositeConstStructType;
     else {
         oppositeConstStructType =
@@ -1987,7 +1987,7 @@ const StructType *StructType::GetAsConstType() const {
 const StructType *StructType::GetAsNonConstType() const {
     if (isConst == false)
         return this;
-    else if (oppositeConstStructType != NULL)
+    else if (oppositeConstStructType != nullptr)
         return oppositeConstStructType;
     else {
         oppositeConstStructType =
@@ -2066,7 +2066,7 @@ llvm::Type *StructType::LLVMType(llvm::LLVMContext *ctx) const {
     std::string mname = lMangleStructName(name, variability);
     if (m->structTypeMap.find(mname) == m->structTypeMap.end()) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return m->structTypeMap[mname];
 }
@@ -2105,18 +2105,18 @@ llvm::DIType *StructType::GetDIType(llvm::DIScope *scope) const {
                                           layout->getSizeInBits(),            // Size in bits
                                           layout->getAlignment().value() * 8, // Alignment in bits
                                           llvm::DINode::FlagZero,             // Flags
-                                          NULL, elements);
+                                          nullptr, elements);
 }
 
 const Type *StructType::GetElementType(int i) const {
     Assert(variability != Variability::Unbound);
     Assert(i < (int)elementTypes.size());
 
-    if (finalElementTypes[i] == NULL) {
+    if (finalElementTypes[i] == nullptr) {
         const Type *type = elementTypes[i];
-        if (type == NULL) {
+        if (type == nullptr) {
             Assert(m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
 
         // If the element has unbound variability, resolve its variability to
@@ -2139,7 +2139,7 @@ const Type *StructType::GetElementType(const std::string &n) const {
     for (unsigned int i = 0; i < elementNames.size(); ++i)
         if (elementNames[i] == n)
             return GetElementType(i);
-    return NULL;
+    return nullptr;
 }
 
 int StructType::GetElementNumber(const std::string &n) const {
@@ -2155,7 +2155,7 @@ bool StructType::checkIfCanBeSOA(const StructType *st) {
         const Type *eltType = st->elementTypes[i];
         const StructType *childStructType = CastType<StructType>(eltType);
 
-        if (childStructType != NULL)
+        if (childStructType != nullptr)
             ok &= checkIfCanBeSOA(childStructType);
         else if (eltType->HasUnboundVariability() == false) {
             Error(st->elementPositions[i],
@@ -2224,7 +2224,7 @@ const UndefinedStructType *UndefinedStructType::GetAsUnboundVariabilityType() co
 
 const UndefinedStructType *UndefinedStructType::GetAsSOAType(int width) const {
     FATAL("UndefinedStructType::GetAsSOAType() shouldn't be called.");
-    return NULL;
+    return nullptr;
 }
 
 const UndefinedStructType *UndefinedStructType::ResolveDependence(TemplateInstantiation &templInst) const {
@@ -2276,7 +2276,7 @@ llvm::Type *UndefinedStructType::LLVMType(llvm::LLVMContext *ctx) const {
     std::string mname = lMangleStructName(name, variability);
     if (m->structTypeMap.find(mname) == m->structTypeMap.end()) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return m->structTypeMap[mname];
 }
@@ -2290,18 +2290,18 @@ llvm::DIType *UndefinedStructType::GetDIType(llvm::DIScope *scope) const {
                                           0,                      // Size
                                           0,                      // Align
                                           llvm::DINode::FlagZero, // Flags
-                                          NULL, elements);
+                                          nullptr, elements);
 }
 
 ///////////////////////////////////////////////////////////////////////////
 // ReferenceType
 
 ReferenceType::ReferenceType(const Type *t, AddressSpace as) : Type(REFERENCE_TYPE), targetType(t), addrSpace(as) {
-    asOtherConstType = NULL;
+    asOtherConstType = nullptr;
 }
 
 Variability ReferenceType::GetVariability() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
         return Variability(Variability::Unbound);
     }
@@ -2309,7 +2309,7 @@ Variability ReferenceType::GetVariability() const {
 }
 
 bool ReferenceType::IsBoolType() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
         return false;
     }
@@ -2317,7 +2317,7 @@ bool ReferenceType::IsBoolType() const {
 }
 
 bool ReferenceType::IsFloatType() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
         return false;
     }
@@ -2325,7 +2325,7 @@ bool ReferenceType::IsFloatType() const {
 }
 
 bool ReferenceType::IsIntType() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
         return false;
     }
@@ -2333,7 +2333,7 @@ bool ReferenceType::IsIntType() const {
 }
 
 bool ReferenceType::IsUnsignedType() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
         return false;
     }
@@ -2341,7 +2341,7 @@ bool ReferenceType::IsUnsignedType() const {
 }
 
 bool ReferenceType::IsConstType() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
         return false;
     }
@@ -2351,17 +2351,17 @@ bool ReferenceType::IsConstType() const {
 const Type *ReferenceType::GetReferenceTarget() const { return targetType; }
 
 const Type *ReferenceType::GetBaseType() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return targetType->GetBaseType();
 }
 
 const ReferenceType *ReferenceType::GetAsVaryingType() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     if (IsVaryingType())
         return this;
@@ -2369,9 +2369,9 @@ const ReferenceType *ReferenceType::GetAsVaryingType() const {
 }
 
 const ReferenceType *ReferenceType::GetAsUniformType() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     if (IsUniformType())
         return this;
@@ -2379,9 +2379,9 @@ const ReferenceType *ReferenceType::GetAsUniformType() const {
 }
 
 const ReferenceType *ReferenceType::GetAsUnboundVariabilityType() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     if (HasUnboundVariability())
         return this;
@@ -2394,30 +2394,30 @@ const Type *ReferenceType::GetAsSOAType(int width) const {
 }
 
 const ReferenceType *ReferenceType::ResolveDependence(TemplateInstantiation &templInst) const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return new ReferenceType(targetType->ResolveDependence(templInst));
 }
 
 const ReferenceType *ReferenceType::ResolveUnboundVariability(Variability v) const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     return new ReferenceType(targetType->ResolveUnboundVariability(v));
 }
 
 const ReferenceType *ReferenceType::GetAsConstType() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     if (IsConstType())
         return this;
 
-    if (asOtherConstType == NULL) {
+    if (asOtherConstType == nullptr) {
         asOtherConstType = new ReferenceType(targetType->GetAsConstType());
         asOtherConstType->asOtherConstType = this;
     }
@@ -2425,14 +2425,14 @@ const ReferenceType *ReferenceType::GetAsConstType() const {
 }
 
 const ReferenceType *ReferenceType::GetAsNonConstType() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     if (!IsConstType())
         return this;
 
-    if (asOtherConstType == NULL) {
+    if (asOtherConstType == nullptr) {
         asOtherConstType = new ReferenceType(targetType->GetAsNonConstType());
         asOtherConstType->asOtherConstType = this;
     }
@@ -2440,9 +2440,9 @@ const ReferenceType *ReferenceType::GetAsNonConstType() const {
 }
 
 const ReferenceType *ReferenceType::GetWithAddrSpace(AddressSpace as) const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     if (addrSpace == as)
         return this;
@@ -2451,7 +2451,7 @@ const ReferenceType *ReferenceType::GetWithAddrSpace(AddressSpace as) const {
 }
 
 std::string ReferenceType::GetString() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
         return "";
     }
@@ -2463,7 +2463,7 @@ std::string ReferenceType::GetString() const {
 }
 
 std::string ReferenceType::Mangle() const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
         return "";
     }
@@ -2473,13 +2473,13 @@ std::string ReferenceType::Mangle() const {
 }
 
 std::string ReferenceType::GetCDeclaration(const std::string &name) const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
         return "";
     }
 
     const ArrayType *at = CastType<ArrayType>(targetType);
-    if (at != NULL) {
+    if (at != nullptr) {
         if (at->GetElementCount() == 0) {
             // emit unsized arrays as pointers to the base type..
             std::string ret;
@@ -2501,24 +2501,24 @@ std::string ReferenceType::GetCDeclaration(const std::string &name) const {
 }
 
 llvm::Type *ReferenceType::LLVMType(llvm::LLVMContext *ctx) const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     llvm::Type *t = targetType->LLVMStorageType(ctx);
-    if (t == NULL) {
+    if (t == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     return llvm::PointerType::get(t, (unsigned)addrSpace);
 }
 
 llvm::DIType *ReferenceType::GetDIType(llvm::DIScope *scope) const {
-    if (targetType == NULL) {
+    if (targetType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     llvm::DIType *diTargetType = targetType->GetDIType(scope);
     // Specifying address space for Xe target is necessary for correct work of SPIR-V Translator and other SPIR-V
@@ -2536,9 +2536,9 @@ FunctionType::FunctionType(const Type *r, const llvm::SmallVector<const Type *, 
     : Type(FUNCTION_TYPE), isTask(false), isExported(false), isExternC(false), isExternSYCL(false), isUnmasked(false),
       isVectorCall(false), isRegCall(false), returnType(r), paramTypes(a),
       paramNames(llvm::SmallVector<std::string, 8>(a.size(), "")),
-      paramDefaults(llvm::SmallVector<Expr *, 8>(a.size(), NULL)),
+      paramDefaults(llvm::SmallVector<Expr *, 8>(a.size(), nullptr)),
       paramPositions(llvm::SmallVector<SourcePos, 8>(a.size(), p)) {
-    Assert(returnType != NULL);
+    Assert(returnType != nullptr);
     isSafe = false;
     costOverride = -1;
 }
@@ -2552,7 +2552,7 @@ FunctionType::FunctionType(const Type *r, const llvm::SmallVector<const Type *, 
       paramPositions(ap) {
     Assert(paramTypes.size() == paramNames.size() && paramNames.size() == paramDefaults.size() &&
            paramDefaults.size() == paramPositions.size());
-    Assert(returnType != NULL);
+    Assert(returnType != nullptr);
     isSafe = false;
     costOverride = -1;
 }
@@ -2577,41 +2577,41 @@ bool FunctionType::IsISPCExternal() const {
 
 const Type *FunctionType::GetBaseType() const {
     FATAL("FunctionType::GetBaseType() shouldn't be called");
-    return NULL;
+    return nullptr;
 }
 
 const Type *FunctionType::GetAsVaryingType() const {
     FATAL("FunctionType::GetAsVaryingType shouldn't be called");
-    return NULL;
+    return nullptr;
 }
 
 const Type *FunctionType::GetAsUniformType() const {
     FATAL("FunctionType::GetAsUniformType shouldn't be called");
-    return NULL;
+    return nullptr;
 }
 
 const Type *FunctionType::GetAsUnboundVariabilityType() const {
     FATAL("FunctionType::GetAsUnboundVariabilityType shouldn't be called");
-    return NULL;
+    return nullptr;
 }
 
 const Type *FunctionType::GetAsSOAType(int width) const {
     FATAL("FunctionType::GetAsSOAType() shouldn't be called");
-    return NULL;
+    return nullptr;
 }
 
 const FunctionType *FunctionType::ResolveDependence(TemplateInstantiation &templInst) const {
-    if (returnType == NULL) {
+    if (returnType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     const Type *rt = returnType->ResolveDependenceForTopType(templInst);
 
     llvm::SmallVector<const Type *, 8> pt;
     for (unsigned int i = 0; i < paramTypes.size(); ++i) {
-        if (paramTypes[i] == NULL) {
+        if (paramTypes[i] == nullptr) {
             Assert(m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
         const Type *argt = paramTypes[i]->ResolveDependenceForTopType(templInst);
         pt.push_back(argt);
@@ -2625,17 +2625,17 @@ const FunctionType *FunctionType::ResolveDependence(TemplateInstantiation &templ
 }
 
 const FunctionType *FunctionType::ResolveUnboundVariability(Variability v) const {
-    if (returnType == NULL) {
+    if (returnType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
     const Type *rt = returnType->ResolveUnboundVariability(v);
 
     llvm::SmallVector<const Type *, 8> pt;
     for (unsigned int i = 0; i < paramTypes.size(); ++i) {
-        if (paramTypes[i] == NULL) {
+        if (paramTypes[i] == nullptr) {
             Assert(m->errorCount > 0);
-            return NULL;
+            return nullptr;
         }
         pt.push_back(paramTypes[i]->ResolveUnboundVariability(v));
     }
@@ -2658,7 +2658,7 @@ std::string FunctionType::GetString() const {
     ret += GetReturnTypeString();
     ret += "(";
     for (unsigned int i = 0; i < paramTypes.size(); ++i) {
-        if (paramTypes[i] == NULL) {
+        if (paramTypes[i] == nullptr) {
             ret += "/* ERROR */";
         } else {
             ret += paramTypes[i]->GetString();
@@ -2666,7 +2666,7 @@ std::string FunctionType::GetString() const {
 
         ret += " " + paramNames[i];
 
-        if (paramDefaults[i] != NULL) {
+        if (paramDefaults[i] != nullptr) {
             ret += " = init";
         }
 
@@ -2684,7 +2684,7 @@ std::string FunctionType::Mangle() const {
         ret += "UM_";
 
     for (unsigned int i = 0; i < paramTypes.size(); ++i)
-        if (paramTypes[i] == NULL)
+        if (paramTypes[i] == nullptr)
             Assert(m->errorCount > 0);
         else
             ret += paramTypes[i]->Mangle();
@@ -2705,7 +2705,7 @@ std::string FunctionType::GetCDeclaration(const std::string &fname) const {
         // to print out for multidimensional arrays (i.e. "float foo[][4] "
         // versus "float (foo *)[4]").
         const PointerType *pt = CastType<PointerType>(type);
-        if (pt != NULL && CastType<ArrayType>(pt->GetBaseType()) != NULL) {
+        if (pt != nullptr && CastType<ArrayType>(pt->GetBaseType()) != nullptr) {
             type = new ArrayType(pt->GetBaseType(), 0);
         }
 
@@ -2733,12 +2733,12 @@ std::string FunctionType::GetCDeclarationForDispatch(const std::string &fname) c
         // to print out for multidimensional arrays (i.e. "float foo[][4] "
         // versus "float (foo *)[4]").
         const PointerType *pt = CastType<PointerType>(type);
-        if (pt != NULL && CastType<ArrayType>(pt->GetBaseType()) != NULL) {
+        if (pt != nullptr && CastType<ArrayType>(pt->GetBaseType()) != nullptr) {
             type = new ArrayType(pt->GetBaseType(), 0);
         }
 
         // Change pointers to varying thingies to void *
-        if (pt != NULL && pt->GetBaseType()->IsVaryingType()) {
+        if (pt != nullptr && pt->GetBaseType()->IsVaryingType()) {
             PointerType *t = PointerType::Void;
 
             if (paramNames[i] != "")
@@ -2760,7 +2760,7 @@ std::string FunctionType::GetCDeclarationForDispatch(const std::string &fname) c
 
 llvm::Type *FunctionType::LLVMType(llvm::LLVMContext *ctx) const {
     FATAL("FunctionType::LLVMType() shouldn't be called");
-    return NULL;
+    return nullptr;
 }
 
 llvm::DIType *FunctionType::GetDIType(llvm::DIScope *scope) const {
@@ -2769,9 +2769,9 @@ llvm::DIType *FunctionType::GetDIType(llvm::DIScope *scope) const {
     retArgTypes.push_back(returnType->GetDIType(scope));
     for (int i = 0; i < GetNumParameters(); ++i) {
         const Type *t = GetParameterType(i);
-        if (t == NULL)
+        if (t == nullptr)
 
-            return NULL;
+            return nullptr;
         retArgTypes.push_back(t->GetDIType(scope));
     }
 
@@ -2781,7 +2781,7 @@ llvm::DIType *FunctionType::GetDIType(llvm::DIScope *scope) const {
 }
 
 const std::string FunctionType::GetReturnTypeString() const {
-    if (returnType == NULL)
+    if (returnType == nullptr)
         return "/* ERROR */";
 
     std::string ret;
@@ -2846,7 +2846,7 @@ std::vector<llvm::Type *> FunctionType::LLVMFunctionArgTypes(llvm::LLVMContext *
     // Get the LLVM Type *s for the function arguments
     std::vector<llvm::Type *> llvmArgTypes;
     for (unsigned int i = 0; i < paramTypes.size(); ++i) {
-        if (paramTypes[i] == NULL) {
+        if (paramTypes[i] == nullptr) {
             Assert(m->errorCount > 0);
             return llvmArgTypes;
         }
@@ -2877,7 +2877,7 @@ std::vector<llvm::Type *> FunctionType::LLVMFunctionArgTypes(llvm::LLVMContext *
             }
         }
 
-        if (castedArgType == NULL) {
+        if (castedArgType == nullptr) {
             Assert(m->errorCount > 0);
             return llvmArgTypes;
         }
@@ -2922,9 +2922,9 @@ llvm::FunctionType *FunctionType::LLVMFunctionType(llvm::LLVMContext *ctx, bool 
         callTypes = llvmArgTypes;
     }
 
-    if (returnType == NULL) {
+    if (returnType == nullptr) {
         Assert(m->errorCount > 0);
-        return NULL;
+        return nullptr;
     }
 
     const Type *retType = returnType;
@@ -2937,8 +2937,8 @@ llvm::FunctionType *FunctionType::LLVMFunctionType(llvm::LLVMContext *ctx, bool 
             llvmReturnType = retType->GetAsVaryingType()->LLVMType(ctx);
         }
     }
-    if (llvmReturnType == NULL)
-        return NULL;
+    if (llvmReturnType == nullptr)
+        return nullptr;
     return llvm::FunctionType::get(llvmReturnType, callTypes, false);
 }
 
@@ -3013,7 +3013,7 @@ const Type *Type::GetReferenceTarget() const {
 
 const Type *Type::GetAsUnsignedType() const {
     // For many types, this doesn't make any sesne
-    return NULL;
+    return nullptr;
 }
 
 /** Given an atomic or vector type, return a vector type of the given
@@ -3028,7 +3028,7 @@ static const Type *lVectorConvert(const Type *type, SourcePos pos, const char *r
                   "Implicit conversion between from vector type "
                   "\"%s\" to vector type of length %d for %s is not possible.",
                   type->GetString().c_str(), vecSize, reason);
-            return NULL;
+            return nullptr;
         }
         return vt;
     } else {
@@ -3038,7 +3038,7 @@ static const Type *lVectorConvert(const Type *type, SourcePos pos, const char *r
                   "Non-atomic type \"%s\" can't be converted to vector type "
                   "for %s.",
                   type->GetString().c_str(), reason);
-            return NULL;
+            return nullptr;
         }
         return new VectorType(at, vecSize);
     }
@@ -3046,7 +3046,7 @@ static const Type *lVectorConvert(const Type *type, SourcePos pos, const char *r
 
 const Type *Type::MoreGeneralType(const Type *t0, const Type *t1, SourcePos pos, const char *reason, bool forceVarying,
                                   int vecSize) {
-    Assert(reason != NULL);
+    Assert(reason != nullptr);
 
     // First, if one or both types are function types, convert them to
     // pointer to function types and then try again.
@@ -3071,7 +3071,7 @@ const Type *Type::MoreGeneralType(const Type *t0, const Type *t1, SourcePos pos,
         t0 = lVectorConvert(t0, pos, reason, vecSize);
         t1 = lVectorConvert(t1, pos, reason, vecSize);
         if (!t0 || !t1)
-            return NULL;
+            return nullptr;
     }
 
     // Are they both the same type?  If so, we're done, QED.
@@ -3084,7 +3084,7 @@ const Type *Type::MoreGeneralType(const Type *t0, const Type *t1, SourcePos pos,
     if (CastType<FunctionType>(t0) || CastType<FunctionType>(t1)) {
         Error(pos, "Incompatible function types \"%s\" and \"%s\" in %s.", t0->GetString().c_str(),
               t1->GetString().c_str(), reason);
-        return NULL;
+        return nullptr;
     }
 
     // Not the same types, but only a const/non-const difference?  Return
@@ -3094,7 +3094,7 @@ const Type *Type::MoreGeneralType(const Type *t0, const Type *t1, SourcePos pos,
 
     const PointerType *pt0 = CastType<PointerType>(t0);
     const PointerType *pt1 = CastType<PointerType>(t1);
-    if (pt0 != NULL && pt1 != NULL) {
+    if (pt0 != nullptr && pt1 != nullptr) {
         if (PointerType::IsVoidPointer(pt0))
             return pt1;
         else if (PointerType::IsVoidPointer(pt1))
@@ -3104,7 +3104,7 @@ const Type *Type::MoreGeneralType(const Type *t0, const Type *t1, SourcePos pos,
                   "Conversion between incompatible pointer types \"%s\" "
                   "and \"%s\" isn't possible.",
                   t0->GetString().c_str(), t1->GetString().c_str());
-            return NULL;
+            return nullptr;
         }
     }
 
@@ -3118,39 +3118,39 @@ const Type *Type::MoreGeneralType(const Type *t0, const Type *t1, SourcePos pos,
                   "Implicit conversion between differently sized vector types "
                   "(%s, %s) for %s is not possible.",
                   t0->GetString().c_str(), t1->GetString().c_str(), reason);
-            return NULL;
+            return nullptr;
         }
         const Type *t = MoreGeneralType(vt0->GetElementType(), vt1->GetElementType(), pos, reason, forceVarying);
         if (!t)
-            return NULL;
+            return nullptr;
 
         // The 'more general' version of the two vector element types must
         // be an AtomicType (that's all that vectors can hold...)
         const AtomicType *at = CastType<AtomicType>(t);
-        Assert(at != NULL);
+        Assert(at != nullptr);
 
         return new VectorType(at, vt0->GetElementCount());
     } else if (vt0) {
         // If one type is a vector type but the other isn't, see if we can
         // promote the other one to a vector type.  This will fail and
-        // return NULL if t1 is e.g. an array type and it's illegal to have
+        // return nullptr if t1 is e.g. an array type and it's illegal to have
         // a vector of it..
         const Type *t = MoreGeneralType(vt0->GetElementType(), t1, pos, reason, forceVarying);
         if (!t)
-            return NULL;
+            return nullptr;
 
         const AtomicType *at = CastType<AtomicType>(t);
-        Assert(at != NULL);
+        Assert(at != nullptr);
         return new VectorType(at, vt0->GetElementCount());
     } else if (vt1) {
         // As in the above case, see if we can promote t0 to make a vector
         // that matches vt1.
         const Type *t = MoreGeneralType(t0, vt1->GetElementType(), pos, reason, forceVarying);
         if (!t)
-            return NULL;
+            return nullptr;
 
         const AtomicType *at = CastType<AtomicType>(t);
-        Assert(at != NULL);
+        Assert(at != nullptr);
         return new VectorType(at, vt1->GetElementCount());
     }
 
@@ -3161,12 +3161,12 @@ const Type *Type::MoreGeneralType(const Type *t0, const Type *t1, SourcePos pos,
 
     const EnumType *et0 = CastType<EnumType>(t0->GetReferenceTarget());
     const EnumType *et1 = CastType<EnumType>(t1->GetReferenceTarget());
-    if (et0 != NULL && et1 != NULL) {
+    if (et0 != nullptr && et1 != nullptr) {
         // Two different enum types -> make them uint32s...
         Assert(et0->IsVaryingType() == et1->IsVaryingType());
         return et0->IsVaryingType() ? AtomicType::VaryingUInt32 : AtomicType::UniformUInt32;
-    } else if (et0 != NULL) {
-        if (at1 != NULL)
+    } else if (et0 != nullptr) {
+        if (at1 != nullptr)
             // Enum type and atomic type -> convert the enum to the atomic type
             // TODO: should we return uint32 here, unless the atomic type is
             // a 64-bit atomic type, in which case we return that?
@@ -3176,10 +3176,10 @@ const Type *Type::MoreGeneralType(const Type *t0, const Type *t1, SourcePos pos,
                   "Implicit conversion from enum type \"%s\" to "
                   "non-atomic type \"%s\" for %s not possible.",
                   t0->GetString().c_str(), t1->GetString().c_str(), reason);
-            return NULL;
+            return nullptr;
         }
-    } else if (et1 != NULL) {
-        if (at0 != NULL)
+    } else if (et1 != nullptr) {
+        if (at0 != nullptr)
             // Enum type and atomic type; see TODO above here as well...
             return at0;
         else {
@@ -3187,16 +3187,16 @@ const Type *Type::MoreGeneralType(const Type *t0, const Type *t1, SourcePos pos,
                   "Implicit conversion from enum type \"%s\" to "
                   "non-atomic type \"%s\" for %s not possible.",
                   t1->GetString().c_str(), t0->GetString().c_str(), reason);
-            return NULL;
+            return nullptr;
         }
     }
 
     // Now all we can do is promote atomic types...
-    if (at0 == NULL || at1 == NULL) {
-        Assert(reason != NULL);
+    if (at0 == nullptr || at1 == nullptr) {
+        Assert(reason != nullptr);
         Error(pos, "Implicit conversion from type \"%s\" to \"%s\" for %s not possible.", t0->GetString().c_str(),
               t1->GetString().c_str(), reason);
-        return NULL;
+        return nullptr;
     }
 
     // Finally, to determine which of the two atomic types is more general,
@@ -3205,12 +3205,12 @@ const Type *Type::MoreGeneralType(const Type *t0, const Type *t1, SourcePos pos,
 }
 
 bool Type::IsBasicType(const Type *type) {
-    return (CastType<AtomicType>(type) != NULL || CastType<EnumType>(type) != NULL ||
-            CastType<PointerType>(type) != NULL);
+    return (CastType<AtomicType>(type) != nullptr || CastType<EnumType>(type) != nullptr ||
+            CastType<PointerType>(type) != nullptr);
 }
 
 static bool lCheckTypeEquality(const Type *a, const Type *b, bool ignoreConst) {
-    if (a == NULL || b == NULL)
+    if (a == nullptr || b == nullptr)
         return false;
 
     if (ignoreConst == false && a->IsConstType() != b->IsConstType())
@@ -3218,7 +3218,7 @@ static bool lCheckTypeEquality(const Type *a, const Type *b, bool ignoreConst) {
 
     const AtomicType *ata = CastType<AtomicType>(a);
     const AtomicType *atb = CastType<AtomicType>(b);
-    if (ata != NULL && atb != NULL) {
+    if (ata != nullptr && atb != nullptr) {
         return ((ata->basicType == atb->basicType) && (ata->GetVariability() == atb->GetVariability()));
     }
 
@@ -3227,19 +3227,19 @@ static bool lCheckTypeEquality(const Type *a, const Type *b, bool ignoreConst) {
     // see if all of the relevant bits are equal...
     const EnumType *eta = CastType<EnumType>(a);
     const EnumType *etb = CastType<EnumType>(b);
-    if (eta != NULL && etb != NULL)
+    if (eta != nullptr && etb != nullptr)
         // Kind of goofy, but this sufficies to check
         return (eta->pos == etb->pos && eta->GetVariability() == etb->GetVariability());
 
     const ArrayType *arta = CastType<ArrayType>(a);
     const ArrayType *artb = CastType<ArrayType>(b);
-    if (arta != NULL && artb != NULL)
+    if (arta != nullptr && artb != nullptr)
         return (arta->GetElementCount() == artb->GetElementCount() &&
                 lCheckTypeEquality(arta->GetElementType(), artb->GetElementType(), ignoreConst));
 
     const VectorType *vta = CastType<VectorType>(a);
     const VectorType *vtb = CastType<VectorType>(b);
-    if (vta != NULL && vtb != NULL)
+    if (vta != nullptr && vtb != nullptr)
         return (vta->GetElementCount() == vtb->GetElementCount() &&
                 lCheckTypeEquality(vta->GetElementType(), vtb->GetElementType(), ignoreConst));
 
@@ -3247,7 +3247,7 @@ static bool lCheckTypeEquality(const Type *a, const Type *b, bool ignoreConst) {
     const StructType *stb = CastType<StructType>(b);
     const UndefinedStructType *usta = CastType<UndefinedStructType>(a);
     const UndefinedStructType *ustb = CastType<UndefinedStructType>(b);
-    if ((sta != NULL || usta != NULL) && (stb != NULL || ustb != NULL)) {
+    if ((sta != nullptr || usta != nullptr) && (stb != nullptr || ustb != nullptr)) {
         // Report both defuned and undefined structs as equal if their
         // names are the same.
         if (a->GetVariability() != b->GetVariability())
@@ -3260,19 +3260,19 @@ static bool lCheckTypeEquality(const Type *a, const Type *b, bool ignoreConst) {
 
     const PointerType *pta = CastType<PointerType>(a);
     const PointerType *ptb = CastType<PointerType>(b);
-    if (pta != NULL && ptb != NULL)
+    if (pta != nullptr && ptb != nullptr)
         return (pta->IsUniformType() == ptb->IsUniformType() && pta->IsSlice() == ptb->IsSlice() &&
                 pta->IsFrozenSlice() == ptb->IsFrozenSlice() &&
                 lCheckTypeEquality(pta->GetBaseType(), ptb->GetBaseType(), ignoreConst));
 
     const ReferenceType *rta = CastType<ReferenceType>(a);
     const ReferenceType *rtb = CastType<ReferenceType>(b);
-    if (rta != NULL && rtb != NULL)
+    if (rta != nullptr && rtb != nullptr)
         return (lCheckTypeEquality(rta->GetReferenceTarget(), rtb->GetReferenceTarget(), ignoreConst));
 
     const FunctionType *fta = CastType<FunctionType>(a);
     const FunctionType *ftb = CastType<FunctionType>(b);
-    if (fta != NULL && ftb != NULL) {
+    if (fta != nullptr && ftb != nullptr) {
         // Both the return types and all of the argument types must match
         // for function types to match
         if (!lCheckTypeEquality(fta->GetReturnType(), ftb->GetReturnType(), ignoreConst))
@@ -3294,7 +3294,7 @@ static bool lCheckTypeEquality(const Type *a, const Type *b, bool ignoreConst) {
 
     const TemplateTypeParmType *ttpa = CastType<TemplateTypeParmType>(a);
     const TemplateTypeParmType *ttpb = CastType<TemplateTypeParmType>(b);
-    if (ttpa != NULL && ttpb != NULL) {
+    if (ttpa != nullptr && ttpb != nullptr) {
         // Template type parameter types must have the same name to match.
         if (ttpa->GetName() != ttpb->GetName()) {
             return false;

--- a/src/type.h
+++ b/src/type.h
@@ -211,7 +211,7 @@ class Type : public Traceable {
 
     /** Given two types, returns the least general Type that is more general
         than both of them.  (i.e. that can represent their values without
-        any loss of data.)  If there is no such Type, return NULL.
+        any loss of data.)  If there is no such Type, return nullptr.
 
         @param type0        First of the two types
         @param type1        Second of the two types
@@ -729,7 +729,7 @@ class StructType : public CollectionType {
     llvm::DIType *GetDIType(llvm::DIScope *scope) const;
 
     /** Returns the type of the structure element with the given name (if any).
-        Returns NULL if there is no such named element. */
+        Returns nullptr if there is no such named element. */
     const Type *GetElementType(const std::string &name) const;
 
     /** Returns the type of the i'th structure element.  The value of \c i must
@@ -1003,7 +1003,7 @@ class FunctionType : public Type {
     const llvm::SmallVector<const Type *, 8> paramTypes;
     const llvm::SmallVector<std::string, 8> paramNames;
     /** Default values of the function's arguments.  For arguments without
-        default values provided, NULL is stored. */
+        default values provided, nullptr is stored. */
     mutable llvm::SmallVector<Expr *, 8> paramDefaults;
     /** The names provided (if any) with the function arguments in the
         function's signature.  These should only be used for error messages
@@ -1013,102 +1013,102 @@ class FunctionType : public Type {
 };
 
 /* Efficient dynamic casting of Types.  First, we specify a default
-   template function that returns NULL, indicating a failed cast, for
+   template function that returns nullptr, indicating a failed cast, for
    arbitrary types. */
-template <typename T> inline const T *CastType(const Type *type) { return NULL; }
+template <typename T> inline const T *CastType(const Type *type) { return nullptr; }
 
 /* Now we have template specializaitons for the Types implemented in this
    file.  Each one checks the Type::typeId member and then performs the
    corresponding static cast if it's safe as per the typeId.
  */
 template <> inline const AtomicType *CastType(const Type *type) {
-    if (type != NULL && type->typeId == ATOMIC_TYPE)
+    if (type != nullptr && type->typeId == ATOMIC_TYPE)
         return (const AtomicType *)type;
     else
-        return NULL;
+        return nullptr;
 }
 
 template <> inline const TemplateTypeParmType *CastType(const Type *type) {
-    if (type != NULL && type->typeId == TEMPLATE_TYPE_PARM_TYPE)
+    if (type != nullptr && type->typeId == TEMPLATE_TYPE_PARM_TYPE)
         return (const TemplateTypeParmType *)type;
     else
-        return NULL;
+        return nullptr;
 }
 
 template <> inline const EnumType *CastType(const Type *type) {
-    if (type != NULL && type->typeId == ENUM_TYPE)
+    if (type != nullptr && type->typeId == ENUM_TYPE)
         return (const EnumType *)type;
     else
-        return NULL;
+        return nullptr;
 }
 
 template <> inline const PointerType *CastType(const Type *type) {
-    if (type != NULL && type->typeId == POINTER_TYPE)
+    if (type != nullptr && type->typeId == POINTER_TYPE)
         return (const PointerType *)type;
     else
-        return NULL;
+        return nullptr;
 }
 
 template <> inline const ArrayType *CastType(const Type *type) {
-    if (type != NULL && type->typeId == ARRAY_TYPE)
+    if (type != nullptr && type->typeId == ARRAY_TYPE)
         return (const ArrayType *)type;
     else
-        return NULL;
+        return nullptr;
 }
 
 template <> inline const VectorType *CastType(const Type *type) {
-    if (type != NULL && type->typeId == VECTOR_TYPE)
+    if (type != nullptr && type->typeId == VECTOR_TYPE)
         return (const VectorType *)type;
     else
-        return NULL;
+        return nullptr;
 }
 
 template <> inline const SequentialType *CastType(const Type *type) {
     // Note that this function must be updated if other sequential type
     // implementations are added.
-    if (type != NULL && (type->typeId == ARRAY_TYPE || type->typeId == VECTOR_TYPE))
+    if (type != nullptr && (type->typeId == ARRAY_TYPE || type->typeId == VECTOR_TYPE))
         return (const SequentialType *)type;
     else
-        return NULL;
+        return nullptr;
 }
 
 template <> inline const CollectionType *CastType(const Type *type) {
     // Similarly a new collection type implementation requires updating
     // this function.
-    if (type != NULL && (type->typeId == ARRAY_TYPE || type->typeId == VECTOR_TYPE || type->typeId == STRUCT_TYPE))
+    if (type != nullptr && (type->typeId == ARRAY_TYPE || type->typeId == VECTOR_TYPE || type->typeId == STRUCT_TYPE))
         return (const CollectionType *)type;
     else
-        return NULL;
+        return nullptr;
 }
 
 template <> inline const StructType *CastType(const Type *type) {
-    if (type != NULL && type->typeId == STRUCT_TYPE)
+    if (type != nullptr && type->typeId == STRUCT_TYPE)
         return (const StructType *)type;
     else
-        return NULL;
+        return nullptr;
 }
 
 template <> inline const UndefinedStructType *CastType(const Type *type) {
-    if (type != NULL && type->typeId == UNDEFINED_STRUCT_TYPE)
+    if (type != nullptr && type->typeId == UNDEFINED_STRUCT_TYPE)
         return (const UndefinedStructType *)type;
     else
-        return NULL;
+        return nullptr;
 }
 
 template <> inline const ReferenceType *CastType(const Type *type) {
-    if (type != NULL && type->typeId == REFERENCE_TYPE)
+    if (type != nullptr && type->typeId == REFERENCE_TYPE)
         return (const ReferenceType *)type;
     else
-        return NULL;
+        return nullptr;
 }
 
 template <> inline const FunctionType *CastType(const Type *type) {
-    if (type != NULL && type->typeId == FUNCTION_TYPE)
+    if (type != nullptr && type->typeId == FUNCTION_TYPE)
         return (const FunctionType *)type;
     else
-        return NULL;
+        return nullptr;
 }
 
-inline bool IsReferenceType(const Type *t) { return CastType<ReferenceType>(t) != NULL; }
+inline bool IsReferenceType(const Type *t) { return CastType<ReferenceType>(t) != nullptr; }
 
 } // namespace ispc

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -54,7 +54,7 @@ int ispc::TerminalWidth() {
 
 #if defined(ISPC_HOST_IS_WINDOWS)
     HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
-    if (h == INVALID_HANDLE_VALUE || h == NULL)
+    if (h == INVALID_HANDLE_VALUE || h == nullptr)
         return 80;
     CONSOLE_SCREEN_BUFFER_INFO bufferInfo = {{0}};
     GetConsoleScreenBufferInfo(h, &bufferInfo);
@@ -68,7 +68,7 @@ int ispc::TerminalWidth() {
 }
 
 static bool lHaveANSIColors() {
-    static bool r = (getenv("TERM") != NULL && strcmp(getenv("TERM"), "dumb") != 0);
+    static bool r = (getenv("TERM") != nullptr && strcmp(getenv("TERM"), "dumb") != 0);
 #ifndef ISPC_HOST_IS_WINDOWS
     r &= (bool)isatty(2);
     r |= g->forceColoredOutput;
@@ -251,8 +251,8 @@ void ispc::PrintWithWordBreaks(const char *buf, int indent, int columnWidth, FIL
 #ifdef ISPC_HOST_IS_WINDOWS
 // we cover for the lack vasprintf and asprintf on windows (also covers mingw)
 int vasprintf(char **sptr, const char *fmt, va_list argv) {
-    int wanted = vsnprintf(*sptr = NULL, 0, fmt, argv);
-    if ((wanted < 0) || ((*sptr = (char *)malloc(1 + wanted)) == NULL))
+    int wanted = vsnprintf(*sptr = nullptr, 0, fmt, argv);
+    if ((wanted < 0) || ((*sptr = (char *)malloc(1 + wanted)) == nullptr))
         return -1;
 
     return vsprintf(*sptr, fmt, argv);
@@ -324,7 +324,7 @@ static void lPrint(const char *type, bool isError, SourcePos p, const char *fmt,
 }
 
 void ispc::Error(SourcePos p, const char *fmt, ...) {
-    if (m != NULL) {
+    if (m != nullptr) {
         ++m->errorCount;
         if ((g->errorLimit != -1) && (g->errorLimit <= m->errorCount - 1))
             return;
@@ -355,7 +355,7 @@ void ispc::Warning(SourcePos p, const char *fmt, ...) {
     if ((turnOffWarnings_it != g->turnOffWarnings.end()) && (turnOffWarnings_it->second == false))
         return;
 
-    if (g->warningsAsErrors && m != NULL)
+    if (g->warningsAsErrors && m != nullptr)
         ++m->errorCount;
 
     if (g->disableWarnings || g->quiet)
@@ -381,7 +381,7 @@ void ispc::PerformanceWarning(SourcePos p, const char *fmt, ...) {
     if (turnOffWarnings_it != g->turnOffWarnings.end())
         return;
 
-    if (g->warningsAsErrors && m != NULL)
+    if (g->warningsAsErrors && m != nullptr)
         ++m->errorCount;
 
     va_list args;
@@ -491,7 +491,7 @@ void ispc::GetDirectoryAndFileName(const std::string &currentDirectory, const st
 #ifdef ISPC_HOST_IS_WINDOWS
     char path[MAX_PATH];
     const char *combPath = PathCombine(path, currentDirectory.c_str(), relativeName.c_str());
-    Assert(combPath != NULL);
+    Assert(combPath != nullptr);
     const char *filenamePtr = PathFindFileName(combPath);
     *filename = filenamePtr;
     *directory = std::string(combPath, filenamePtr - combPath);
@@ -513,7 +513,7 @@ void ispc::GetDirectoryAndFileName(const std::string &currentDirectory, const st
     // now, we need to separate it into the base name and the directory
     const char *fp = fullPath.c_str();
     const char *basenameStart = strrchr(fp, '/');
-    Assert(basenameStart != NULL);
+    Assert(basenameStart != nullptr);
     ++basenameStart;
     Assert(basenameStart[0] != '\0');
     *filename = basenameStart;


### PR DESCRIPTION
`NULL` is a legacy constant from C that lacks proper typing, while `nullptr` is a typed alternative introduced in C++. Using `nullptr` is generally preferred over `NULL` in modern C++ code. Mixing both can create confusion for contributors and result in less readable code. This PR aims to standardize the use of `nullptr` by replacing all occurrences of `NULL` with `nullptr` in the `src`, `examples` (excluding C files), and `ispcrt` directories.

The changes in `src` folder is result of `sed` command followed by `clang-format` (except `parse.yy` and `lex.ll`). `examples` and `ispcrt` were changed manually.

Update:
In the source some of the changes were reverted with following policy and rational:
- all C++ `nullptr` remain - i.e. what is actually parsed by C++ as `nullptr`, but not comments or part of string literal;
- comments also use `nullptr` for the sake of consistency with the source code, even though in some cases it look a bit strange;
- string literals used for generating valid user errors keep using `NULL` - the intent is not to change use output
- string literals used for generating ICE, i.e. FATAL("...") message use `nullptr` - there's only one instance of such message and it looks good to me.
- string literals used in AST dump, i.e. `Print()` function keep using `NULL` as they indicate missing field and it's useful to have all-caps word to draw attention.