### PR TITLE
ispcrt: add ispcrtSetTaskingCallbacks

### DIFF
--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -71,6 +71,17 @@ typedef void (*ISPCRTErrorFunc)(ISPCRTError, const char *errorMessage);
 
 void ispcrtSetErrorFunc(ISPCRTErrorFunc);
 
+// Tasking ////////////////////////////////////////////////////////////////////
+// Tasking is CPU specific part of API.
+
+// Callback types definition.
+typedef void (*ISPCRTTaskingLaunchFType)(void **, void *, void *, int, int, int);
+typedef void *(*ISPCRTTaskingAllocFType)(void **, int64_t, int32_t);
+typedef void (*ISPCRTTaskingSyncFType)(void *);
+
+// Applications can provide their own implementation of ISPCLaunch/ISPCAlloc/ISPCSync tasking API.
+void ispcrtSetTaskingCallbacks(ISPCRTTaskingLaunchFType, ISPCRTTaskingAllocFType, ISPCRTTaskingSyncFType);
+
 // Object lifetime ////////////////////////////////////////////////////////////
 
 long long ispcrtUseCount(ISPCRTGenericHandle);


### PR DESCRIPTION
The new structure of ISPCRT and the logic of loading symbols ISPCLaunch, ISPCAlloc, ISPCSync from ispcrt_device_cpu solib prevents users of ISPCRT (e.g., OSPRay) from overriding these symbols to integrate their own tasking systems and memory allocation with ISPC.

To address that, ispcrtSetTaskingCallbacks was added and exposed to ISPCRT API. It has three arguments to set ISPCLaunch, ISPCAlloc, ISPCSync implementations.

Fixes #2540.