### PR TITLE
Updates for Github Actions CI

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -219,8 +219,7 @@ jobs:
     continue-on-error: false
     strategy:
       fail-fast: false
-      matrix:
-        target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
+
     steps:
     - uses: actions/checkout@v3
     - name: Download package
@@ -239,7 +238,7 @@ jobs:
     - name: Running tests
       run: |
         echo PATH=$PATH
-        ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+        ./alloy.py -r --only="stability current -O2" --only-targets="avx2-i32x8" --time --update-errors=FP
 
     - name: Check
       run: |
@@ -250,7 +249,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: fail_db.llvm13.${{matrix.target}}.txt
+        name: fail_db.llvm13.avx2.txt
         path: fail_db.txt
 
   linux-test-llvm14:
@@ -635,7 +634,6 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86, x86-64]
-        target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
 
     steps:
     - uses: actions/checkout@v3
@@ -657,7 +655,7 @@ jobs:
       run: |
         $env:ISPC_HOME = "$pwd"
         .github/workflows/scripts/load-vs-env.ps1 "${{ matrix.arch }}"
-        python .\alloy.py -r --only="stability ${{ matrix.arch }} current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+        python .\alloy.py -r --only="stability ${{ matrix.arch }} current -O2" --only-targets="avx2-i32x8" --time --update-errors=FP
 
     - name: Check
       run: |
@@ -668,7 +666,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: fail_db.llvm13.${{matrix.arch}}.${{matrix.target}}.txt
+        name: fail_db.llvm13.${{matrix.arch}}.avx2.txt
         path: fail_db.txt
 
   win-test-llvm14:

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -417,10 +417,10 @@ jobs:
 
   macos-build-ispc-llvm15:
     needs: [define-flow]
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       LLVM_VERSION: "15.0"
-      LLVM_TAR: llvm-15.0.7-macos11-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-15.0.7-macos-Release+Asserts-universal-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -447,7 +447,7 @@ jobs:
 
     - name: Build package
       run: |
-        .github/workflows/scripts/build-ispc.sh -DBENCHMARKS_ISPC_TARGETS=avx1-i32x4
+        .github/workflows/scripts/build-ispc.sh #-DBENCHMARKS_ISPC_TARGETS=avx1-i32x4
 
     - name: Sanity testing (make check-all, make test)
       run: |
@@ -458,6 +458,47 @@ jobs:
       with:
         name: ispc_llvm15_macos
         path: build/ispc-trunk-macos.tar.gz
+
+  macos-test-ispc-llvm15:
+    needs: [define-flow, macos-build-ispc-llvm15]
+    runs-on: macos-12
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+    - name: Download package
+      uses: actions/download-artifact@v3
+      with:
+        name: ispc_llvm15_macos
+
+    - name: Install dependencies and unpack artifacts
+      run: |
+        tar xf ispc-trunk-macos.tar.gz
+        echo "$GITHUB_WORKSPACE/ispc-trunk-macos/bin" >> $GITHUB_PATH
+        echo "ISPC_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        echo "LLVM_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+
+    - name: Check environment
+      run: |
+        sysctl -n machdep.cpu.brand_string
+
+    - name: Running tests
+      run: |
+        echo PATH=$PATH
+        ./alloy.py -r --only="stability current x86-64 -O0 -O2" --only-targets="sse4-i32x4" --time --update-errors=FP
+
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
+    - name: Upload fail_db.txt
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: fail_db.llvm15.macos.sse4.txt
+        path: fail_db.txt
 
   win-build-ispc-llvm13:
     needs: [define-flow]

--- a/.github/workflows/scripts/build-ispc.sh
+++ b/.github/workflows/scripts/build-ispc.sh
@@ -5,7 +5,7 @@ if [[ $OSTYPE == 'darwin'* ]]; then
   # macOS is treated differently because we don't build benchmarks and package name is different.
   # Benchmarks are not built, because Github Action macOS shared runners run on too old hardware -
   # IvyBridge, i.e. AVX1, while our benchmark setup assumes at least AVX2.
-  cmake -B build -DISPC_PREPARE_PACKAGE=ON -DCMAKE_CXX_FLAGS="-Werror" -DISPC_PACKAGE_NAME=ispc-trunk-macos -DISPC_OPAQUE_PTR_MODE=${ISPC_OPAQUE_PTR_MODE} $@
+  cmake -B build -DISPC_PREPARE_PACKAGE=ON -DCMAKE_CXX_FLAGS="-Werror" -DISPC_MACOS_UNIVERSAL_BINARIES=ON -DISPC_PACKAGE_NAME=ispc-trunk-macos -DISPC_OPAQUE_PTR_MODE=${ISPC_OPAQUE_PTR_MODE} $@
 else
   cmake -B build -DISPC_PREPARE_PACKAGE=ON -DISPC_INCLUDE_BENCHMARKS=ON -DCMAKE_CXX_FLAGS="-Werror" -DISPC_PACKAGE_NAME=ispc-trunk-linux -DISPC_OPAQUE_PTR_MODE=${ISPC_OPAQUE_PTR_MODE} $@
 fi

--- a/alloy.py
+++ b/alloy.py
@@ -94,7 +94,7 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     if  version_LLVM == "trunk":
         GIT_TAG="main"
     elif  version_LLVM == "16_0":
-        GIT_TAG="llvmorg-16.0.2"
+        GIT_TAG="llvmorg-16.0.3"
     elif  version_LLVM == "15_0":
         GIT_TAG="llvmorg-15.0.7"
     elif  version_LLVM == "14_0":


### PR DESCRIPTION
- `alloy.py` to build LLVM `16.0.3` instead of `16.0.2`
- macOS job to use LLVM Universal Binaries.
- add test run on macOS, instead of just a build.
- limit the number of optsets to run with LLVM 13
- build ISPC as Universal Binary in GHA CI, as this is what we release. We need to verify that it build for both x86_64 and arm64