### PR TITLE
Generate vector instructions for uniform vector conversions

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -6127,9 +6127,11 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
     }
     const char *cOpName = opName.c_str();
 
+    llvm::Type *targetType = fromType->IsUniformType() ? toType->GetAsUniformType()->LLVMType(g->ctx)
+                                                       : toType->GetAsVaryingType()->LLVMType(g->ctx);
+
     switch (toType->basicType) {
     case AtomicType::TYPE_FLOAT16: {
-        llvm::Type *targetType = fromType->IsUniformType() ? LLVMTypes::Float16Type : LLVMTypes::Float16VectorType;
         switch (fromType->basicType) {
         case AtomicType::TYPE_BOOL:
             if (fromType->IsVaryingType())
@@ -6182,7 +6184,6 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
         break;
     }
     case AtomicType::TYPE_FLOAT: {
-        llvm::Type *targetType = fromType->IsUniformType() ? LLVMTypes::FloatType : LLVMTypes::FloatVectorType;
         switch (fromType->basicType) {
         case AtomicType::TYPE_BOOL:
             if (fromType->IsVaryingType())
@@ -6235,7 +6236,6 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
         break;
     }
     case AtomicType::TYPE_DOUBLE: {
-        llvm::Type *targetType = fromType->IsUniformType() ? LLVMTypes::DoubleType : LLVMTypes::DoubleVectorType;
         switch (fromType->basicType) {
         case AtomicType::TYPE_BOOL:
             if (fromType->IsVaryingType())
@@ -6285,7 +6285,6 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
         break;
     }
     case AtomicType::TYPE_INT8: {
-        llvm::Type *targetType = fromType->IsUniformType() ? LLVMTypes::Int8Type : LLVMTypes::Int8VectorType;
         switch (fromType->basicType) {
         case AtomicType::TYPE_BOOL:
             if (fromType->IsVaryingType())
@@ -6316,7 +6315,6 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
         break;
     }
     case AtomicType::TYPE_UINT8: {
-        llvm::Type *targetType = fromType->IsUniformType() ? LLVMTypes::Int8Type : LLVMTypes::Int8VectorType;
         switch (fromType->basicType) {
         case AtomicType::TYPE_BOOL:
             if (fromType->IsVaryingType())
@@ -6353,7 +6351,6 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
         break;
     }
     case AtomicType::TYPE_INT16: {
-        llvm::Type *targetType = fromType->IsUniformType() ? LLVMTypes::Int16Type : LLVMTypes::Int16VectorType;
         switch (fromType->basicType) {
         case AtomicType::TYPE_BOOL:
             if (fromType->IsVaryingType())
@@ -6388,7 +6385,6 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
         break;
     }
     case AtomicType::TYPE_UINT16: {
-        llvm::Type *targetType = fromType->IsUniformType() ? LLVMTypes::Int16Type : LLVMTypes::Int16VectorType;
         switch (fromType->basicType) {
         case AtomicType::TYPE_BOOL:
             if (fromType->IsVaryingType())
@@ -6429,7 +6425,6 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
         break;
     }
     case AtomicType::TYPE_INT32: {
-        llvm::Type *targetType = fromType->IsUniformType() ? LLVMTypes::Int32Type : LLVMTypes::Int32VectorType;
         switch (fromType->basicType) {
         case AtomicType::TYPE_BOOL:
             if (fromType->IsVaryingType())
@@ -6464,7 +6459,6 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
         break;
     }
     case AtomicType::TYPE_UINT32: {
-        llvm::Type *targetType = fromType->IsUniformType() ? LLVMTypes::Int32Type : LLVMTypes::Int32VectorType;
         switch (fromType->basicType) {
         case AtomicType::TYPE_BOOL:
             if (fromType->IsVaryingType())
@@ -6514,7 +6508,6 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
         break;
     }
     case AtomicType::TYPE_INT64: {
-        llvm::Type *targetType = fromType->IsUniformType() ? LLVMTypes::Int64Type : LLVMTypes::Int64VectorType;
         switch (fromType->basicType) {
         case AtomicType::TYPE_BOOL:
             if (fromType->IsVaryingType())
@@ -6547,7 +6540,6 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
         break;
     }
     case AtomicType::TYPE_UINT64: {
-        llvm::Type *targetType = fromType->IsUniformType() ? LLVMTypes::Int64Type : LLVMTypes::Int64VectorType;
         switch (fromType->basicType) {
         case AtomicType::TYPE_BOOL:
             if (fromType->IsVaryingType())

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -6597,50 +6597,40 @@ static llvm::Value *lTypeConvAtomic(FunctionEmitContext *ctx, llvm::Value *exprV
             break;
         case AtomicType::TYPE_INT8:
         case AtomicType::TYPE_UINT8: {
-            llvm::Value *zero =
-                fromType->IsUniformType() ? (llvm::Value *)LLVMInt8(0) : (llvm::Value *)LLVMInt8Vector((int8_t)0);
+            llvm::Value *zero = LLVMIntAsType(0, fromType->LLVMType(g->ctx));
             cast = ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_NE, exprVal, zero, cOpName);
             break;
         }
         case AtomicType::TYPE_INT16:
         case AtomicType::TYPE_UINT16: {
-            llvm::Value *zero =
-                fromType->IsUniformType() ? (llvm::Value *)LLVMInt16(0) : (llvm::Value *)LLVMInt16Vector((int16_t)0);
+            llvm::Value *zero = LLVMIntAsType(0, fromType->LLVMType(g->ctx));
             cast = ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_NE, exprVal, zero, cOpName);
             break;
         }
         case AtomicType::TYPE_INT32:
         case AtomicType::TYPE_UINT32: {
-            llvm::Value *zero =
-                fromType->IsUniformType() ? (llvm::Value *)LLVMInt32(0) : (llvm::Value *)LLVMInt32Vector(0);
+            llvm::Value *zero = LLVMIntAsType(0, fromType->LLVMType(g->ctx));
             cast = ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_NE, exprVal, zero, cOpName);
             break;
         }
         case AtomicType::TYPE_INT64:
         case AtomicType::TYPE_UINT64: {
-            llvm::Value *zero =
-                fromType->IsUniformType() ? (llvm::Value *)LLVMInt64(0) : (llvm::Value *)LLVMInt64Vector((int64_t)0);
+            llvm::Value *zero = LLVMIntAsType(0, fromType->LLVMType(g->ctx));
             cast = ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_NE, exprVal, zero, cOpName);
             break;
         }
         case AtomicType::TYPE_FLOAT16: {
-            llvm::APFloat zf16 = llvm::APFloat::getZero((LLVMTypes::Float16Type)->getFltSemantics());
-            llvm::Value *zero =
-                fromType->IsUniformType() ? (llvm::Value *)LLVMFloat16(zf16) : (llvm::Value *)LLVMFloat16Vector(zf16);
+            llvm::Value *zero = LLVMFPZeroAsType(fromType->LLVMType(g->ctx));
             cast = ctx->CmpInst(llvm::Instruction::FCmp, llvm::CmpInst::FCMP_ONE, exprVal, zero, cOpName);
             break;
         }
         case AtomicType::TYPE_FLOAT: {
-            llvm::APFloat zf = llvm::APFloat::getZero((LLVMTypes::FloatType)->getFltSemantics());
-            llvm::Value *zero =
-                fromType->IsUniformType() ? (llvm::Value *)LLVMFloat(zf) : (llvm::Value *)LLVMFloatVector(zf);
+            llvm::Value *zero = LLVMFPZeroAsType(fromType->LLVMType(g->ctx));
             cast = ctx->CmpInst(llvm::Instruction::FCmp, llvm::CmpInst::FCMP_ONE, exprVal, zero, cOpName);
             break;
         }
         case AtomicType::TYPE_DOUBLE: {
-            llvm::APFloat zd = llvm::APFloat::getZero((LLVMTypes::DoubleType)->getFltSemantics());
-            llvm::Value *zero =
-                fromType->IsUniformType() ? (llvm::Value *)LLVMDouble(zd) : (llvm::Value *)LLVMDoubleVector(zd);
+            llvm::Value *zero = LLVMFPZeroAsType(fromType->LLVMType(g->ctx));
             cast = ctx->CmpInst(llvm::Instruction::FCmp, llvm::CmpInst::FCMP_ONE, exprVal, zero, cOpName);
             break;
         }

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -491,6 +491,22 @@ llvm::Constant *LLVMUIntAsType(uint64_t val, llvm::Type *type) {
         return llvm::ConstantInt::get(type, val, false /* unsigned */);
 }
 
+llvm::Constant *LLVMFPZeroAsType(llvm::Type *type) {
+    llvm::FixedVectorType *vecType = llvm::dyn_cast<llvm::FixedVectorType>(type);
+
+    if (vecType != nullptr) {
+        llvm::APFloat zf = llvm::APFloat::getZero(vecType->getElementType()->getFltSemantics());
+        llvm::Constant *v = llvm::ConstantFP::get(vecType->getElementType(), zf);
+        std::vector<llvm::Constant *> vals;
+        for (int i = 0; i < (int)vecType->getNumElements(); ++i)
+            vals.push_back(v);
+        return llvm::ConstantVector::get(vals);
+    } else {
+        llvm::APFloat zf = llvm::APFloat::getZero(type->getFltSemantics());
+        return llvm::ConstantFP::get(type, zf);
+    }
+}
+
 /** Conservative test to see if two llvm::Values are equal.  There are
     (potentially many) cases where the two values actually are equal but
     this will return false.  However, if it does return true, the two

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -180,6 +180,9 @@ extern llvm::Constant *LLVMIntAsType(int64_t, llvm::Type *t);
     the given unsigned integer value. */
 extern llvm::Constant *LLVMUIntAsType(uint64_t, llvm::Type *t);
 
+/** Returns a zero constant half/float/double or vector (according to the given type). */
+extern llvm::Constant *LLVMFPZeroAsType(llvm::Type *type);
+
 /** Returns an LLVM boolean vector based on the given array of values.
     The array should have g->target.vectorWidth elements. */
 extern llvm::Constant *LLVMBoolVector(const bool *v);

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -150,7 +150,16 @@ bool Type::IsPointerType() const { return (CastType<PointerType>(this) != nullpt
 
 bool Type::IsArrayType() const { return (CastType<ArrayType>(this) != nullptr); }
 
+bool Type::IsAtomicType() const { return (CastType<AtomicType>(this) != nullptr); }
+
+bool Type::IsVaryingAtomicOrUniformVectorType() const {
+    return ((CastType<AtomicType>(this) != nullptr && IsVaryingType()) ||
+            (CastType<VectorType>(this) != nullptr && IsUniformType()));
+}
+
 bool Type::IsReferenceType() const { return (CastType<ReferenceType>(this) != nullptr); }
+
+bool Type::IsVectorType() const { return (CastType<VectorType>(this) != nullptr); }
 
 bool Type::IsVoidType() const { return EqualIgnoringConst(this, AtomicType::Void); }
 

--- a/src/type.h
+++ b/src/type.h
@@ -91,8 +91,17 @@ class Type : public Traceable {
     /** Returns true if the underlying type is a array type */
     bool IsArrayType() const;
 
+    /** Returns true if the underlying type is an atomic type */
+    bool IsAtomicType() const;
+
+    /** Returns true if the underlying type is an varying atomic or uniform vector type */
+    bool IsVaryingAtomicOrUniformVectorType() const;
+
     /** Returns true if the underlying type is a reference type */
     bool IsReferenceType() const;
+
+    /** Returns true if the underlying type is vector type */
+    bool IsVectorType() const;
 
     /** Returns true if the underlying type is either a pointer or an array */
     bool IsVoidType() const;

--- a/tests/lit-tests/vector_type_convert.ispc
+++ b/tests/lit-tests/vector_type_convert.ispc
@@ -1,0 +1,9 @@
+// This test checks that uniform vectors convertion is perfomed using vector instructions.
+// RUN: %{ispc} %s --target=host --emit-llvm-text -o - | FileCheck %s
+// CHECK: fpext <4 x float>
+// CHECK-NOT: fpext float
+void test(uniform float RET[], uniform float b) {
+    uniform float<3> x = {1,2,3};
+    uniform double<3> z = x+b;
+    RET[programIndex] = z[programIndex];
+}


### PR DESCRIPTION
Currently for uniform short vector conversions ISPC generates scalar instructions.
For example for the following case:
```
uniform float<3> x = {1,2,3};
uniform double<3> z = x;
```
ISPC generates 3x`fpext float` instructions.

The PR enables generation of vector instructions for such cases. So instead of 3x`fpext float`, 1x`fpext<4xfloat>` will be produced.
It's used now for conversions only but planned to be extended for short vector initialization as well.