### PR TITLE
Use vector conversion for uniform vector initialization

### DIFF
--- a/tests/lit-tests/vector_type_init-1.ispc
+++ b/tests/lit-tests/vector_type_init-1.ispc
@@ -1,0 +1,51 @@
+// This test checks that uniform vectors conversion during initialization is perfomed using vector instructions.
+// RUN: %{ispc} %s --target=host -O0 --emit-llvm-text -o - | FileCheck %s
+
+// Vector initialization
+// CHECK-LABEL: define <4 x double> @test1
+// CHECK: fpext <4 x float>
+// CHECK-NOT: fpext float
+uniform double<4> test1() {
+  const uniform float<4> f = {1.f, 2.f, 3.f, 4.f}; 
+  const uniform double<4> d = {f[1], f[3], f.y, 0.0};
+  return d;
+}
+
+// Vector initialization
+// CHECK-LABEL: define <4 x i64> @test2
+// CHECK: sext <4 x i32>
+// CHECK-NOT: sext i32
+uniform int64<4> test2(uniform int k) {
+  const uniform int<4> i = {k, k*2, 3, k*3}; 
+  const uniform int64<4> d = {i[1], i[3], i.y, 0};
+  return d;
+}
+
+// Vector initialization
+// CHECK-LABEL: define <4 x i64> @test3
+// CHECK: sext <4 x i32>
+// CHECK-NOT: sext i32
+uniform int64<4> test3(uniform int k) {
+  const uniform int<4> i = {k, k*2, 3, k*3}; 
+  const uniform int64<4> d = {i.y, i.w, i.y};
+  return d;
+}
+
+// Initialize per element since initializers are of different types
+// CHECK-LABEL: define <4 x double> @test4
+// CHECK: sitofp i32
+// CHECK-COUNT-2: fpext float
+uniform double<4> test4(uniform int k) {
+  const uniform float<4> f = {1.f, 2.f, 3.f, 4.f}; 
+  const uniform double<4> d = {k, f[3], f.y, 0.0};
+  return d;
+}
+
+// CHECK-LABEL: define <4 x double> @test5
+// CHECK: fpext <4 x float>
+// CHECK-NOT: fpext float
+uniform double<3> test5() {
+  const uniform float<3> f = {1.f, 2.f, 3.f}; 
+  const uniform double<3> d = {2.f, f.z, f.y};
+  return d;
+}

--- a/tests/lit-tests/vector_type_init-2.ispc
+++ b/tests/lit-tests/vector_type_init-2.ispc
@@ -1,0 +1,73 @@
+// This test checks that uniform vectors conversion during initialization is perfomed using vector instructions.
+// The example is used from https://github.com/ispc/ispc/issues/2147
+
+// RUN: %{ispc} %s --target=avx2-i32x8 -O2 --emit-llvm-text -o - | FileCheck %s -check-prefix=CHECK_IR
+// RUN: %{ispc} %s --target=avx2-i32x8 -O2 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_ASM
+// REQUIRES: X86_ENABLED
+
+// CHECK_IR: define <4 x double> @TestCross2
+// CHECK_IR: fpext <4 x float>
+// CHECK_IR-NOT: fpext float
+
+// CHECK_IR: define <4 x double> @TestCross3
+// CHECK_IR: fpext <4 x float>
+// CHECK_IR-NOT: fpext float
+
+// CHECK_ASM: TestCross2
+// CHECK_ASM-COUNT-2: vcvtps2pd
+// CHECK_ASM-NOT: vcvtss2sd
+
+// CHECK_ASM: TestCross3
+// CHECK_ASM-COUNT-2: vcvtps2pd
+// CHECK_ASM-NOT: vcvtss2sd
+
+struct FVector {
+    float V[3];
+};
+
+struct FVector4 {
+    float V[4];
+};
+
+typedef double<4> QVec3;
+
+inline uniform QVec3 SetQVec3(const uniform double X, const uniform double Y, const uniform double Z) {
+    const uniform QVec3 Result = {X, Y, Z, 0.0};
+    return Result;
+}
+
+inline uniform QVec3 SetQVec3(uniform const FVector fp0) {
+    const uniform QVec3 Result = {fp0.V[0], fp0.V[1], fp0.V[2], 0.0};
+    return Result;
+}
+
+inline uniform QVec3 SetQVec3(uniform const FVector4 fp0) {
+    const uniform QVec3 Result = {fp0.V[0], fp0.V[1], fp0.V[2], fp0.V[3]};
+    return Result;
+}
+
+inline uniform QVec3 QVec3Swizzle(const uniform QVec3 Vec, const uniform int X, const uniform int Y,
+                                  const uniform int Z) {
+    return SetQVec3(Vec[X], Vec[Y], Vec[Z]);
+}
+
+inline uniform QVec3 QVec3Cross(const uniform QVec3 Vec1, const uniform QVec3 Vec2) {
+    uniform QVec3 Tmp0 = QVec3Swizzle(Vec2, 1, 2, 0);
+    uniform QVec3 Tmp1 = QVec3Swizzle(Vec1, 1, 2, 0);
+    Tmp0 = Tmp0 * Vec1;
+    Tmp1 = Tmp1 * Vec2;
+    uniform QVec3 Tmp2 = Tmp0 - Tmp1;
+    return QVec3Swizzle(Tmp2, 1, 2, 0);
+}
+
+uniform QVec3 TestCross2(const uniform FVector a, const uniform FVector b) {
+    const uniform QVec3 tmp1 = SetQVec3(a);
+    const uniform QVec3 tmp2 = SetQVec3(b);
+    return QVec3Cross(tmp1, tmp2);
+}
+
+uniform QVec3 TestCross3(const uniform FVector4 a, const uniform FVector4 b) {
+    const uniform QVec3 tmp1 = SetQVec3(a);
+    const uniform QVec3 tmp2 = SetQVec3(b);
+    return QVec3Cross(tmp1, tmp2);
+}


### PR DESCRIPTION
Try to produce vector type conversion when initializing short vectors.
It's not a partial fix for https://github.com/ispc/ispc/issues/2147. The frontend produces the same code as in https://github.com/ispc/ispc/issues/2147#issuecomment-922027113 with fake varying trick.