### PR TITLE
Fix ICE when postfix expession fetches unknown member

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -5286,6 +5286,12 @@ MemberExpr *MemberExpr::create(Expr *e, const char *id, SourcePos p, SourcePos i
     if (CastType<StructType>(exprType) != nullptr) {
         const StructType *st = CastType<StructType>(exprType);
         if (st->IsDefined()) {
+            std::string elemName(id);
+            const Type *elemType = st->GetElementType(elemName);
+            if (elemType == nullptr) {
+                Error(p, "'%s' has no member named \"%s\"", st->GetString().c_str(), id);
+                return nullptr;
+            }
             return new StructMemberExpr(e, id, p, idpos, derefLValue);
         } else {
             Error(p,

--- a/tests/lit-tests/2514.ispc
+++ b/tests/lit-tests/2514.ispc
@@ -1,0 +1,12 @@
+// RUN: not %{ispc} --nostdlib --target=avx1-i32x4 %s > %t 2>&1
+// RUN: FileCheck --input-file=%t %s
+
+// CHECK-NOT: FATAL ERROR: Unhandled signal sent to process
+// CHECK: has no member named "f"
+struct D {
+    int h;
+};
+struct D d;
+int foo() {
+     return d.f;
+}


### PR DESCRIPTION
This fixes issue #2514 

```bash
./tests/lit-tests/2514.ispc:11:13: Error: 'varying struct D' has no member named "f"
     return d.f;
            ^^^

./tests/lit-tests/2514.ispc:11:6: Error: Must provide return value for return statement for non-void function.
     return d.f;
     ^^^^^^^^^^^
```