### PR TITLE
builtins: Refactor mangling utilities

### DIFF
--- a/src/builtins.h
+++ b/src/builtins.h
@@ -38,4 +38,8 @@ void AddBitcodeToModule(const BitcodeLib *lib, llvm::Module *module, SymbolTable
  */
 Symbol *CreateISPCSymbolForLLVMIntrinsic(llvm::Function *func, SymbolTable *symbolTable);
 
+#ifdef ISPC_XE_ENABLED
+std::string mangleSPIRVBuiltin(const llvm::Function &func);
+#endif
+
 } // namespace ispc

--- a/src/opt/MangleOpenCLBuiltins.cpp
+++ b/src/opt/MangleOpenCLBuiltins.cpp
@@ -78,7 +78,11 @@ static std::string mangleOCLBuiltin(const llvm::Function &func) {
 std::string mangleSPIRVBuiltin(const llvm::Function &func) {
     Assert(func.getName().startswith("__spirv_") && "wrong argument: spirv builtin is expected");
     std::string mangledName;
-    mangleOpenClBuiltin(func.getName().str(), func.getArg(0)->getType(),
+    std::vector<llvm::Type *> tyArgs;
+    for (const auto &arg : func.args()) {
+        tyArgs.push_back(arg.getType());
+    }
+    mangleOpenClBuiltin(func.getName().str(), tyArgs,
 #if ISPC_LLVM_VERSION == ISPC_LLVM_15_0
                         // spirv builtins doesn't have pointer arguments
                         {},

--- a/src/opt/MangleOpenCLBuiltins.cpp
+++ b/src/opt/MangleOpenCLBuiltins.cpp
@@ -75,7 +75,7 @@ static std::string mangleOCLBuiltin(const llvm::Function &func) {
     return mangleMathOCLBuiltin(func);
 }
 
-static std::string mangleSPIRVBuiltin(const llvm::Function &func) {
+std::string mangleSPIRVBuiltin(const llvm::Function &func) {
     Assert(func.getName().startswith("__spirv_") && "wrong argument: spirv builtin is expected");
     std::string mangledName;
     mangleOpenClBuiltin(func.getName().str(), func.getArg(0)->getType(),


### PR DESCRIPTION
Changes:
*   Move name mangling out of opt to common builtins header.
    | `src/builtins.cpp`,
    | `src/builtins.h`,
    | `src/opt/MangleOpenCLBuiltins.cpp`,
    | `src/opt/MangleOpenCLBuiltins.h`

Description:
>When adding functions declarations to ISPC modules via `AddFunctionDeclaration`, names are expected to be unique.
>If the the same function is registered more than once, the resulting declaration is renamed with a numeric suffix (e.g. `foo.1`).
>For the specialization constants feature, we need declarations for each `constspec` type we would like to initialize.
>However, the base name for the builtin for all types is `__spirv_specConstant`.
>Adding declarations with the appropriate signature does not prevent the mangling from attempting to disambiguate the function names.
>Moving the mangling utilities out of the optimization in which they are used allows for us to mangle the name manually so that the correct names can be used when emitting IR.