### PR TITLE
ispcrt: Expose device type

### DIFF
--- a/ispcrt/detail/Device.h
+++ b/ispcrt/detail/Device.h
@@ -33,6 +33,8 @@ struct Device : public RefCounted {
     virtual void *deviceNativeHandle() const = 0;
     virtual void *contextNativeHandle() const = 0;
 
+    virtual ISPCRTDeviceType getType() const = 0;
+
     virtual ISPCRTAllocationType getMemAllocType(void* appMemory) const = 0;
 };
 

--- a/ispcrt/detail/cpu/CPUDevice.cpp
+++ b/ispcrt/detail/cpu/CPUDevice.cpp
@@ -294,6 +294,10 @@ void *CPUDevice::deviceNativeHandle() const { return nullptr; }
 
 void *CPUDevice::contextNativeHandle() const { return nullptr; }
 
+ISPCRTDeviceType CPUDevice::getType() const {
+    return ISPCRT_DEVICE_TYPE_CPU;
+}
+
 ISPCRTAllocationType CPUDevice::getMemAllocType(void* appMemory) const {
     return ISPCRT_ALLOC_TYPE_UNKNOWN;
 }

--- a/ispcrt/detail/cpu/CPUDevice.h
+++ b/ispcrt/detail/cpu/CPUDevice.h
@@ -33,6 +33,8 @@ struct CPUDevice : public base::Device {
     void *deviceNativeHandle() const override;
     void *contextNativeHandle() const override;
 
+    ISPCRTDeviceType getType() const override;
+
     ISPCRTAllocationType getMemAllocType(void* appMemory) const override;
 };
 

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -1646,6 +1646,10 @@ void *GPUDevice::deviceNativeHandle() const { return m_device; }
 
 void *GPUDevice::contextNativeHandle() const { return m_context; }
 
+ISPCRTDeviceType GPUDevice::getType() const {
+    return ISPCRT_DEVICE_TYPE_GPU;
+}
+
 ISPCRTAllocationType GPUDevice::getMemAllocType(void *appMemory) const {
     ze_memory_allocation_properties_t memProperties = {ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES};
     ze_device_handle_t gpuDevice = (ze_device_handle_t)m_device;

--- a/ispcrt/detail/gpu/GPUDevice.h
+++ b/ispcrt/detail/gpu/GPUDevice.h
@@ -42,6 +42,8 @@ struct GPUDevice : public base::Device {
     void *deviceNativeHandle() const override;
     void *contextNativeHandle() const override;
 
+    ISPCRTDeviceType getType() const override;
+
     ISPCRTAllocationType getMemAllocType(void* appMemory) const override;
 
   private:

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -583,6 +583,12 @@ ISPCRTDevice ispcrtGetDeviceFromNativeHandle(ISPCRTContext context, ISPCRTGeneri
     return getISPCRTDevice(c.getDeviceType(), context, d, 0);
 }
 
+ISPCRTDeviceType ispcrtGetDeviceType(ISPCRTDevice d) ISPCRT_CATCH_BEGIN {
+    const auto &device = referenceFromHandle<ispcrt::base::Device>(d);
+    return device.getType();
+}
+ISPCRT_CATCH_END(ISPCRT_DEVICE_TYPE_AUTO)
+
 uint32_t ispcrtGetDeviceCount(ISPCRTDeviceType type) ISPCRT_CATCH_BEGIN {
     uint32_t devices = 0;
 

--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -89,6 +89,8 @@ ISPCRTDevice ispcrtGetDeviceFromContext(ISPCRTContext, uint32_t deviceIdx);
 // Alternatively ISPCRTDevice can be constructed from device native handler
 ISPCRTDevice ispcrtGetDeviceFromNativeHandle(ISPCRTContext context, ISPCRTGenericHandle d);
 
+ISPCRTDeviceType ispcrtGetDeviceType(ISPCRTDevice d);
+
 uint32_t ispcrtGetDeviceCount(ISPCRTDeviceType);
 void ispcrtGetDeviceInfo(ISPCRTDeviceType, uint32_t deviceIdx, ISPCRTDeviceInfo*);
 

--- a/ispcrt/ispcrt.hpp
+++ b/ispcrt/ispcrt.hpp
@@ -140,6 +140,7 @@ class Device : public GenericObject<ISPCRTDevice> {
     void* nativePlatformHandle() const;
     void* nativeDeviceHandle() const;
     void* nativeContextHandle() const;
+    ISPCRTDeviceType getType() const;
     // static methods to get information about available devices
     static uint32_t deviceCount(ISPCRTDeviceType type);
     static ISPCRTDeviceInfo deviceInformation(ISPCRTDeviceType type, uint32_t deviceIdx);
@@ -167,6 +168,10 @@ inline Device::Device(const Context &context, ISPCRTGenericHandle nativeDeviceHa
 inline void* Device::nativePlatformHandle() const { return ispcrtPlatformNativeHandle(handle()); }
 inline void* Device::nativeDeviceHandle() const { return ispcrtDeviceNativeHandle(handle()); }
 inline void* Device::nativeContextHandle() const { return ispcrtDeviceContextNativeHandle(handle()); }
+
+inline ISPCRTDeviceType Device::getType() const {
+    return ispcrtGetDeviceType(handle());
+}
 
 inline uint32_t Device::deviceCount(ISPCRTDeviceType type) {
     return ispcrtGetDeviceCount(type);

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -191,6 +191,20 @@ TEST_F(MockTest, Device_Constructor_FromContext) {
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
+TEST_F(MockTest, Device_Type_CPU) {
+    ispcrt::Context c(ISPCRT_DEVICE_TYPE_CPU);
+    ispcrt::Device d(c);
+    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
+    ASSERT_EQ(d.getType(), ISPCRT_DEVICE_TYPE_CPU);
+}
+
+TEST_F(MockTest, Device_Type_GPU) {
+    ispcrt::Context c(ISPCRT_DEVICE_TYPE_GPU);
+    ispcrt::Device d(c);
+    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
+    ASSERT_EQ(d.getType(), ISPCRT_DEVICE_TYPE_GPU);
+}
+
 /////////////////////////////////////////////////////////////////////
 // Context tests
 


### PR DESCRIPTION
Changes:
*   Added `getType` to `Device` interface. 
    | `ispcrt/detail/Device.h`,
    | `ispcrt/detail/cpu/CPUDevice.cpp`,
    | `ispcrt/detail/cpu/CPUDevice.h`,
    | `ispcrt/detail/gpu/GPUDevice.cpp`,
    | `ispcrt/detail/gpu/GPUDevice.h`,
    | `ispcrt/ispcrt.cpp`,
    | `ispcrt/ispcrt.h`,
    | `ispcrt/ispcrt.hpp`,
    | `iscprt/tests/mock_tests/ispcrt_mock_main.cpp`