### PR TITLE
tests: fix 2514.ispc test adding --nowrap

### DIFF
--- a/tests/lit-tests/2514.ispc
+++ b/tests/lit-tests/2514.ispc
@@ -1,4 +1,4 @@
-// RUN: not %{ispc} --nostdlib --target=avx1-i32x4 %s > %t 2>&1
+// RUN: not %{ispc} --nostdlib --nowrap --target=avx1-i32x4 %s > %t 2>&1
 // RUN: FileCheck --input-file=%t %s
 
 // CHECK-NOT: FATAL ERROR: Unhandled signal sent to process


### PR DESCRIPTION
By default, output of ISPC is wrapped to some fixed width. When ispc test suite is placed in the relatively short or long path, output is wrapped in a way that can disjoint the search pattern to different lines whereas CHECK is searching for substring on the same line. It may cause fails specific to build/test environment.