### PR TITLE
Remove GCC 4.x.x workaround in dispatch code.

### DIFF
--- a/builtins/dispatch-macos.ll
+++ b/builtins/dispatch-macos.ll
@@ -33,13 +33,8 @@
 ;;                           : "0" (infoType));
 ;; }
 ;;
-;; // Save %ebx in case it's the PIC register.
 ;; static void __cpuid_count(int info[4], int level, int count) {
-;;   __asm__ __volatile__ ("xchg{l}\t{%%}ebx, %1\n\t"
-;;                         "cpuid\n\t"
-;;                         "xchg{l}\t{%%}ebx, %1\n\t"
-;;                         : "=a" (info[0]), "=r" (info[1]), "=c" (info[2]), "=d" (info[3])
-;;                         : "0" (level), "2" (count));
+;;     __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(level), "2"(count));
 ;; }
 ;;
 ;; static int __os_has_avx_support() {
@@ -116,7 +111,7 @@ entry:
   %0 = tail call { i32, i32, i32, i32 } asm sideeffect "cpuid", "={ax},={bx},={cx},={dx},0,~{dirflag},~{fpsr},~{flags}"(i32 1) nounwind
   %asmresult5.i = extractvalue { i32, i32, i32, i32 } %0, 2
   %asmresult6.i = extractvalue { i32, i32, i32, i32 } %0, 3
-  %1 = tail call { i32, i32, i32, i32 } asm sideeffect "xchg$(l$)\09$(%$)ebx, $1\0A\09cpuid\0A\09xchg$(l$)\09$(%$)ebx, $1\0A\09", "={ax},=r,={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 7, i32 0) nounwind
+  %1 = tail call { i32, i32, i32, i32 } asm sideeffect "cpuid", "={ax},={bx},={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 7, i32 0) nounwind
   %asmresult4.i84 = extractvalue { i32, i32, i32, i32 } %1, 1
   %and = and i32 %asmresult5.i, 134217728
   %cmp = icmp eq i32 %and, 0

--- a/builtins/dispatch-no-spr.ll
+++ b/builtins/dispatch-no-spr.ll
@@ -29,13 +29,8 @@
 ;;                           : "0" (infoType));
 ;; }
 ;; 
-;; // Save %ebx in case it's the PIC register.
 ;; static void __cpuid_count(int info[4], int level, int count) {
-;;   __asm__ __volatile__ ("xchg{l}\t{%%}ebx, %1\n\t"
-;;                         "cpuid\n\t"
-;;                         "xchg{l}\t{%%}ebx, %1\n\t"
-;;                         : "=a" (info[0]), "=r" (info[1]), "=c" (info[2]), "=d" (info[3])
-;;                         : "0" (level), "2" (count));
+;;     __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(level), "2"(count));
 ;; }
 ;; 
 ;; static int __os_has_avx_support() {
@@ -124,7 +119,7 @@ entry:
   %0 = tail call { i32, i32, i32, i32 } asm sideeffect "cpuid", "={ax},={bx},={cx},={dx},0,~{dirflag},~{fpsr},~{flags}"(i32 1) nounwind
   %asmresult5.i = extractvalue { i32, i32, i32, i32 } %0, 2
   %asmresult6.i = extractvalue { i32, i32, i32, i32 } %0, 3
-  %1 = tail call { i32, i32, i32, i32 } asm sideeffect "xchg$(l$)\09$(%$)ebx, $1\0A\09cpuid\0A\09xchg$(l$)\09$(%$)ebx, $1\0A\09", "={ax},=r,={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 7, i32 0) nounwind
+  %1 = tail call { i32, i32, i32, i32 } asm sideeffect "cpuid", "={ax},={bx},={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 7, i32 0) nounwind
   %asmresult4.i87 = extractvalue { i32, i32, i32, i32 } %1, 1
   %and = and i32 %asmresult5.i, 134217728
   %cmp = icmp eq i32 %and, 0

--- a/builtins/dispatch.ll
+++ b/builtins/dispatch.ll
@@ -29,13 +29,8 @@
 ;;                           : "0" (infoType));
 ;; }
 ;; 
-;; // Save %ebx in case it's the PIC register.
 ;; static void __cpuid_count(int info[4], int level, int count) {
-;;   __asm__ __volatile__ ("xchg{l}\t{%%}ebx, %1\n\t"
-;;                         "cpuid\n\t"
-;;                         "xchg{l}\t{%%}ebx, %1\n\t"
-;;                         : "=a" (info[0]), "=r" (info[1]), "=c" (info[2]), "=d" (info[3])
-;;                         : "0" (level), "2" (count));
+;;     __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(level), "2"(count));
 ;; }
 ;; 
 ;; static int __os_has_avx_support() {
@@ -162,11 +157,11 @@ entry:
   %0 = tail call { i32, i32, i32, i32 } asm sideeffect "cpuid", "={ax},={bx},={cx},={dx},0,~{dirflag},~{fpsr},~{flags}"(i32 1) nounwind
   %asmresult5.i = extractvalue { i32, i32, i32, i32 } %0, 2
   %asmresult6.i = extractvalue { i32, i32, i32, i32 } %0, 3
-  %1 = tail call { i32, i32, i32, i32 } asm sideeffect "xchg$(l$)\09$(%$)ebx, $1\0A\09cpuid\0A\09xchg$(l$)\09$(%$)ebx, $1\0A\09", "={ax},=r,={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 7, i32 0) nounwind
+  %1 = tail call { i32, i32, i32, i32 } asm sideeffect "cpuid", "={ax},={bx},={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 7, i32 0) nounwind
   %asmresult4.i277 = extractvalue { i32, i32, i32, i32 } %1, 1
   %asmresult5.i278 = extractvalue { i32, i32, i32, i32 } %1, 2
   %asmresult6.i279 = extractvalue { i32, i32, i32, i32 } %1, 3
-  %2 = tail call { i32, i32, i32, i32 } asm sideeffect "xchg$(l$)\09$(%$)ebx, $1\0A\09cpuid\0A\09xchg$(l$)\09$(%$)ebx, $1\0A\09", "={ax},=r,={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 7, i32 1) nounwind
+  %2 = tail call { i32, i32, i32, i32 } asm sideeffect "cpuid", "={ax},={bx},={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 7, i32 1) nounwind
   %asmresult.i283 = extractvalue { i32, i32, i32, i32 } %2, 0
   %and = and i32 %asmresult6.i, 67108864
   %cmp.not = icmp ne i32 %and, 0

--- a/check_isa.cpp
+++ b/check_isa.cpp
@@ -25,13 +25,8 @@ static void __cpuid(int info[4], int infoType) {
     __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(infoType));
 }
 
-/* Save %ebx in case it's the PIC register */
 static void __cpuidex(int info[4], int level, int count) {
-    __asm__ __volatile__("xchg{l}\t{%%}ebx, %1\n\t"
-                         "cpuid\n\t"
-                         "xchg{l}\t{%%}ebx, %1\n\t"
-                         : "=a"(info[0]), "=r"(info[1]), "=c"(info[2]), "=d"(info[3])
-                         : "0"(level), "2"(count));
+    __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(level), "2"(count));
 }
 #endif // !HOST_IS_WINDOWS
 

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -66,13 +66,8 @@ static void __cpuid(int info[4], int infoType) {
     __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(infoType));
 }
 
-/* Save %ebx in case it's the PIC register */
 static void __cpuidex(int info[4], int level, int count) {
-    __asm__ __volatile__("xchg{l}\t{%%}ebx, %1\n\t"
-                         "cpuid\n\t"
-                         "xchg{l}\t{%%}ebx, %1\n\t"
-                         : "=a"(info[0]), "=r"(info[1]), "=c"(info[2]), "=d"(info[3])
-                         : "0"(level), "2"(count));
+    __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(level), "2"(count));
 }
 #endif // !ISPC_HOST_IS_WINDOWS && !__ARM__ && !__AARCH64__
 


### PR DESCRIPTION
Fix #2504.

This fix removes GCC 4.x.x workaround in dispatch code. It causes problems on 64 bit target, which showed up as `check_isa.cpp` fail when compiled with -O0. It could also potentially affect ISPC output produced with auto-dispatch.

For the complete description of the problem see #2504.