### PR TITLE
Add signing to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -777,6 +777,13 @@ if (ISPC_PREPARE_PACKAGE)
     set(CPACK_PACKAGE_VERSION_PATCH ${ISPC_VERSION_PATCH}${ISPC_VERSION_SUFFIX})
     set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
     set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+
+    # Sign files in the package if ISPC_SIGN_KEY is set
+    if (DEFINED ISPC_SIGN_KEY)
+        configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/Signing.cmake.in"
+                       "${CMAKE_CURRENT_BINARY_DIR}/Signing.cmake" @ONLY)
+        set(CPACK_PRE_BUILD_SCRIPTS "${CMAKE_CURRENT_BINARY_DIR}/Signing.cmake")
+    endif()
     # Allow use custom package name with -DISPC_PACKAGE_NAME
     if (NOT ISPC_PACKAGE_NAME)
         set(ISPC_ARCH_SUFFIX)

--- a/cmake/Signing.cmake.in
+++ b/cmake/Signing.cmake.in
@@ -11,12 +11,19 @@
 if (WIN32)
     set(ISPC_SIGN_COMMAND signtool.exe)
     set(ISPC_SIGN_ARGS sign /fd sha256 /sha1 @ISPC_SIGN_KEY@ /tr http://timestamp.comodoca.com/rfc3161 /td sha256)
-    file(GLOB ISPC_SIGN_FILES ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/bin/ispc.exe ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/bin/*.dll)
+    file(GLOB ISPC_SIGN_FILES_ALL ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/bin/ispc.exe ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/bin/*.dll)
 elseif (APPLE)
     set(ISPC_SIGN_COMMAND codesign)
     set(ISPC_SIGN_ARGS -fs "@ISPC_SIGN_KEY@" --strict --timestamp --options=runtime)
-    file(GLOB ISPC_SIGN_FILES ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/bin/ispc ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/lib/*.dylib)
+    file(GLOB ISPC_SIGN_FILES_ALL ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/bin/ispc ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/lib/*.dylib)
 endif()
+
+# If we have symlinks, we sign the symlink target twice, so filter out symlinks
+foreach(file ${ISPC_SIGN_FILES_ALL})
+    if(NOT IS_SYMLINK "${file}")
+        list(APPEND ISPC_SIGN_FILES "${file}")
+    endif()
+endforeach()
 
 # Execute the signing command
 execute_process(

--- a/cmake/Signing.cmake.in
+++ b/cmake/Signing.cmake.in
@@ -1,0 +1,39 @@
+#
+#  Copyright (c) 2023, Intel Corporation
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+
+#
+# ispc Signing.cmake.in
+#
+# Signing of build artifacts
+
+if (WIN32)
+    set(ISPC_SIGN_COMMAND signtool.exe)
+    set(ISPC_SIGN_ARGS sign /fd sha256 /sha1 @ISPC_SIGN_KEY@ /tr http://timestamp.comodoca.com/rfc3161 /td sha256)
+    file(GLOB ISPC_SIGN_FILES ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/bin/ispc.exe ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/bin/*.dll)
+elseif (APPLE)
+    set(ISPC_SIGN_COMMAND codesign)
+    set(ISPC_SIGN_ARGS -fs "@ISPC_SIGN_KEY@" --strict --timestamp --options=runtime)
+    file(GLOB ISPC_SIGN_FILES ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/bin/ispc ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/lib/*.dylib)
+endif()
+
+# Execute the signing command
+execute_process(
+    COMMAND ${ISPC_SIGN_COMMAND} ${ISPC_SIGN_ARGS} ${ISPC_SIGN_FILES}
+    RESULT_VARIABLE ISPC_SIGN_RESULT
+    OUTPUT_VARIABLE ISPC_SIGN_OUTPUT
+    ERROR_VARIABLE ISPC_SIGN_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+
+if (ISPC_SIGN_RESULT EQUAL 0)
+    message(STATUS "Successfully signed:" )
+    foreach(file ${ISPC_SIGN_FILES})
+        get_filename_component(SHORT_NAME ${file} NAME)
+        message(STATUS " - ${SHORT_NAME}")
+    endforeach()
+else ()
+    message(FATAL_ERROR "Cannot sign ${ISPC_SIGN_FILES}: ${ISPC_SIGN_OUTPUT} ${ISPC_SIGN_ERROR}")
+endif()


### PR DESCRIPTION
To sign binaries and libraries, the one need to define `ISPC_SIGN_KEY`, when configuring CMake to build a package.

The signature assumed to work on Windows and macOS. Signing works when building `package` target and is executed after stripping.