### PR TITLE
Enable Codespaces for ISPC

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,20 @@
+Codespaces - ISPC developer's environment (CPU only)
+====================================================
+
+This is the minimal environment that enables CPU-only ISPC build (i.e. GPU backend is not enabled).
+
+To build ISPC and run the tests do the following:
+```bash
+# `build` folder already contains result of `cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
+cd build
+# build ISPC and examples
+make -j4
+# run LIT tests
+make check-all
+```
+
+Note that `build` folder already contains `compile_commands.json`, which is needed for VSCode to be able correctly parse and browse C++ files.
+
+The container also contains pre-installed [C/C++ Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools-extension-pack) for VSCode.
+
+Enjoy and please let us know if you use Codespaces to hack ISPC and have any suggestions or feedback: [Github Discussions](https://github.com/ispc/ispc/discussions)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,13 @@
     "command1": "cd ${containerWorkspaceFolder} && mkdir build && cd build && cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
   },
   "customizations": {
+    "codespaces": {
+      "openFiles": [
+        ".devcontainer/README.md",
+        "CONTRIBUTING.md",
+        "src/main.cpp"
+      ]
+    },
     "vscode": {
       "settings": {
         "C_Cpp.default.compileCommands": "${containerWorkspaceFolder}/build/compile_commands.json"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "__comment1__": "Copyright (c) 2023, Intel Corporation",
+  "__comment2__": "SPDX-License-Identifier: BSD-3-Clause",
+  "name": "ISPC developers environment (CPU only)",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": { "packages" : "libc6-dev,libc6-dev-i386,flex,wget" },
+    "ghcr.io/wxw-matt/devcontainer-features/command_runner:latest": {
+      "command1" : "mkdir /llvm && cd /llvm && wget -q https://github.com/ispc/ispc.dependencies/releases/download/llvm-15.0-ispc-dev/llvm-15.0.7-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz",
+      "command2" : "cd /llvm && tar xvf llvm-15.0.7-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz && rm -rf llvm-*" }
+  },
+  "containerEnv": {
+    "ISPC_HOME" : "/workspaces/ispc",
+    "LLVM_HOME" : "/llvm"
+  },
+  "remoteEnv": { "PATH": "/llvm/bin-15.0/bin:${containerEnv:PATH}" },
+  "onCreateCommand": {
+    "command1": "cd ${containerWorkspaceFolder} && mkdir build && cd build && cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "C_Cpp.default.compileCommands": "${containerWorkspaceFolder}/build/compile_commands.json"
+      },
+      "extensions": ["ms-vscode.cpptools-extension-pack"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Appveyor build status (Windows)](https://ci.appveyor.com/api/projects/status/xfllw9vkp3lj4l0v/branch/main?svg=true)](https://ci.appveyor.com/project/ispc/ispc/branch/main)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=1931356)
 
 Intel® Implicit SPMD Program Compiler (Intel® ISPC)
 ===================================================


### PR DESCRIPTION
PR includes a minimal Codespaces container for comfortable browsing, editing, and building ISPC project.

The configuration includes pre-built LLVM 15.0.7.

If it works well, we can add GPU-enabled env, though I'm not sure if we can have Intel GPU-enabled cloud instance.