### PR TITLE
alloy.py to build LLVM 16.0.2 and build it in CI.

### DIFF
--- a/.github/workflows/rebuild-llvm16.yml
+++ b/.github/workflows/rebuild-llvm16.yml
@@ -1,0 +1,26 @@
+# Copyright 2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Rebuild LLVM 16.0
+
+on:
+  push:
+    branches:
+      - main
+      - '**rebuild_llvm**'
+    paths:
+      - "llvm_patches/*16_0*"
+      - "alloy.py"
+      - ".github/workflows/rebuild-llvm16.yml"
+      - ".github/workflows/reusable.rebuild.yml"
+  workflow_dispatch:
+
+jobs:
+  llvm16:
+    uses: ./.github/workflows/reusable.rebuild.yml
+    with:
+      version: '16.0'
+      full_version: '16.0.2'
+      ubuntu: '18.04'
+      vs_generator: 'Visual Studio 16 2019'
+      vs_version_str: 'vs2019'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Appveyor build status (Windows)](https://ci.appveyor.com/api/projects/status/xfllw9vkp3lj4l0v/branch/main?svg=true)](https://ci.appveyor.com/project/ispc/ispc/branch/main)
+
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=1931356)
 
 Intel® Implicit SPMD Program Compiler (Intel® ISPC)

--- a/alloy.py
+++ b/alloy.py
@@ -94,7 +94,7 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     if  version_LLVM == "trunk":
         GIT_TAG="main"
     elif  version_LLVM == "16_0":
-        GIT_TAG="release/16.x"
+        GIT_TAG="llvmorg-16.0.2"
     elif  version_LLVM == "15_0":
         GIT_TAG="llvmorg-15.0.7"
     elif  version_LLVM == "14_0":


### PR DESCRIPTION
- `alloy.py` to build `16.0.2` when LLVM 16 is requested.
- add pipeline to build LLVM 16.
- fix README - move Codespaces badge to a separate line