### PR TITLE
Support different types in short vector type initialization

### DIFF
--- a/src/expr.h
+++ b/src/expr.h
@@ -249,6 +249,27 @@ class ExprList : public Expr {
     bool HasAmbiguousVariability(std::vector<const Expr *> &warn) const;
 
     std::vector<Expr *> exprs;
+
+    // Utility structs to support initializers lists for vectors
+    struct ExprPosMapping {
+        Expr *expr;
+        int pos;
+        ExprPosMapping(Expr *e, int p) : expr(e), pos(p) {}
+    };
+
+    struct ExprPosMappingVectorForVector {
+        int vec_mem_pos_from;
+        int vec_mem_pos_to;
+        Expr *expr;
+        ExprPosMappingVectorForVector(int from, int to, Expr *e)
+            : vec_mem_pos_from(from), vec_mem_pos_to(to), expr(e) {}
+        ExprPosMappingVectorForVector(int from, ExprPosMapping map)
+            : vec_mem_pos_from(from), vec_mem_pos_to(map.pos), expr(map.expr) {}
+    };
+
+    // Returns true if each expression in expression list has AtomicType.
+    // It also constructs a map of initializers for each atomic basetype.
+    bool HasAtomicInitializerList(std::map<AtomicType::BasicType, std::vector<ExprPosMapping>> &map);
 };
 
 /** @brief Expression representing a function call.

--- a/tests/lit-tests/vector_type_init-1.ispc
+++ b/tests/lit-tests/vector_type_init-1.ispc
@@ -6,7 +6,7 @@
 // CHECK: fpext <4 x float>
 // CHECK-NOT: fpext float
 uniform double<4> test1() {
-  const uniform float<4> f = {1.f, 2.f, 3.f, 4.f}; 
+  const uniform float<4> f = {1.f, 2.f, 3.f, 4.f};
   const uniform double<4> d = {f[1], f[3], f.y, 0.0};
   return d;
 }
@@ -16,7 +16,7 @@ uniform double<4> test1() {
 // CHECK: sext <4 x i32>
 // CHECK-NOT: sext i32
 uniform int64<4> test2(uniform int k) {
-  const uniform int<4> i = {k, k*2, 3, k*3}; 
+  const uniform int<4> i = {k, k*2, 3, k*3};
   const uniform int64<4> d = {i[1], i[3], i.y, 0};
   return d;
 }
@@ -26,17 +26,17 @@ uniform int64<4> test2(uniform int k) {
 // CHECK: sext <4 x i32>
 // CHECK-NOT: sext i32
 uniform int64<4> test3(uniform int k) {
-  const uniform int<4> i = {k, k*2, 3, k*3}; 
+  const uniform int<4> i = {k, k*2, 3, k*3};
   const uniform int64<4> d = {i.y, i.w, i.y};
   return d;
 }
 
-// Initialize per element since initializers are of different types
 // CHECK-LABEL: define <4 x double> @test4
 // CHECK: sitofp i32
-// CHECK-COUNT-2: fpext float
+// CHECK: fpext <4 x float>
+// CHECK-NOT: fpext float
 uniform double<4> test4(uniform int k) {
-  const uniform float<4> f = {1.f, 2.f, 3.f, 4.f}; 
+  const uniform float<4> f = {1.f, 2.f, 3.f, 4.f};
   const uniform double<4> d = {k, f[3], f.y, 0.0};
   return d;
 }
@@ -45,7 +45,18 @@ uniform double<4> test4(uniform int k) {
 // CHECK: fpext <4 x float>
 // CHECK-NOT: fpext float
 uniform double<3> test5() {
-  const uniform float<3> f = {1.f, 2.f, 3.f}; 
+  const uniform float<3> f = {1.f, 2.f, 3.f};
   const uniform double<3> d = {2.f, f.z, f.y};
+  return d;
+}
+
+// CHECK-LABEL: define <8 x double> @test6
+// CHECK: sitofp <8 x i32>
+// CHECK: fpext <8 x float>
+// CHECK-NOT: fpext float
+uniform double<5> test6(uniform int k, uniform float p) {
+  const uniform float<3> f = {p + 1.f, p + 2.f, p + 3.f};
+  const uniform int<3> i = {k, k+1, k+2};
+  const uniform double<5> d = {f.x, i.x, f.y, i.y, 0.d};
   return d;
 }

--- a/tests/lit-tests/vector_type_init-2.ispc
+++ b/tests/lit-tests/vector_type_init-2.ispc
@@ -5,28 +5,16 @@
 // RUN: %{ispc} %s --target=avx2-i32x8 -O2 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_ASM
 // REQUIRES: X86_ENABLED
 
-// CHECK_IR: define <4 x double> @TestCross2
+// CHECK_IR: define <4 x double> @TestCross
 // CHECK_IR: fpext <4 x float>
 // CHECK_IR-NOT: fpext float
 
-// CHECK_IR: define <4 x double> @TestCross3
-// CHECK_IR: fpext <4 x float>
-// CHECK_IR-NOT: fpext float
-
-// CHECK_ASM: TestCross2
-// CHECK_ASM-COUNT-2: vcvtps2pd
-// CHECK_ASM-NOT: vcvtss2sd
-
-// CHECK_ASM: TestCross3
+// CHECK_ASM: TestCross
 // CHECK_ASM-COUNT-2: vcvtps2pd
 // CHECK_ASM-NOT: vcvtss2sd
 
 struct FVector {
-    float V[3];
-};
-
-struct FVector4 {
-    float V[4];
+    float<4> V;
 };
 
 typedef double<4> QVec3;
@@ -38,11 +26,6 @@ inline uniform QVec3 SetQVec3(const uniform double X, const uniform double Y, co
 
 inline uniform QVec3 SetQVec3(uniform const FVector fp0) {
     const uniform QVec3 Result = {fp0.V[0], fp0.V[1], fp0.V[2], 0.0};
-    return Result;
-}
-
-inline uniform QVec3 SetQVec3(uniform const FVector4 fp0) {
-    const uniform QVec3 Result = {fp0.V[0], fp0.V[1], fp0.V[2], fp0.V[3]};
     return Result;
 }
 
@@ -60,13 +43,7 @@ inline uniform QVec3 QVec3Cross(const uniform QVec3 Vec1, const uniform QVec3 Ve
     return QVec3Swizzle(Tmp2, 1, 2, 0);
 }
 
-uniform QVec3 TestCross2(const uniform FVector a, const uniform FVector b) {
-    const uniform QVec3 tmp1 = SetQVec3(a);
-    const uniform QVec3 tmp2 = SetQVec3(b);
-    return QVec3Cross(tmp1, tmp2);
-}
-
-uniform QVec3 TestCross3(const uniform FVector4 a, const uniform FVector4 b) {
+uniform QVec3 TestCross(const uniform FVector a, const uniform FVector b) {
     const uniform QVec3 tmp1 = SetQVec3(a);
     const uniform QVec3 tmp2 = SetQVec3(b);
     return QVec3Cross(tmp1, tmp2);


### PR DESCRIPTION
Support vector type conversions in initialization of short vectors from different types.
Additional fix for #2147 