### PR TITLE
Enable macOS build on the new OS supporting old OS

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
   },
   "remoteEnv": { "PATH": "/llvm/bin-15.0/bin:${containerEnv:PATH}" },
   "onCreateCommand": {
-    "command1": "cd ${containerWorkspaceFolder} && mkdir build && cd build && cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+    "command1": "cd ${containerWorkspaceFolder} && mkdir build && cd build && cmake .."
   },
   "customizations": {
     "codespaces": {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,19 @@ if (UNIX)
     endif()
 endif()
 
+if (APPLE)
+    # We need to target different minimum macOS versions on x86 and arm by default, but before
+    # we execute project() command, the regular CMAKE_* variables with host info are not initialized,
+    # so we do this hack to detect the platform. It's not perfect, but good enough.
+    execute_process(COMMAND uname -m OUTPUT_VARIABLE UNAME)
+    if (UNAME MATCHES "x86_64")
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum macOS version to support")
+    else()
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum macOS version to support")
+    endif()
+    message(STATUS "Targeting minimum macOS version: ${CMAKE_OSX_DEPLOYMENT_TARGET}")
+endif()
+
 set(PROJECT_NAME ispc)
 set(ISPC_BUILD TRUE)
 project(${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ if (UNIX)
     endif()
 endif()
 
+# Generate compile_commands.json by default - this enables VSCode to do better job interpretting
+# C++ files form the project.
+set(CMAKE_EXPORT_COMPILE_COMMANDS "ON" CACHE BOOL "Export compile commands")
+
 if (APPLE)
     # We need to target different minimum macOS versions on x86 and arm by default, but before
     # we execute project() command, the regular CMAKE_* variables with host info are not initialized,


### PR DESCRIPTION
Fixes #2461.

To enable the binary running on old macOS, `CMAKE_OSX_DEPLOYMENT_TARGET` needs to be properly set for all components of the binary, so it needs to be done for LLVM and ISPC itself. This PR does this defaulting the target to `10.12` (Sierra) for x86 and `11.0` (Big Sur). `10.12` is pretty old OS, but there seem to be no reasons not to support it. `11.0` is the minimum that supports macOS on ARM.

As a bonus, `CMAKE_EXPORT_COMPILE_COMMANDS` is always enabled now, it makes setting up VSCode browsing easier and it's handy for debugging compilation commands (figuring out what was really passed to the compiler).