### PR TITLE
ispcrt: support Fence

### DIFF
--- a/docs/ispc_for_xe.rst
+++ b/docs/ispc_for_xe.rst
@@ -168,7 +168,7 @@ The ``ISPC Run Time`` uses the following abstractions to manage code execution:
   there is no need to explicitly handle data movement between the CPU and the
   GPU. This is handled automatically by the ``oneAPI Level Zero`` runtime.
 
-* ``Task queue`` - Each ``device`` has a task (command) queue and executes
+* ``Task queue`` - each ``device`` has a task (command) queue and executes
   commands from it. Commands may be executed simultaneously. To prevent that
   one should explicitly insert barriers in places where synchronization is
   required. ``Task queue`` ``sync`` method stops the host thread until GPU
@@ -176,8 +176,7 @@ The ``ISPC Run Time`` uses the following abstractions to manage code execution:
   ``CommandQueue`` and ``CommandList`` objects.
 
 * ``CommandQueue`` - represents a logical input stream to the device and
-  directly maps to L0 command queues. Queues are needed to be constructed to
-  submit the actual commands contained in command lists.
+  directly maps to L0 command queues.
 
 * ``CommandList`` - represents commands to be executed on a command queue. It
   can be created by calling ``createCommandList`` method of ``CommandQueue``

--- a/docs/ispc_for_xe.rst
+++ b/docs/ispc_for_xe.rst
@@ -169,10 +169,28 @@ The ``ISPC Run Time`` uses the following abstractions to manage code execution:
   GPU. This is handled automatically by the ``oneAPI Level Zero`` runtime.
 
 * ``Task queue`` - Each ``device`` has a task (command) queue and executes
-  commands from it. The execution may be asynchronous, which means that
-  subsequent commands can begin executing before the previous ones complete.
-  There are synchronization primitives available to make the execution
-  synchronous.
+  commands from it. Commands may be executed simultaneously. To prevent that
+  one should explicitly insert barriers in places where synchronization is
+  required. ``Task queue`` ``sync`` method stops the host thread until GPU
+  computation completed. For asynchronous computation, one should utilize
+  ``CommandQueue`` and ``CommandList`` objects.
+
+* ``CommandQueue`` - represents a logical input stream to the device and
+  directly maps to L0 command queues. Queues are needed to be constructed to
+  submit the actual commands contained in command lists.
+
+* ``CommandList`` - represents commands to be executed on a command queue. It
+  can be created by calling ``createCommandList`` method of ``CommandQueue``
+  object. Synchronization between all commands in list has to be done
+  explicitly by putting barriers if needed. Fine-grained synchronization via
+  ``Events`` are not supported yet.
+
+* ``Fence`` - is a synchronization primitive to communicate to the host that
+  command list execution has completed. ``Fence`` is created upon command list
+  submission. It can be waited synchronously (``sync``) and asynchronously
+  (periodically checking ``status``). Fence has two states
+  ``ISPCRT_FENCE_UNSIGNALED`` and ``ISPCRT_FENCE_SIGNALED`` returned by
+  ``status`` method.
 
 * ``Barrier`` - synchronization primitive that can be inserted into a ``task
   queue`` to make sure that all tasks previously inserted into this queue have

--- a/examples/xpu/CMakeLists.txt
+++ b/examples/xpu/CMakeLists.txt
@@ -59,6 +59,7 @@ add_subdirectory(aobench)
 add_subdirectory(mandelbrot)
 add_subdirectory(simple)
 add_subdirectory(simple-usm)
+add_subdirectory(simple-fence)
 add_subdirectory(usm-mem)
 
 # DPC++ related examples should not run as part of ISPC_BUILD

--- a/examples/xpu/README.md
+++ b/examples/xpu/README.md
@@ -36,6 +36,24 @@ device. This is handled by the Level Zero.
 The ISPC Runtime enables using the USM via Array type and provides an allocator that can be used in standard C++
 containers, such as `std::vector`.
 
+
+Simple-fence
+============
+
+This example shows how one can use ISPCRT to asynchronously compute something on GPU with other work being
+done on CPU in parallel. It is derived from `Simple` example. The key difference is that `TaskQueue` object is not used
+here. `CommandQueue` and `CommandList` objects are explicitly constructed here instead. Commands are submitted with
+`copyToDevice`, `launch` and `copyToHost` methods of the command list object. It is important to notice that barriers
+should be inserted explicitly if needed between computations or memory copying. It can be done with `barrier` method
+of `CommandList` object. After filling the command list, `submit` method is called. It instructs GPU to execute
+the submitted commands. This method returns a `Fence` object. It has two states: unsignalled and signalled. GPU change
+the fence object state to signalled when execution is completed. Fence state is checked via `status` method. After
+submission, host CPU thread computes the validation result effectively in parallel with GPU computation. After that,
+fence object is waited in the loop until being signalled.
+
+`host_simple-fence [--gpu | --cpu ]`
+
+
 AOBench
 =======
 

--- a/examples/xpu/TestLists.txt
+++ b/examples/xpu/TestLists.txt
@@ -15,6 +15,11 @@ test_add(NAME simple-usm host_simple-usm "")
 test_add(NAME simple-usm host_simple-usm --cpu)
 test_add(NAME simple-usm host_simple-usm --gpu)
 
+# auto | --cpu | --gpu
+test_add(NAME simple-fence host_simple-fence "")
+test_add(NAME simple-fence host_simple-fence --cpu)
+test_add(NAME simple-fence host_simple-fence --gpu)
+
 test_add(NAME usm-mem host_usm-mem 1)
 test_add(NAME usm-mem host_usm-mem 2)
 

--- a/examples/xpu/simple-fence/CMakeLists.txt
+++ b/examples/xpu/simple-fence/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+#  Copyright (c) 2023, Intel Corporation
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+
+#
+# ispc examples: simple-fence
+#
+
+cmake_minimum_required(VERSION 3.13)
+
+set(TEST_NAME "simple-fence")
+set(ISPC_SRC_NAME "simple-fence.ispc")
+set(ISPC_TARGET_XE "gen9-x8")
+set(HOST_SOURCES simple-fence.cpp)
+
+add_perf_example(
+    ISPC_SRC_NAME ${ISPC_SRC_NAME}
+    TEST_NAME ${TEST_NAME}
+    ISPC_TARGET_XE ${ISPC_TARGET_XE}
+    HOST_SOURCES ${HOST_SOURCES}
+)
+

--- a/examples/xpu/simple-fence/simple-fence.cpp
+++ b/examples/xpu/simple-fence/simple-fence.cpp
@@ -1,0 +1,173 @@
+/*
+  Copyright (c) 2023, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <chrono>
+#include <thread>
+
+// ispcrt
+#include "ispcrt.hpp"
+
+std::ostream &operator<<(std::ostream &os, const ISPCRTDeviceType dt) {
+    switch (dt) {
+    case ISPCRT_DEVICE_TYPE_AUTO:
+        os << "Auto";
+        break;
+    case ISPCRT_DEVICE_TYPE_GPU:
+        os << "GPU";
+        break;
+    case ISPCRT_DEVICE_TYPE_CPU:
+        os << "CPU";
+        break;
+    default:
+        break;
+    }
+    return os;
+}
+
+struct Parameters {
+    float *vin;
+    float *vout;
+    int count;
+};
+
+void simple_CPU_validation(std::vector<float> vin, std::vector<float> &vgold, const unsigned int SIZE) {
+    for (unsigned int i = 0; i < SIZE; i++) {
+        float v = vin[i];
+        for (int i = 0; i < 100000; i++) {
+            if (v < 3.)
+                v = v * v;
+            else
+                v = std::sqrt(v);
+        }
+
+        vgold[i] = v;
+    }
+}
+
+#define EPSILON 0.01f
+bool validate_result(std::vector<float> vout, std::vector<float> vgold, const unsigned int SIZE) {
+    bool bValid = true;
+    for (unsigned int i = 0; i < SIZE; i++) {
+        float delta = (float)fabs(vgold[i] - vout[i]);
+        if (delta > EPSILON) {
+            std::cout << "Validation failed on i=" << i << ": vout[i] = " << vout[i] << ", but " << vgold[i]
+                      << " was expected\n";
+            bValid = false;
+        }
+    }
+    return bValid;
+}
+
+int run(const ISPCRTDeviceType device_type, const unsigned int SIZE) {
+    std::vector<float> vin(SIZE);
+    std::vector<float> vout(SIZE);
+    std::vector<float> vgold(SIZE);
+
+    ispcrt::Device device(device_type);
+
+    // Setup input array
+    ispcrt::Array<float> vin_dev(device, vin);
+
+    // Setup output array
+    ispcrt::Array<float> vout_dev(device, vout);
+
+    // Setup parameters structure
+    Parameters p;
+
+    p.vin = vin_dev.devicePtr();
+    p.vout = vout_dev.devicePtr();
+    p.count = SIZE;
+
+    auto p_dev = ispcrt::Array<Parameters>(device, p);
+
+    // Create module and kernel to execute
+    ispcrt::Module module(device, "xe_simple-fence");
+    ispcrt::Kernel kernel(device, module, "simple_ispc");
+
+    // Create task queue and execute kernel
+    ispcrt::CommandQueue queue(device, 0);
+    ispcrt::CommandList cmds = queue.createCommandList();
+
+    std::generate(vin.begin(), vin.end(), [i = 0]() mutable { return i++; });
+
+    // ispcrt::Array objects which used as inputs for ISPC kernel should be
+    // explicitly copied to device from host
+    cmds.copyToDevice(p_dev);
+    cmds.copyToDevice(vin_dev);
+    cmds.barrier();
+    // Launch the kernel on the device using 1 thread
+    cmds.launch(kernel, p_dev, 1);
+    cmds.barrier();
+    // ispcrt::Array objects which used as outputs of ISPC kernel should be
+    // explicitly copied to host from device
+    cmds.copyToHost(vout_dev);
+
+    ispcrt::Fence fence = cmds.submit();
+    std::cout << "fence status " << fence.status() << std::endl;
+
+    // Calculate gold result.
+    // Note that this work is processed in parallel with computation on GPU.
+    simple_CPU_validation(vin, vgold, SIZE);
+
+    // Wait until GPU computation completed.
+    while (!fence.status()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::cout << "Wait fence to be signaled" << std::endl;
+    }
+    std::cout << "Wait finished" << std::endl;
+    std::cout << "fence status " << fence.status() << std::endl;
+
+    std::cout << "Executed on: " << device_type << '\n' << std::setprecision(6) << std::fixed;
+
+    // Check and print result
+    bool bValid = validate_result(vout, vgold, SIZE);
+    if (bValid) {
+        for (int i = 0; i < SIZE; i++) {
+            std::cout << i << ": simple(" << vin[i] << ") = " << vout[i] << '\n';
+        }
+        return 0;
+    }
+    return -1;
+}
+
+void usage(const char *p) {
+    std::cout << "Usage:\n";
+    std::cout << p << " --cpu | --gpu | -h\n";
+}
+
+int main(int argc, char *argv[]) {
+    std::ios_base::fmtflags f(std::cout.flags());
+
+    constexpr unsigned int SIZE = 16;
+
+    // Run on CPU by default
+    ISPCRTDeviceType device_type = ISPCRT_DEVICE_TYPE_AUTO;
+
+    if (argc > 2 || (argc == 2 && std::string(argv[1]) == "-h")) {
+        usage(argv[0]);
+        return -1;
+    }
+
+    if (argc == 2) {
+        std::string dev_param = argv[1];
+        if (dev_param == "--cpu") {
+            device_type = ISPCRT_DEVICE_TYPE_CPU;
+        } else if (dev_param == "--gpu") {
+            device_type = ISPCRT_DEVICE_TYPE_GPU;
+        } else {
+            usage(argv[0]);
+            return -1;
+        }
+    }
+
+    int success = run(device_type, SIZE);
+    std::cout.flags(f);
+    return success;
+}

--- a/examples/xpu/simple-fence/simple-fence.ispc
+++ b/examples/xpu/simple-fence/simple-fence.ispc
@@ -1,0 +1,35 @@
+/*
+  Copyright (c) 2023, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+struct Parameters {
+    float *vin;
+    float *vout;
+    int    count;
+};
+
+task void simple_ispc(void *uniform _p) {
+    Parameters *uniform p = (Parameters * uniform) _p;
+
+    foreach (index = 0 ... p->count) {
+        // Load the appropriate input value for this program instance.
+        float v = p->vin[index];
+
+        // Do an arbitrary computation, but at least make the
+        // computation dependent on the value being processed
+        for(int i = 0; i < 100000; i++) {
+            if (v < 3.)
+                v = v * v;
+            else
+                v = sqrt(v);
+        }
+
+        // And write the result to the output array.
+        p->vout[index] = v;
+    }
+}
+
+#include "ispcrt.isph"
+DEFINE_CPU_ENTRY_POINT(simple_ispc)

--- a/ispcrt/detail/CommandList.h
+++ b/ispcrt/detail/CommandList.h
@@ -1,0 +1,37 @@
+// Copyright 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+// public
+#include "../ispcrt.h"
+// internal
+#include "Fence.h"
+#include "Future.h"
+#include "Kernel.h"
+#include "MemoryView.h"
+#include "IntrusivePtr.h"
+
+namespace ispcrt {
+namespace base {
+
+struct CommandList : public RefCounted {
+    CommandList() = default;
+    virtual ~CommandList() = default;
+
+    virtual void barrier() = 0;
+    virtual base::Future *copyToHost(base::MemoryView &mv) = 0;
+    virtual base::Future *copyToDevice(base::MemoryView &mv) = 0;
+    virtual base::Future *copyMemoryView(base::MemoryView &mv_dst, base::MemoryView &mv_src, const size_t size) = 0;
+    virtual base::Future *launch(Kernel &k, base::MemoryView *params, size_t dim0, size_t dim1, size_t dim2) = 0;
+
+    virtual void close() = 0;
+    virtual base::Fence *submit() = 0;
+    virtual void reset() = 0;
+
+    virtual void enableTimestamps() = 0;
+    virtual void *nativeHandle() const = 0;
+};
+
+} // namespace base
+} // namespace ispcrt

--- a/ispcrt/detail/CommandQueue.h
+++ b/ispcrt/detail/CommandQueue.h
@@ -1,0 +1,26 @@
+// Copyright 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+// public
+#include "../ispcrt.h"
+// internal
+#include "CommandList.h"
+#include "IntrusivePtr.h"
+
+namespace ispcrt {
+namespace base {
+
+struct CommandQueue : public RefCounted {
+    CommandQueue() = default;
+    virtual ~CommandQueue() = default;
+
+    virtual base::CommandList *createCommandList() = 0;
+    virtual void sync() = 0;
+
+    virtual void *nativeHandle() const = 0;
+};
+
+} // namespace base
+} // namespace ispcrt

--- a/ispcrt/detail/Device.h
+++ b/ispcrt/detail/Device.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 Intel Corporation
+// Copyright 2020-2023 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
@@ -8,6 +8,7 @@
 // internal
 #include "Kernel.h"
 #include "Module.h"
+#include "CommandQueue.h"
 #include "TaskQueue.h"
 
 namespace ispcrt {
@@ -19,6 +20,8 @@ struct Device : public RefCounted {
     virtual ~Device() = default;
 
     virtual MemoryView *newMemoryView(void *appMemory, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const = 0;
+
+    virtual CommandQueue *newCommandQueue(uint32_t ordinal) const = 0;
 
     virtual TaskQueue *newTaskQueue() const = 0;
 

--- a/ispcrt/detail/Fence.h
+++ b/ispcrt/detail/Fence.h
@@ -1,0 +1,26 @@
+// Copyright 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+// public
+#include "../ispcrt.h"
+// internal
+#include "IntrusivePtr.h"
+
+namespace ispcrt {
+namespace base {
+
+struct Fence : public RefCounted {
+    Fence() = default;
+    virtual ~Fence() = default;
+
+    virtual void sync() = 0;
+    virtual ISPCRTFenceStatus status() const = 0;
+    virtual void reset() = 0;
+
+    virtual void* nativeHandle() const = 0;
+};
+
+} // namespace base
+} // namespace ispcrt

--- a/ispcrt/detail/TaskQueue.h
+++ b/ispcrt/detail/TaskQueue.h
@@ -1,8 +1,9 @@
-// Copyright 2020-2021 Intel Corporation
+// Copyright 2020-2023 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 
+#include "Fence.h"
 #include "Future.h"
 #include "Kernel.h"
 #include "MemoryView.h"
@@ -22,7 +23,6 @@ struct TaskQueue : public RefCounted {
 
     virtual base::Future *launch(Kernel &k, base::MemoryView *params, size_t dim0, size_t dim1, size_t dim2) = 0;
 
-    virtual void submit() = 0;
     virtual void sync() = 0;
 
     virtual void* taskQueueNativeHandle() const = 0;

--- a/ispcrt/detail/cpu/CPUDevice.h
+++ b/ispcrt/detail/cpu/CPUDevice.h
@@ -5,6 +5,7 @@
 
 #include "../Device.h"
 #include "../Future.h"
+#include "../CommandQueue.h"
 
 namespace ispcrt {
 
@@ -19,6 +20,8 @@ struct CPUDevice : public base::Device {
     CPUDevice() = default;
 
     base::MemoryView *newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const override;
+
+    base::CommandQueue *newCommandQueue(uint32_t ordinal) const override;
 
     base::TaskQueue *newTaskQueue() const override;
 

--- a/ispcrt/detail/gpu/GPUDevice.h
+++ b/ispcrt/detail/gpu/GPUDevice.h
@@ -6,6 +6,9 @@
 #include "../Context.h"
 #include "../Device.h"
 #include "../Future.h"
+#include "../Fence.h"
+#include "../CommandList.h"
+#include "../CommandQueue.h"
 
 // std
 #include <unordered_map>
@@ -28,6 +31,8 @@ struct GPUDevice : public base::Device {
     ~GPUDevice();
 
     base::MemoryView *newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const override;
+
+    base::CommandQueue *newCommandQueue(uint32_t ordinal) const override;
 
     base::TaskQueue *newTaskQueue() const override;
 

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -798,6 +798,127 @@ ISPCRTKernel ispcrtNewKernel(ISPCRTDevice d, ISPCRTModule m, const char *name) I
 ISPCRT_CATCH_END(nullptr)
 
 ///////////////////////////////////////////////////////////////////////////////
+// Command lists //////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+
+void ispcrtCommandListBarrier(ISPCRTCommandList l) ISPCRT_CATCH_BEGIN {
+    auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
+    list.barrier();
+}
+ISPCRT_CATCH_END_NO_RETURN()
+
+ISPCRTFuture ispcrtCommandListCopyToDevice(ISPCRTCommandList l, ISPCRTMemoryView mv) ISPCRT_CATCH_BEGIN {
+    auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
+    auto &view = referenceFromHandle<ispcrt::base::MemoryView>(mv);
+    return (ISPCRTFuture) list.copyToDevice(view);
+}
+ISPCRT_CATCH_END(nullptr)
+
+ISPCRTFuture ispcrtCommandListCopyToHost(ISPCRTCommandList l, ISPCRTMemoryView mv) ISPCRT_CATCH_BEGIN {
+    auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
+    auto &view = referenceFromHandle<ispcrt::base::MemoryView>(mv);
+    return (ISPCRTFuture) list.copyToHost(view);
+}
+ISPCRT_CATCH_END(nullptr)
+
+ISPCRTFuture ispcrtCommandListCopyMemoryView(ISPCRTCommandList l, ISPCRTMemoryView mvDst, ISPCRTMemoryView mvSrc, const size_t size) ISPCRT_CATCH_BEGIN {
+    auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
+    auto &viewDst = referenceFromHandle<ispcrt::base::MemoryView>(mvDst);
+    auto &viewSrc = referenceFromHandle<ispcrt::base::MemoryView>(mvSrc);
+    if (size > viewDst.numBytes()) {
+        throw std::runtime_error("Requested copy size is bigger than destination buffer size!");
+    }
+    if (size > viewSrc.numBytes()) {
+        throw std::runtime_error("Requested copy size is bigger than source buffer size!");
+    }
+    return (ISPCRTFuture) list.copyMemoryView(viewDst, viewSrc, size);
+}
+ISPCRT_CATCH_END(nullptr)
+
+ISPCRTFuture ispcrtCommandListLaunch1D(ISPCRTCommandList l, ISPCRTKernel k, ISPCRTMemoryView p, size_t dim0) ISPCRT_CATCH_BEGIN {
+    return ispcrtCommandListLaunch3D(l, k, p, dim0, 1, 1);
+}
+ISPCRT_CATCH_END(nullptr)
+
+ISPCRTFuture ispcrtCommandListLaunch2D(ISPCRTCommandList l, ISPCRTKernel k, ISPCRTMemoryView p, size_t dim0,
+                                       size_t dim1) ISPCRT_CATCH_BEGIN {
+    return ispcrtCommandListLaunch3D(l, k, p, dim0, dim1, 1);
+}
+ISPCRT_CATCH_END(nullptr)
+
+ISPCRTFuture ispcrtCommandListLaunch3D(ISPCRTCommandList l, ISPCRTKernel k, ISPCRTMemoryView p, size_t dim0, size_t dim1,
+                                       size_t dim2) ISPCRT_CATCH_BEGIN {
+    auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
+    auto &kernel = referenceFromHandle<ispcrt::base::Kernel>(k);
+
+    ispcrt::base::MemoryView *params = nullptr;
+
+    if (p)
+        params = &referenceFromHandle<ispcrt::base::MemoryView>(p);
+
+    return (ISPCRTFuture)list.launch(kernel, params, dim0, dim1, dim2);
+}
+ISPCRT_CATCH_END(nullptr)
+
+void ispcrtCommandListClose(ISPCRTCommandList l) ISPCRT_CATCH_BEGIN {
+    auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
+    list.close();
+}
+ISPCRT_CATCH_END_NO_RETURN()
+
+ISPCRTFence ispcrtCommandListSubmit(ISPCRTCommandList l) ISPCRT_CATCH_BEGIN {
+    auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
+    return (ISPCRTFence) list.submit();
+}
+ISPCRT_CATCH_END(nullptr)
+
+void ispcrtCommandListReset(ISPCRTCommandList l) ISPCRT_CATCH_BEGIN {
+    auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
+    list.reset();
+}
+ISPCRT_CATCH_END_NO_RETURN()
+
+void ispcrtCommandListEnableTimestamps(ISPCRTCommandList l) ISPCRT_CATCH_BEGIN {
+    auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
+    return list.enableTimestamps();
+}
+ISPCRT_CATCH_END_NO_RETURN()
+
+ISPCRTGenericHandle ispcrtCommandListNativeHandle(ISPCRTCommandList l) ISPCRT_CATCH_BEGIN {
+    auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
+    return list.nativeHandle();
+}
+ISPCRT_CATCH_END(nullptr)
+
+///////////////////////////////////////////////////////////////////////////////
+// Command queues /////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+
+ISPCRTCommandQueue ispcrtNewCommandQueue(ISPCRTDevice d, uint32_t ordinal) ISPCRT_CATCH_BEGIN {
+    const auto &device = referenceFromHandle<ispcrt::base::Device>(d);
+    return (ISPCRTCommandQueue)device.newCommandQueue(ordinal);
+}
+ISPCRT_CATCH_END(nullptr)
+
+ISPCRTCommandList ispcrtCommandQueueCreateCommandList(ISPCRTCommandQueue q) ISPCRT_CATCH_BEGIN {
+    auto &queue = referenceFromHandle<ispcrt::base::CommandQueue>(q);
+    return (ISPCRTCommandList) queue.createCommandList();
+}
+ISPCRT_CATCH_END(nullptr)
+
+void ispcrtCommandQueueSync(ISPCRTCommandQueue q) ISPCRT_CATCH_BEGIN {
+    auto &queue = referenceFromHandle<ispcrt::base::CommandQueue>(q);
+    queue.sync();
+}
+ISPCRT_CATCH_END_NO_RETURN()
+
+ISPCRTGenericHandle ispcrtCommandQueueNativeHandle(ISPCRTCommandQueue q) ISPCRT_CATCH_BEGIN {
+    auto &queue = referenceFromHandle<ispcrt::base::CommandQueue>(q);
+    return queue.nativeHandle();
+}
+ISPCRT_CATCH_END(nullptr)
+
+///////////////////////////////////////////////////////////////////////////////
 // Task queues ////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -871,6 +992,30 @@ void ispcrtSync(ISPCRTTaskQueue q) ISPCRT_CATCH_BEGIN {
     queue.sync();
 }
 ISPCRT_CATCH_END_NO_RETURN()
+
+void ispcrtFenceSync(ISPCRTFence f) ISPCRT_CATCH_BEGIN {
+    auto &fence = referenceFromHandle<ispcrt::base::Fence>(f);
+    fence.sync();
+}
+ISPCRT_CATCH_END_NO_RETURN()
+
+ISPCRTFenceStatus ispcrtFenceStatus(ISPCRTFence f) ISPCRT_CATCH_BEGIN {
+    auto &fence = referenceFromHandle<ispcrt::base::Fence>(f);
+    return fence.status();
+}
+ISPCRT_CATCH_END(ISPCRT_FENCE_SIGNALED)
+
+void ispcrtFenceReset(ISPCRTFence f) ISPCRT_CATCH_BEGIN {
+    auto &fence = referenceFromHandle<ispcrt::base::Fence>(f);
+    fence.reset();
+}
+ISPCRT_CATCH_END_NO_RETURN()
+
+ISPCRTGenericHandle ispcrtFenceNativeHandle(ISPCRTFence f) ISPCRT_CATCH_BEGIN {
+    auto &fence = referenceFromHandle<ispcrt::base::Fence>(f);
+    return fence.nativeHandle();
+}
+ISPCRT_CATCH_END(nullptr)
 
 uint64_t ispcrtFutureGetTimeNs(ISPCRTFuture f) ISPCRT_CATCH_BEGIN {
     if (!f)

--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -20,6 +20,9 @@ struct _ISPCRTTaskQueue;
 struct _ISPCRTModule;
 struct _ISPCRTKernel;
 struct _ISPCRTFuture;
+struct _ISPCRTFence;
+struct _ISPCRTCommandQueue;
+struct _ISPCRTCommandList;
 
 typedef _ISPCRTContext *ISPCRTContext;
 typedef _ISPCRTDevice *ISPCRTDevice;
@@ -28,6 +31,9 @@ typedef _ISPCRTTaskQueue *ISPCRTTaskQueue;
 typedef _ISPCRTModule *ISPCRTModule;
 typedef _ISPCRTKernel *ISPCRTKernel;
 typedef _ISPCRTFuture *ISPCRTFuture;
+typedef _ISPCRTFence *ISPCRTFence;
+typedef _ISPCRTCommandQueue *ISPCRTCommandQueue;
+typedef _ISPCRTCommandList *ISPCRTCommandList;
 #else
 typedef void *ISPCRTContext;
 typedef void *ISPCRTDevice;
@@ -36,6 +42,9 @@ typedef void *ISPCRTTaskQueue;
 typedef void *ISPCRTModule;
 typedef void *ISPCRTKernel;
 typedef void *ISPCRTFuture;
+typedef void *ISPCRTFence;
+typedef void *ISPCRTCommandQueue;
+typedef void *ISPCRTCommandList;
 #endif
 
 // NOTE: ISPCRTGenericHandle usage implies compatibility with any of the above
@@ -160,6 +169,30 @@ ISPCRTModule ispcrtStaticLinkModules(ISPCRTDevice, ISPCRTModule *modules, uint32
 void *ispcrtFunctionPtr(ISPCRTModule, const char *name);
 ISPCRTKernel ispcrtNewKernel(ISPCRTDevice, ISPCRTModule, const char *name);
 
+// Command lists //////////////////////////////////////////////////////////////
+void ispcrtCommandListBarrier(ISPCRTCommandList);
+
+ISPCRTFuture ispcrtCommandListCopyToDevice(ISPCRTCommandList, ISPCRTMemoryView);
+ISPCRTFuture ispcrtCommandListCopyToHost(ISPCRTCommandList, ISPCRTMemoryView);
+ISPCRTFuture ispcrtCommandListCopyMemoryView(ISPCRTCommandList, ISPCRTMemoryView, ISPCRTMemoryView, const size_t size);
+
+// NOTE: 'params' can be a nullptr handle (nullptr will get passed to the ISPC task as the function parameter)
+ISPCRTFuture ispcrtCommandListLaunch1D(ISPCRTCommandList, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0);
+ISPCRTFuture ispcrtCommandListLaunch2D(ISPCRTCommandList, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0, size_t dim1);
+ISPCRTFuture ispcrtCommandListLaunch3D(ISPCRTCommandList, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0, size_t dim1,
+                            size_t dim2);
+
+void ispcrtCommandListClose(ISPCRTCommandList);
+ISPCRTFence ispcrtCommandListSubmit(ISPCRTCommandList);
+void ispcrtCommandListReset(ISPCRTCommandList);
+void ispcrtCommandListEnableTimestamps(ISPCRTCommandList);
+
+// Command queues /////////////////////////////////////////////////////////////
+ISPCRTCommandQueue ispcrtNewCommandQueue(ISPCRTDevice, uint32_t ordinal);
+
+ISPCRTCommandList ispcrtCommandQueueCreateCommandList(ISPCRTCommandQueue);
+void ispcrtCommandQueueSync(ISPCRTCommandQueue);
+
 // Task queues ////////////////////////////////////////////////////////////////
 
 ISPCRTTaskQueue ispcrtNewTaskQueue(ISPCRTDevice);
@@ -178,6 +211,16 @@ ISPCRTFuture ispcrtLaunch3D(ISPCRTTaskQueue, ISPCRTKernel, ISPCRTMemoryView para
 
 void ispcrtSync(ISPCRTTaskQueue);
 
+// Fence //////////////////////////////////////////////////////////////////////
+typedef enum {
+    ISPCRT_FENCE_UNSIGNALED = 0,
+    ISPCRT_FENCE_SIGNALED = 1,
+} ISPCRTFenceStatus;
+
+void ispcrtFenceSync(ISPCRTFence);
+ISPCRTFenceStatus ispcrtFenceStatus(ISPCRTFence);
+void ispcrtFenceReset(ISPCRTFence);
+
 // Futures and task timing ////////////////////////////////////////////////////
 
 uint64_t ispcrtFutureGetTimeNs(ISPCRTFuture);
@@ -189,7 +232,10 @@ ISPCRTGenericHandle ispcrtPlatformNativeHandle(ISPCRTDevice);
 ISPCRTGenericHandle ispcrtDeviceNativeHandle(ISPCRTDevice);
 ISPCRTGenericHandle ispcrtDeviceContextNativeHandle(ISPCRTDevice);
 ISPCRTGenericHandle ispcrtContextNativeHandle(ISPCRTContext);
+ISPCRTGenericHandle ispcrtCommandListNativeHandle(ISPCRTCommandList);
+ISPCRTGenericHandle ispcrtCommandQueueNativeHandle(ISPCRTCommandQueue);
 ISPCRTGenericHandle ispcrtTaskQueueNativeHandle(ISPCRTTaskQueue);
+ISPCRTGenericHandle ispcrtFenceNativeHandle(ISPCRTFence);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/ispcrt/tests/level_zero_mock/ze_mock.cpp
+++ b/ispcrt/tests/level_zero_mock/ze_mock.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Intel Corporation
+// Copyright 2020-2023 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "ze_mock.h"


### PR DESCRIPTION
Expose `CommandQueue`, `CommandList` and `Fence` objects from `L0` to ISPCRT. It allows to explicitly construct them and manage in more ways than `TaskQueue` object. With that change, one can compute something in CPU thread in parallel with GPU computation.