### PR TITLE
Build Universal Binaries on macOS

### DIFF
--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -314,7 +314,7 @@ jobs:
         name: llvmrel_win_x86
         path: llvm/llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release-x86.arm.wasm.tar.7z
 
-  mac-build-1:
+  mac-build:
     runs-on: macos-11
 
     steps:
@@ -335,68 +335,20 @@ jobs:
 
     - name: Build LLVM
       run: |
-        ./alloy.py -b --version=${{ inputs.version }} --selfbuild-phase1 --verbose
-
-    - name: Tar itermediate results
-      run: |
-        cd llvm
-        rm -rf llvm*/.git
-        tar cf llvm_stage1.tar bin* llvm*
-
-    - name: Upload package
-      uses: actions/upload-artifact@v3
-      with:
-        name: llvm_macos_x86_stage1
-        path: |
-          llvm/llvm_stage1.tar
-
-  mac-build-2:
-    needs: [mac-build-1]
-    runs-on: macos-11
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-
-    - name: Install dependencies
-      run: |
-        .github/workflows/scripts/install-llvm-deps-mac.sh
-
-    - name: Check environment
-      run: |
-        ./check_env.py
-        which -a clang
-        sysctl -n machdep.cpu.brand_string
-        sysctl -n hw.ncpu
-
-    - name: Download package
-      uses: actions/download-artifact@v3
-      with:
-        name: llvm_macos_x86_stage1
-        path: llvm
-
-    - name: Extract intermediate results
-      run: |
-        cd llvm
-        tar xf llvm_stage1.tar
-
-    - name: Build LLVM
-      run: |
-        ./alloy.py -b --version=${{ inputs.version }} --selfbuild-phase2 --verbose
+        ./alloy.py -b --version=${{ inputs.version }} --selfbuild --macos-universal-binary --verbose
 
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-${{ inputs.full_version }}-macos11-Release+Asserts-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
+        tar cJvf llvm-${{ inputs.full_version }}-macos-Release+Asserts-universal-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvm_macos_x86
-        path: llvm/llvm-${{ inputs.full_version }}-macos11-Release+Asserts-x86.arm.wasm.tar.xz
+        name: llvm_macos_universal
+        path: llvm/llvm-${{ inputs.full_version }}-macos-Release+Asserts-universal-x86.arm.wasm.tar.xz
 
-  mac-build-release-1:
+  mac-build-release:
     runs-on: macos-11
 
     steps:
@@ -417,63 +369,15 @@ jobs:
 
     - name: Build LLVM
       run: |
-        ./alloy.py -b --version=${{ inputs.version }} --selfbuild-phase1 --verbose --llvm-disable-assertions
-
-    - name: Tar itermediate results
-      run: |
-        cd llvm
-        rm -rf llvm*/.git
-        tar cf llvm_stage1.tar bin* llvm*
-
-    - name: Upload package
-      uses: actions/upload-artifact@v3
-      with:
-        name: llvmrel_macos_x86_stage1
-        path: |
-          llvm/llvm_stage1.tar
-
-  mac-build-release-2:
-    needs: [mac-build-release-1]
-    runs-on: macos-11
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-
-    - name: Install dependencies
-      run: |
-        .github/workflows/scripts/install-llvm-deps-mac.sh
-
-    - name: Check environment
-      run: |
-        ./check_env.py
-        which -a clang
-        sysctl -n machdep.cpu.brand_string
-        sysctl -n hw.ncpu
-
-    - name: Download package
-      uses: actions/download-artifact@v3
-      with:
-        name: llvmrel_macos_x86_stage1
-        path: llvm
-
-    - name: Extract intermediate results
-      run: |
-        cd llvm
-        tar xf llvm_stage1.tar
-
-    - name: Build LLVM
-      run: |
-        ./alloy.py -b --version=${{ inputs.version }} --selfbuild-phase2 --verbose --llvm-disable-assertions
+        ./alloy.py -b --version=${{ inputs.version }} --selfbuild --macos-universal-binary --verbose --llvm-disable-assertions
 
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-${{ inputs.full_version }}-macos11-Release-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
+        tar cJvf llvm-${{ inputs.full_version }}-macos-Release-universal-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvmrel_macos_x86
-        path: llvm/llvm-${{ inputs.full_version }}-macos11-Release-x86.arm.wasm.tar.xz
+        name: llvmrel_macos_universal
+        path: llvm/llvm-${{ inputs.full_version }}-macos-Release-universal-x86.arm.wasm.tar.xz

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -315,7 +315,7 @@ jobs:
         path: llvm/llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release-x86.arm.wasm.tar.7z
 
   mac-build:
-    runs-on: macos-11
+    runs-on: macos-12-xl
 
     steps:
     - uses: actions/checkout@v3
@@ -349,7 +349,7 @@ jobs:
         path: llvm/llvm-${{ inputs.full_version }}-macos-Release+Asserts-universal-x86.arm.wasm.tar.xz
 
   mac-build-release:
-    runs-on: macos-11
+    runs-on: macos-12-xl
 
     steps:
     - uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,16 +22,27 @@ endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON" CACHE BOOL "Export compile commands")
 
 if (APPLE)
+    # Setting ISPC_MACOS_UNIVERSAL_BINARIES to ON is conventional way of building ISPC as Universal Binary.
+    # If cross compilation is needed (arm64->x86_64 or x86_64->arm64), specify CMAKE_OSX_ARCHITECTURES
+    # on the command line explicitly
+    option(ISPC_MACOS_UNIVERSAL_BINARIES "Build Universal Binaries on macOS" OFF)
+    if (ISPC_MACOS_UNIVERSAL_BINARIES)
+        message(STATUS "Building Universal Binaries (x86_64+arm64)")
+        set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "OSX architectures")
+    endif()
+
     # We need to target different minimum macOS versions on x86 and arm by default, but before
     # we execute project() command, the regular CMAKE_* variables with host info are not initialized,
     # so we do this hack to detect the platform. It's not perfect, but good enough.
     execute_process(COMMAND uname -m OUTPUT_VARIABLE UNAME)
-    if (UNAME MATCHES "x86_64")
+    if (UNAME MATCHES "x86_64" OR CMAKE_OSX_ARCHITECTURES MATCHES "x86_64")
+        # Note: it's ok to have 10.12 for Universal Binaries.
         set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum macOS version to support")
     else()
         set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum macOS version to support")
     endif()
     message(STATUS "Targeting minimum macOS version: ${CMAKE_OSX_DEPLOYMENT_TARGET}")
+
 endif()
 
 set(PROJECT_NAME ispc)
@@ -768,16 +779,32 @@ if (ISPC_PREPARE_PACKAGE)
     set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
     # Allow use custom package name with -DISPC_PACKAGE_NAME
     if (NOT ISPC_PACKAGE_NAME)
+        set(ISPC_ARCH_SUFFIX)
+        if (APPLE)
+            if (CMAKE_OSX_ARCHITECTURES MATCHES "x86_64" AND CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+                set(ISPC_ARCH_SUFFIX ".universal")
+            elseif(CMAKE_OSX_ARCHITECTURES MATCHES "x86_64" OR
+                   (CMAKE_OSX_ARCHITECTURES STREQUAL "" AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64"))
+                set(ISPC_ARCH_SUFFIX ".x86_64")
+            elseif(CMAKE_OSX_ARCHITECTURES MATCHES "arm64" OR
+                   (CMAKE_OSX_ARCHITECTURES STREQUAL "" AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64"))
+                set(ISPC_ARCH_SUFFIX ".arm64")
+            else()
+                message (FATAL_ERROR "Was not able to detect package architecture")
+            endif()
+        endif()
         if (${CPACK_PACKAGE_VERSION_PATCH} MATCHES ".*dev")
             string(CONCAT CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}"
                                 "-trunk"
-                                "-${ISPC_SYSTEM_NAME}")
+                                "-${ISPC_SYSTEM_NAME}"
+                                "${ISPC_ARCH_SUFFIX}")
         else()
             string(CONCAT CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}"
                                 "-v${CPACK_PACKAGE_VERSION_MAJOR}"
                                 ".${CPACK_PACKAGE_VERSION_MINOR}"
                                 ".${CPACK_PACKAGE_VERSION_PATCH}"
-                                "-${ISPC_SYSTEM_NAME}")
+                                "-${ISPC_SYSTEM_NAME}"
+                                "${ISPC_ARCH_SUFFIX}")
 
         endif()
     else()

--- a/llvm_patches/15_0_disable-A-B-A-B-and-BSWAP-in-InstCombine.patch
+++ b/llvm_patches/15_0_disable-A-B-A-B-and-BSWAP-in-InstCombine.patch
@@ -17,7 +17,7 @@ index 4a459ec6c550..0404bd63affa 100644
 @@ -1376,9 +1377,12 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
      return BinaryOperator::CreateAnd(A, NewMask);
    }
-
+ 
 -  // A+B --> A|B iff A and B have no bits set in common.
 -  if (haveNoCommonBitsSet(LHS, RHS, DL, &AC, &I, &DT))
 -    return BinaryOperator::CreateOr(LHS, RHS);
@@ -27,7 +27,7 @@ index 4a459ec6c550..0404bd63affa 100644
 +    if (haveNoCommonBitsSet(LHS, RHS, DL, &AC, &I, &DT))
 +      return BinaryOperator::CreateOr(LHS, RHS);
 +  }
-
+ 
    // add (select X 0 (sub n A)) A  -->  select X A n
    {
 diff --git a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -36,7 +36,7 @@ index 8253c575bc37..a0e9c561dbbd 100644
 +++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
 @@ -11,6 +11,7 @@
  //===----------------------------------------------------------------------===//
-
+ 
  #include "InstCombineInternal.h"
 +#include "llvm/ADT/Triple.h"
  #include "llvm/Analysis/CmpInstAnalysis.h"
@@ -45,7 +45,7 @@ index 8253c575bc37..a0e9c561dbbd 100644
 @@ -2748,9 +2749,12 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
    if (Instruction *FoldedLogic = foldBinOpIntoSelectOrPhi(I))
      return FoldedLogic;
-
+ 
 -  if (Instruction *BitOp = matchBSwapOrBitReverse(I, /*MatchBSwaps*/ true,
 -                                                  /*MatchBitReversals*/ true))
 -    return BitOp;
@@ -55,6 +55,6 @@ index 8253c575bc37..a0e9c561dbbd 100644
 +                                                    /*MatchBitReversals*/ true))
 +      return BitOp;
 +  }
-
+ 
    if (Instruction *Funnel = matchFunnelShift(I, *this))
      return Funnel;


### PR DESCRIPTION
Fixes #2329.

- add `--macos-universal-binary` to `alloy.py`, which triggers LLVM build as Universal Binary (x86_64 + arm64)
- add `ISPC_MACOS_UNIVERSAL_BINARIES` to CMake on macOS, which builds ISPC as Universal Binary.
- add arch suffix to package name on macOS, it's either `x64_64`, `arm64`, or `universal`.
- build LLVM as Universal Binary on macOS in CI.
- fix LLVM patch for `15.0`, so it properly applies on Windows in CI.
- run macOS rebuild jobs on `macos-12-xl` runners, which are "big" instances (12 cores) and allow finishing selfbuild jobs within the time limit.

The plan is to release 3 set of binaries `x64_64`, `arm64`, and `universal`.