### PR TITLE
loops: Fix codegen for overflow in signed expressions

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -112,6 +112,7 @@ Contents:
   + `Types`_
 
     * `Basic Types and Type Qualifiers`_
+    * `Signed and Unsigned Integer Types_`
     * `"uniform" and "varying" Qualifiers`_
     * `Defining New Names For Types`_
     * `Pointer Types`_
@@ -1933,6 +1934,35 @@ global variable defined in another source file, and the ``static``
 qualifier can be used to define a variable or function that is only visible
 in the current scope.  The values of ``static`` variables declared in
 functions are preserved across function calls.
+
+Signed and Unsigned Integer Types
+---------------------------------
+
+Like in C and C++ signed and unsigned integer types behave differently with
+respect to overflow. Unsigned integer types have defined behavior in case of
+overflow and underflow, they are guaranteed to wraparound. I.e. maximum
+unsigned integer value plus one is guaranteed to be zero. Signed integer types
+have **undefined** behavior in case of overflow and underflow, they are **not**
+guaranteed to wraparound. This is done on purpose to enable compiler to be more
+aggressive with optimizations of signed types.
+
+There is a subtle difference with C and C++ for 8 and 16 bit integer types. In
+C and C++ binary operations require *integer promotions* for both operands,
+while ``ispc`` does not. This means that C and C++ do not have 8 and 16 bit
+arithmetic and all operations are promoted to at least to 32 bits, and hence,
+overflow and underflow do not happen for these types. If the resulting value is
+outside the 8 and 16 bit type range and it is assigned to 8 or 16 bit variable,
+the result is truncated. In ``ispc`` there are no *integer promotions* rules,
+and hence, overflow and underflow may happen for 8 and 16 bit types.
+
+Note that undefined behavior for signed integer overflow was introduced in
+``ispc`` only starting from version ``1.21.0``, which may cause compatibility
+issues. This behavior can be managed by ``--[no-]wrap-signed-int`` compiler
+switch. ``--no-wrap-signed-int`` enables undefined behavior for signed integer
+overflow / underflow and it is the default. If the old behavior (before
+``1.21.0``) needs to be preserved, use ``--wrap-signed-int``, which cause
+signed integers to have defined wraparound behavior (keep in mind that it will
+prevent some compiler optimizations).
 
 "uniform" and "varying" Qualifiers
 ----------------------------------

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -396,9 +396,25 @@ class FunctionEmitContext {
     /** Emit the binary operator given by the inst parameter.  If
         llvm::Values corresponding to VectorTypes are given as operands,
         this also handles applying the given operation to the vector
-        elements. */
+        elements.
+
+        The isSigned parameter toggles whether the nsw attribute is applied
+        to signed integer arithmetic operations.
+        The value of isSigned is determined either by
+        1.  the sign of the incoming generated expression's type
+            (e.g. using type->IsSignedType()), or
+        2.  the sign of a constructed expression (e.g. false for pointer
+            arithmetic, true for foreach induction variables).
+        The only arithmetic oparations modified by this parameter are Add, Sub, and Mul.
+        Shl supports the attribute (https://llvm.org/docs/LangRef.html#shl-instruction),
+        but we elect not to emit nsw for these operations to match Clang/GCC behavior.
+        Care should be used, as some optimizations may rely on undefined behavior
+        for signed integer overflow.
+        See the Expressions section of docs/ispc.rst for more information on this
+        optimization.
+    */
     llvm::Value *BinaryOperator(llvm::Instruction::BinaryOps inst, llvm::Value *v0, llvm::Value *v1,
-                                const llvm::Twine &name = "");
+                                WrapSemantics wrapSemantics, const llvm::Twine &name = "");
 
     /** Emit the "not" operator.  Like BinaryOperator(), this also handles
         a VectorType-based operand. */

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2291,6 +2291,7 @@ Globals::Globals() {
     debugIR = -1;
     disableWarnings = false;
     warningsAsErrors = false;
+    wrapSignedInt = false;
     quiet = false;
     forceColoredOutput = false;
     disableLineWrap = false;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -734,6 +734,12 @@ struct Globals {
     /** Indicates whether warnings should be issued as errors. */
     bool warningsAsErrors;
 
+    /** Preserve wrap-around on signed integer overflow by disabling the
+        nsw attribute when emitting arithmetic for signed integer
+        expressions.  Without this disabled, the compiler may rely on UB
+        behavior for optimizations on signed integer types.  */
+    bool wrapSignedInt;
+
     /** Indicates whether line wrapping of error messages to the terminal
         width should be disabled. */
     bool disableLineWrap;
@@ -911,5 +917,12 @@ class Traceable {
   public:
     void *operator new(size_t size) { return BookKeeper::in().add(static_cast<Traceable *>(::operator new(size))); }
     virtual ~Traceable() = default;
+};
+
+// An enum class enumerating wrap semantic settings for use with BinaryOperator and other
+// signed arithmetic IR emitters in cases of signed overflow
+enum class WrapSemantics {
+    NSW = 0, // Do not preserve wraparound behavior
+    None = 1 // Preserve wraparound behavior
 };
 } // namespace ispc

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -1317,7 +1317,8 @@ static llvm::Value *lUpdateVaryingCounter(int dim, int nDims, FunctionEmitContex
 
     // Add the deltas to compute the varying counter values; store the
     // result to memory and then return it directly as well.
-    llvm::Value *varyingCounter = ctx->BinaryOperator(llvm::Instruction::Add, smearCounter, delta, "iter_val");
+    llvm::Value *varyingCounter =
+        ctx->BinaryOperator(llvm::Instruction::Add, smearCounter, delta, WrapSemantics::NSW, "iter_val");
     ctx->StoreInst(varyingCounter, varyingCounterPtrInfo);
     return varyingCounter;
 }
@@ -1430,16 +1431,18 @@ void ForeachStmt::EmitCode(FunctionEmitContext *ctx) const {
         endVals.push_back(ev);
 
         // nItems = endVal - startVal
-        llvm::Value *nItems = ctx->BinaryOperator(llvm::Instruction::Sub, ev, sv, "nitems");
+        llvm::Value *nItems = ctx->BinaryOperator(llvm::Instruction::Sub, ev, sv, WrapSemantics::NSW, "nitems");
 
         // nExtras = nItems % (span for this dimension)
         // This gives us the number of extra elements we need to deal with
         // at the end of the loop for this dimension that don't fit cleanly
         // into a vector width.
-        nExtras.push_back(ctx->BinaryOperator(llvm::Instruction::SRem, nItems, LLVMInt32(span[i]), "nextras"));
+        nExtras.push_back(
+            ctx->BinaryOperator(llvm::Instruction::SRem, nItems, LLVMInt32(span[i]), WrapSemantics::None, "nextras"));
 
         // alignedEnd = endVal - nExtras
-        alignedEnd.push_back(ctx->BinaryOperator(llvm::Instruction::Sub, ev, nExtras[i], "aligned_end"));
+        alignedEnd.push_back(
+            ctx->BinaryOperator(llvm::Instruction::Sub, ev, nExtras[i], WrapSemantics::NSW, "aligned_end"));
 
         ///////////////////////////////////////////////////////////////////////
         // Each dimension has a loop counter that is a uniform value that
@@ -1495,7 +1498,7 @@ void ForeachStmt::EmitCode(FunctionEmitContext *ctx) const {
         ctx->SetCurrentBasicBlock(bbStep[i]);
         llvm::Value *counter = ctx->LoadInst(uniformCounterPtrs[i]);
         llvm::Value *newCounter =
-            ctx->BinaryOperator(llvm::Instruction::Add, counter, LLVMInt32(span[i]), "new_counter");
+            ctx->BinaryOperator(llvm::Instruction::Add, counter, LLVMInt32(span[i]), WrapSemantics::NSW, "new_counter");
         ctx->StoreInst(newCounter, uniformCounterPtrs[i]);
         ctx->BranchInst(bbTest[i]);
     }
@@ -1512,12 +1515,14 @@ void ForeachStmt::EmitCode(FunctionEmitContext *ctx) const {
         llvm::Value *counter = ctx->LoadInst(uniformCounterPtrs[i], nullptr, "counter");
         llvm::Value *atAlignedEnd =
             ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_EQ, counter, alignedEnd[i], "at_aligned_end");
-        llvm::Value *inEx = ctx->BinaryOperator(llvm::Instruction::And, haveExtras, atAlignedEnd, "in_extras");
+        llvm::Value *inEx =
+            ctx->BinaryOperator(llvm::Instruction::And, haveExtras, atAlignedEnd, WrapSemantics::None, "in_extras");
 
         if (i == 0)
             inExtras.push_back(inEx);
         else
-            inExtras.push_back(ctx->BinaryOperator(llvm::Instruction::Or, inEx, inExtras[i - 1], "in_extras_all"));
+            inExtras.push_back(ctx->BinaryOperator(llvm::Instruction::Or, inEx, inExtras[i - 1], WrapSemantics::None,
+                                                   "in_extras_all"));
 
         llvm::Value *varyingCounter =
             lUpdateVaryingCounter(i, nDims, ctx, uniformCounterPtrs[i], dimVariables[i]->storageInfo, span);
@@ -1533,7 +1538,8 @@ void ForeachStmt::EmitCode(FunctionEmitContext *ctx) const {
             ctx->StoreInst(emask, extrasMaskPtrs[i]);
         else {
             llvm::Value *oldMask = ctx->LoadInst(extrasMaskPtrs[i - 1]);
-            llvm::Value *newMask = ctx->BinaryOperator(llvm::Instruction::And, oldMask, emask, "extras_mask");
+            llvm::Value *newMask =
+                ctx->BinaryOperator(llvm::Instruction::And, oldMask, emask, WrapSemantics::None, "extras_mask");
             ctx->StoreInst(newMask, extrasMaskPtrs[i]);
         }
 
@@ -1668,7 +1674,8 @@ void ForeachStmt::EmitCode(FunctionEmitContext *ctx) const {
             ctx->SetInternalMask(emask);
         } else {
             llvm::Value *oldMask = ctx->LoadInst(extrasMaskPtrs[nDims - 2]);
-            llvm::Value *newMask = ctx->BinaryOperator(llvm::Instruction::And, oldMask, emask, "extras_mask");
+            llvm::Value *newMask =
+                ctx->BinaryOperator(llvm::Instruction::And, oldMask, emask, WrapSemantics::None, "extras_mask");
             ctx->SetInternalMask(newMask);
         }
 
@@ -1726,8 +1733,8 @@ void ForeachStmt::EmitCode(FunctionEmitContext *ctx) const {
     {
         ctx->RestoreContinuedLanes();
         llvm::Value *counter = ctx->LoadInst(uniformCounterPtrs[nDims - 1]);
-        llvm::Value *newCounter =
-            ctx->BinaryOperator(llvm::Instruction::Add, counter, LLVMInt32(span[nDims - 1]), "new_counter");
+        llvm::Value *newCounter = ctx->BinaryOperator(llvm::Instruction::Add, counter, LLVMInt32(span[nDims - 1]),
+                                                      WrapSemantics::NSW, "new_counter");
         ctx->StoreInst(newCounter, uniformCounterPtrs[nDims - 1]);
         ctx->BranchInst(bbOuterNotInExtras);
     }
@@ -1793,8 +1800,8 @@ void ForeachStmt::EmitCode(FunctionEmitContext *ctx) const {
     ctx->SetCurrentBasicBlock(bbStepInnerIndex);
     {
         llvm::Value *counter = ctx->LoadInst(uniformCounterPtrs[nDims - 1]);
-        llvm::Value *newCounter =
-            ctx->BinaryOperator(llvm::Instruction::Add, counter, LLVMInt32(span[nDims - 1]), "new_counter");
+        llvm::Value *newCounter = ctx->BinaryOperator(llvm::Instruction::Add, counter, LLVMInt32(span[nDims - 1]),
+                                                      WrapSemantics::NSW, "new_counter");
         ctx->StoreInst(newCounter, uniformCounterPtrs[nDims - 1]);
         ctx->BranchInst(bbOuterInExtras);
     }
@@ -1873,7 +1880,7 @@ void ForeachStmt::EmitCodeForXe(FunctionEmitContext *ctx) const {
         // Store varying start
         sv = ctx->BroadcastValue(sv, LLVMTypes::Int32VectorType, "start_broadcast");
         llvm::Constant *delta = lCalculateDeltaForVaryingCounter(i, nDims, span);
-        sv = ctx->BinaryOperator(llvm::Instruction::Add, sv, delta, "varying_start");
+        sv = ctx->BinaryOperator(llvm::Instruction::Add, sv, delta, WrapSemantics::NSW, "varying_start");
         startVals.push_back(sv);
 
         // Store broadcasted end values
@@ -1919,7 +1926,8 @@ void ForeachStmt::EmitCodeForXe(FunctionEmitContext *ctx) const {
     for (int i = 0; i < nDims; ++i) {
         ctx->SetCurrentBasicBlock(bbStep[i]);
         llvm::Value *counter = ctx->LoadInst(dimVariables[i]->storageInfo);
-        llvm::Value *newCounter = ctx->BinaryOperator(llvm::Instruction::Add, counter, steps[i], "new_counter");
+        llvm::Value *newCounter =
+            ctx->BinaryOperator(llvm::Instruction::Add, counter, steps[i], WrapSemantics::NSW, "new_counter");
         ctx->StoreInst(newCounter, dimVariables[i]->storageInfo);
         ctx->BranchInst(bbTest[i]);
     }
@@ -2220,10 +2228,11 @@ void ForeachActiveStmt::EmitCode(FunctionEmitContext *ctx) const {
 
         // Also update the bitvector of lanes left to turn off the bit for
         // the lane we're about to run.
-        llvm::Value *setMask = ctx->BinaryOperator(llvm::Instruction::Shl, LLVMInt64(1), firstSet, "set_mask");
+        llvm::Value *setMask =
+            ctx->BinaryOperator(llvm::Instruction::Shl, LLVMInt64(1), firstSet, WrapSemantics::None, "set_mask");
         llvm::Value *notSetMask = ctx->NotOperator(setMask);
-        llvm::Value *newRemaining =
-            ctx->BinaryOperator(llvm::Instruction::And, remainingBits, notSetMask, "new_remaining");
+        llvm::Value *newRemaining = ctx->BinaryOperator(llvm::Instruction::And, remainingBits, notSetMask,
+                                                        WrapSemantics::None, "new_remaining");
         ctx->StoreInst(newRemaining, maskBitsPtrInfo);
 
         // and onward to run the loop body...
@@ -2449,8 +2458,8 @@ void ForeachUniqueStmt::EmitCode(FunctionEmitContext *ctx) const {
                 ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_EQ, uniqueSmear, exprValue, "matching_lanes");
         matchingLanes = ctx->I1VecToBoolVec(matchingLanes);
 
-        llvm::Value *loopMask =
-            ctx->BinaryOperator(llvm::Instruction::And, oldMask, matchingLanes, "foreach_unique_loop_mask");
+        llvm::Value *loopMask = ctx->BinaryOperator(llvm::Instruction::And, oldMask, matchingLanes, WrapSemantics::None,
+                                                    "foreach_unique_loop_mask");
 
         // Don't need to change this mask in XE: execution
         // is performed according to Xe EM
@@ -2462,8 +2471,8 @@ void ForeachUniqueStmt::EmitCode(FunctionEmitContext *ctx) const {
         // remainingBits &= ~movmsk(current mask)
         llvm::Value *loopMaskMM = ctx->LaneMask(loopMask);
         llvm::Value *notLoopMaskMM = ctx->NotOperator(loopMaskMM);
-        llvm::Value *newRemaining =
-            ctx->BinaryOperator(llvm::Instruction::And, remainingBits, notLoopMaskMM, "new_remaining");
+        llvm::Value *newRemaining = ctx->BinaryOperator(llvm::Instruction::And, remainingBits, notLoopMaskMM,
+                                                        WrapSemantics::None, "new_remaining");
         ctx->StoreInst(newRemaining, maskBitsPtrInfo);
 
         // and onward...

--- a/tests/lit-tests/2460_ind-var_promotion.ispc
+++ b/tests/lit-tests/2460_ind-var_promotion.ispc
@@ -1,0 +1,67 @@
+// This test checks for the simplification of induction variables for loops and efficient
+// generation of accumulator widening/arithmetic.
+// See [GitHub issue ISPC/#2460](https://github.com/ispc/ispc/issues/2460) for details.
+
+// RUN: %{ispc} -DVECTOR=0 %s -o - -O2 --nostdlib --emit-asm --target=avx2-i32x4 --arch=x86-64 --x86-asm-syntax=intel | FileCheck %s --check-prefix=CHECK_ASM
+// RUN: %{ispc} -DVECTOR=1 %s -o - -O2 --nostdlib --emit-asm --target=avx2-i32x4 --arch=x86-64 --x86-asm-syntax=intel | FileCheck %s --check-prefix=CHECK_ASM
+
+// CHECK_ASM-LABEL:  Max_Uniform_FVector4f:
+// CHECK_ASM:        .{{.*}}:
+// CHECK_ASM-NOT:      cdqe
+// CHECK_ASM-NOT:      movsxd
+// CHECK_ASM-LABEL:  Max1_Uniform_FVector4f:
+// CHECK_ASM:        .{{.*}}:
+// CHECK_ASM-NOT:      cdqe
+// CHECK_ASM-NOT:      movsxd
+
+// REQUIRES: X86_ENABLED
+
+struct FVector4f {
+#if VECTOR == 0
+    float V[4];
+#else
+    float<4> V;
+#endif
+};
+
+extern float max(float, float);
+
+inline unmasked uniform FVector4f VectorMax(const uniform FVector4f &V1, const uniform FVector4f &V2) {
+    varying float S0, S1, Result;
+    *((uniform FVector4f * uniform) & S0) = *((uniform FVector4f * uniform) & V1);
+    *((uniform FVector4f * uniform) & S1) = *((uniform FVector4f * uniform) & V2);
+
+    Result = max(S0, S1);
+
+    return *((uniform FVector4f * uniform) & Result);
+}
+
+export void Max_Uniform_FVector4f(uniform float A[], uniform float B[], uniform float C[], uniform int Num) {
+    for (uniform int i = 0; i < Num; i += 4) {
+        uniform FVector4f *uniform pA = (uniform FVector4f * uniform) & A[i];
+        uniform FVector4f *uniform pB = (uniform FVector4f * uniform) & B[i];
+        uniform FVector4f *uniform pC = (uniform FVector4f * uniform) & C[i];
+
+        *pA = VectorMax(VectorMax(*pB, *pC), *pA);
+    }
+}
+
+inline unmasked uniform FVector4f VectorMax1(const uniform FVector4f &V1, const uniform FVector4f &V2) {
+    uniform FVector4f Result;
+
+    foreach (i = 0 ... 4) {
+        Result.V[i] = max(V1.V[i], V2.V[i]);
+    }
+
+    return Result;
+}
+
+export void Max1_Uniform_FVector4f(uniform float A[], uniform float B[], uniform float C[], uniform int Num) {
+    for (uniform int i = 0; i < Num; i += 4) {
+        uniform FVector4f *uniform pA = (uniform FVector4f * uniform) & A[i];
+        uniform FVector4f *uniform pB = (uniform FVector4f * uniform) & B[i];
+        uniform FVector4f *uniform pC = (uniform FVector4f * uniform) & C[i];
+
+        *pA = VectorMax1(VectorMax1(*pB, *pC), *pA);
+    }
+}

--- a/tests/lit-tests/foreach-ind-var.ispc
+++ b/tests/lit-tests/foreach-ind-var.ispc
@@ -1,0 +1,21 @@
+// This tests ensures arithmetic on the foreach induction variable is signed.
+// RUN: %{ispc} %s --emit-llvm-text --target=host -o - -O0 --nowrap | FileCheck %s
+
+// REQUIRES: !XE_ENABLED
+
+// CHECK-LABEL: define void @fold_add_0
+
+// CHECK-LABEL: allocas:
+// CHECK:           %nitems = sub{{.}}nsw
+// CHECK:           %aligned_end = sub{{.*}}nsw
+
+// CHECK-LABEL: foreach_full_body:
+// CHECK:           %new_counter = add{{.*}}nsw
+
+task void fold_add_0(uniform float A[], uniform int64 Num, uniform float Result[]) {
+    Result[programIndex] = 0;
+    foreach (i = 0 ... Num) {
+        Result[programIndex] += A[i];
+    }
+    Result[0] = reduce_add(Result[programIndex]);
+}

--- a/tests/lit-tests/ind-var-simplify-xe.ispc
+++ b/tests/lit-tests/ind-var-simplify-xe.ispc
@@ -1,0 +1,16 @@
+// This test checks that induction variables are not canonicalized or widened on GPU.
+
+// RUN: %{ispc} %s --nostdlib --emit-llvm-text --target=xehpg-x8 --arch=xe64 -o - | FileCheck %s
+
+// REQUIRES: XE_ENABLED
+
+// CHECK-LABEL: for_test:
+// CHECK:           %i{{.*}} = phi i32
+// CHECK:           %add{{.*}} = add{{.*}} i32 %i{{.*}}
+
+task void widen(uniform float A[], uniform int64 Num, uniform int64 N) {
+    uniform float result = 0;
+    for (uniform int i = 0; i < Num; i += N) {
+        result += A[i];
+    }
+}

--- a/tests/lit-tests/ind-var-simplify.ispc
+++ b/tests/lit-tests/ind-var-simplify.ispc
@@ -1,0 +1,16 @@
+// This test checks that induction variables are canonicalized and widened on CPU.
+
+// RUN: %{ispc} %s --nostdlib --emit-llvm-text --target=avx2-i32x4 --arch=x86-64 -o - | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK-LABEL: for_test:
+// CHECK:           %indvars.iv = phi i64
+// CHECK:           %indvars.iv.next = add{{.*}} i64 %indvars.iv
+
+task void widen(uniform float A[], uniform int64 Num, uniform int64 N) {
+    uniform float result = 0;
+    for (uniform int i = 0; i < Num; i += N) {
+        result += A[i];
+    }
+}

--- a/tests/lit-tests/loop_unroll_varying.ispc
+++ b/tests/lit-tests/loop_unroll_varying.ispc
@@ -13,7 +13,7 @@
 // CHECKO0:         for_loop:
 // CHECKO0:         call void @goo_for___
 // CHECKO0-NOT:     call void @goo_for___
-// CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO0:         }
 
 // CHECKO2:         for_loop{{.*}}:
@@ -23,7 +23,7 @@
 // CHECKO2:         for_loop{{.*}}:
 // CHECKO2:         call void @goo_for___
 // CHECKO2-NOT:     call void @goo_for___
-// CHECKO2:         br i1 %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// CHECKO2:         br {{(i1)|(label)}} %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO2:         }
 
 extern void goo_for(int);
@@ -40,7 +40,7 @@ void foo_for() {
 // CHECKO0:         for_loop:
 // CHECKO0:         call void @goo_for_unroll8___
 // CHECKO0-NOT:     call void @goo_for_unroll8___
-// CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO0:         }
 
 // CHECKO2:         for_loop{{.*}}:
@@ -60,7 +60,7 @@ void foo_for() {
 // CHECKO2:         for_loop{{.*}}:
 // CHECKO2:         call void @goo_for_unroll8___
 // CHECKO2-NOT:     call void @goo_for_unroll8___
-// CHECKO2:         br i1 %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// CHECKO2:         br {{(i1)|(label)}} %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO2:         }
 
 extern void goo_for_unroll8(int);
@@ -77,7 +77,7 @@ void foo_for_unroll8() {
 // CHECKO0:         for_loop:
 // CHECKO0:         call void @goo_for_packed___
 // CHECKO0-NOT:     call void @goo_for_packed___
-// CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO0:         }
 
 // CHECKO2:         for_loop{{.*}}:
@@ -89,7 +89,7 @@ void foo_for_unroll8() {
 // CHECKO2:         for_loop{{.*}}:
 // CHECKO2:         call void @goo_for_packed___
 // CHECK02-NOT:     call void @goo_for_packed___
-// CHECKO2:         br i1 %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// CHECKO2:         br {{(i1)|(label)}} %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO2:         }
 
 extern void goo_for_packed(int);
@@ -108,7 +108,7 @@ void foo_for_packed() {
 // COM: CHECKO0:         for_loop:
 // COM: CHECKO0:         load <{{[0-9]*}} x i32>, <{{[0-9]*}} x i32>* %iter1{{[0-9]*}}
 // COM: CHECKO0-NOT:     load <{{[0-9]*}} x i32>, <{{[0-9]*}} x i32>* %iter1{{[0-9]*}}
-// COM: CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// COM: CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // COM: CHECKO0:         }
 
 // COM: CHECKO2:         for_loop{{.*}}:
@@ -120,7 +120,7 @@ void foo_for_packed() {
 // COM: CHECKO2:         for_loop{{.*}}:
 // COM: CHECKO2:         load <{{[0-9]*}} x i32>, <{{[0-9]*}} x i32>* %iter1{{[0-9]*}}
 // COM: CHECKO2-NOT:     load <{{[0-9]*}} x i32>, <{{[0-9]*}} x i32>* %iter1{{[0-9]*}}
-// COM: CHECKO2:         br i1 %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// COM: CHECKO2:         br {{(i1)|(label)}} %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // COM: CHECKO2:         }
 
 //void foo_for_packed_nocall(uniform int _in[], uniform int _out[], const uniform int k) {
@@ -136,13 +136,13 @@ void foo_for_packed() {
 // CHECKO0:         foreach_full_body:
 // CHECKO0:         call <{{[0-9]*}} x i32> @goo_foreach___
 // CHECKO0-NOT:     call <{{[0-9]*}} x i32> @goo_foreach___
-// CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO0:         }
 
 // CHECKO2:         foreach_full_body:
 // CHECKO2-COUNT-3: call <{{[0-9]*}} x i32> @goo_foreach___
 // CHECKO2-NOT:     call <{{[0-9]*}} x i32> @goo_foreach___
-// CHECKO2:         br {{(i1)|(label)}} %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// CHECKO2:         br {{(i1)|(label)}} %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO2:         }
 
 extern int goo_foreach(int);
@@ -161,13 +161,13 @@ int foo_foreach() {
 // CHECKO0:         foreach_full_body:
 // CHECKO0:         call <{{[0-9]*}} x i32> @goo_foreach_unroll8___
 // CHECKO0-NOT:     call <{{[0-9]*}} x i32> @goo_foreach_unroll8___
-// CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO0:         }
 
 // CHECKO2:         foreach_full_body:
 // CHECKO2-COUNT-8: call <{{[0-9]*}} x i32> @goo_foreach_unroll8___
 // CHECKO2-NOT:     call <{{[0-9]*}} x i32> @goo_foreach_unroll8___
-// CHECKO2:         br {{(i1)|(label)}} %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// CHECKO2:         br {{(i1)|(label)}} %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO2:         }
 
 extern int goo_foreach_unroll8(int);
@@ -186,13 +186,13 @@ int foo_foreach_unroll8() {
 // CHECKO0:         foreach_full_body:
 // CHECKO0:         load <{{[0-9]*}} x i32>, {{.*}} %iter1{{[0-9]*}}
 // CHECKO0-NOT:     load <{{[0-9]*}} x i32>, {{.*}} %iter1{{[0-9]*}}
-// CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO0:         }
 
 // CHECKO2:         foreach_full_body:
 // CHECKO2-COUNT-4: load <{{[0-9]*}} x i32>, {{.*}} %ptr
 // CHECKO2-NOT:     load <{{[0-9]*}} x i32>, {{.*}} %ptr
-// CHECKO2:         br {{(i1)|(label)}} %{{[a-zA-Z_][a-zA-Z0-9_]*}}
+// CHECKO2:         br {{(i1)|(label)}} %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO2:         }
 
 extern int goo_foreach_nocall(int);

--- a/tests/lit-tests/signed-integer-overflow.ispc
+++ b/tests/lit-tests/signed-integer-overflow.ispc
@@ -1,0 +1,187 @@
+// This test checks for the use of the no signed wrap (`nsw`) attribute for arithmetic
+// expressions which may suffer from overflow.
+// Needed for induction variable simplification dicussed in
+// [GitHub issue ISPC/#2460](https://github.com/ispc/ispc/issues/2460).
+
+// RUN: %{ispc} %s --nostdlib --emit-llvm-text --target=host -o - |  FileCheck %s --check-prefix=CHECK_NSW
+
+// REQUIRES: !XE_ENABLED
+
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @mul_64
+// CHECK_NSW-COUNT-1:         %{{.*}}= mul{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @mul_32
+// CHECK_NSW-COUNT-1:         %{{.*}}= mul{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @mul_16
+// CHECK_NSW-COUNT-1:         %{{.*}}= mul{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @mul_8
+// CHECK_NSW-COUNT-1:         %{{.*}}= mul{{.*}}nsw{{.*}}i8
+
+unmasked int64 mul_64(int64 a, int64 b) { return a * b; }
+
+unmasked int32 mul_32(int32 a, int32 b) { return a * b; }
+
+unmasked int16 mul_16(int16 a, int16 b) { return a * b; }
+
+unmasked int8 mul_8(int8 a, int8 b) { return a * b; }
+
+
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @mul_u64
+// CHECK_NSW-NOT:             %{{.*}}= mul{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @mul_u32
+// CHECK_NSW-NOT:             %{{.*}}= mul{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @mul_u16
+// CHECK_NSW-NOT:             %{{.*}}= mul{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @mul_u8
+// CHECK_NSW-NOT:             %{{.*}}= mul{{.*}}nsw{{.*}}i8
+
+unmasked uint64 mul_u64(uint64 a, uint64 b) { return a * b; }
+
+unmasked uint32 mul_u32(uint32 a, uint32 b) { return a * b; }
+
+unmasked uint16 mul_u16(uint16 a, uint16 b) { return a * b; }
+
+unmasked uint8 mul_u8(uint8 a, uint8 b) { return a * b; }
+
+
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @add_64
+// CHECK_NSW-COUNT-1:         %{{.*}}= add{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @add_32
+// CHECK_NSW-COUNT-1:         %{{.*}}= add{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @add_16
+// CHECK_NSW-COUNT-1:         %{{.*}}= add{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @add_8
+// CHECK_NSW-COUNT-1:         %{{.*}}= add{{.*}}nsw{{.*}}i8
+
+unmasked int64 add_64(int64 a, int64 b) { return a + b; }
+
+unmasked int32 add_32(int32 a, int32 b) { return a + b; }
+
+unmasked int16 add_16(int16 a, int16 b) { return a + b; }
+
+unmasked int8 add_8(int8 a, int8 b) { return a + b; }
+
+
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @add_u64
+// CHECK_NSW-NOT:             %{{.*}}= add{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @add_u32
+// CHECK_NSW-NOT:             %{{.*}}= add{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @add_u16
+// CHECK_NSW-NOT:             %{{.*}}= add{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @add_u8
+// CHECK_NSW-NOT:             %{{.*}}= add{{.*}}nsw{{.*}}i8
+
+unmasked uint64 add_u64(uint64 a, uint64 b) { return a + b; }
+
+unmasked uint32 add_u32(uint32 a, uint32 b) { return a + b; }
+
+unmasked uint16 add_u16(uint16 a, uint16 b) { return a + b; }
+
+unmasked uint8 add_u8(uint8 a, uint8 b) { return a + b; }
+
+
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @sub_64
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @sub_32
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @sub_16
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @sub_8
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i8
+
+unmasked int64 sub_64(int64 a, int64 b) { return a - b; }
+
+unmasked int32 sub_32(int32 a, int32 b) { return a - b; }
+
+unmasked int16 sub_16(int16 a, int16 b) { return a - b; }
+
+unmasked int8 sub_8(int8 a, int8 b) { return a - b; }
+
+
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @sub_u64
+// CHECK_NSW-NOT:             %{{.*}}= sub{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @sub_u32
+// CHECK_NSW-NOT:             %{{.*}}= sub{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @sub_u16
+// CHECK_NSW-NOT:             %{{.*}}= sub{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @sub_u8
+// CHECK_NSW-NOT:             %{{.*}}= sub{{.*}}nsw{{.*}}i8
+
+unmasked uint64 sub_u64(uint64 a, uint64 b) { return a - b; }
+
+unmasked uint32 sub_u32(uint32 a, uint32 b) { return a - b; }
+
+unmasked uint16 sub_u16(uint16 a, uint16 b) { return a - b; }
+
+unmasked uint8 sub_u8(uint8 a, uint8 b) { return a - b; }
+
+
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @shl_64
+// CHECK_NSW-NOT:             %{{.*}}= shl{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @shl_32
+// CHECK_NSW-NOT:             %{{.*}}= shl{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @shl_16
+// CHECK_NSW-NOT:             %{{.*}}= shl{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @shl_8
+// CHECK_NSW-NOT:             %{{.*}}= shl{{.*}}nsw{{.*}}i8
+
+unmasked int64 shl_64(int64 a, int64 b) { return a << b; }
+
+unmasked int32 shl_32(int32 a, int32 b) { return a << b; }
+
+unmasked int16 shl_16(int16 a, int16 b) { return a << b; }
+
+unmasked int8 shl_8(int8 a, int8 b) { return a << b; }
+
+
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @shl_u64
+// CHECK_NSW-NOT:             %{{.*}}= shl{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @shl_u32
+// CHECK_NSW-NOT:             %{{.*}}= shl{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @shl_u16
+// CHECK_NSW-NOT:             %{{.*}}= shl{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @shl_u8
+// CHECK_NSW-NOT:             %{{.*}}= shl{{.*}}nsw{{.*}}i8
+
+unmasked uint64 shl_u64(uint64 a, uint64 b) { return a << b; }
+
+unmasked uint32 shl_u32(uint32 a, uint32 b) { return a << b; }
+
+unmasked uint16 shl_u16(uint16 a, uint16 b) { return a << b; }
+
+unmasked uint8 shl_u8(uint8 a, uint8 b) { return a << b; }
+
+
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @neg_64
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @neg_32
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @neg_16
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @neg_8
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i8
+
+unmasked int64 neg_64(int64 a) { return -a; }
+
+unmasked int32 neg_32(int32 a) { return -a; }
+
+unmasked int16 neg_16(int16 a) { return -a; }
+
+unmasked int8 neg_8(int8 a) { return -a; }
+
+
+// CHECK_NSW-LABEL:         define {{.*}} @ptrMath_64
+// CHECK_NSW-NOT:             nsw
+// CHECK_NSW-LABEL:         define {{.*}} @ptrMath_32
+// CHECK_NSW-NOT:             nsw
+// CHECK_NSW-LABEL:         define {{.*}} @ptrMath_16
+// CHECK_NSW-NOT:             nsw
+// CHECK_NSW-LABEL:         define {{.*}} @ptrMath_8
+// CHECK_NSW-NOT:             nsw
+
+unmasked uniform int64 * uniform ptrMath_64(uniform int64 * uniform a, uniform int64 k) { return &a[0] + k; }
+
+unmasked uniform int32 * uniform ptrMath_32(uniform int32 * uniform a, uniform int32 k) { return &a[0] + k; }
+
+unmasked uniform int16 * uniform ptrMath_16(uniform int16 * uniform a, uniform int16 k) { return &a[0] + k; }
+
+unmasked uniform int8 * uniform ptrMath_8(uniform int8 * uniform a, uniform int8 k) { return &a[0] + k; }

--- a/tests/lit-tests/wrap-signed-int-xe.ispc
+++ b/tests/lit-tests/wrap-signed-int-xe.ispc
@@ -1,0 +1,93 @@
+// The test ensures that the nsw bit is suppressed for Xe targets in LLVMIR, unless specified on.
+// RUN: %{ispc} %s --emit-llvm-text --target=xehpg-x8 -o - | FileCheck %s --check-prefix=CHECK_NONSW
+// RUN: %{ispc} %s --emit-llvm-text --target=xehpc-x16 -o - | FileCheck %s --check-prefix=CHECK_NONSW
+// RUN: %{ispc} %s --emit-llvm-text --target=xelp-x8 -o - | FileCheck %s --check-prefix=CHECK_NONSW
+// RUN: %{ispc} %s --emit-llvm-text --target=xehpg-x8 -o - --no-wrap-signed-int | FileCheck %s --check-prefix=CHECK_NSW
+// RUN: %{ispc} %s --emit-llvm-text --target=xehpc-x16 -o - --no-wrap-signed-int | FileCheck %s --check-prefix=CHECK_NSW
+// RUN: %{ispc} %s --emit-llvm-text --target=xelp-x8 -o - --no-wrap-signed-int | FileCheck %s --check-prefix=CHECK_NSW
+// RUN: %{ispc} %s --emit-llvm-text --target=xehpg-x8 -o - --wrap-signed-int | FileCheck %s --check-prefix=CHECK_NONSW
+// RUN: %{ispc} %s --emit-llvm-text --target=xehpc-x16 -o - --wrap-signed-int | FileCheck %s --check-prefix=CHECK_NONSW
+// RUN: %{ispc} %s --emit-llvm-text --target=xelp-x8 -o - --wrap-signed-int | FileCheck %s --check-prefix=CHECK_NONSW
+
+// REQUIRES: XE_ENABLED
+
+
+// CHECK_NONSW-LABEL:       define{{( spir_func)?}} <{{[0-9]*}} x i64> @mul_64
+// CHECK_NONSW-NOT:           %{{.*}}= mul{{.*}}nsw{{.*}}i64
+// CHECK_NONSW-LABEL:       define{{( spir_func)?}} <{{[0-9]*}} x i32> @mul_32
+// CHECK_NONSW-NOT:           %{{.*}}= mul{{.*}}nsw{{.*}}i32
+// CHECK_NONSW-LABEL:       define{{( spir_func)?}} <{{[0-9]*}} x i16> @mul_16
+// CHECK_NONSW-NOT:           %{{.*}}= mul{{.*}}nsw{{.*}}i16
+// CHECK_NONSW-LABEL:       define{{( spir_func)?}} <{{[0-9]*}} x i8> @mul_8
+// CHECK_NONSW-NOT:           %{{.*}}= mul{{.*}}nsw{{.*}}i8
+
+// CHECK_NSW-LABEL:         define{{( spir_func)?}} <{{[0-9]*}} x i64> @mul_64
+// CHECK_NSW-COUNT-1:         %{{.*}}= mul{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define{{( spir_func)?}} <{{[0-9]*}} x i32> @mul_32
+// CHECK_NSW-COUNT-1:         %{{.*}}= mul{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define{{( spir_func)?}} <{{[0-9]*}} x i16> @mul_16
+// CHECK_NSW-COUNT-1:         %{{.*}}= mul{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define{{( spir_func)?}} <{{[0-9]*}} x i8> @mul_8
+// CHECK_NSW-COUNT-1:         %{{.*}}= mul{{.*}}nsw{{.*}}i8
+
+unmasked int64 mul_64(int64 a, int64 b) { return a * b; }
+
+unmasked int32 mul_32(int32 a, int32 b) { return a * b; }
+
+unmasked int16 mul_16(int16 a, int16 b) { return a * b; }
+
+unmasked int8 mul_8(int8 a, int8 b) { return a * b; }
+
+
+// CHECK_NONSW-LABEL:       define{{( spir_func)?}} <{{[0-9]*}} x i64> @add_64
+// CHECK_NONSW-NOT:           %{{.*}}= add{{.*}}nsw{{.*}}i64
+// CHECK_NONSW-LABEL:       define{{( spir_func)?}} <{{[0-9]*}} x i32> @add_32
+// CHECK_NONSW-NOT:           %{{.*}}= add{{.*}}nsw{{.*}}i32
+// CHECK_NONSW-LABEL:       define{{( spir_func)?}} <{{[0-9]*}} x i16> @add_16
+// CHECK_NONSW-NOT:           %{{.*}}= add{{.*}}nsw{{.*}}i16
+// CHECK_NONSW-LABEL:       define{{( spir_func)?}} <{{[0-9]*}} x i8> @add_8
+// CHECK_NONSW-NOT:           %{{.*}}= add{{.*}}nsw{{.*}}i8
+
+// CHECK_NSW-LABEL:         define{{( spir_func)?}} <{{[0-9]*}} x i64> @add_64
+// CHECK_NSW-COUNT-1:         %{{.*}}= add{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define{{( spir_func)?}} <{{[0-9]*}} x i32> @add_32
+// CHECK_NSW-COUNT-1:         %{{.*}}= add{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define{{( spir_func)?}} <{{[0-9]*}} x i16> @add_16
+// CHECK_NSW-COUNT-1:         %{{.*}}= add{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define{{( spir_func)?}} <{{[0-9]*}} x i8> @add_8
+// CHECK_NSW-COUNT-1:         %{{.*}}= add{{.*}}nsw{{.*}}i8
+
+unmasked int64 add_64(int64 a, int64 b) { return a + b; }
+
+unmasked int32 add_32(int32 a, int32 b) { return a + b; }
+
+unmasked int16 add_16(int16 a, int16 b) { return a + b; }
+
+unmasked int8 add_8(int8 a, int8 b) { return a + b; }
+
+
+// CHECK_NONSW-LABEL:       define{{( spir_func)?}} <{{[0-9]*}} x i64> @sub_64
+// CHECK_NONSW-NOT:           %{{.*}}= sub{{.*}}nsw{{.*}}i64
+// CHECK_NONSW-LABEL:       define{{( spir_func)?}} <{{[0-9]*}} x i32> @sub_32
+// CHECK_NONSW-NOT:           %{{.*}}= sub{{.*}}nsw{{.*}}i32
+// CHECK_NONSW-LABEL:       define{{( spir_func)?}} <{{[0-9]*}} x i16> @sub_16
+// CHECK_NONSW-NOT:           %{{.*}}= sub{{.*}}nsw{{.*}}i16
+// CHECK_NONSW-LABEL:       define{{( spir_func)?}} <{{[0-9]*}} x i8> @sub_8
+// CHECK_NONSW-NOT:           %{{.*}}= sub{{.*}}nsw{{.*}}i8
+
+// CHECK_NSW-LABEL:         define{{( spir_func)?}} <{{[0-9]*}} x i64> @sub_64
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define{{( spir_func)?}} <{{[0-9]*}} x i32> @sub_32
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define{{( spir_func)?}} <{{[0-9]*}} x i16> @sub_16
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define{{( spir_func)?}} <{{[0-9]*}} x i8> @sub_8
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i8
+
+unmasked int64 sub_64(int64 a, int64 b) { return a - b; }
+
+unmasked int32 sub_32(int32 a, int32 b) { return a - b; }
+
+unmasked int16 sub_16(int16 a, int16 b) { return a - b; }
+
+unmasked int8 sub_8(int8 a, int8 b) { return a - b; }

--- a/tests/lit-tests/wrap-signed-int.ispc
+++ b/tests/lit-tests/wrap-signed-int.ispc
@@ -1,0 +1,87 @@
+// This test ensures the wrap-signed-int flag works for CPU and is on by default.
+// RUN: %{ispc} %s --emit-llvm-text --target=host -o - | FileCheck %s --check-prefix=CHECK_NSW
+// RUN: %{ispc} %s --emit-llvm-text --target=host -o - --wrap-signed-int | FileCheck %s --check-prefix=CHECK_NONSW
+// RUN: %{ispc} %s --emit-llvm-text --target=host -o - --no-wrap-signed-int | FileCheck %s --check-prefix=CHECK_NSW
+
+// REQUIRES: !XE_ENABLED
+
+
+// CHECK_NONSW-LABEL:       define <{{[0-9]*}} x i64> @mul_64
+// CHECK_NONSW-NOT:           %{{.*}}= mul{{.*}}nsw{{.*}}i64
+// CHECK_NONSW-LABEL:       define <{{[0-9]*}} x i32> @mul_32
+// CHECK_NONSW-NOT:           %{{.*}}= mul{{.*}}nsw{{.*}}i32
+// CHECK_NONSW-LABEL:       define <{{[0-9]*}} x i16> @mul_16
+// CHECK_NONSW-NOT:           %{{.*}}= mul{{.*}}nsw{{.*}}i16
+// CHECK_NONSW-LABEL:       define <{{[0-9]*}} x i8> @mul_8
+// CHECK_NONSW-NOT:           %{{.*}}= mul{{.*}}nsw{{.*}}i8
+
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @mul_64
+// CHECK_NSW-COUNT-1:         %{{.*}}= mul{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @mul_32
+// CHECK_NSW-COUNT-1:         %{{.*}}= mul{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @mul_16
+// CHECK_NSW-COUNT-1:         %{{.*}}= mul{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @mul_8
+// CHECK_NSW-COUNT-1:         %{{.*}}= mul{{.*}}nsw{{.*}}i8
+
+unmasked int64 mul_64(int64 a, int64 b) { return a * b; }
+
+unmasked int32 mul_32(int32 a, int32 b) { return a * b; }
+
+unmasked int16 mul_16(int16 a, int16 b) { return a * b; }
+
+unmasked int8 mul_8(int8 a, int8 b) { return a * b; }
+
+
+// CHECK_NONSW-LABEL:       define <{{[0-9]*}} x i64> @add_64
+// CHECK_NONSW-NOT:           %{{.*}}= add{{.*}}nsw{{.*}}i64
+// CHECK_NONSW-LABEL:       define <{{[0-9]*}} x i32> @add_32
+// CHECK_NONSW-NOT:           %{{.*}}= add{{.*}}nsw{{.*}}i32
+// CHECK_NONSW-LABEL:       define <{{[0-9]*}} x i16> @add_16
+// CHECK_NONSW-NOT:           %{{.*}}= add{{.*}}nsw{{.*}}i16
+// CHECK_NONSW-LABEL:       define <{{[0-9]*}} x i8> @add_8
+// CHECK_NONSW-NOT:           %{{.*}}= add{{.*}}nsw{{.*}}i8
+
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @add_64
+// CHECK_NSW-COUNT-1:         %{{.*}}= add{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @add_32
+// CHECK_NSW-COUNT-1:         %{{.*}}= add{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @add_16
+// CHECK_NSW-COUNT-1:         %{{.*}}= add{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @add_8
+// CHECK_NSW-COUNT-1:         %{{.*}}= add{{.*}}nsw{{.*}}i8
+
+unmasked int64 add_64(int64 a, int64 b) { return a + b; }
+
+unmasked int32 add_32(int32 a, int32 b) { return a + b; }
+
+unmasked int16 add_16(int16 a, int16 b) { return a + b; }
+
+unmasked int8 add_8(int8 a, int8 b) { return a + b; }
+
+
+// CHECK_NONSW-LABEL:       define <{{[0-9]*}} x i64> @sub_64
+// CHECK_NONSW-NOT:           %{{.*}}= sub{{.*}}nsw{{.*}}i64
+// CHECK_NONSW-LABEL:       define <{{[0-9]*}} x i32> @sub_32
+// CHECK_NONSW-NOT:           %{{.*}}= sub{{.*}}nsw{{.*}}i32
+// CHECK_NONSW-LABEL:       define <{{[0-9]*}} x i16> @sub_16
+// CHECK_NONSW-NOT:           %{{.*}}= sub{{.*}}nsw{{.*}}i16
+// CHECK_NONSW-LABEL:       define <{{[0-9]*}} x i8> @sub_8
+// CHECK_NONSW-NOT:           %{{.*}}= sub{{.*}}nsw{{.*}}i8
+
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @sub_64
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i64
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @sub_32
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i32
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @sub_16
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i16
+// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @sub_8
+// CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i8
+
+unmasked int64 sub_64(int64 a, int64 b) { return a - b; }
+
+unmasked int32 sub_32(int32 a, int32 b) { return a - b; }
+
+unmasked int16 sub_16(int16 a, int16 b) { return a - b; }
+
+unmasked int8 sub_8(int8 a, int8 b) { return a - b; }


### PR DESCRIPTION
Changes:
*   Add test checking for performant loop codegen.
    | `tests/lit-tests/loop-codegen-acc-width.ispc`

May close #2460.