### PR TITLE
Add --mcmodel switch

### DIFF
--- a/src/ispc.h
+++ b/src/ispc.h
@@ -156,6 +156,13 @@ enum class PerfWarningType : PerfWarningTypeUnderlyingType {
     VariableShiftRight = 0x8,
 };
 
+/** Code model */
+enum class MCModel {
+    Default, /** default model - i.e. not specified on the command line */
+    Small,   /** small model */
+    Large,   /** large model */
+};
+
 /** @brief Structure that defines a compilation target
 
     This structure defines a compilation target for the ispc compiler.
@@ -206,7 +213,7 @@ class Target {
     /** Initializes the given Target pointer for a target of the given
         name, if the name is a known target.  Returns true if the
         target was initialized and false if the name is unknown. */
-    Target(Arch arch, const char *cpu, ISPCTarget isa, bool pic, bool printTarget);
+    Target(Arch arch, const char *cpu, ISPCTarget isa, bool pic, MCModel code_model, bool printTarget);
 
     /** Check if LLVM intrinsic is supported for the current target. */
     bool checkIntrinsticSupport(llvm::StringRef name, SourcePos pos);
@@ -298,6 +305,8 @@ class Target {
     int getVectorWidth() const { return m_vectorWidth; }
 
     bool getGeneratePIC() const { return m_generatePIC; }
+
+    MCModel getMCModel() const { return m_codeModel; }
 
     bool getMaskingIsFree() const { return m_maskingIsFree; }
 
@@ -396,6 +405,9 @@ class Target {
 
     /** Indicates whether position independent code should be generated. */
     bool m_generatePIC;
+
+    /** Code model */
+    MCModel m_codeModel;
 
     /** Is there overhead associated with masking on the target
         architecture; e.g. there is on SSE, due to extra blends and the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,31 +109,31 @@ static void lPrintVersion() {
     printf("        small\t\t\t\tThe program and its symbols must be linked in the lower 2GB of the address space "
            "(default)\n");
     printf("        large\t\t\t\tThe program has no assumprion about addresses and sizes of sections\n");
-    printf("    [-MMM <filename>]\t\t\tWrite #include dependencies to given file.\n");
+    printf("    [-MMM <filename>]\t\t\tWrite #include dependencies to given file\n");
     printf("    [-M]\t\t\t\tOutput a rule suitable for `make' describing the dependencies of the main source file to "
-           "stdout.\n");
-    printf("    [-MF <filename>]\t\t\tWhen used with `-M', specifies a file to write the dependencies to.\n");
+           "stdout\n");
+    printf("    [-MF <filename>]\t\t\tWhen used with `-M', specifies a file to write the dependencies to\n");
     printf("    [-MT <filename>]\t\t\tWhen used with `-M', changes the target of the rule emitted by dependency "
-           "generation.\n");
+           "generation\n");
     printf("    [--no-omit-frame-pointer]\t\tDisable frame pointer omission. It may be useful for profiling\n");
     printf("    [--nostdlib]\t\t\tDon't make the ispc standard library available\n");
     printf("    [--no-pragma-once]\t\t\tDon't use #pragma once in created headers\n");
     printf("    [--nocpp]\t\t\t\tDon't run the C preprocessor\n");
     printf("    [-o <name>/--outfile=<name>]\tOutput filename (may be \"-\" for standard output)\n");
-    printf("    [-O0/-O(1/2/3)]\t\t\tSet optimization level. Default behavior is to optimize for speed.\n");
-    printf("        -O0\t\t\t\tOptimizations disabled.\n");
-    printf("        -O1\t\t\t\tOptimization for size.\n");
-    printf("        -O2/O3\t\t\t\tOptimization for speed.\n");
+    printf("    [-O0/-O(1/2/3)]\t\t\tSet optimization level. Default behavior is to optimize for speed\n");
+    printf("        -O0\t\t\t\tOptimizations disabled\n");
+    printf("        -O1\t\t\t\tOptimization for size\n");
+    printf("        -O2/O3\t\t\t\tOptimization for speed\n");
     printf("    [--opt=<option>]\t\t\tSet optimization option\n");
-    printf("        disable-assertions\t\tRemove assertion statements from final code.\n");
+    printf("        disable-assertions\t\tRemove assertion statements from final code\n");
     printf("        disable-fma\t\t\tDisable 'fused multiply-add' instructions (on targets that support them)\n");
-    printf("        disable-loop-unroll\t\tDisable loop unrolling.\n");
+    printf("        disable-loop-unroll\t\tDisable loop unrolling\n");
     printf(
         "        disable-zmm\t\t\tDisable using zmm registers for avx512 targets in favour of ymm. This also affects "
-        "ABI.\n");
+        "ABI\n");
 #ifdef ISPC_XE_ENABLED
-    printf("        emit-xe-hardware-mask\t\tEnable emitting of Xe implicit hardware mask.\n");
-    printf("        enable-xe-foreach-varying\t\tEnable experimental foreach support inside varying control flow.\n");
+    printf("        emit-xe-hardware-mask\t\tEnable emitting of Xe implicit hardware mask\n");
+    printf("        enable-xe-foreach-varying\t\tEnable experimental foreach support inside varying control flow\n");
 #endif
     printf("        fast-masked-vload\t\tFaster masked vector loads on SSE (may go past end of array)\n");
     printf("        fast-math\t\t\tPerform non-IEEE-compliant optimizations of numeric expressions\n");
@@ -145,7 +145,7 @@ static void lPrintVersion() {
     printf("    ");
     char targetHelp[2048];
     snprintf(targetHelp, sizeof(targetHelp),
-             "[--target=<t>]\t\t\tSelect target ISA and width.\n"
+             "[--target=<t>]\t\t\tSelect target ISA and width\n"
              "<t>={%s}",
              g->target_registry->getSupportedTargets().c_str());
     PrintWithWordBreaks(targetHelp, 24, TerminalWidth(), stdout);
@@ -153,9 +153,9 @@ static void lPrintVersion() {
     snprintf(targetHelp, sizeof(targetHelp), "[--target-os=<os>]\t\t\tSelect target OS.  <os>={%s}",
              g->target_registry->getSupportedOSes().c_str());
     PrintWithWordBreaks(targetHelp, 24, TerminalWidth(), stdout);
-    printf("    [--time-trace]\t\t\tTurn on time profiler. Generates JSON file based on output filename.\n");
+    printf("    [--time-trace]\t\t\tTurn on time profiler. Generates JSON file based on output filename\n");
     printf("    [--time-trace-granularity=<value>]\tMinimum time granularity (in microseconds) traced by time "
-           "profiler.\n");
+           "profiler\n");
     printf("    [--vectorcall/--no-vectorcall]\tEnable/disable vectorcall calling convention on Windows (x64 only). "
            "Disabled by default\n");
     printf("    [--version]\t\t\t\tPrint ispc version\n");
@@ -169,7 +169,7 @@ static void lPrintVersion() {
     printf("        intel\t\t\t\tEmit Intel-style assembly\n");
     printf("        att\t\t\t\tEmit AT&T-style assembly\n");
 #ifdef ISPC_XE_ENABLED
-    printf("    [--xe-stack-mem-size=<value>\t\tSet size of stateless stack memory in VC backend.\n");
+    printf("    [--xe-stack-mem-size=<value>\t\tSet size of stateless stack memory in VC backend\n");
 #endif
     printf("    [@<filename>]\t\t\tRead additional arguments from the given file\n");
     printf("    <file to compile or \"-\" for stdin>\n");
@@ -204,7 +204,7 @@ static void lPrintVersion() {
     printf("    [--debug-llvm]\t\t\tEnable LLVM debugging information (dumps to stderr)\n");
     printf("    [--debug-phase=<value>]\t\tSet optimization phases to dump. "
            "--debug-phase=first,210:220,300,305,310:last\n");
-    printf("    [--[no-]discard-value-names]\tDo not discard/Discard value names when generating LLVM IR.\n");
+    printf("    [--[no-]discard-value-names]\tDo not discard/Discard value names when generating LLVM IR\n");
     printf("    [--dump-file[=<path>]]\t\tDump module IR to file(s) in "
            "current directory, or to <path> if specified\n");
     printf("    [--fuzz-seed=<value>]\t\tSeed value for RNG for fuzz testing\n");
@@ -224,9 +224,9 @@ static void lPrintVersion() {
 #ifdef ISPC_XE_ENABLED
     printf("        disable-xe-gather-coalescing\t\tDisable Xe gather coalescing\n");
     printf("        threshold-for-xe-gather-coalescing=<0>\tMinimal number of eliminated memory instructions for "
-           "Xe gather coalescing.\n");
+           "Xe gather coalescing\n");
     printf("        build-llvm-loads-on-xe-gather-coalescing\t\tExperimental: build standard llvm loads on "
-           "Xe gather coalescing.\n");
+           "Xe gather coalescing\n");
     printf("        enable-xe-unsafe-masked-load\t\tEnable Xe unsafe masked load\n");
 #endif
     printf("    [--print-target]\t\t\tPrint target's information\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,12 +59,11 @@ static void lPrintVersion() {
 [[noreturn]] static void usage(int ret) {
     lPrintVersion();
     printf("\nusage: ispc\n");
-    printf("    [--addressing={32,64}]\t\tSelect 32- or 64-bit addressing. (Note that 32-bit\n");
-    printf("                          \t\taddressing calculations are done by default, even\n");
-    printf("                          \t\ton 64-bit target architectures.)\n");
+    printf("    [--addressing={32,64}]\t\tSelect 32- or 64-bit addressing. (Note that 32-bit addressing calculations "
+           "are done by default, even on 64-bit target architectures.)\n");
     printf("    [--arch={%s}]\t\tSelect target architecture\n", g->target_registry->getSupportedArchs().c_str());
 #ifndef ISPC_HOST_IS_WINDOWS
-    printf("    [--colored-output]\t\tAlways use terminal colors in error/warning messages\n");
+    printf("    [--colored-output]\t\t\tAlways use terminal colors in error/warning messages\n");
 #endif
     printf("    [--cpu=<type>]\t\t\tAn alias for [--device=<type>] switch\n");
     printf("    [-D<foo>]\t\t\t\t#define given value when running preprocessor\n");
@@ -129,8 +128,9 @@ static void lPrintVersion() {
     printf("        disable-assertions\t\tRemove assertion statements from final code.\n");
     printf("        disable-fma\t\t\tDisable 'fused multiply-add' instructions (on targets that support them)\n");
     printf("        disable-loop-unroll\t\tDisable loop unrolling.\n");
-    printf("        disable-zmm\t\tDisable using zmm registers for avx512 targets in favour of ymm. This also affects "
-           "ABI.\n");
+    printf(
+        "        disable-zmm\t\t\tDisable using zmm registers for avx512 targets in favour of ymm. This also affects "
+        "ABI.\n");
 #ifdef ISPC_XE_ENABLED
     printf("        emit-xe-hardware-mask\t\tEnable emitting of Xe implicit hardware mask.\n");
     printf("        enable-xe-foreach-varying\t\tEnable experimental foreach support inside varying control flow.\n");

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1253,7 +1253,7 @@ bool Module::writeOutput(OutputType outputType, OutputFlags flags, const char *o
         else
             return writeHeader(outFileName);
     } else if (outputType == Deps)
-        return writeDeps(outFileName, 0 != (flags & GenerateMakeRuleForDeps), depTargetFileName, sourceFileName);
+        return writeDeps(outFileName, flags.isMakeRuleDeps(), depTargetFileName, sourceFileName);
     else if (outputType == CPPStub)
         return writeCPPStub(outFileName);
     else if (outputType == HostStub)
@@ -3098,7 +3098,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
         if (targets.size() == 1) {
             target = targets[0];
         }
-        g->target = new Target(arch, cpu, target, 0 != (outputFlags & GeneratePIC), g->printTarget);
+        g->target = new Target(arch, cpu, target, outputFlags.isPIC(), g->printTarget);
         if (!g->target->isValid())
             return 1;
 
@@ -3130,7 +3130,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             if (headerFileName != nullptr)
                 if (!m->writeOutput(Module::Header, outputFlags, headerFileName))
                     return 1;
-            if (depsFileName != nullptr || (outputFlags & Module::OutputDepsToStdout)) {
+            if (depsFileName != nullptr || outputFlags.isDepsToStdout()) {
                 std::string targetName;
                 if (depsTargetName)
                     targetName = depsTargetName;
@@ -3221,7 +3221,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
 
         std::vector<Module *> modules(targets.size());
         for (unsigned int i = 0; i < targets.size(); ++i) {
-            g->target = new Target(arch, cpu, targets[i], 0 != (outputFlags & GeneratePIC), g->printTarget);
+            g->target = new Target(arch, cpu, targets[i], outputFlags.isPIC(), g->printTarget);
             if (!g->target->isValid())
                 return 1;
 
@@ -3320,7 +3320,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
         Assert(firstTarget != ISPCTarget::none);
         Assert(firstTargetMachine != nullptr);
 
-        g->target = new Target(arch, cpu, firstTarget, 0 != (outputFlags & GeneratePIC), false);
+        g->target = new Target(arch, cpu, firstTarget, outputFlags.isPIC(), false);
         if (!g->target->isValid()) {
             return 1;
         }
@@ -3355,7 +3355,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             }
         }
 
-        if (depsFileName != nullptr || (outputFlags & Module::OutputDepsToStdout)) {
+        if (depsFileName != nullptr || outputFlags.isDepsToStdout()) {
             std::string targetName;
             if (depsTargetName)
                 targetName = depsTargetName;

--- a/src/module.h
+++ b/src/module.h
@@ -112,12 +112,29 @@ class Module {
 #endif
     };
 
-    enum OutputFlags : int {
-        NoFlags = 0,
-        GeneratePIC = 0x1,
-        GenerateFlatDeps = 0x2,        /** Dependencies will be output as a flat list. */
-        GenerateMakeRuleForDeps = 0x4, /** Dependencies will be output in a make rule format instead of a flat list. */
-        OutputDepsToStdout = 0x8,      /** Dependency information will be output to stdout instead of file. */
+    class OutputFlags {
+    public:
+        OutputFlags() : pic(false), flatDeps(false), makeRuleDeps(false), depsToStdout(false) {}
+        OutputFlags(OutputFlags &o) : pic(o.pic), flatDeps(o.flatDeps), makeRuleDeps(o.makeRuleDeps), depsToStdout(o.depsToStdout) {}
+
+        void setPIC(bool v = true) { pic = v; }
+        bool isPIC() const { return pic; }
+        void setFlatDeps(bool v = true) { flatDeps = v; }
+        bool isFlatDeps() const { return flatDeps; }
+        void setMakeRuleDeps(bool v = true) { makeRuleDeps = v; }
+        bool isMakeRuleDeps() const { return makeRuleDeps; }
+        void setDepsToStdout(bool v = true) { depsToStdout = v; }
+        bool isDepsToStdout() const { return depsToStdout; }
+
+    private:
+        // --pic
+        bool pic;
+        // -MMM
+        bool flatDeps;
+        // -M
+        bool makeRuleDeps;
+        // deps output to stdout
+        bool depsToStdout;
     };
 
     /** Compile the given source file, generating assembly, object file, or
@@ -130,8 +147,7 @@ class Module {
         @param targets      %Target ISAs; this parameter may give a single target
                             ISA, or may give a comma-separated list of them in
                             case we are compiling to multiple ISAs.
-        @param generatePIC  Indicates whether position-independent code should
-                            be generated.
+        @param OutputFlags  A set of flags for output generation.
         @param outputType   %Type of output to generate (object files, assembly,
                             LLVM bitcode.)
         @param outFileName  Base name of output filename for object files, etc.
@@ -226,13 +242,4 @@ class Module {
     void clearCPPBuffer();
 };
 
-inline Module::OutputFlags &operator|=(Module::OutputFlags &lhs, const __underlying_type(Module::OutputFlags) rhs) {
-    return lhs = (Module::OutputFlags)((__underlying_type(Module::OutputFlags))lhs | rhs);
-}
-inline Module::OutputFlags &operator&=(Module::OutputFlags &lhs, const __underlying_type(Module::OutputFlags) rhs) {
-    return lhs = (Module::OutputFlags)((__underlying_type(Module::OutputFlags))lhs & rhs);
-}
-inline Module::OutputFlags operator|(const Module::OutputFlags lhs, const Module::OutputFlags rhs) {
-    return (Module::OutputFlags)((__underlying_type(Module::OutputFlags))lhs | rhs);
-}
 } // namespace ispc

--- a/src/module.h
+++ b/src/module.h
@@ -113,9 +113,12 @@ class Module {
     };
 
     class OutputFlags {
-    public:
-        OutputFlags() : pic(false), flatDeps(false), makeRuleDeps(false), depsToStdout(false) {}
-        OutputFlags(OutputFlags &o) : pic(o.pic), flatDeps(o.flatDeps), makeRuleDeps(o.makeRuleDeps), depsToStdout(o.depsToStdout) {}
+      public:
+        OutputFlags()
+            : pic(false), flatDeps(false), makeRuleDeps(false), depsToStdout(false), mcModel(MCModel::Default) {}
+        OutputFlags(OutputFlags &o)
+            : pic(o.pic), flatDeps(o.flatDeps), makeRuleDeps(o.makeRuleDeps), depsToStdout(o.depsToStdout),
+              mcModel(o.mcModel) {}
 
         void setPIC(bool v = true) { pic = v; }
         bool isPIC() const { return pic; }
@@ -125,8 +128,10 @@ class Module {
         bool isMakeRuleDeps() const { return makeRuleDeps; }
         void setDepsToStdout(bool v = true) { depsToStdout = v; }
         bool isDepsToStdout() const { return depsToStdout; }
+        void setMCModel(MCModel m) { mcModel = m; }
+        MCModel getMCModel() const { return mcModel; }
 
-    private:
+      private:
         // --pic
         bool pic;
         // -MMM
@@ -135,6 +140,8 @@ class Module {
         bool makeRuleDeps;
         // deps output to stdout
         bool depsToStdout;
+        // --mcmodel value
+        MCModel mcModel;
     };
 
     /** Compile the given source file, generating assembly, object file, or

--- a/tests/lit-tests/mcmodel.ispc
+++ b/tests/lit-tests/mcmodel.ispc
@@ -1,0 +1,26 @@
+// RUN: %{ispc} %s --nostdlib --target=avx2-i32x8 --arch=x86-64 --emit-asm -o - | FileCheck %s -check-prefix=CHECK-NOMODEL-ASM
+// RUN: %{ispc} %s --nostdlib --target=avx2-i32x8 --arch=x86-64 --emit-asm --mcmodel=small -o - | FileCheck %s -check-prefix=CHECK-SMALL-ASM
+// RUN: %{ispc} %s --nostdlib --target=avx2-i32x8 --arch=x86-64 --emit-asm --mcmodel=large -o - | FileCheck %s -check-prefix=CHECK-LARGE-ASM
+// RUN: %{ispc} %s --nostdlib --target=avx2-i32x8 --arch=x86-64 --emit-llvm-text -o - | FileCheck %s -check-prefix=CHECK-NOMODEL-IR
+// RUN: %{ispc} %s --nostdlib --target=avx2-i32x8 --arch=x86-64 --emit-llvm-text --mcmodel=small -o - | FileCheck %s -check-prefix=CHECK-SMALL-IR
+// RUN: %{ispc} %s --nostdlib --target=avx2-i32x8 --arch=x86-64 --emit-llvm-text --mcmodel=large -o - | FileCheck %s -check-prefix=CHECK-LARGE-IR
+
+// REQUIRES: X86_ENABLED
+
+// CHECK-NOMODEL-ASM: {{lea|array@GOTPCREL}}
+// CHECK-SMALL-ASM: {{lea|array@GOTPCREL}}
+// CHECK-LARGE-ASM movabsq:
+// CHECK-LARGE-ASM-NOT: lea
+// CHECK-LARGE-ASM-NOT: array@GOTPCREL
+
+// CHECK-SMALL-IR: !llvm.module.flags = !{{{.*}}}
+// CHECK-SMALL-IR: !{{[0-9]+}} = !{i32 1, !"Code Model", i32 1}
+// CHECK-LARGE-IR: !llvm.module.flags = !{{{.*}}}
+// CHECK-LARGE-IR: !{{[0-9]+}} = !{i32 1, !"Code Model", i32 4}
+// CHECK-NOMODEL-IR-NOT: Code Model
+
+uniform int array[100];
+
+uniform int foo(uniform int i) {
+  return array[i];
+}


### PR DESCRIPTION
Fixes #2530 

Add `--mcmodel` switch, it accepts only `small` and `large` values. `medium` was not added as it requires additional parameter (and additional switch, which is `-mlarge-data-threshold` for clang/gcc) and we don't have request for that. Large model is needed to enable random testing using YARPGen which tends to generate large arrays.

Note, that in LLVM there are two mechanisms for setting Code Model - through `TargetMachine` parameter and as a `Module` metadata. We trigger both mechanisms, even though metadata is not necessary if we control TargetMachine directly. But this is necessary if LLVM IR is used in LTO or manually passed to `llc`.

This PR also contains:
- refactor for `OutputFlags`, this is more explicit (and I believe convenient) way of managing flags and is needed to add Code Model seamlessly.
- some clean up for help message (tabulations, line breaks, period signed in the end of line).