### PR TITLE
gitignore: Add build directory to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@ examples/*/ref
 examples/*/test
 *.swp
 check_isa.exe
-build
+build*
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@ examples/*/ref
 examples/*/test
 *.swp
 check_isa.exe
-
+build
 


### PR DESCRIPTION
Ignore the build directory. Useful for Codespaces with build included in the root.