### PR TITLE
Updates for Xe targets (19)

### DIFF
--- a/bitcode2cpp.py
+++ b/bitcode2cpp.py
@@ -12,7 +12,7 @@ parser.add_argument("src", help="Source file to process")
 parser.add_argument("--type", help="Type of processed file", choices=['dispatch', 'builtins-c', 'ispc-target'], required=True)
 parser.add_argument("--runtime", help="Runtime", choices=['32', '64'], nargs='?', default='')
 parser.add_argument("--os", help="Target OS", choices=['windows', 'linux', 'macos', 'freebsd', 'android', 'ios', 'ps4', 'web', 'WINDOWS', 'UNIX', 'WEB'], default='')
-parser.add_argument("--arch", help="Target architecture", choices=['i686', 'x86_64', 'armv7', 'arm64', 'aarch64', 'wasm32', 'xe32', 'xe64'], default='')
+parser.add_argument("--arch", help="Target architecture", choices=['i686', 'x86_64', 'armv7', 'arm64', 'aarch64', 'wasm32', 'xe64'], default='')
 parser.add_argument("--llvm_as", help="Path to LLVM assembler executable", dest="path_to_llvm_as")
 args = parser.parse_known_args()
 src = args[0].src
@@ -63,7 +63,7 @@ else:
 
 target_arch = ""
 ispc_arch = ""
-if args[0].arch in ["i686", "x86_64", "amd64", "armv7", "arm64", "aarch64", "wasm32", "xe32", "xe64"]:
+if args[0].arch in ["i686", "x86_64", "amd64", "armv7", "arm64", "aarch64", "wasm32", "xe64"]:
     target_arch = args[0].arch + "_"
     # Canoncalization of arch value for Arch enum in ISPC.
     if args[0].arch == "i686":
@@ -76,7 +76,7 @@ if args[0].arch in ["i686", "x86_64", "amd64", "armv7", "arm64", "aarch64", "was
         ispc_arch = "aarch64"
     elif args[0].arch == "wasm32":
         ispc_arch = "wasm32"
-    elif args[0].arch == "xe32" or args[0].arch == "xe64":
+    elif args[0].arch == "xe64":
         ispc_arch = args[0].arch
 
 width = 16
@@ -128,7 +128,7 @@ elif args[0].type == 'ispc-target':
     elif "wasm" in target:
         arch = "wasm32"
     elif ("gen9" in target) or ("xe" in target):
-        arch = "xe32" if args[0].runtime == "32" else "xe64" if args[0].runtime == "64" else "error"
+        arch = "xe64"
     else:
         sys.stderr.write("Unknown target detected: " + target + "\n")
         sys.exit(1)

--- a/check_format.sh
+++ b/check_format.sh
@@ -24,7 +24,21 @@ fi
 
 # Check all source files.
 # For benchmarks folder do not check 03_complex, as these tests come from real projects with their formatting.
-FILES=`ls src/*.{cpp,h} src/opt/*.{cpp,h} *.cpp builtins/*{cpp,hpp,c} benchmarks/{01,02}*/*{cpp,ispc} common/*.h stdlib.ispc`
+FILES=$(ls                                  \
+    src/*.{cpp,h}                           \
+    src/opt/*.{cpp,h}                       \
+    *.cpp                                   \
+    builtins/*{cpp,hpp,c}                   \
+    benchmarks/{01,02}*/*{cpp,ispc}         \
+    common/*.h                              \
+    stdlib.ispc                             \
+    ispcrt/*.{h,hpp,cpp}                    \
+    ispcrt/detail/*.h                       \
+    ispcrt/detail/cpu/*.{h,cpp}             \
+    ispcrt/detail/gpu/*.{h,cpp}             \
+    ispcrt/tests/level_zero_mock/*.{h,cpp}  \
+    ispcrt/tests/mock_tests/*.cpp           \
+)
 for FILE in $FILES; do
     diff -uN --label original/$FILE --label formatted/$FILE <(cat $FILE) <($CLANG_FORMAT $FILE)
     if [ $? -ne 0 ]; then

--- a/cmake/GenerateBuiltins.cmake
+++ b/cmake/GenerateBuiltins.cmake
@@ -52,6 +52,12 @@ function(target_ll_to_cpp llFileName bit os_name resultFileName)
         return()
     endif()
 
+    # Xe targets are implemented only for 64 bit.
+    string(REGEX MATCH "^target-xe" isXe "${llFileName}")
+    if ("${bit}" STREQUAL "32" AND isXe)
+        return()
+    endif()
+
     set(output ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/builtins-${llFileName}-${bit}bit-${os_name}.cpp)
     add_custom_command(
         OUTPUT ${output}
@@ -290,11 +296,8 @@ function(builtin_xe_to_cpp bit resultFileName)
         set(os_name "linux")
     endif()
 
-    if ("${bit}" STREQUAL "32")
-        set(target_arch "xe32")
-    elseif ("${bit}" STREQUAL "64")
-        set(target_arch "xe64")
-    else()
+    set(target_arch "xe64")
+    if (NOT "${bit}" STREQUAL "64")
         set(SKIP ON)
     endif()
 
@@ -344,6 +347,7 @@ function (generate_target_builtins resultList)
             endforeach()
         endforeach()
     endforeach()
+
     # WASM targets.
     if (WASM_ENABLED)
         set(wasm_targets ${ARGN})
@@ -407,14 +411,13 @@ function (generate_common_builtins resultList)
         endforeach()
     endforeach()
     if (XE_ENABLED)
-        foreach (bit 32 64)
-            builtin_xe_to_cpp(${bit} res_xe_${bit})
-            list(APPEND tmpList ${res_xe_${bit}} )
-            if(MSVC)
-                # Group generated files inside Visual Studio
-                source_group("Generated Builtins" FILES ${res_xe_${bit}})
-            endif()
-        endforeach()
+        set(bit 64)
+        builtin_xe_to_cpp(${bit} res_xe_${bit})
+        list(APPEND tmpList ${res_xe_${bit}} )
+        if(MSVC)
+            # Group generated files inside Visual Studio
+            source_group("Generated Builtins" FILES ${res_xe_${bit}})
+        endif()
     endif()
     set(${resultList} ${tmpList} PARENT_SCOPE)
 endfunction()

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -772,8 +772,8 @@ To compile for Intel Xe LP platform:
 
    ispc foo.ispc -o foo.bin --target=xelp-x16 --device=tgllp --emit-zebin
 
-Currently-supported architectures are ``x86``, ``x86-64``, ``xe32``,
-``xe64``, ``arm``, and ``aarch64``.
+Currently-supported architectures are ``x86``, ``x86-64``, ``xe64``,
+``arm``, and ``aarch64``.
 
 The target CPU determines both the default instruction set used as well as
 which CPU architecture the code is tuned for.  ``ispc --help`` provides a

--- a/docs/ispc_for_xe.rst
+++ b/docs/ispc_for_xe.rst
@@ -97,9 +97,9 @@ To generate L0 binary, use ``--emit-zebin`` flag. When you use L0 binary you may
 want to pass some additional options to the vector backend. You can do this
 using ``--vc-options`` flag.
 
-Also two new ``arch`` options were introduced: ``xe32`` and ``xe64``.  ``xe64``
-is default and corresponds to 64-bit host and has 64-bit pointer size, ``xe32``
-corresponds to 32-bit host and has 32-bit pointer size.
+When targeting Xe targets, ``xe64`` architecture must be used. It corresponds to
+64-bit host and has 64-bit pointer size. We don't support 32-bit pointers for Xe
+targets.
 
 To generate LLVM bitcode, use the ``--emit-llvm`` flag.  To generate LLVM
 bitcode in textual form, use the ``--emit-llvm-text`` flag.
@@ -109,11 +109,6 @@ Optimizations are on by default; they can be turned off with ``-O0``.
 Generating a text assembly file using ``--emit-asm`` is not supported yet.  See
 `How to Get an Assembly File from SPIR-V?`_ section about how to get the
 assembly from SPIR-V file.
-
-By default, 64-bit addressing is used. You can change it to 32-bit addressing by
-using ``--addressing=32`` or ``--arch=xe32`` however pointer size should be the
-same for host and device code so 32-bit addressing will only work with 32-bit
-host programs.
 
 There is a new ``link`` mode in ``ispc`` allowing to link several LLVM bitcode
 or SPIR-V files to selected output format: LLVM bitcode (default), LLVM bitcode

--- a/fail_db.txt
+++ b/fail_db.txt
@@ -60,10 +60,10 @@
 ./tests/idiv-uint16.ispc runfail    xe64       gen9-x8 unspec   Linux LLVM 15.0 clang++15.0 O2 spv *
 ./tests/idiv-int16.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 15.0 clang++15.0 O2 spv *
 ./tests/idiv-uint16.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 15.0 clang++15.0 O2 spv *
-./tests/idiv-int16.ispc runfail    xe64       gen9-x8 unspec   Linux LLVM 15.0 clang++15.0 O2 ze *
-./tests/idiv-uint16.ispc runfail    xe64       gen9-x8 unspec   Linux LLVM 15.0 clang++15.0 O2 ze *
-./tests/idiv-int16.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 15.0 clang++15.0 O2 ze *
-./tests/idiv-uint16.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 15.0 clang++15.0 O2 ze *
+./tests/idiv-int32.ispc runfail    xe64       gen9-x8 unspec   Linux LLVM 15.0 clang++15.0 O2 spv *
+./tests/idiv-uint32.ispc runfail    xe64       gen9-x8 unspec   Linux LLVM 15.0 clang++15.0 O2 spv *
+./tests/idiv-int32.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 15.0 clang++15.0 O2 spv *
+./tests/idiv-uint32.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 15.0 clang++15.0 O2 spv *
 ./tests/int8-wrap.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 15.0 clang++15.0 O2 spv *
 .\tests\idiv-uint16.ispc runfail    xe64        xelp-x8 tgllp Windows LLVM 15.0         cl O2 spv *
 .\tests\idiv-uint32.ispc runfail    xe64        xelp-x8 tgllp Windows LLVM 15.0         cl O2 spv *

--- a/fail_db.txt
+++ b/fail_db.txt
@@ -6,14 +6,6 @@
 % folder). The recommended way to build LLVM on Unix is to use "alloy.py".
 %
  List of known fails.
-./tests/funcptr-varying-3.ispc runfail    xe64        gen9-x8 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
-./tests/recursion-forward-func-decl.ispc runfail    xe64        gen9-x8 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
-./tests/recursion.ispc runfail    xe64        gen9-x8 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
-./tests/short-vec-6.ispc runfail    xe64        gen9-x8 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
-./tests/funcptr-varying-3.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
-./tests/recursion-forward-func-decl.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
-./tests/recursion.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
-./tests/short-vec-6.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 12.0 clang++12.0 O0 spv *
 ./tests/short-vec-6.ispc runfail    xe64        gen9-x8 unspec   Linux LLVM 13.0 clang++13.0 O0 spv *
 ./tests/short-vec-6.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 13.0 clang++13.0 O0 spv *
 ./tests/int8-wrap.ispc runfail    xe64      xehpc-x16 pvc   Linux LLVM 13.0 clang++13.0 O2 spv *

--- a/ispcrt/cmake/ispc.cmake
+++ b/ispcrt/cmake/ispc.cmake
@@ -80,7 +80,7 @@ endmacro()
 
 define_ispc_supported_arch(X86 "x86|x86-64")
 define_ispc_supported_arch(ARM "arm|aarch64")
-define_ispc_supported_arch(XE "xe32|xe64")
+define_ispc_supported_arch(XE "xe64")
 
 macro(define_ispc_isa_options ISA_NAME)
   set(ISPC_TARGET_${ISA_NAME} ${ARGV1} CACHE STRING "ispc target used for ${ISA_NAME} ISA")

--- a/ispcrt/detail/CommandList.h
+++ b/ispcrt/detail/CommandList.h
@@ -8,9 +8,9 @@
 // internal
 #include "Fence.h"
 #include "Future.h"
+#include "IntrusivePtr.h"
 #include "Kernel.h"
 #include "MemoryView.h"
-#include "IntrusivePtr.h"
 
 namespace ispcrt {
 namespace base {

--- a/ispcrt/detail/Context.h
+++ b/ispcrt/detail/Context.h
@@ -17,7 +17,7 @@ struct Context : public RefCounted {
     virtual MemoryView *newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const = 0;
     virtual ISPCRTDeviceType getDeviceType() const = 0;
 
-    virtual void* contextNativeHandle() const = 0;
+    virtual void *contextNativeHandle() const = 0;
 };
 
 } // namespace base

--- a/ispcrt/detail/Device.h
+++ b/ispcrt/detail/Device.h
@@ -6,9 +6,9 @@
 // public
 #include "../ispcrt.h"
 // internal
+#include "CommandQueue.h"
 #include "Kernel.h"
 #include "Module.h"
-#include "CommandQueue.h"
 #include "TaskQueue.h"
 
 namespace ispcrt {
@@ -19,7 +19,8 @@ struct Device : public RefCounted {
 
     virtual ~Device() = default;
 
-    virtual MemoryView *newMemoryView(void *appMemory, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const = 0;
+    virtual MemoryView *newMemoryView(void *appMemory, size_t numBytes,
+                                      const ISPCRTNewMemoryViewFlags *flags) const = 0;
 
     virtual CommandQueue *newCommandQueue(uint32_t ordinal) const = 0;
 
@@ -28,7 +29,7 @@ struct Device : public RefCounted {
     virtual Module *newModule(const char *moduleFile, const ISPCRTModuleOptions &opts) const = 0;
 
     virtual void dynamicLinkModules(Module **modules, uint32_t numModules) const = 0;
-    virtual Module* staticLinkModules(Module **modules, uint32_t numModules) const = 0;
+    virtual Module *staticLinkModules(Module **modules, uint32_t numModules) const = 0;
 
     virtual Kernel *newKernel(const Module &module, const char *name) const = 0;
 
@@ -38,7 +39,7 @@ struct Device : public RefCounted {
 
     virtual ISPCRTDeviceType getType() const = 0;
 
-    virtual ISPCRTAllocationType getMemAllocType(void* appMemory) const = 0;
+    virtual ISPCRTAllocationType getMemAllocType(void *appMemory) const = 0;
 };
 
 } // namespace base

--- a/ispcrt/detail/Exception.h
+++ b/ispcrt/detail/Exception.h
@@ -16,9 +16,8 @@ namespace base {
 struct ispcrt_runtime_error : public std::runtime_error {
     ISPCRTError e;
 
-    ispcrt_runtime_error(ISPCRTError _e, const std::string& msg) : std::runtime_error(msg), e {_e} {}
+    ispcrt_runtime_error(ISPCRTError _e, const std::string &msg) : std::runtime_error(msg), e{_e} {}
 };
-
 
 } // namespace base
 } // namespace ispcrt

--- a/ispcrt/detail/Fence.h
+++ b/ispcrt/detail/Fence.h
@@ -19,7 +19,7 @@ struct Fence : public RefCounted {
     virtual ISPCRTFenceStatus status() const = 0;
     virtual void reset() = 0;
 
-    virtual void* nativeHandle() const = 0;
+    virtual void *nativeHandle() const = 0;
 };
 
 } // namespace base

--- a/ispcrt/detail/Module.h
+++ b/ispcrt/detail/Module.h
@@ -12,7 +12,7 @@ struct Module : public RefCounted {
     Module() = default;
     virtual ~Module() = default;
 
-    virtual void* functionPtr(const char *name) const = 0;
+    virtual void *functionPtr(const char *name) const = 0;
 };
 
 } // namespace base

--- a/ispcrt/detail/TaskQueue.h
+++ b/ispcrt/detail/TaskQueue.h
@@ -25,7 +25,7 @@ struct TaskQueue : public RefCounted {
 
     virtual void sync() = 0;
 
-    virtual void* taskQueueNativeHandle() const = 0;
+    virtual void *taskQueueNativeHandle() const = 0;
 };
 
 } // namespace base

--- a/ispcrt/detail/cpu/CPUContext.h
+++ b/ispcrt/detail/cpu/CPUContext.h
@@ -9,10 +9,11 @@ namespace ispcrt {
 
 struct CPUContext : public base::Context {
     CPUContext() = default;
-    base::MemoryView *newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const override;
+    base::MemoryView *newMemoryView(void *appMem, size_t numBytes,
+                                    const ISPCRTNewMemoryViewFlags *flags) const override;
     ISPCRTDeviceType getDeviceType() const override;
 
-    virtual void* contextNativeHandle() const override;
+    virtual void *contextNativeHandle() const override;
 };
 
 } // namespace ispcrt

--- a/ispcrt/detail/cpu/CPUDevice.h
+++ b/ispcrt/detail/cpu/CPUDevice.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include "../CommandQueue.h"
 #include "../Device.h"
 #include "../Future.h"
-#include "../CommandQueue.h"
 
 namespace ispcrt {
 
@@ -14,12 +14,13 @@ namespace cpu {
 uint32_t deviceCount();
 ISPCRTDeviceInfo deviceInfo(uint32_t deviceIdx);
 
-}; // cpu
+}; // namespace cpu
 
 struct CPUDevice : public base::Device {
     CPUDevice() = default;
 
-    base::MemoryView *newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const override;
+    base::MemoryView *newMemoryView(void *appMem, size_t numBytes,
+                                    const ISPCRTNewMemoryViewFlags *flags) const override;
 
     base::CommandQueue *newCommandQueue(uint32_t ordinal) const override;
 
@@ -38,7 +39,7 @@ struct CPUDevice : public base::Device {
 
     ISPCRTDeviceType getType() const override;
 
-    ISPCRTAllocationType getMemAllocType(void* appMemory) const override;
+    ISPCRTAllocationType getMemAllocType(void *appMemory) const override;
 };
 
 } // namespace ispcrt

--- a/ispcrt/detail/cpu/ispc_tasking.cpp
+++ b/ispcrt/detail/cpu/ispc_tasking.cpp
@@ -646,7 +646,8 @@ static void InitTaskSystem() {
                     srand(time(nullptr));
                     for (int i = 0; i < 10; i++) {
                         // Some platforms (e.g. FreeBSD) require the name to begin with a slash
-                        snprintf(semaphoreName, SEM_NAME_MAX_SIZE, "/ispc_task.%d.%d", static_cast<int>(getpid()), static_cast<int>(rand()));
+                        snprintf(semaphoreName, SEM_NAME_MAX_SIZE, "/ispc_task.%d.%d", static_cast<int>(getpid()),
+                                 static_cast<int>(rand()));
                         workerSemaphore = sem_open(semaphoreName, O_CREAT, S_IRUSR | S_IWUSR, 0);
                         if (workerSemaphore != SEM_FAILED) {
                             success = true;

--- a/ispcrt/detail/gpu/GPUContext.h
+++ b/ispcrt/detail/gpu/GPUContext.h
@@ -6,26 +6,30 @@
 #include <memory>
 
 namespace ispcrt {
-namespace gpu { class ChunkedPool; }
+namespace gpu {
+class ChunkedPool;
+}
 
 struct GPUContext : public ispcrt::base::Context {
     GPUContext();
-    GPUContext(void* nativeContext);
+    GPUContext(void *nativeContext);
     ~GPUContext();
-    base::MemoryView *newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const override;
+    base::MemoryView *newMemoryView(void *appMem, size_t numBytes,
+                                    const ISPCRTNewMemoryViewFlags *flags) const override;
     ISPCRTDeviceType getDeviceType() const override;
 
-    virtual void* contextNativeHandle() const override;
+    virtual void *contextNativeHandle() const override;
     gpu::ChunkedPool *memPool(ISPCRTSharedMemoryAllocationHint type) const;
-private:
+
+  private:
     void *m_context{nullptr};
     void *m_driver{nullptr};
-    bool  m_is_mock{false};
-    bool  m_has_context_ownership{true};
+    bool m_is_mock{false};
+    bool m_has_context_ownership{true};
     std::unique_ptr<gpu::ChunkedPool> m_memPoolHWDR;
     std::unique_ptr<gpu::ChunkedPool> m_memPoolHRDW;
 };
-}
+} // namespace ispcrt
 
 // Expose API of GPU device solib for dlsym.
 extern "C" {

--- a/ispcrt/detail/gpu/GPUDevice.h
+++ b/ispcrt/detail/gpu/GPUDevice.h
@@ -3,12 +3,12 @@
 
 #pragma once
 
-#include "../Context.h"
-#include "../Device.h"
-#include "../Future.h"
-#include "../Fence.h"
 #include "../CommandList.h"
 #include "../CommandQueue.h"
+#include "../Context.h"
+#include "../Device.h"
+#include "../Fence.h"
+#include "../Future.h"
 
 // std
 #include <unordered_map>
@@ -21,16 +21,17 @@ namespace gpu {
 uint32_t deviceCount();
 ISPCRTDeviceInfo deviceInfo(uint32_t deviceIdx);
 
-}; // gpu
+}; // namespace gpu
 
 struct GPUDevice : public base::Device {
 
     GPUDevice();
-    GPUDevice(void* nativeContext, void* nativeDevice, uint32_t deviceIdx);
+    GPUDevice(void *nativeContext, void *nativeDevice, uint32_t deviceIdx);
 
     ~GPUDevice();
 
-    base::MemoryView *newMemoryView(void *appMem, size_t numBytes, const ISPCRTNewMemoryViewFlags *flags) const override;
+    base::MemoryView *newMemoryView(void *appMem, size_t numBytes,
+                                    const ISPCRTNewMemoryViewFlags *flags) const override;
 
     base::CommandQueue *newCommandQueue(uint32_t ordinal) const override;
 
@@ -49,14 +50,14 @@ struct GPUDevice : public base::Device {
 
     ISPCRTDeviceType getType() const override;
 
-    ISPCRTAllocationType getMemAllocType(void* appMemory) const override;
+    ISPCRTAllocationType getMemAllocType(void *appMemory) const override;
 
   private:
     void *m_driver{nullptr};
     void *m_device{nullptr};
     void *m_context{nullptr};
-    bool  m_is_mock{false};
-    bool  m_has_context_ownership{true};
+    bool m_is_mock{false};
+    bool m_has_context_ownership{true};
 };
 
 } // namespace ispcrt
@@ -64,7 +65,7 @@ struct GPUDevice : public base::Device {
 // Expose API of GPU device solib for dlsym.
 extern "C" {
 ispcrt::base::Device *load_gpu_device();
-ispcrt::base::Device *load_gpu_device_ctx(void* ctx, void* dev, uint32_t idx);
+ispcrt::base::Device *load_gpu_device_ctx(void *ctx, void *dev, uint32_t idx);
 uint32_t gpu_device_count();
 ISPCRTDeviceInfo gpu_device_info(uint32_t idx);
 }

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -20,13 +20,13 @@
 #include "detail/TaskQueue.h"
 
 #ifdef ISPCRT_BUILD_CPU
-#include "detail/cpu/CPUDevice.h"
 #include "detail/cpu/CPUContext.h"
+#include "detail/cpu/CPUDevice.h"
 #endif
 
 #ifdef ISPCRT_BUILD_GPU
-#include "detail/gpu/GPUDevice.h"
 #include "detail/gpu/GPUContext.h"
+#include "detail/gpu/GPUDevice.h"
 #endif
 
 static void defaultErrorFcn(ISPCRTError e, const char *msg) {
@@ -87,7 +87,6 @@ static OBJECT_T &referenceFromHandle(HANDLE_T handle) {
         return a;                                                                                                      \
     }
 
-
 // Define names of devices libraries.
 #if defined(_WIN32) || defined(_WIN64)
 #define ISPCRT_SO_LIB_PREFIX ""
@@ -108,16 +107,16 @@ static OBJECT_T &referenceFromHandle(HANDLE_T handle) {
 #if defined(_WIN32) || defined(_WIN64)
 #define ISPCRT_DEVICE_CPU_SOLIB_MAJOR_VERSION_NAME nullptr
 #define ISPCRT_DEVICE_GPU_SOLIB_MAJOR_VERSION_NAME nullptr
-#define ISPCRT_DEVICE_CPU_SOLIB_FULL_VERSION_NAME  nullptr
-#define ISPCRT_DEVICE_GPU_SOLIB_FULL_VERSION_NAME  nullptr
+#define ISPCRT_DEVICE_CPU_SOLIB_FULL_VERSION_NAME nullptr
+#define ISPCRT_DEVICE_GPU_SOLIB_FULL_VERSION_NAME nullptr
 #elif defined(__APPLE__)
-#define ISPCRT_DEVICE_CPU_SOLIB_MAJOR_VERSION_NAME \
+#define ISPCRT_DEVICE_CPU_SOLIB_MAJOR_VERSION_NAME                                                                     \
     ISPCRT_DEVICE_CPU_SOLIB_PREFIX "." ISPCRT_VERSION_MAJOR "." ISPCRT_SO_LIB_SUFFIX
-#define ISPCRT_DEVICE_GPU_SOLIB_MAJOR_VERSION_NAME \
+#define ISPCRT_DEVICE_GPU_SOLIB_MAJOR_VERSION_NAME                                                                     \
     ISPCRT_DEVICE_GPU_SOLIB_PREFIX "." ISPCRT_VERSION_MAJOR "." ISPCRT_SO_LIB_SUFFIX
-#define ISPCRT_DEVICE_CPU_SOLIB_FULL_VERSION_NAME \
+#define ISPCRT_DEVICE_CPU_SOLIB_FULL_VERSION_NAME                                                                      \
     ISPCRT_DEVICE_CPU_SOLIB_PREFIX "." ISPCRT_VERSION_FULL "." ISPCRT_SO_LIB_SUFFIX
-#define ISPCRT_DEVICE_GPU_SOLIB_FULL_VERSION_NAME \
+#define ISPCRT_DEVICE_GPU_SOLIB_FULL_VERSION_NAME                                                                      \
     ISPCRT_DEVICE_GPU_SOLIB_PREFIX "." ISPCRT_VERSION_FULL "." ISPCRT_SO_LIB_SUFFIX
 #else
 #define ISPCRT_DEVICE_CPU_SOLIB_MAJOR_VERSION_NAME ISPCRT_DEVICE_CPU_SOLIB_NAME "." ISPCRT_VERSION_MAJOR
@@ -150,17 +149,16 @@ void *dyn_load_lib(const char *name, const char *name_major_version, const char 
 // OS agnostic function to get an address of symbol from the previously loaded shared library.
 void *dyn_load_sym(void *handle, const char *symbol) {
 #if defined(_WIN32) || defined(_WIN64)
-    return (void*) GetProcAddress((HMODULE)handle, symbol);
+    return (void *)GetProcAddress((HMODULE)handle, symbol);
 #else
     return dlsym(handle, symbol);
 #endif
 }
 
-
 // CPU device API.
-typedef void (*ISPCLaunchF)(void**, void*, void*, int, int, int);
-typedef void* (*ISPCAllocF)(void**, int64_t, int32_t);
-typedef void (*ISPCSyncF)(void*);
+typedef void (*ISPCLaunchF)(void **, void *, void *, int, int, int);
+typedef void *(*ISPCAllocF)(void **, int64_t, int32_t);
+typedef void (*ISPCSyncF)(void *);
 static ISPCLaunchF ispc_launch_fptr = nullptr;
 static ISPCAllocF ispc_alloc_fptr = nullptr;
 static ISPCSyncF ispc_sync_fptr = nullptr;
@@ -202,26 +200,24 @@ void *handleCPUDeviceLib() {
     if (handle) {
         return handle;
     }
-    handle = dyn_load_lib(
-                ISPCRT_DEVICE_CPU_SOLIB_NAME,
-                ISPCRT_DEVICE_CPU_SOLIB_MAJOR_VERSION_NAME,
-                ISPCRT_DEVICE_CPU_SOLIB_FULL_VERSION_NAME);
+    handle = dyn_load_lib(ISPCRT_DEVICE_CPU_SOLIB_NAME, ISPCRT_DEVICE_CPU_SOLIB_MAJOR_VERSION_NAME,
+                          ISPCRT_DEVICE_CPU_SOLIB_FULL_VERSION_NAME);
     if (!handle) {
         throw std::runtime_error("Fail to load " ISPCRT_DEVICE_CPU_SOLIB_NAME " library");
     }
 
 #ifdef ISPCRT_BUILD_TASKING
-    ispc_launch_fptr = (ISPCLaunchF) dyn_load_sym(handle, "ISPCLaunch_cpu");
+    ispc_launch_fptr = (ISPCLaunchF)dyn_load_sym(handle, "ISPCLaunch_cpu");
     if (!ispc_launch_fptr) {
         throw std::runtime_error("Missing ISPCLaunch_cpu symbol");
     }
 
-    ispc_alloc_fptr = (ISPCAllocF) dyn_load_sym(handle, "ISPCAlloc_cpu");
+    ispc_alloc_fptr = (ISPCAllocF)dyn_load_sym(handle, "ISPCAlloc_cpu");
     if (!ispc_alloc_fptr) {
         throw std::runtime_error("Missing ISPCAlloc_cpu symbol");
     }
 
-    ispc_sync_fptr = (ISPCSyncF) dyn_load_sym(handle, "ISPCSync_cpu");
+    ispc_sync_fptr = (ISPCSyncF)dyn_load_sym(handle, "ISPCSync_cpu");
     if (!ispc_sync_fptr) {
         throw std::runtime_error("Missing ISPCSync_cpu symbol");
     }
@@ -236,10 +232,8 @@ void *handleGPUDeviceLib() {
     if (handle) {
         return handle;
     }
-    handle = dyn_load_lib(
-                ISPCRT_DEVICE_GPU_SOLIB_NAME,
-                ISPCRT_DEVICE_GPU_SOLIB_MAJOR_VERSION_NAME,
-                ISPCRT_DEVICE_GPU_SOLIB_FULL_VERSION_NAME);
+    handle = dyn_load_lib(ISPCRT_DEVICE_GPU_SOLIB_NAME, ISPCRT_DEVICE_GPU_SOLIB_MAJOR_VERSION_NAME,
+                          ISPCRT_DEVICE_GPU_SOLIB_FULL_VERSION_NAME);
     if (!handle) {
         throw std::runtime_error("Fail to load " ISPCRT_DEVICE_GPU_SOLIB_NAME " library");
     }
@@ -263,11 +257,10 @@ ispcrt::base::Context *loadGPUContext(void *ctx);
 // Function pointer types declarations.
 typedef uint32_t (*DeviceCountF)();
 typedef ISPCRTDeviceInfo (*DeviceInfoF)(uint32_t);
-typedef ispcrt::base::Device* (*LoadDeviceF)();
-typedef ispcrt::base::Device* (*LoadDeviceCtxF)(void*, void*, uint32_t);
-typedef ispcrt::base::Context* (*LoadContextF)();
-typedef ispcrt::base::Context* (*LoadContextCtxF)(void *);
-
+typedef ispcrt::base::Device *(*LoadDeviceF)();
+typedef ispcrt::base::Device *(*LoadDeviceCtxF)(void *, void *, uint32_t);
+typedef ispcrt::base::Context *(*LoadContextF)();
+typedef ispcrt::base::Context *(*LoadContextCtxF)(void *);
 
 // CPU stubs
 uint32_t cpuDeviceCount() {
@@ -283,7 +276,7 @@ uint32_t cpuDeviceCount() {
         return device_count();
     }
 
-    device_count = (DeviceCountF) dyn_load_sym(handleCPUDeviceLib(), "cpu_device_count");
+    device_count = (DeviceCountF)dyn_load_sym(handleCPUDeviceLib(), "cpu_device_count");
     if (!device_count) {
         throw std::runtime_error("Missing cpu_device_count symbol");
     }
@@ -304,7 +297,7 @@ ISPCRTDeviceInfo cpuDeviceInfo(uint32_t idx) {
         return device_info(idx);
     }
 
-    device_info = (DeviceInfoF) dyn_load_sym(handleCPUDeviceLib(), "cpu_device_info");
+    device_info = (DeviceInfoF)dyn_load_sym(handleCPUDeviceLib(), "cpu_device_info");
     if (!device_info) {
         throw std::runtime_error("Missing cpu_device_info symbol");
     }
@@ -325,8 +318,8 @@ ispcrt::base::Device *loadCPUDevice() {
         return load_device();
     }
 
-    load_device = (LoadDeviceF) dyn_load_sym(handleCPUDeviceLib(), "load_cpu_device");
-    if (!load_device)  {
+    load_device = (LoadDeviceF)dyn_load_sym(handleCPUDeviceLib(), "load_cpu_device");
+    if (!load_device) {
         throw std::runtime_error("Missing load_cpu_device symbol");
     }
 
@@ -347,7 +340,7 @@ ispcrt::base::Context *loadCPUContext() {
         return load_context();
     }
 
-    load_context = (LoadContextF) dyn_load_sym(handleCPUDeviceLib(), "load_cpu_context");
+    load_context = (LoadContextF)dyn_load_sym(handleCPUDeviceLib(), "load_cpu_context");
     if (!load_context) {
         throw std::runtime_error("Missing load_cpu_context symbol");
     }
@@ -355,7 +348,6 @@ ispcrt::base::Context *loadCPUContext() {
     return load_context();
 #endif
 }
-
 
 // GPU stubs.
 uint32_t gpuDeviceCount() {
@@ -371,7 +363,7 @@ uint32_t gpuDeviceCount() {
         return device_count();
     }
 
-    device_count = (DeviceCountF) dyn_load_sym(handleGPUDeviceLib(), "gpu_device_count");
+    device_count = (DeviceCountF)dyn_load_sym(handleGPUDeviceLib(), "gpu_device_count");
     if (!device_count) {
         throw std::runtime_error("Missing gpu_device_count symbol");
     }
@@ -392,7 +384,7 @@ ISPCRTDeviceInfo gpuDeviceInfo(uint32_t idx) {
         return device_info(idx);
     }
 
-    device_info = (DeviceInfoF) dyn_load_sym(handleGPUDeviceLib(), "gpu_device_info");
+    device_info = (DeviceInfoF)dyn_load_sym(handleGPUDeviceLib(), "gpu_device_info");
     if (!device_info) {
         throw std::runtime_error("Missing gpu_device_info symbol");
     }
@@ -413,8 +405,8 @@ ispcrt::base::Device *loadGPUDevice() {
         return load_device();
     }
 
-    load_device = (LoadDeviceF) dyn_load_sym(handleGPUDeviceLib(), "load_gpu_device");
-    if (!load_device)  {
+    load_device = (LoadDeviceF)dyn_load_sym(handleGPUDeviceLib(), "load_gpu_device");
+    if (!load_device) {
         throw std::runtime_error("Missing load_gpu_device symbol");
     }
 
@@ -435,15 +427,14 @@ ispcrt::base::Device *loadGPUDevice(void *ctx, void *dev, uint32_t idx) {
         return load_device(ctx, dev, idx);
     }
 
-    load_device = (LoadDeviceCtxF) dyn_load_sym(handleGPUDeviceLib(), "load_gpu_device_ctx");
-    if (!load_device)  {
+    load_device = (LoadDeviceCtxF)dyn_load_sym(handleGPUDeviceLib(), "load_gpu_device_ctx");
+    if (!load_device) {
         throw std::runtime_error("Missing load_gpu_device_ctx symbol");
     }
 
     return load_device(ctx, dev, idx);
 #endif
 }
-
 
 ispcrt::base::Context *loadGPUContext() {
 #ifdef ISPCRT_BUILD_STATIC
@@ -458,7 +449,7 @@ ispcrt::base::Context *loadGPUContext() {
         return load_context();
     }
 
-    load_context = (LoadContextF) dyn_load_sym(handleGPUDeviceLib(), "load_gpu_context");
+    load_context = (LoadContextF)dyn_load_sym(handleGPUDeviceLib(), "load_gpu_context");
     if (!load_context) {
         throw std::runtime_error("Missing load_gpu_context symbol");
     }
@@ -480,7 +471,7 @@ ispcrt::base::Context *loadGPUContext(void *ctx) {
         return load_context(ctx);
     }
 
-    load_context = (LoadContextCtxF) dyn_load_sym(handleGPUDeviceLib(), "load_gpu_context_ctx");
+    load_context = (LoadContextCtxF)dyn_load_sym(handleGPUDeviceLib(), "load_gpu_context_ctx");
     if (!load_context) {
         throw std::runtime_error("Missing load_gpu_context_ctx symbol");
     }
@@ -522,10 +513,11 @@ ISPCRT_CATCH_END_NO_RETURN()
 ///////////////////////////////////////////////////////////////////////////////
 // Device initialization //////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
-static ISPCRTDevice getISPCRTDevice(ISPCRTDeviceType type, ISPCRTContext context, ISPCRTGenericHandle d, uint32_t deviceIdx) ISPCRT_CATCH_BEGIN {
+static ISPCRTDevice getISPCRTDevice(ISPCRTDeviceType type, ISPCRTContext context, ISPCRTGenericHandle d,
+                                    uint32_t deviceIdx) ISPCRT_CATCH_BEGIN {
     ispcrt::base::Device *device = nullptr;
 
-    void* nativeContext = nullptr;
+    void *nativeContext = nullptr;
     if (context) {
         auto &c = referenceFromHandle<ispcrt::base::Context>(context);
         nativeContext = c.contextNativeHandle();
@@ -691,11 +683,9 @@ static ISPCRTContext getISPCRTContext(ISPCRTDeviceType type, ISPCRTGenericHandle
 }
 ISPCRT_CATCH_END(0)
 
-ISPCRTContext ispcrtNewContext(ISPCRTDeviceType type) {
-    return getISPCRTContext(type, nullptr);
-}
+ISPCRTContext ispcrtNewContext(ISPCRTDeviceType type) { return getISPCRTContext(type, nullptr); }
 
-ISPCRTContext ispcrtGetContextFromNativeHandle(ISPCRTDeviceType type, ISPCRTGenericHandle c){
+ISPCRTContext ispcrtGetContextFromNativeHandle(ISPCRTDeviceType type, ISPCRTGenericHandle c) {
     return getISPCRTContext(type, c);
 }
 ///////////////////////////////////////////////////////////////////////////////
@@ -747,7 +737,7 @@ ISPCRTAllocationType ispcrtGetMemoryViewAllocType(ISPCRTMemoryView h) ISPCRT_CAT
 }
 ISPCRT_CATCH_END(ISPCRTAllocationType::ISPCRT_ALLOC_TYPE_UNKNOWN)
 
-ISPCRTAllocationType ispcrtGetMemoryAllocType(ISPCRTDevice d, void* memBuffer) ISPCRT_CATCH_BEGIN {
+ISPCRTAllocationType ispcrtGetMemoryAllocType(ISPCRTDevice d, void *memBuffer) ISPCRT_CATCH_BEGIN {
     const auto &device = referenceFromHandle<ispcrt::base::Device>(d);
     return device.getMemAllocType(memBuffer);
 }
@@ -768,7 +758,6 @@ ISPCRTModule ispcrtLoadModule(ISPCRTDevice d, const char *moduleFile,
     const auto &device = referenceFromHandle<ispcrt::base::Device>(d);
     auto module = (ISPCRTModule)device.newModule(moduleFile, moduleOpts);
     return module;
-
 }
 ISPCRT_CATCH_END(nullptr)
 
@@ -778,7 +767,8 @@ void ispcrtDynamicLinkModules(ISPCRTDevice d, ISPCRTModule *modules, const uint3
 }
 ISPCRT_CATCH_END()
 
-ISPCRTModule ispcrtStaticLinkModules(ISPCRTDevice d, ISPCRTModule *modules, const uint32_t numModules) ISPCRT_CATCH_BEGIN {
+ISPCRTModule ispcrtStaticLinkModules(ISPCRTDevice d, ISPCRTModule *modules,
+                                     const uint32_t numModules) ISPCRT_CATCH_BEGIN {
     const auto &device = referenceFromHandle<ispcrt::base::Device>(d);
     return (ISPCRTModule)device.staticLinkModules((ispcrt::base::Module **)modules, numModules);
 }
@@ -810,18 +800,19 @@ ISPCRT_CATCH_END_NO_RETURN()
 ISPCRTFuture ispcrtCommandListCopyToDevice(ISPCRTCommandList l, ISPCRTMemoryView mv) ISPCRT_CATCH_BEGIN {
     auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
     auto &view = referenceFromHandle<ispcrt::base::MemoryView>(mv);
-    return (ISPCRTFuture) list.copyToDevice(view);
+    return (ISPCRTFuture)list.copyToDevice(view);
 }
 ISPCRT_CATCH_END(nullptr)
 
 ISPCRTFuture ispcrtCommandListCopyToHost(ISPCRTCommandList l, ISPCRTMemoryView mv) ISPCRT_CATCH_BEGIN {
     auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
     auto &view = referenceFromHandle<ispcrt::base::MemoryView>(mv);
-    return (ISPCRTFuture) list.copyToHost(view);
+    return (ISPCRTFuture)list.copyToHost(view);
 }
 ISPCRT_CATCH_END(nullptr)
 
-ISPCRTFuture ispcrtCommandListCopyMemoryView(ISPCRTCommandList l, ISPCRTMemoryView mvDst, ISPCRTMemoryView mvSrc, const size_t size) ISPCRT_CATCH_BEGIN {
+ISPCRTFuture ispcrtCommandListCopyMemoryView(ISPCRTCommandList l, ISPCRTMemoryView mvDst, ISPCRTMemoryView mvSrc,
+                                             const size_t size) ISPCRT_CATCH_BEGIN {
     auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
     auto &viewDst = referenceFromHandle<ispcrt::base::MemoryView>(mvDst);
     auto &viewSrc = referenceFromHandle<ispcrt::base::MemoryView>(mvSrc);
@@ -831,11 +822,12 @@ ISPCRTFuture ispcrtCommandListCopyMemoryView(ISPCRTCommandList l, ISPCRTMemoryVi
     if (size > viewSrc.numBytes()) {
         throw std::runtime_error("Requested copy size is bigger than source buffer size!");
     }
-    return (ISPCRTFuture) list.copyMemoryView(viewDst, viewSrc, size);
+    return (ISPCRTFuture)list.copyMemoryView(viewDst, viewSrc, size);
 }
 ISPCRT_CATCH_END(nullptr)
 
-ISPCRTFuture ispcrtCommandListLaunch1D(ISPCRTCommandList l, ISPCRTKernel k, ISPCRTMemoryView p, size_t dim0) ISPCRT_CATCH_BEGIN {
+ISPCRTFuture ispcrtCommandListLaunch1D(ISPCRTCommandList l, ISPCRTKernel k, ISPCRTMemoryView p,
+                                       size_t dim0) ISPCRT_CATCH_BEGIN {
     return ispcrtCommandListLaunch3D(l, k, p, dim0, 1, 1);
 }
 ISPCRT_CATCH_END(nullptr)
@@ -846,8 +838,8 @@ ISPCRTFuture ispcrtCommandListLaunch2D(ISPCRTCommandList l, ISPCRTKernel k, ISPC
 }
 ISPCRT_CATCH_END(nullptr)
 
-ISPCRTFuture ispcrtCommandListLaunch3D(ISPCRTCommandList l, ISPCRTKernel k, ISPCRTMemoryView p, size_t dim0, size_t dim1,
-                                       size_t dim2) ISPCRT_CATCH_BEGIN {
+ISPCRTFuture ispcrtCommandListLaunch3D(ISPCRTCommandList l, ISPCRTKernel k, ISPCRTMemoryView p, size_t dim0,
+                                       size_t dim1, size_t dim2) ISPCRT_CATCH_BEGIN {
     auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
     auto &kernel = referenceFromHandle<ispcrt::base::Kernel>(k);
 
@@ -868,7 +860,7 @@ ISPCRT_CATCH_END_NO_RETURN()
 
 ISPCRTFence ispcrtCommandListSubmit(ISPCRTCommandList l) ISPCRT_CATCH_BEGIN {
     auto &list = referenceFromHandle<ispcrt::base::CommandList>(l);
-    return (ISPCRTFence) list.submit();
+    return (ISPCRTFence)list.submit();
 }
 ISPCRT_CATCH_END(nullptr)
 
@@ -902,7 +894,7 @@ ISPCRT_CATCH_END(nullptr)
 
 ISPCRTCommandList ispcrtCommandQueueCreateCommandList(ISPCRTCommandQueue q) ISPCRT_CATCH_BEGIN {
     auto &queue = referenceFromHandle<ispcrt::base::CommandQueue>(q);
-    return (ISPCRTCommandList) queue.createCommandList();
+    return (ISPCRTCommandList)queue.createCommandList();
 }
 ISPCRT_CATCH_END(nullptr)
 
@@ -948,7 +940,8 @@ void ispcrtCopyToHost(ISPCRTTaskQueue q, ISPCRTMemoryView mv) ISPCRT_CATCH_BEGIN
 }
 ISPCRT_CATCH_END_NO_RETURN()
 
-void ispcrtCopyMemoryView(ISPCRTTaskQueue q, ISPCRTMemoryView mvDst, ISPCRTMemoryView mvSrc, const size_t size) ISPCRT_CATCH_BEGIN {
+void ispcrtCopyMemoryView(ISPCRTTaskQueue q, ISPCRTMemoryView mvDst, ISPCRTMemoryView mvSrc,
+                          const size_t size) ISPCRT_CATCH_BEGIN {
     auto &queue = referenceFromHandle<ispcrt::base::TaskQueue>(q);
     auto &viewDst = referenceFromHandle<ispcrt::base::MemoryView>(mvDst);
     auto &viewSrc = referenceFromHandle<ispcrt::base::MemoryView>(mvSrc);

--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -101,7 +101,7 @@ ISPCRTDevice ispcrtGetDeviceFromNativeHandle(ISPCRTContext context, ISPCRTGeneri
 ISPCRTDeviceType ispcrtGetDeviceType(ISPCRTDevice d);
 
 uint32_t ispcrtGetDeviceCount(ISPCRTDeviceType);
-void ispcrtGetDeviceInfo(ISPCRTDeviceType, uint32_t deviceIdx, ISPCRTDeviceInfo*);
+void ispcrtGetDeviceInfo(ISPCRTDeviceType, uint32_t deviceIdx, ISPCRTDeviceInfo *);
 
 // Context initialization //////////////////////////////////////////////////////
 
@@ -137,7 +137,8 @@ typedef struct {
 } ISPCRTNewMemoryViewFlags;
 
 ISPCRTMemoryView ispcrtNewMemoryView(ISPCRTDevice, void *appMemory, size_t numBytes, ISPCRTNewMemoryViewFlags *flags);
-ISPCRTMemoryView ispcrtNewMemoryViewForContext(ISPCRTContext c, void *appMemory, size_t numBytes, ISPCRTNewMemoryViewFlags *flags);
+ISPCRTMemoryView ispcrtNewMemoryViewForContext(ISPCRTContext c, void *appMemory, size_t numBytes,
+                                               ISPCRTNewMemoryViewFlags *flags);
 
 void *ispcrtHostPtr(ISPCRTMemoryView);
 void *ispcrtDevicePtr(ISPCRTMemoryView);
@@ -146,7 +147,7 @@ void *ispcrtSharedPtr(ISPCRTMemoryView);
 size_t ispcrtSize(ISPCRTMemoryView);
 
 ISPCRTAllocationType ispcrtGetMemoryViewAllocType(ISPCRTMemoryView);
-ISPCRTAllocationType ispcrtGetMemoryAllocType(ISPCRTDevice d, void* memBuffer);
+ISPCRTAllocationType ispcrtGetMemoryAllocType(ISPCRTDevice d, void *memBuffer);
 
 // Modules ////////////////////////////////////////////////////////////////////
 typedef enum {
@@ -178,9 +179,10 @@ ISPCRTFuture ispcrtCommandListCopyMemoryView(ISPCRTCommandList, ISPCRTMemoryView
 
 // NOTE: 'params' can be a nullptr handle (nullptr will get passed to the ISPC task as the function parameter)
 ISPCRTFuture ispcrtCommandListLaunch1D(ISPCRTCommandList, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0);
-ISPCRTFuture ispcrtCommandListLaunch2D(ISPCRTCommandList, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0, size_t dim1);
-ISPCRTFuture ispcrtCommandListLaunch3D(ISPCRTCommandList, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0, size_t dim1,
-                            size_t dim2);
+ISPCRTFuture ispcrtCommandListLaunch2D(ISPCRTCommandList, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0,
+                                       size_t dim1);
+ISPCRTFuture ispcrtCommandListLaunch3D(ISPCRTCommandList, ISPCRTKernel, ISPCRTMemoryView params, size_t dim0,
+                                       size_t dim1, size_t dim2);
 
 void ispcrtCommandListClose(ISPCRTCommandList);
 ISPCRTFence ispcrtCommandListSubmit(ISPCRTCommandList);

--- a/ispcrt/ispcrt.hpp
+++ b/ispcrt/ispcrt.hpp
@@ -93,7 +93,10 @@ class Future : public GenericObject<ISPCRTFuture> {
     uint64_t time() const;
 };
 
-inline Future::Future(ISPCRTFuture f) : GenericObject<ISPCRTFuture>(f) { if (f) ispcrtRetain(f); }
+inline Future::Future(ISPCRTFuture f) : GenericObject<ISPCRTFuture>(f) {
+    if (f)
+        ispcrtRetain(f);
+}
 
 inline bool Future::valid() const { return handle() && ispcrtFutureIsValid(handle()); }
 
@@ -111,10 +114,13 @@ class Fence : public GenericObject<ISPCRTFence> {
     void sync();
     ISPCRTFenceStatus status() const;
     void reset();
-    void* nativeFenceHandle() const;
+    void *nativeFenceHandle() const;
 };
 
-inline Fence::Fence(ISPCRTFence f) : GenericObject<ISPCRTFence>(f) { if (f) ispcrtRetain(f); }
+inline Fence::Fence(ISPCRTFence f) : GenericObject<ISPCRTFence>(f) {
+    if (f)
+        ispcrtRetain(f);
+}
 
 inline void Fence::sync() { ispcrtFenceSync(handle()); }
 
@@ -122,7 +128,7 @@ inline ISPCRTFenceStatus Fence::status() const { return ispcrtFenceStatus(handle
 
 inline void Fence::reset() { ispcrtFenceReset(handle()); }
 
-inline void* Fence::nativeFenceHandle() const { return ispcrtFenceNativeHandle(handle()); }
+inline void *Fence::nativeFenceHandle() const { return ispcrtFenceNativeHandle(handle()); }
 
 /////////////////////////////////////////////////////////////////////////////
 // Context wrapper ///////////////////////////////////////////////////////////
@@ -134,18 +140,16 @@ class Context : public GenericObject<ISPCRTContext> {
     Context(ISPCRTDeviceType type);
     Context(ISPCRTDeviceType type, ISPCRTGenericHandle nativeContextHandle);
     ~Context() = default;
-    void* nativeContextHandle() const;
+    void *nativeContextHandle() const;
 };
 
 // Inlined definitions //
-inline Context::Context(ISPCRTDeviceType type)
-    : GenericObject<ISPCRTContext>(ispcrtNewContext(type)) {}
+inline Context::Context(ISPCRTDeviceType type) : GenericObject<ISPCRTContext>(ispcrtNewContext(type)) {}
 
 inline Context::Context(ISPCRTDeviceType type, ISPCRTGenericHandle nativeContextHandle)
-    : GenericObject<ISPCRTContext>(ispcrtGetContextFromNativeHandle(type, nativeContextHandle))
-{}
+    : GenericObject<ISPCRTContext>(ispcrtGetContextFromNativeHandle(type, nativeContextHandle)) {}
 
-inline void* Context::nativeContextHandle() const { return ispcrtContextNativeHandle(handle()); }
+inline void *Context::nativeContextHandle() const { return ispcrtContextNativeHandle(handle()); }
 /////////////////////////////////////////////////////////////////////////////
 // Device wrapper ///////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
@@ -162,45 +166,40 @@ class Device : public GenericObject<ISPCRTDevice> {
     Device(ISPCRTDeviceType type, uint32_t deviceIdx);
     Device(const Context &context, uint32_t deviceIdx);
     Device(const Context &context, ISPCRTGenericHandle nativeDeviceHandle);
-    void* nativePlatformHandle() const;
-    void* nativeDeviceHandle() const;
-    void* nativeContextHandle() const;
+    void *nativePlatformHandle() const;
+    void *nativeDeviceHandle() const;
+    void *nativeContextHandle() const;
     ISPCRTDeviceType getType() const;
     // static methods to get information about available devices
     static uint32_t deviceCount(ISPCRTDeviceType type);
     static ISPCRTDeviceInfo deviceInformation(ISPCRTDeviceType type, uint32_t deviceIdx);
     static std::vector<ISPCRTDeviceInfo> allDevicesInformation(ISPCRTDeviceType type);
     // link modules
-    void dynamicLinkModules(ISPCRTModule* modules, const uint32_t num);
-    Module staticLinkModules(ISPCRTModule* modules, const uint32_t num);
+    void dynamicLinkModules(ISPCRTModule *modules, const uint32_t num);
+    Module staticLinkModules(ISPCRTModule *modules, const uint32_t num);
     // check memory type
     ISPCRTAllocationType getMemoryAllocType(void *memBuffer);
 };
 
 // Inlined definitions //
-inline Device::Device(ISPCRTDeviceType type, uint32_t deviceIdx) :
-    GenericObject<ISPCRTDevice>(ispcrtGetDevice(type, deviceIdx)) { }
+inline Device::Device(ISPCRTDeviceType type, uint32_t deviceIdx)
+    : GenericObject<ISPCRTDevice>(ispcrtGetDevice(type, deviceIdx)) {}
 inline Device::Device(ISPCRTDeviceType type) : Device(type, uint32_t(0)) {}
 
-inline Device::Device(const Context &context, uint32_t deviceIdx) :
-    GenericObject<ISPCRTDevice>(ispcrtGetDeviceFromContext(context.handle(), deviceIdx)) { }
+inline Device::Device(const Context &context, uint32_t deviceIdx)
+    : GenericObject<ISPCRTDevice>(ispcrtGetDeviceFromContext(context.handle(), deviceIdx)) {}
 inline Device::Device(const Context &context) : Device(context, uint32_t(0)) {}
 
 inline Device::Device(const Context &context, ISPCRTGenericHandle nativeDeviceHandle)
-    : GenericObject<ISPCRTDevice>(ispcrtGetDeviceFromNativeHandle(context.handle(), nativeDeviceHandle))
-{}
+    : GenericObject<ISPCRTDevice>(ispcrtGetDeviceFromNativeHandle(context.handle(), nativeDeviceHandle)) {}
 
-inline void* Device::nativePlatformHandle() const { return ispcrtPlatformNativeHandle(handle()); }
-inline void* Device::nativeDeviceHandle() const { return ispcrtDeviceNativeHandle(handle()); }
-inline void* Device::nativeContextHandle() const { return ispcrtDeviceContextNativeHandle(handle()); }
+inline void *Device::nativePlatformHandle() const { return ispcrtPlatformNativeHandle(handle()); }
+inline void *Device::nativeDeviceHandle() const { return ispcrtDeviceNativeHandle(handle()); }
+inline void *Device::nativeContextHandle() const { return ispcrtDeviceContextNativeHandle(handle()); }
 
-inline ISPCRTDeviceType Device::getType() const {
-    return ispcrtGetDeviceType(handle());
-}
+inline ISPCRTDeviceType Device::getType() const { return ispcrtGetDeviceType(handle()); }
 
-inline uint32_t Device::deviceCount(ISPCRTDeviceType type) {
-    return ispcrtGetDeviceCount(type);
-}
+inline uint32_t Device::deviceCount(ISPCRTDeviceType type) { return ispcrtGetDeviceCount(type); }
 
 inline ISPCRTDeviceInfo Device::deviceInformation(ISPCRTDeviceType type, uint32_t deviceIdx) {
     ISPCRTDeviceInfo devInfo;
@@ -217,8 +216,8 @@ inline std::vector<ISPCRTDeviceInfo> Device::allDevicesInformation(ISPCRTDeviceT
     return devInfo;
 }
 
-inline void Device::dynamicLinkModules(ISPCRTModule* modules, const uint32_t num) {
-    ispcrtDynamicLinkModules(handle(), (ISPCRTModule*)modules, num);
+inline void Device::dynamicLinkModules(ISPCRTModule *modules, const uint32_t num) {
+    ispcrtDynamicLinkModules(handle(), (ISPCRTModule *)modules, num);
 }
 
 inline ISPCRTAllocationType Device::getMemoryAllocType(void *memBuffer) {
@@ -231,182 +230,187 @@ inline ISPCRTAllocationType Device::getMemoryAllocType(void *memBuffer) {
 
 enum class AllocType { Device, Shared };
 
-enum class SharedMemoryUsageHint {
-    HostDeviceReadWrite,
-    HostWriteDeviceRead,
-    HostReadDeviceWrite
-};
+enum class SharedMemoryUsageHint { HostDeviceReadWrite, HostWriteDeviceRead, HostReadDeviceWrite };
 
 template <typename T, AllocType AT = AllocType::Device> class Array : public GenericObject<ISPCRTMemoryView> {
   public:
-    template<AllocType alloc> using EnableForSharedAllocation = typename std::enable_if<(alloc == AllocType::Shared)>::type*;
-    template<AllocType alloc> using EnableForDeviceAllocation = typename std::enable_if<(alloc == AllocType::Device)>::type*;
+    template <AllocType alloc>
+    using EnableForSharedAllocation = typename std::enable_if<(alloc == AllocType::Shared)>::type *;
+    template <AllocType alloc>
+    using EnableForDeviceAllocation = typename std::enable_if<(alloc == AllocType::Device)>::type *;
 
     Array() = default;
 
     //////// Constructors that can be used for Device memory allocations ////////
 
     // Construct from raw array //
-    template<AllocType alloc = AT>
-        Array(const Device &device, T *appMemory, size_t size, EnableForDeviceAllocation<alloc> = 0);
+    template <AllocType alloc = AT>
+    Array(const Device &device, T *appMemory, size_t size, EnableForDeviceAllocation<alloc> = 0);
 
     // Construct from std:: containers (array + vector) //
-    template<std::size_t N, AllocType alloc = AT>
-        Array(const Device &device, std::array<T, N> &arr, EnableForDeviceAllocation<alloc> = 0);
+    template <std::size_t N, AllocType alloc = AT>
+    Array(const Device &device, std::array<T, N> &arr, EnableForDeviceAllocation<alloc> = 0);
 
-    template<typename ALLOC_T, AllocType alloc = AT>
-        Array(const Device &device, std::vector<T, ALLOC_T> &v, EnableForDeviceAllocation<alloc> = 0);
+    template <typename ALLOC_T, AllocType alloc = AT>
+    Array(const Device &device, std::vector<T, ALLOC_T> &v, EnableForDeviceAllocation<alloc> = 0);
 
     // Construct from single object //
-    template<AllocType alloc = AT>
-        Array(const Device &device, T &obj, EnableForDeviceAllocation<alloc> = 0);
+    template <AllocType alloc = AT> Array(const Device &device, T &obj, EnableForDeviceAllocation<alloc> = 0);
 
     //////// Constructors that can be used for Shared memory allocations ////////
 
     // Allocate single object in shared memory
-    template<AllocType alloc = AT>
-        Array(const Device &device,
-              SharedMemoryUsageHint SMAT = SharedMemoryUsageHint::HostDeviceReadWrite,
-              EnableForSharedAllocation<alloc> = 0);
+    template <AllocType alloc = AT>
+    Array(const Device &device, SharedMemoryUsageHint SMAT = SharedMemoryUsageHint::HostDeviceReadWrite,
+          EnableForSharedAllocation<alloc> = 0);
 
     // Allocate single object in shared memory for context
-    template<AllocType alloc = AT>
-        Array(const Context &context,
-              SharedMemoryUsageHint SMAT = SharedMemoryUsageHint::HostDeviceReadWrite,
-              EnableForSharedAllocation<alloc> = 0);
+    template <AllocType alloc = AT>
+    Array(const Context &context, SharedMemoryUsageHint SMAT = SharedMemoryUsageHint::HostDeviceReadWrite,
+          EnableForSharedAllocation<alloc> = 0);
 
     // Allocate multiple objects in shared memory
-    template<AllocType alloc = AT>
-        Array(const Device &device, size_t size,
-              SharedMemoryUsageHint SMAT = SharedMemoryUsageHint::HostDeviceReadWrite,
-              EnableForSharedAllocation<alloc> = 0);
+    template <AllocType alloc = AT>
+    Array(const Device &device, size_t size, SharedMemoryUsageHint SMAT = SharedMemoryUsageHint::HostDeviceReadWrite,
+          EnableForSharedAllocation<alloc> = 0);
 
     // Allocate multiple objects in shared memory for context
-    template<AllocType alloc = AT>
-        Array(const Context &context, size_t size,
-              SharedMemoryUsageHint SMAT = SharedMemoryUsageHint::HostDeviceReadWrite,
-              EnableForSharedAllocation<alloc> = 0);
+    template <AllocType alloc = AT>
+    Array(const Context &context, size_t size, SharedMemoryUsageHint SMAT = SharedMemoryUsageHint::HostDeviceReadWrite,
+          EnableForSharedAllocation<alloc> = 0);
 
     //////// Methods valid only for Device memory allocations ////////
 
     // For shared memory objects those will return the same pointer //
-    template<AllocType alloc = AT>
-        T *hostPtr(EnableForDeviceAllocation<alloc> = 0) const;
-    template<AllocType alloc = AT>
-        T *devicePtr(EnableForDeviceAllocation<alloc> = 0) const;
+    template <AllocType alloc = AT> T *hostPtr(EnableForDeviceAllocation<alloc> = 0) const;
+    template <AllocType alloc = AT> T *devicePtr(EnableForDeviceAllocation<alloc> = 0) const;
 
     //////// Methods valid for Shared memory allocations ////////
 
-    template<AllocType alloc = AT>
-        T *sharedPtr(EnableForSharedAllocation<alloc> = 0) const;
+    template <AllocType alloc = AT> T *sharedPtr(EnableForSharedAllocation<alloc> = 0) const;
 
-    template<AllocType alloc = AT>
-        SharedMemoryUsageHint smType(EnableForSharedAllocation<alloc> = 0) const;
+    template <AllocType alloc = AT> SharedMemoryUsageHint smType(EnableForSharedAllocation<alloc> = 0) const;
 
     //////// Methods for all types of memory allocations ////////
 
     size_t size() const;
     AllocType type() const;
 
-private:
+  private:
     SharedMemoryUsageHint m_smuh{SharedMemoryUsageHint::HostDeviceReadWrite};
 };
 
 // Inlined definitions //
 
 // Device memory allocations
-template<typename T, AllocType AT>
-template<AllocType alloc>
-    inline Array<T, AT>::Array(const Device &device, T *appMemory, size_t size, EnableForDeviceAllocation<alloc>)
-        : GenericObject<ISPCRTMemoryView>() {
-            ISPCRTNewMemoryViewFlags flags;
-            flags.allocType = ISPCRT_ALLOC_TYPE_DEVICE;
-            flags.smHint = ISPCRT_SM_HOST_DEVICE_READ_WRITE;
-            m_handle = ispcrtNewMemoryView(device.handle(), appMemory, size * sizeof(T), &flags);
-        }
+template <typename T, AllocType AT>
+template <AllocType alloc>
+inline Array<T, AT>::Array(const Device &device, T *appMemory, size_t size, EnableForDeviceAllocation<alloc>)
+    : GenericObject<ISPCRTMemoryView>() {
+    ISPCRTNewMemoryViewFlags flags;
+    flags.allocType = ISPCRT_ALLOC_TYPE_DEVICE;
+    flags.smHint = ISPCRT_SM_HOST_DEVICE_READ_WRITE;
+    m_handle = ispcrtNewMemoryView(device.handle(), appMemory, size * sizeof(T), &flags);
+}
 
-template<typename T, AllocType AT>
-template<std::size_t N, AllocType alloc>
-    inline Array<T,AT>::Array(const Device &device, std::array<T, N> &arr, EnableForDeviceAllocation<alloc>)
-        : Array<T,AT>(device, arr.data(), N) {}
+template <typename T, AllocType AT>
+template <std::size_t N, AllocType alloc>
+inline Array<T, AT>::Array(const Device &device, std::array<T, N> &arr, EnableForDeviceAllocation<alloc>)
+    : Array<T, AT>(device, arr.data(), N) {}
 
-template<typename T, AllocType AT>
-template<typename ALLOC_T, AllocType alloc>
-    inline Array<T,AT>::Array(const Device &device, std::vector<T, ALLOC_T> &v, EnableForDeviceAllocation<alloc>)
-        : Array<T,AT>(device, v.data(), v.size()) {}
+template <typename T, AllocType AT>
+template <typename ALLOC_T, AllocType alloc>
+inline Array<T, AT>::Array(const Device &device, std::vector<T, ALLOC_T> &v, EnableForDeviceAllocation<alloc>)
+    : Array<T, AT>(device, v.data(), v.size()) {}
 
-template<typename T, AllocType AT>
-template<AllocType alloc>
-    inline Array<T,AT>::Array(const Device &device, T &obj, EnableForDeviceAllocation<alloc>) : Array<T,AT>(device, &obj, 1) {}
+template <typename T, AllocType AT>
+template <AllocType alloc>
+inline Array<T, AT>::Array(const Device &device, T &obj, EnableForDeviceAllocation<alloc>)
+    : Array<T, AT>(device, &obj, 1) {}
 
 // Shared memory allocations
-template<typename T, AllocType AT>
-template<AllocType alloc>
-    inline Array<T, AT>::Array(const Device &device, SharedMemoryUsageHint smuh, EnableForSharedAllocation<alloc>) : Array<T, AT>(device, 1, smuh) {}
+template <typename T, AllocType AT>
+template <AllocType alloc>
+inline Array<T, AT>::Array(const Device &device, SharedMemoryUsageHint smuh, EnableForSharedAllocation<alloc>)
+    : Array<T, AT>(device, 1, smuh) {}
 
-template<typename T, AllocType AT>
-template<AllocType alloc>
-    inline Array<T, AT>::Array(const Context &context, SharedMemoryUsageHint smuh, EnableForSharedAllocation<alloc>) : Array<T, AT>(context, 1, smuh) {}
+template <typename T, AllocType AT>
+template <AllocType alloc>
+inline Array<T, AT>::Array(const Context &context, SharedMemoryUsageHint smuh, EnableForSharedAllocation<alloc>)
+    : Array<T, AT>(context, 1, smuh) {}
 
 inline void set_shared_memory_view_flags(ISPCRTNewMemoryViewFlags *p, SharedMemoryUsageHint t) {
     p->allocType = ISPCRT_ALLOC_TYPE_SHARED;
     switch (t) {
     case SharedMemoryUsageHint::HostDeviceReadWrite:
-        p->smHint = ISPCRT_SM_HOST_DEVICE_READ_WRITE; break;
+        p->smHint = ISPCRT_SM_HOST_DEVICE_READ_WRITE;
+        break;
     case SharedMemoryUsageHint::HostWriteDeviceRead:
-        p->smHint = ISPCRT_SM_HOST_WRITE_DEVICE_READ; break;
+        p->smHint = ISPCRT_SM_HOST_WRITE_DEVICE_READ;
+        break;
     case SharedMemoryUsageHint::HostReadDeviceWrite:
-        p->smHint = ISPCRT_SM_HOST_READ_DEVICE_WRITE; break;
+        p->smHint = ISPCRT_SM_HOST_READ_DEVICE_WRITE;
+        break;
     default:
         throw std::bad_alloc();
     }
 }
 
-template<typename T, AllocType AT>
-template<AllocType alloc>
-    inline Array<T, AT>::Array(const Device &device, size_t size, SharedMemoryUsageHint smuh, EnableForSharedAllocation<alloc>) : m_smuh(smuh),
-        GenericObject<ISPCRTMemoryView>() {
-            ISPCRTNewMemoryViewFlags flags;
-            set_shared_memory_view_flags(&flags, smuh);
-            m_handle = ispcrtNewMemoryView(device.handle(), nullptr, size * sizeof(T), &flags);
-        }
+template <typename T, AllocType AT>
+template <AllocType alloc>
+inline Array<T, AT>::Array(const Device &device, size_t size, SharedMemoryUsageHint smuh,
+                           EnableForSharedAllocation<alloc>)
+    : m_smuh(smuh), GenericObject<ISPCRTMemoryView>() {
+    ISPCRTNewMemoryViewFlags flags;
+    set_shared_memory_view_flags(&flags, smuh);
+    m_handle = ispcrtNewMemoryView(device.handle(), nullptr, size * sizeof(T), &flags);
+}
 
-template<typename T, AllocType AT>
-template<AllocType alloc>
-    inline Array<T, AT>::Array(const Context &context, size_t size, SharedMemoryUsageHint smuh, EnableForSharedAllocation<alloc>) : m_smuh(smuh),
-        GenericObject<ISPCRTMemoryView>() {
-            ISPCRTNewMemoryViewFlags flags;
-            set_shared_memory_view_flags(&flags, smuh);
-            m_handle = ispcrtNewMemoryViewForContext(context.handle(), nullptr, size * sizeof(T), &flags);
-        }
+template <typename T, AllocType AT>
+template <AllocType alloc>
+inline Array<T, AT>::Array(const Context &context, size_t size, SharedMemoryUsageHint smuh,
+                           EnableForSharedAllocation<alloc>)
+    : m_smuh(smuh), GenericObject<ISPCRTMemoryView>() {
+    ISPCRTNewMemoryViewFlags flags;
+    set_shared_memory_view_flags(&flags, smuh);
+    m_handle = ispcrtNewMemoryViewForContext(context.handle(), nullptr, size * sizeof(T), &flags);
+}
 
 // Device-only methods
 
-template<typename T, AllocType AT>
-template<AllocType alloc>
-    inline T *Array<T,AT>::hostPtr(EnableForDeviceAllocation<alloc>) const { return (T *)ispcrtHostPtr(handle()); }
+template <typename T, AllocType AT>
+template <AllocType alloc>
+inline T *Array<T, AT>::hostPtr(EnableForDeviceAllocation<alloc>) const {
+    return (T *)ispcrtHostPtr(handle());
+}
 
-template<typename T, AllocType AT>
-template<AllocType alloc>
-    inline T *Array<T,AT>::devicePtr(EnableForDeviceAllocation<alloc>) const { return (T *)ispcrtDevicePtr(handle()); }
+template <typename T, AllocType AT>
+template <AllocType alloc>
+inline T *Array<T, AT>::devicePtr(EnableForDeviceAllocation<alloc>) const {
+    return (T *)ispcrtDevicePtr(handle());
+}
 
 // Shared-only methods
 
-template<typename T, AllocType AT>
-template<AllocType alloc>
-    inline T *Array<T,AT>::sharedPtr(EnableForSharedAllocation<alloc>) const { return (T *)ispcrtSharedPtr(handle()); }
+template <typename T, AllocType AT>
+template <AllocType alloc>
+inline T *Array<T, AT>::sharedPtr(EnableForSharedAllocation<alloc>) const {
+    return (T *)ispcrtSharedPtr(handle());
+}
 
-template<typename T, AllocType AT>
-template<AllocType alloc>
-    inline SharedMemoryUsageHint Array<T,AT>::smType(EnableForSharedAllocation<alloc>) const { return m_smuh; }
+template <typename T, AllocType AT>
+template <AllocType alloc>
+inline SharedMemoryUsageHint Array<T, AT>::smType(EnableForSharedAllocation<alloc>) const {
+    return m_smuh;
+}
 
 // All other methods
 
-template <typename T, AllocType AT>
-    inline size_t Array<T,AT>::size() const { return ispcrtSize(handle()) / sizeof(T); }
+template <typename T, AllocType AT> inline size_t Array<T, AT>::size() const {
+    return ispcrtSize(handle()) / sizeof(T);
+}
 
-template <typename T, AllocType AT>
-    inline AllocType Array<T,AT>::type() const { return AT; }
+template <typename T, AllocType AT> inline AllocType Array<T, AT>::type() const { return AT; }
 
 /////////////////////////////////////////////////////////////////////////////
 // Shared Memory Allocator //////////////////////////////////////////////////
@@ -417,39 +421,40 @@ template <typename T> class SharedMemoryAllocator {
     using value_type = T;
 
     SharedMemoryAllocator() = delete;
-    SharedMemoryAllocator(const Context &context, SharedMemoryUsageHint smuh = SharedMemoryUsageHint::HostDeviceReadWrite) : m_context(context), m_smuh(smuh) {}
-    SharedMemoryAllocator(const SharedMemoryAllocator&) = default;
+    SharedMemoryAllocator(const Context &context,
+                          SharedMemoryUsageHint smuh = SharedMemoryUsageHint::HostDeviceReadWrite)
+        : m_context(context), m_smuh(smuh) {}
+    SharedMemoryAllocator(const SharedMemoryAllocator &) = default;
     ~SharedMemoryAllocator() = default;
-    SharedMemoryAllocator& operator=(const SharedMemoryAllocator&) = delete;
+    SharedMemoryAllocator &operator=(const SharedMemoryAllocator &) = delete;
 
-    T* allocate(const size_t n);
-    void deallocate(T* const p, const size_t n);
+    T *allocate(const size_t n);
+    void deallocate(T *const p, const size_t n);
 
     SharedMemoryUsageHint smType() const { return m_smuh; }
-protected:
+
+  protected:
     Context m_context;
     SharedMemoryUsageHint m_smuh;
-    std::unordered_map<void*, Array<T, AllocType::Shared>> m_ptrToArray;
+    std::unordered_map<void *, Array<T, AllocType::Shared>> m_ptrToArray;
 };
 
 // Inlined definitions //
 
-template <typename T>
-inline T *SharedMemoryAllocator<T>::allocate(const size_t n) {
+template <typename T> inline T *SharedMemoryAllocator<T>::allocate(const size_t n) {
     // Allocate a memory that can be shared between the host and the device
     auto a = Array<T, AllocType::Shared>(m_context, n, m_smuh);
 
-    void* ptr = a.sharedPtr();
+    void *ptr = a.sharedPtr();
     if (ptr == nullptr) {
         throw std::bad_alloc();
     }
     m_ptrToArray[ptr] = a;
 
-    return static_cast<T*>(ptr);
+    return static_cast<T *>(ptr);
 }
 
-template <typename T>
-inline void SharedMemoryAllocator<T>::deallocate(T* const p, const size_t) {
+template <typename T> inline void SharedMemoryAllocator<T>::deallocate(T *const p, const size_t) {
     if (m_ptrToArray.find(p) == m_ptrToArray.end())
         throw std::invalid_argument("pointer not allocated with this allocator");
     m_ptrToArray.erase(p);
@@ -461,7 +466,6 @@ template <typename T> using SharedVector = std::vector<T, ispcrt::SharedMemoryAl
 /////////////////////////////////////////////////////////////////////////////
 // Module wrapper ///////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
-
 
 class Module : public GenericObject<ISPCRTModule> {
   public:
@@ -478,12 +482,10 @@ inline Module::Module(const Device &device, const char *moduleName, const ISPCRT
 
 inline Module::Module(ISPCRTModule module) : GenericObject<ISPCRTModule>(module) {}
 
-inline void* Module::functionPtr(const char *functionName){
-    return ispcrtFunctionPtr(handle(), functionName);
-}
+inline void *Module::functionPtr(const char *functionName) { return ispcrtFunctionPtr(handle(), functionName); }
 
-inline Module Device::staticLinkModules(ISPCRTModule* modules, const uint32_t num) {
-    return Module(ispcrtStaticLinkModules(handle(), (ISPCRTModule*)modules, num));
+inline Module Device::staticLinkModules(ISPCRTModule *modules, const uint32_t num) {
+    return Module(ispcrtStaticLinkModules(handle(), (ISPCRTModule *)modules, num));
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -512,18 +514,20 @@ class CommandList : public GenericObject<ISPCRTCommandList> {
 
     void barrier();
 
-    template <typename T, AllocType AT> Future copyToDevice(const Array<T,AT> &arr) const;
-    template <typename T, AllocType AT> Future copyToHost(const Array<T,AT> &arr) const;
-    template <typename T, AllocType AT> Future copyArray(const Array<T,AT> &arrDst, const Array<T,AT> &arrSrc, const size_t size) const;
+    template <typename T, AllocType AT> Future copyToDevice(const Array<T, AT> &arr) const;
+    template <typename T, AllocType AT> Future copyToHost(const Array<T, AT> &arr) const;
+    template <typename T, AllocType AT>
+    Future copyArray(const Array<T, AT> &arrDst, const Array<T, AT> &arrSrc, const size_t size) const;
 
     Future launch(const Kernel &k, size_t dim0) const;
     Future launch(const Kernel &k, size_t dim0, size_t dim1) const;
     Future launch(const Kernel &k, size_t dim0, size_t dim1, size_t dim2) const;
 
-    template <typename T, AllocType AT> Future launch(const Kernel &k, const Array<T,AT> &p, size_t dim0) const;
-    template <typename T, AllocType AT> Future launch(const Kernel &k, const Array<T,AT> &p, size_t dim0, size_t dim1) const;
+    template <typename T, AllocType AT> Future launch(const Kernel &k, const Array<T, AT> &p, size_t dim0) const;
     template <typename T, AllocType AT>
-    Future launch(const Kernel &k, const Array<T,AT> &p, size_t dim0, size_t dim1, size_t dim2) const;
+    Future launch(const Kernel &k, const Array<T, AT> &p, size_t dim0, size_t dim1) const;
+    template <typename T, AllocType AT>
+    Future launch(const Kernel &k, const Array<T, AT> &p, size_t dim0, size_t dim1, size_t dim2) const;
 
     void close();
     Fence submit();
@@ -533,19 +537,23 @@ class CommandList : public GenericObject<ISPCRTCommandList> {
     void *nativeHandle() const;
 };
 
-inline CommandList::CommandList(ISPCRTCommandList l) : GenericObject<ISPCRTCommandList>(l) { if (l) ispcrtRetain(l); }
+inline CommandList::CommandList(ISPCRTCommandList l) : GenericObject<ISPCRTCommandList>(l) {
+    if (l)
+        ispcrtRetain(l);
+}
 
 inline void CommandList::barrier() { ispcrtCommandListBarrier(handle()); }
 
-template <typename T, AllocType AT> inline Future CommandList::copyToDevice(const Array<T,AT> &arr) const {
+template <typename T, AllocType AT> inline Future CommandList::copyToDevice(const Array<T, AT> &arr) const {
     return ispcrtCommandListCopyToDevice(handle(), arr.handle());
 }
 
-template <typename T, AllocType AT> inline Future CommandList::copyToHost(const Array<T,AT> &arr) const {
+template <typename T, AllocType AT> inline Future CommandList::copyToHost(const Array<T, AT> &arr) const {
     return ispcrtCommandListCopyToHost(handle(), arr.handle());
 }
 
-template <typename T, AllocType AT> inline Future CommandList::copyArray(const Array<T,AT> &arrDst, const Array<T,AT> &arrSrc, const size_t size) const {
+template <typename T, AllocType AT>
+inline Future CommandList::copyArray(const Array<T, AT> &arrDst, const Array<T, AT> &arrSrc, const size_t size) const {
     return ispcrtCommandListCopyMemoryView(handle(), arrDst.handle(), arrSrc.handle(), size * sizeof(T));
 }
 
@@ -561,17 +569,18 @@ inline Future CommandList::launch(const Kernel &k, size_t dim0, size_t dim1, siz
     return ispcrtCommandListLaunch3D(handle(), k.handle(), nullptr, dim0, dim1, dim2);
 }
 
-template <typename T, AllocType AT> inline Future CommandList::launch(const Kernel &k, const Array<T,AT> &p, size_t dim0) const {
+template <typename T, AllocType AT>
+inline Future CommandList::launch(const Kernel &k, const Array<T, AT> &p, size_t dim0) const {
     return ispcrtCommandListLaunch1D(handle(), k.handle(), p.handle(), dim0);
 }
 
 template <typename T, AllocType AT>
-inline Future CommandList::launch(const Kernel &k, const Array<T,AT> &p, size_t dim0, size_t dim1) const {
+inline Future CommandList::launch(const Kernel &k, const Array<T, AT> &p, size_t dim0, size_t dim1) const {
     return ispcrtCommandListLaunch2D(handle(), k.handle(), p.handle(), dim0, dim1);
 }
 
 template <typename T, AllocType AT>
-inline Future CommandList::launch(const Kernel &k, const Array<T,AT> &p, size_t dim0, size_t dim1, size_t dim2) const {
+inline Future CommandList::launch(const Kernel &k, const Array<T, AT> &p, size_t dim0, size_t dim1, size_t dim2) const {
     return ispcrtCommandListLaunch3D(handle(), k.handle(), p.handle(), dim0, dim1, dim2);
 }
 
@@ -620,23 +629,25 @@ class TaskQueue : public GenericObject<ISPCRTTaskQueue> {
 
     void barrier() const;
 
-    template <typename T, AllocType AT> void copyToDevice(const Array<T,AT> &arr) const;
-    template <typename T, AllocType AT> void copyToHost(const Array<T,AT> &arr) const;
-    template <typename T, AllocType AT> void copyArray(const Array<T,AT> &arrDst, const Array<T,AT> &arrSrc, const size_t size) const;
+    template <typename T, AllocType AT> void copyToDevice(const Array<T, AT> &arr) const;
+    template <typename T, AllocType AT> void copyToHost(const Array<T, AT> &arr) const;
+    template <typename T, AllocType AT>
+    void copyArray(const Array<T, AT> &arrDst, const Array<T, AT> &arrSrc, const size_t size) const;
 
     Future launch(const Kernel &k, size_t dim0) const;
     Future launch(const Kernel &k, size_t dim0, size_t dim1) const;
     Future launch(const Kernel &k, size_t dim0, size_t dim1, size_t dim2) const;
 
-    template <typename T, AllocType AT> Future launch(const Kernel &k, const Array<T,AT> &p, size_t dim0) const;
-    template <typename T, AllocType AT> Future launch(const Kernel &k, const Array<T,AT> &p, size_t dim0, size_t dim1) const;
+    template <typename T, AllocType AT> Future launch(const Kernel &k, const Array<T, AT> &p, size_t dim0) const;
     template <typename T, AllocType AT>
-    Future launch(const Kernel &k, const Array<T,AT> &p, size_t dim0, size_t dim1, size_t dim2) const;
+    Future launch(const Kernel &k, const Array<T, AT> &p, size_t dim0, size_t dim1) const;
+    template <typename T, AllocType AT>
+    Future launch(const Kernel &k, const Array<T, AT> &p, size_t dim0, size_t dim1, size_t dim2) const;
 
     // wait for the command list to be executed (start the execution if needed as well)
     void sync() const;
 
-    void* nativeTaskQueueHandle() const;
+    void *nativeTaskQueueHandle() const;
 };
 
 // Inlined definitions //
@@ -646,15 +657,16 @@ inline TaskQueue::TaskQueue(const Device &device)
 
 inline void TaskQueue::barrier() const { ispcrtDeviceBarrier(handle()); }
 
-template <typename T, AllocType AT> inline void TaskQueue::copyToDevice(const Array<T,AT> &arr) const {
+template <typename T, AllocType AT> inline void TaskQueue::copyToDevice(const Array<T, AT> &arr) const {
     ispcrtCopyToDevice(handle(), arr.handle());
 }
 
-template <typename T, AllocType AT> inline void TaskQueue::copyToHost(const Array<T,AT> &arr) const {
+template <typename T, AllocType AT> inline void TaskQueue::copyToHost(const Array<T, AT> &arr) const {
     ispcrtCopyToHost(handle(), arr.handle());
 }
 
-template <typename T, AllocType AT> inline void TaskQueue::copyArray(const Array<T,AT> &arrDst, const Array<T,AT> &arrSrc, const size_t size) const {
+template <typename T, AllocType AT>
+inline void TaskQueue::copyArray(const Array<T, AT> &arrDst, const Array<T, AT> &arrSrc, const size_t size) const {
     ispcrtCopyMemoryView(handle(), arrDst.handle(), arrSrc.handle(), size * sizeof(T));
 }
 
@@ -670,22 +682,23 @@ inline Future TaskQueue::launch(const Kernel &k, size_t dim0, size_t dim1, size_
     return ispcrtLaunch3D(handle(), k.handle(), nullptr, dim0, dim1, dim2);
 }
 
-template <typename T, AllocType AT> inline Future TaskQueue::launch(const Kernel &k, const Array<T,AT> &p, size_t dim0) const {
+template <typename T, AllocType AT>
+inline Future TaskQueue::launch(const Kernel &k, const Array<T, AT> &p, size_t dim0) const {
     return ispcrtLaunch1D(handle(), k.handle(), p.handle(), dim0);
 }
 
 template <typename T, AllocType AT>
-inline Future TaskQueue::launch(const Kernel &k, const Array<T,AT> &p, size_t dim0, size_t dim1) const {
+inline Future TaskQueue::launch(const Kernel &k, const Array<T, AT> &p, size_t dim0, size_t dim1) const {
     return ispcrtLaunch2D(handle(), k.handle(), p.handle(), dim0, dim1);
 }
 
 template <typename T, AllocType AT>
-inline Future TaskQueue::launch(const Kernel &k, const Array<T,AT> &p, size_t dim0, size_t dim1, size_t dim2) const {
+inline Future TaskQueue::launch(const Kernel &k, const Array<T, AT> &p, size_t dim0, size_t dim1, size_t dim2) const {
     return ispcrtLaunch3D(handle(), k.handle(), p.handle(), dim0, dim1, dim2);
 }
 
 inline void TaskQueue::sync() const { ispcrtSync(handle()); }
 
-inline void* TaskQueue::nativeTaskQueueHandle() const { return ispcrtTaskQueueNativeHandle(handle()); }
+inline void *TaskQueue::nativeTaskQueueHandle() const { return ispcrtTaskQueueNativeHandle(handle()); }
 
 } // namespace ispcrt

--- a/ispcrt/tests/level_zero_mock/ze_mock.cpp
+++ b/ispcrt/tests/level_zero_mock/ze_mock.cpp
@@ -11,20 +11,12 @@ namespace mock {
 
 std::unordered_map<std::string, int> CallCounters::counters;
 
-void CallCounters::inc(const std::string& fun) {
-    counters[fun]++;
-}
+void CallCounters::inc(const std::string &fun) { counters[fun]++; }
 
-int  CallCounters::get(const std::string& fun) {
-    return counters[fun];
-}
-void CallCounters::resetAll() {
-    counters.clear();
-}
+int CallCounters::get(const std::string &fun) { return counters[fun]; }
+void CallCounters::resetAll() { counters.clear(); }
 
-void CallCounters::resetOne(const std::string& fun) {
-    counters[fun] = 0;
-}
+void CallCounters::resetOne(const std::string &fun) { counters[fun] = 0; }
 
 // Config
 
@@ -61,30 +53,22 @@ void Config::closeCmdList() { cmdListOpened = false; }
 
 bool Config::isCmdListClosed() { return !cmdListOpened; }
 
-bool Config::checkCmdList(const std::vector<CmdListElem>& expected) { return expected == cmdList; }
+bool Config::checkCmdList(const std::vector<CmdListElem> &expected) { return expected == cmdList; }
 
 void Config::setDeviceCount(uint32_t count) {
     devices.clear();
     devices.resize(count, DefaultGpuDevice);
 }
 
-void Config::setExpectedDevice(uint32_t deviceIdx) {
-    expectedDevice = deviceIdx;
-}
+void Config::setExpectedDevice(uint32_t deviceIdx) { expectedDevice = deviceIdx; }
 
-uint32_t Config::getExpectedDevice() {
-    return expectedDevice;
-}
+uint32_t Config::getExpectedDevice() { return expectedDevice; }
 
-uint32_t Config::getDeviceCount() {
-    return devices.size();
-}
+uint32_t Config::getDeviceCount() { return devices.size(); }
 
-DeviceProperties* Config::getDevicePtr(uint32_t deviceIdx) {
-    return &devices[deviceIdx];
-}
+DeviceProperties *Config::getDevicePtr(uint32_t deviceIdx) { return &devices[deviceIdx]; }
 
-void Config::setDeviceProperties(uint32_t deviceIdx, const DeviceProperties& dp) {
+void Config::setDeviceProperties(uint32_t deviceIdx, const DeviceProperties &dp) {
     if (deviceIdx >= devices.size())
         throw std::runtime_error("Config::setDeviceProperties: invalid device number");
     devices[deviceIdx] = dp;

--- a/ispcrt/tests/level_zero_mock/ze_mock.h
+++ b/ispcrt/tests/level_zero_mock/ze_mock.h
@@ -20,18 +20,18 @@ namespace mock {
 enum class CmdListElem { MemoryCopy, KernelLaunch, Barrier };
 
 namespace VendorId {
-  constexpr uint32_t Intel  = 0x8086;
-  constexpr uint32_t Nvidia = 0x10DE;
-  constexpr uint32_t AMD    = 0x1002;
+constexpr uint32_t Intel = 0x8086;
+constexpr uint32_t Nvidia = 0x10DE;
+constexpr uint32_t AMD = 0x1002;
 } // namespace VendorId
 
 namespace DeviceId {
-  constexpr uint32_t Gen9   = 0x9BCA;
-  constexpr uint32_t Gen12  = 0xAABB; // some fake number
+constexpr uint32_t Gen9 = 0x9BCA;
+constexpr uint32_t Gen12 = 0xAABB; // some fake number
 
-  constexpr uint32_t GenericNvidia = 0x1234;
-  constexpr uint32_t GenericAMD    = 0x5678;
-} // namespace DeviceIdIntel
+constexpr uint32_t GenericNvidia = 0x1234;
+constexpr uint32_t GenericAMD = 0x5678;
+} // namespace DeviceId
 
 struct DeviceProperties {
     uint32_t vendorId;
@@ -42,10 +42,11 @@ struct DeviceProperties {
 };
 
 struct CallCounters {
-    static void inc(const std::string& fun);
-    static int  get(const std::string& fun);
+    static void inc(const std::string &fun);
+    static int get(const std::string &fun);
     static void resetAll();
-    static void resetOne(const std::string& fun);
+    static void resetOne(const std::string &fun);
+
   private:
     static std::unordered_map<std::string, int> counters;
 };
@@ -59,13 +60,13 @@ class Config {
     static void resetCmdList();
     static void closeCmdList();
     static bool isCmdListClosed();
-    static bool checkCmdList(const std::vector<CmdListElem>& expected);
+    static bool checkCmdList(const std::vector<CmdListElem> &expected);
     static void setDeviceCount(uint32_t count);
-    static DeviceProperties* getDevicePtr(uint32_t deviceIdx);
+    static DeviceProperties *getDevicePtr(uint32_t deviceIdx);
     static uint32_t getDeviceCount();
     static void setExpectedDevice(uint32_t deviceIdx);
     static uint32_t getExpectedDevice();
-    static void setDeviceProperties(uint32_t deviceIdx, const DeviceProperties& dp);
+    static void setDeviceProperties(uint32_t deviceIdx, const DeviceProperties &dp);
 
   private:
     static std::unordered_map<std::string, ze_result_t> resultsMap;

--- a/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
+++ b/ispcrt/tests/level_zero_mock/ze_mock_driver.cpp
@@ -232,7 +232,8 @@ ze_result_t zeEventHostReset(ze_event_handle_t hEvent) {
 }
 
 static int fenceSignalTimerCounter = 0;
-ze_result_t zeFenceCreate(ze_command_queue_handle_t hCommandQueue, const ze_fence_desc_t *desc, ze_fence_handle_t *phFence) {
+ze_result_t zeFenceCreate(ze_command_queue_handle_t hCommandQueue, const ze_fence_desc_t *desc,
+                          ze_fence_handle_t *phFence) {
     MOCK_CNT_CALL;
     if (hCommandQueue != CmdQueueHandle.get() || !desc || !phFence)
         return ZE_RESULT_ERROR_INVALID_NULL_HANDLE;

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -132,8 +132,7 @@ class MockTestWithModuleQueueKernel : public MockTestWithModule {
             if (expectError && i >= errorIter) {
                 ASSERT_NE(sm_rt_error, ISPCRT_NO_ERROR);
                 return;
-            }
-            else {
+            } else {
                 ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
             }
             futures.push_back(f);
@@ -143,7 +142,7 @@ class MockTestWithModuleQueueKernel : public MockTestWithModule {
         tq.sync();
         ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
         ASSERT_TRUE(Config::checkCmdList({}));
-        for (const auto& f : futures) {
+        for (const auto &f : futures) {
             ASSERT_TRUE(f.valid());
         }
     }
@@ -217,34 +216,31 @@ TEST_F(MockTestWithContext, SharedMemAlloc1) {
 
 TEST_F(MockTestWithContext, SharedMemAlloc4) {
     ispcrt::SharedMemoryAllocator<char> sma(m_ctxt);
-    for(int i = 0; i < 4; i++)
+    for (int i = 0; i < 4; i++)
         sma.allocate(1);
     ASSERT_EQ(CallCounters::get("zeMemAllocShared"), 4);
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
 TEST_F(MockTestWithContext, SharedMemAllocHDRW) {
-    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt,
-                                            ispcrt::SharedMemoryUsageHint::HostDeviceReadWrite);
-    for(int i = 0; i < 10; i++)
+    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt, ispcrt::SharedMemoryUsageHint::HostDeviceReadWrite);
+    for (int i = 0; i < 10; i++)
         sma.allocate(1ULL << 10);
     ASSERT_EQ(CallCounters::get("zeMemAllocShared"), 10);
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
 TEST_F(MockTestWithContext, SharedMemAllocHRDW) {
-    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt,
-                                            ispcrt::SharedMemoryUsageHint::HostReadDeviceWrite);
-    for(int i = 0; i < 5; i++)
+    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt, ispcrt::SharedMemoryUsageHint::HostReadDeviceWrite);
+    for (int i = 0; i < 5; i++)
         sma.allocate(1ULL << 5);
     ASSERT_EQ(CallCounters::get("zeMemAllocShared"), 5);
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
 TEST_F(MockTestWithContext, SharedMemAllocHWDR) {
-    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt,
-                                            ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
-    for(int i = 0; i < 7; i++)
+    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt, ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
+    for (int i = 0; i < 7; i++)
         sma.allocate((1ULL << 7) - 100);
     ASSERT_EQ(CallCounters::get("zeMemAllocShared"), 7);
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
@@ -265,38 +261,33 @@ TEST_F(MockTestWithContextMemPool, SharedMemAlloc1) {
 }
 
 TEST_F(MockTestWithContextMemPool, SharedMemAllocHDRW) {
-    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt,
-                                            ispcrt::SharedMemoryUsageHint::HostDeviceReadWrite);
-    for(int i = 0; i < 10; i++)
+    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt, ispcrt::SharedMemoryUsageHint::HostDeviceReadWrite);
+    for (int i = 0; i < 10; i++)
         sma.allocate(1ULL << 10);
     ASSERT_EQ(CallCounters::get("zeMemAllocShared"), 10);
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
 TEST_F(MockTestWithContextMemPool, SharedMemAllocHRDW) {
-    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt,
-                                            ispcrt::SharedMemoryUsageHint::HostReadDeviceWrite);
-    for(int i = 0; i < 5; i++)
+    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt, ispcrt::SharedMemoryUsageHint::HostReadDeviceWrite);
+    for (int i = 0; i < 5; i++)
         sma.allocate(1ULL << 5);
     ASSERT_EQ(CallCounters::get("zeMemAllocShared"), 1);
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
 TEST_F(MockTestWithContextMemPool, SharedMemAllocHWDR) {
-    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt,
-                                            ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
-    for(int i = 0; i < 7; i++)
+    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt, ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
+    for (int i = 0; i < 7; i++)
         sma.allocate((1ULL << 7) - 100);
     ASSERT_EQ(CallCounters::get("zeMemAllocShared"), 1);
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
 TEST_F(MockTestWithContextMemPool, SharedMemAllocMemPool) {
-    ispcrt::SharedMemoryAllocator<char> sma_hrdw(m_ctxt,
-                                                 ispcrt::SharedMemoryUsageHint::HostReadDeviceWrite);
-    ispcrt::SharedMemoryAllocator<char> sma_hwdr(m_ctxt,
-                                                 ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
-    for(int i = 0; i < 5; i++) {
+    ispcrt::SharedMemoryAllocator<char> sma_hrdw(m_ctxt, ispcrt::SharedMemoryUsageHint::HostReadDeviceWrite);
+    ispcrt::SharedMemoryAllocator<char> sma_hwdr(m_ctxt, ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
+    for (int i = 0; i < 5; i++) {
         sma_hrdw.allocate(256);
         sma_hwdr.allocate(512);
     }
@@ -305,12 +296,9 @@ TEST_F(MockTestWithContextMemPool, SharedMemAllocMemPool) {
 }
 
 TEST_F(MockTestWithContextMemPool, SharedMemAllocAllDiff) {
-    ispcrt::SharedMemoryAllocator<char> sma_hdrw(m_ctxt,
-                                                 ispcrt::SharedMemoryUsageHint::HostDeviceReadWrite);
-    ispcrt::SharedMemoryAllocator<char> sma_hrdw(m_ctxt,
-                                                 ispcrt::SharedMemoryUsageHint::HostReadDeviceWrite);
-    ispcrt::SharedMemoryAllocator<char> sma_hwdr(m_ctxt,
-                                                 ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
+    ispcrt::SharedMemoryAllocator<char> sma_hdrw(m_ctxt, ispcrt::SharedMemoryUsageHint::HostDeviceReadWrite);
+    ispcrt::SharedMemoryAllocator<char> sma_hrdw(m_ctxt, ispcrt::SharedMemoryUsageHint::HostReadDeviceWrite);
+    ispcrt::SharedMemoryAllocator<char> sma_hwdr(m_ctxt, ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
     auto *p1 = sma_hdrw.allocate(128);
     auto *p2 = sma_hrdw.allocate(256);
     auto *p3 = sma_hwdr.allocate(512);
@@ -322,26 +310,23 @@ TEST_F(MockTestWithContextMemPool, SharedMemAllocAllDiff) {
 }
 
 TEST_F(MockTestWithContextMemPool, SeveralBulksUnderSameChunkSize1) {
-    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt,
-                                            ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
-    for(int i = 0; i < 3; i++)
+    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt, ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
+    for (int i = 0; i < 3; i++)
         sma.allocate(1ULL << 20);
     ASSERT_EQ(CallCounters::get("zeMemAllocShared"), 2);
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
 TEST_F(MockTestWithContextMemPool, SeveralBulksUnderSameChunkSize2) {
-    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt,
-                                            ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
-    for(int i = 0; i < 23; i++)
+    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt, ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
+    for (int i = 0; i < 23; i++)
         sma.allocate(1ULL << 19);
     ASSERT_EQ(CallCounters::get("zeMemAllocShared"), 6);
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
 TEST_F(MockTestWithContextMemPool, CheckFreeList) {
-    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt,
-                                            ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
+    ispcrt::SharedMemoryAllocator<char> sma(m_ctxt, ispcrt::SharedMemoryUsageHint::HostWriteDeviceRead);
     const size_t size = 1ULL << 20;
     auto *p1 = sma.allocate(size);
     auto *p2 = sma.allocate(size);
@@ -352,8 +337,8 @@ TEST_F(MockTestWithContextMemPool, CheckFreeList) {
     sma.deallocate(p2, size);
     auto *p4 = sma.allocate(size);
     ASSERT_EQ(p2, p4);
-    sma.deallocate(p3,size);
-    sma.deallocate(p4,size);
+    sma.deallocate(p3, size);
+    sma.deallocate(p4, size);
     auto *p5 = sma.allocate(size);
     auto *p6 = sma.allocate(size);
     ASSERT_EQ(p5, p1);
@@ -403,8 +388,7 @@ TEST_F(MockTestWithDevice, Module_DynamicLink) {
     ispcrt::Module m1(m_device, "");
     ispcrt::Module m2(m_device, "");
     Config::setRetValue("zeModuleBuildLogDestroy", ZE_RESULT_SUCCESS);
-    std::array<ISPCRTModule, 2> modules = {
-        (ISPCRTModule)m1.handle(), (ISPCRTModule)m2.handle()};
+    std::array<ISPCRTModule, 2> modules = {(ISPCRTModule)m1.handle(), (ISPCRTModule)m2.handle()};
     m_device.dynamicLinkModules(modules.data(), modules.size());
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
@@ -439,8 +423,7 @@ TEST_F(MockTestWithDevice, Module_StaticLink) {
     ispcrt::Module m1(m_device, "");
     ispcrt::Module m2(m_device, "");
     Config::setRetValue("zeModuleBuildLogDestroy", ZE_RESULT_SUCCESS);
-    std::array<ISPCRTModule, 2> modules = {
-        (ISPCRTModule)m1.handle(), (ISPCRTModule)m2.handle()};
+    std::array<ISPCRTModule, 2> modules = {(ISPCRTModule)m1.handle(), (ISPCRTModule)m2.handle()};
     ispcrt::Module m3 = m_device.staticLinkModules(modules.data(), modules.size());
     ispcrt::Kernel k(m_device, m3, "");
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
@@ -732,8 +715,7 @@ TEST_F(MockTestWithModuleQueueKernel, TaskQueue_FullKernelLaunchNoFuture) {
     ASSERT_TRUE(Config::checkCmdList({CmdListElem::MemoryCopy, CmdListElem::KernelLaunch}));
     tq.barrier();
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList(
-        {CmdListElem::MemoryCopy, CmdListElem::KernelLaunch, CmdListElem::Barrier}));
+    ASSERT_TRUE(Config::checkCmdList({CmdListElem::MemoryCopy, CmdListElem::KernelLaunch, CmdListElem::Barrier}));
     tq.sync();
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
     ASSERT_TRUE(Config::checkCmdList({}));
@@ -755,8 +737,7 @@ TEST_F(MockTestWithModuleQueueKernel, TaskQueue_FullKernelLaunch) {
     ASSERT_TRUE(Config::checkCmdList({CmdListElem::MemoryCopy, CmdListElem::KernelLaunch}));
     tq.barrier();
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
-    ASSERT_TRUE(Config::checkCmdList(
-        {CmdListElem::MemoryCopy, CmdListElem::KernelLaunch, CmdListElem::Barrier}));
+    ASSERT_TRUE(Config::checkCmdList({CmdListElem::MemoryCopy, CmdListElem::KernelLaunch, CmdListElem::Barrier}));
     tq.sync();
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
     ASSERT_TRUE(Config::checkCmdList({}));
@@ -764,9 +745,7 @@ TEST_F(MockTestWithModuleQueueKernel, TaskQueue_FullKernelLaunch) {
 }
 
 // Try to submit a lot of kernel launches
-TEST_F(MockTestWithModuleQueueKernel, TaskQueue_MultipleKernelLaunchesBasic) {
-    testMultipleKernelLaunches(1000);
-}
+TEST_F(MockTestWithModuleQueueKernel, TaskQueue_MultipleKernelLaunchesBasic) { testMultipleKernelLaunches(1000); }
 
 // Check some other sizes
 TEST_F(MockTestWithModuleQueueKernel, TaskQueue_MultipleKernelLaunchesAdvanced) {
@@ -787,7 +766,6 @@ TEST_F(MockTestWithModuleQueueKernel, TaskQueue_MultipleKernelLaunchesLimit) {
     Config::resetCmdList();
     // Double check that we still can enqueue correct amount of events;
     testMultipleKernelLaunches(LIMIT);
-
 }
 
 // Check if setting the expected maximum of kernel launches with env var works
@@ -807,7 +785,7 @@ TEST_F(MockTestWithModuleQueueKernel, TaskQueue_MultipleKernelLaunchesEnvLimitCa
 // Check that capping the value of kernel launches limit works
 // and produces expected warning
 TEST_F(MockTestWithModuleQueueKernel, TaskQueue_MultipleKernelLaunchesEnvLimit) {
-    constexpr const char* EXPECTED_WARNING =
+    constexpr const char *EXPECTED_WARNING =
         "[ISPCRT][WARNING] ISPCRT_MAX_KERNEL_LAUNCHES value too large, using 100000 instead.\n";
     // Set the limit to 200000
     setenv("ISPCRT_MAX_KERNEL_LAUNCHES", "200000", 1);
@@ -973,11 +951,8 @@ TEST_F(MockTest, C_API_DeviceInfoCPU) {
 
 TEST_F(MockTest, C_API_DeviceInfoGPU) {
     std::vector<DeviceProperties> dps = {
-        DeviceProperties(VendorId::Intel, DeviceId::Gen9),
-        DeviceProperties(VendorId::Nvidia, DeviceId::GenericNvidia),
-        DeviceProperties(VendorId::AMD, DeviceId::GenericAMD),
-        DeviceProperties(VendorId::Intel, DeviceId::Gen12)
-    };
+        DeviceProperties(VendorId::Intel, DeviceId::Gen9), DeviceProperties(VendorId::Nvidia, DeviceId::GenericNvidia),
+        DeviceProperties(VendorId::AMD, DeviceId::GenericAMD), DeviceProperties(VendorId::Intel, DeviceId::Gen12)};
     constexpr uint devices = 4;
     Config::setDeviceCount(devices);
     for (int d = 0; d < devices; d++)
@@ -990,8 +965,8 @@ TEST_F(MockTest, C_API_DeviceInfoGPU) {
     for (int d = 0; d < devCnt; d++) {
         ISPCRTDeviceInfo di;
         ispcrtGetDeviceInfo(ISPCRT_DEVICE_TYPE_GPU, d, &di);
-        ASSERT_EQ(dps[d == 0?0:3].deviceId, di.deviceId);
-        ASSERT_EQ(dps[d == 0?0:3].vendorId, di.vendorId);
+        ASSERT_EQ(dps[d == 0 ? 0 : 3].deviceId, di.deviceId);
+        ASSERT_EQ(dps[d == 0 ? 0 : 3].vendorId, di.vendorId);
     }
 }
 
@@ -1041,7 +1016,8 @@ TEST_F(MockTest, C_API_AllocateDeviceMemory) {
     mem_flags.allocType = ISPCRT_ALLOC_TYPE_DEVICE;
     mem_flags.smHint = ISPCRT_SM_HOST_WRITE_DEVICE_READ;
     ISPCRTMemoryView mem = ispcrtNewMemoryViewForContext(context, buffer.data(), buffer.size(), &mem_flags);
-    if (mem) ispcrtRelease(mem);
+    if (mem)
+        ispcrtRelease(mem);
     ispcrtRelease(context);
     ASSERT_EQ(sm_rt_error, ISPCRT_UNKNOWN_ERROR);
 }
@@ -1070,15 +1046,15 @@ TEST_F(MockTest, C_API_MemPoolGeneralTest) {
     setenv("ISPCRT_MEM_POOL", "1", 1);
     void *p = nullptr;
     ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
-    ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
-    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL<<10, &flags);
+    ISPCRTNewMemoryViewFlags flags = {ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ};
+    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL << 10, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<10);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 10);
     ispcrtRelease(view);
-    flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_READ_DEVICE_WRITE };
-    view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL<<10, &flags);
+    flags = {ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_READ_DEVICE_WRITE};
+    view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL << 10, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<10);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 10);
     ispcrtRelease(view);
     ispcrtRelease(context);
     unsetenv("ISPCRT_MEM_POOL");
@@ -1088,14 +1064,14 @@ TEST_F(MockTest, C_API_MemPoolFallBack) {
     setenv("ISPCRT_MEM_POOL", "1", 1);
     void *p = nullptr;
     ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
-    ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
-    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<21) + 1, &flags);
+    ISPCRTNewMemoryViewFlags flags = {ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ};
+    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL << 21) + 1, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), (1ULL<<21) + 1);
+    ASSERT_EQ(ispcrtSize(view), (1ULL << 21) + 1);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<10) - 12, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL << 10) - 12, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<10);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 10);
     ispcrtRelease(view);
     ispcrtRelease(context);
     unsetenv("ISPCRT_MEM_POOL");
@@ -1105,27 +1081,27 @@ TEST_F(MockTest, C_API_MemPoolRoundUpPow2) {
     setenv("ISPCRT_MEM_POOL", "1", 1);
     void *p = nullptr;
     ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
-    ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
+    ISPCRTNewMemoryViewFlags flags = {ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ};
     ISPCRTMemoryView view;
-    view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL<<21, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL << 21, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<21);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 21);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<21) - 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL << 21) - 1, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<21);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 21);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL<<7, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL << 7, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<7);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 7);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL<<20, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL << 20, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<20);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 20);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<20) + 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL << 20) + 1, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<21);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 21);
     ispcrtRelease(view);
     ispcrtRelease(context);
     unsetenv("ISPCRT_MEM_POOL");
@@ -1136,8 +1112,8 @@ TEST_F(MockTest, C_API_MemPoolLiveRange) {
     void *p = nullptr;
     ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
     ASSERT_EQ(ispcrtUseCount(context), 1);
-    ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
-    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL<<10, &flags);
+    ISPCRTNewMemoryViewFlags flags = {ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ};
+    ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, 1ULL << 10, &flags);
     ASSERT_EQ(ispcrtUseCount(context), 2);
     ASSERT_EQ(ispcrtUseCount(view), 1);
     p = ispcrtHostPtr(view);
@@ -1156,18 +1132,18 @@ TEST_F(MockTest, C_API_MemPoolChunkSizes1) {
     setenv("ISPCRT_MEM_POOL_MAX_CHUNK_POW2", "12", 1);
     void *p = nullptr;
     ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
-    ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
+    ISPCRTNewMemoryViewFlags flags = {ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ};
     ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, 1, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<10);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 10);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<12) - 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL << 12) - 1, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<12);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 12);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<12) + 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL << 12) + 1, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), (1ULL<<12) + 1);
+    ASSERT_EQ(ispcrtSize(view), (1ULL << 12) + 1);
     ispcrtRelease(view);
     ispcrtRelease(context);
     unsetenv("ISPCRT_MEM_POOL");
@@ -1181,22 +1157,22 @@ TEST_F(MockTest, C_API_MemPoolChunkSizes2) {
     setenv("ISPCRT_MEM_POOL_MAX_CHUNK_POW2", "9", 1);
     void *p = nullptr;
     ISPCRTContext context = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
-    ISPCRTNewMemoryViewFlags flags = { ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ };
+    ISPCRTNewMemoryViewFlags flags = {ISPCRT_ALLOC_TYPE_SHARED, ISPCRT_SM_HOST_WRITE_DEVICE_READ};
     ISPCRTMemoryView view = ispcrtNewMemoryViewForContext(context, nullptr, 1, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<6);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 6);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<6) - 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL << 6) - 1, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<6);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 6);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<9) - 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL << 9) - 1, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), 1ULL<<9);
+    ASSERT_EQ(ispcrtSize(view), 1ULL << 9);
     ispcrtRelease(view);
-    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL<<9) + 1, &flags);
+    view = ispcrtNewMemoryViewForContext(context, nullptr, (1ULL << 9) + 1, &flags);
     p = ispcrtHostPtr(view);
-    ASSERT_EQ(ispcrtSize(view), (1ULL<<9) + 1);
+    ASSERT_EQ(ispcrtSize(view), (1ULL << 9) + 1);
     ispcrtRelease(view);
     ispcrtRelease(context);
     unsetenv("ISPCRT_MEM_POOL");
@@ -1245,11 +1221,8 @@ TEST_F(MockTest, Device_DeviceInfoCPU) {
 
 TEST_F(MockTest, Device_DeviceInfoGPU) {
     std::vector<DeviceProperties> dps = {
-        DeviceProperties(VendorId::Intel, DeviceId::Gen9),
-        DeviceProperties(VendorId::Nvidia, DeviceId::GenericNvidia),
-        DeviceProperties(VendorId::AMD, DeviceId::GenericAMD),
-        DeviceProperties(VendorId::Intel, DeviceId::Gen12)
-    };
+        DeviceProperties(VendorId::Intel, DeviceId::Gen9), DeviceProperties(VendorId::Nvidia, DeviceId::GenericNvidia),
+        DeviceProperties(VendorId::AMD, DeviceId::GenericAMD), DeviceProperties(VendorId::Intel, DeviceId::Gen12)};
     constexpr uint devices = 4;
     Config::setDeviceCount(devices);
     for (int d = 0; d < devices; d++)
@@ -1258,18 +1231,15 @@ TEST_F(MockTest, Device_DeviceInfoGPU) {
     auto devCnt = ispcrt::Device::deviceCount(ISPCRT_DEVICE_TYPE_GPU);
     for (int d = 0; d < devCnt; d++) {
         auto di = ispcrt::Device::deviceInformation(ISPCRT_DEVICE_TYPE_GPU, d);
-        ASSERT_EQ(dps[d == 0?0:3].deviceId, di.deviceId);
-        ASSERT_EQ(dps[d == 0?0:3].vendorId, di.vendorId);
+        ASSERT_EQ(dps[d == 0 ? 0 : 3].deviceId, di.deviceId);
+        ASSERT_EQ(dps[d == 0 ? 0 : 3].vendorId, di.vendorId);
     }
 }
 
 TEST_F(MockTest, Device_DeviceInfoAllGPUs) {
     std::vector<DeviceProperties> dps = {
-        DeviceProperties(VendorId::Intel, DeviceId::Gen9),
-        DeviceProperties(VendorId::Nvidia, DeviceId::GenericNvidia),
-        DeviceProperties(VendorId::AMD, DeviceId::GenericAMD),
-        DeviceProperties(VendorId::Intel, DeviceId::Gen12)
-    };
+        DeviceProperties(VendorId::Intel, DeviceId::Gen9), DeviceProperties(VendorId::Nvidia, DeviceId::GenericNvidia),
+        DeviceProperties(VendorId::AMD, DeviceId::GenericAMD), DeviceProperties(VendorId::Intel, DeviceId::Gen12)};
     constexpr uint devices = 4;
     Config::setDeviceCount(devices);
     for (int d = 0; d < devices; d++)
@@ -1278,18 +1248,15 @@ TEST_F(MockTest, Device_DeviceInfoAllGPUs) {
     auto di = ispcrt::Device::allDevicesInformation(ISPCRT_DEVICE_TYPE_GPU);
     ASSERT_EQ(di.size(), 2);
     for (int d = 0; d < di.size(); d++) {
-        ASSERT_EQ(dps[d == 0?0:3].deviceId, di[d].deviceId);
-        ASSERT_EQ(dps[d == 0?0:3].vendorId, di[d].vendorId);
+        ASSERT_EQ(dps[d == 0 ? 0 : 3].deviceId, di[d].deviceId);
+        ASSERT_EQ(dps[d == 0 ? 0 : 3].vendorId, di[d].vendorId);
     }
 }
 
 TEST_F(MockTest, Device_SecondGPU) {
     std::vector<DeviceProperties> dps = {
-        DeviceProperties(VendorId::Intel, DeviceId::Gen9),
-        DeviceProperties(VendorId::Nvidia, DeviceId::GenericNvidia),
-        DeviceProperties(VendorId::AMD, DeviceId::GenericAMD),
-        DeviceProperties(VendorId::Intel, DeviceId::Gen12)
-    };
+        DeviceProperties(VendorId::Intel, DeviceId::Gen9), DeviceProperties(VendorId::Nvidia, DeviceId::GenericNvidia),
+        DeviceProperties(VendorId::AMD, DeviceId::GenericAMD), DeviceProperties(VendorId::Intel, DeviceId::Gen12)};
     constexpr uint devices = 4;
     Config::setDeviceCount(devices);
     for (int d = 0; d < devices; d++)
@@ -1337,11 +1304,8 @@ TEST_F(MockTest, Device_SecondGPU) {
 TEST_F(MockTest, Device_ManyGPUs) {
     // Have 4 Gen12s and run on each of them
     std::vector<DeviceProperties> dps = {
-        DeviceProperties(VendorId::Intel, DeviceId::Gen12),
-        DeviceProperties(VendorId::Intel, DeviceId::Gen12),
-        DeviceProperties(VendorId::Intel, DeviceId::Gen12),
-        DeviceProperties(VendorId::Intel, DeviceId::Gen12)
-    };
+        DeviceProperties(VendorId::Intel, DeviceId::Gen12), DeviceProperties(VendorId::Intel, DeviceId::Gen12),
+        DeviceProperties(VendorId::Intel, DeviceId::Gen12), DeviceProperties(VendorId::Intel, DeviceId::Gen12)};
     Config::setDeviceCount(dps.size());
     for (int d = 0; d < dps.size(); d++)
         Config::setDeviceProperties(d, dps[d]);
@@ -1394,11 +1358,8 @@ TEST_F(MockTest, Device_ManyGPUs) {
 TEST_F(MockTest, Device_ManyGPUs_EnvOverride) {
     // Have 4 Gen12s and run on just one of them using env variable override
     std::vector<DeviceProperties> dps = {
-        DeviceProperties(VendorId::Intel, DeviceId::Gen12),
-        DeviceProperties(VendorId::Intel, DeviceId::Gen12),
-        DeviceProperties(VendorId::Intel, DeviceId::Gen12),
-        DeviceProperties(VendorId::Intel, DeviceId::Gen12)
-    };
+        DeviceProperties(VendorId::Intel, DeviceId::Gen12), DeviceProperties(VendorId::Intel, DeviceId::Gen12),
+        DeviceProperties(VendorId::Intel, DeviceId::Gen12), DeviceProperties(VendorId::Intel, DeviceId::Gen12)};
     Config::setDeviceCount(dps.size());
     for (int d = 0; d < dps.size(); d++)
         Config::setDeviceProperties(d, dps[d]);
@@ -1453,7 +1414,9 @@ TEST_F(MockTest, Device_ManyGPUs_EnvOverride) {
 /// Compilation tests
 TEST_F(MockTest, Compilation_SharedArray) {
     auto c = Context(ISPCRT_DEVICE_TYPE_CPU);
-    struct Parameters { int i; };
+    struct Parameters {
+        int i;
+    };
     auto pmv = ispcrt::Array<Parameters, ispcrt::AllocType::Shared>(c);
     auto p = pmv.sharedPtr();
     p->i = 1234;
@@ -1519,7 +1482,7 @@ TEST_F(MockTest, C_API_ispcrtCommandListCopyLaunchSyncQueue) {
     ISPCRTModule m = ispcrtLoadModule(dev, "", opts);
     ISPCRTKernel k = ispcrtNewKernel(dev, m, "");
     ISPCRTNewMemoryViewFlags flags = {ISPCRT_ALLOC_TYPE_SHARED};
-    char mem[100] = { 0 };
+    char mem[100] = {0};
     ISPCRTMemoryView mem1 = ispcrtNewMemoryView(dev, &mem, 10, &flags);
     ISPCRTMemoryView mem2 = ispcrtNewMemoryView(dev, &mem[15], 10, &flags);
     ISPCRTMemoryView mem3 = ispcrtNewMemoryView(dev, &mem[50], 50, &flags);
@@ -1567,7 +1530,7 @@ TEST_F(MockTest, C_API_ispcrtCommandListCopyLaunchFence) {
     ISPCRTModule m = ispcrtLoadModule(dev, "", opts);
     ISPCRTKernel k = ispcrtNewKernel(dev, m, "");
     ISPCRTNewMemoryViewFlags flags = {ISPCRT_ALLOC_TYPE_SHARED};
-    char mem[100] = { 0 };
+    char mem[100] = {0};
     ISPCRTMemoryView mem1 = ispcrtNewMemoryView(dev, &mem, 10, &flags);
     ISPCRTMemoryView mem2 = ispcrtNewMemoryView(dev, &mem[15], 10, &flags);
     ISPCRTMemoryView mem3 = ispcrtNewMemoryView(dev, &mem[50], 50, &flags);

--- a/run_tests.py
+++ b/run_tests.py
@@ -258,9 +258,8 @@ def add_prefix(path, host, target):
 #
 # Examples:
 #
-# 1. Run only on arch xe32 or arch xe64:
+# 1. Run only on arch xe64:
 # // rule: skip on arch=*
-# // rule: run on arch=xe32
 # // rule: run on arch=xe64
 #
 # 2. Run only on Linux OS:
@@ -420,7 +419,7 @@ def run_test(testname, host, target):
 
                 if target.arch == 'arm':
                     gcc_arch = '--with-fpu=hardfp -marm -mfpu=neon -mfloat-abi=hard'
-                elif target.arch == 'x86' or target.arch == "wasm32" or target.arch == 'xe32':
+                elif target.arch == 'x86' or target.arch == "wasm32":
                     gcc_arch = '-m32'
                 elif target.arch == 'aarch64':
                     gcc_arch = '-march=armv8-a'
@@ -1000,7 +999,7 @@ if __name__ == "__main__":
     parser.add_option('-t', '--target', dest='target',
                   help=('Set compilation target. For example: sse4-i32x4, avx2-i32x8, avx512skx-x16, etc.'), default=default_target)
     parser.add_option('-a', '--arch', dest='arch',
-                  help='Set architecture (arm, aarch64, x86, x86-64, xe32, xe64)', default=default_arch)
+                  help='Set architecture (arm, aarch64, x86, x86-64, xe64)', default=default_arch)
     parser.add_option("-c", "--compiler", dest="compiler_exe", help="C/C++ compiler binary to use to run tests",
                   default=None)
     parser.add_option('-o', '--opt', dest='opt', choices=['', 'O0', 'O1', 'O2'], help='Set optimization level passed to the compiler (O0, O1, O2).',

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2199,7 +2199,6 @@ Opt::Opt() {
 #ifdef ISPC_XE_ENABLED
     disableXeGatherCoalescing = false;
     thresholdForXeGatherCoalescing = 0;
-    buildLLVMLoadsOnXeGatherCoalescing = false;
     enableForeachInsideVarying = false;
     emitXeHardwareMask = false;
     enableXeUnsafeMaskedLoad = false;

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -233,7 +233,7 @@ static const bool lIsTargetValidforArch(ISPCTarget target, Arch arch) {
         if (arch != Arch::arm && arch != Arch::aarch64)
             ret = false;
     } else if (ISPCTargetIsGen(target)) {
-        if (arch != Arch::xe32 && arch != Arch::xe64)
+        if (arch != Arch::xe64)
             ret = false;
     }
 
@@ -846,10 +846,8 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, MCM
         m_hasFp64Support = false;
     }
 
-    // In case of Xe target addressing should correspond to host addressing. Otherwise SVM pointers will not work.
-    if (arch == Arch::xe32) {
-        g->opt.force32BitAddressing = true;
-    } else if (arch == Arch::xe64) {
+    // In case of Xe target addressing should correspond to host addressing. Otherwise pointers will not work.
+    if (arch == Arch::xe64) {
         g->opt.force32BitAddressing = false;
     }
 #endif
@@ -1782,8 +1780,6 @@ std::string Target::GetTripleString() const {
             exit(1);
         } else if (m_arch == Arch::aarch64) {
             triple.setArchName("aarch64");
-        } else if (m_arch == Arch::xe32) {
-            triple.setArchName("spir");
         } else if (m_arch == Arch::xe64) {
             triple.setArchName("spir64");
         } else {
@@ -1791,7 +1787,7 @@ std::string Target::GetTripleString() const {
             exit(1);
         }
 #ifdef ISPC_XE_ENABLED
-        if (m_arch == Arch::xe32 || m_arch == Arch::xe64) {
+        if (m_arch == Arch::xe64) {
             //"spir64-unknown-unknown"
             triple.setVendor(llvm::Triple::VendorType::UnknownVendor);
             triple.setOS(llvm::Triple::OSType::UnknownOS);
@@ -1813,8 +1809,6 @@ std::string Target::GetTripleString() const {
             triple.setArchName("armv7");
         } else if (m_arch == Arch::aarch64) {
             triple.setArchName("aarch64");
-        } else if (m_arch == Arch::xe32) {
-            triple.setArchName("spir");
         } else if (m_arch == Arch::xe64) {
             triple.setArchName("spir64");
         } else {
@@ -1822,7 +1816,7 @@ std::string Target::GetTripleString() const {
             exit(1);
         }
 #ifdef ISPC_XE_ENABLED
-        if (m_arch == Arch::xe32 || m_arch == Arch::xe64) {
+        if (m_arch == Arch::xe64) {
             //"spir64-unknown-unknown"
             triple.setVendor(llvm::Triple::VendorType::UnknownVendor);
             triple.setOS(llvm::Triple::OSType::UnknownOS);
@@ -1831,8 +1825,7 @@ std::string Target::GetTripleString() const {
 #endif
         triple.setVendor(llvm::Triple::VendorType::UnknownVendor);
         triple.setOS(llvm::Triple::OSType::Linux);
-        if (m_arch == Arch::x86 || m_arch == Arch::x86_64 || m_arch == Arch::aarch64 || m_arch == Arch::xe32 ||
-            m_arch == Arch::xe64) {
+        if (m_arch == Arch::x86 || m_arch == Arch::x86_64 || m_arch == Arch::aarch64 || m_arch == Arch::xe64) {
             triple.setEnvironment(llvm::Triple::EnvironmentType::GNU);
         } else if (m_arch == Arch::arm) {
             triple.setEnvironment(llvm::Triple::EnvironmentType::GNUEABIHF);

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -594,10 +594,6 @@ struct Opt {
         the default value should be adjusted with some experiments. */
     int thresholdForXeGatherCoalescing;
 
-    /** Experimental: Xe gather coalescing will generate standard
-        vectorized llvm loads instead of block ld intrinsics. */
-    bool buildLLVMLoadsOnXeGatherCoalescing;
-
     /** Enables experimental support of foreach statement inside varying CF.
         Current implementation brings performance degradation due to ineffective
         implementation of unmasked.*/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -879,8 +879,6 @@ int main(int Argc, char *Argv[]) {
                 g->opt.disableXeGatherCoalescing = true;
             else if (!strncmp(opt, "threshold-for-xe-gather-coalescing=", 37))
                 g->opt.thresholdForXeGatherCoalescing = atoi(opt + 37);
-            else if (!strcmp(opt, "build-llvm-loads-on-xe-gather-coalescing"))
-                g->opt.buildLLVMLoadsOnXeGatherCoalescing = true;
             else if (!strcmp(opt, "emit-xe-hardware-mask"))
                 g->opt.emitXeHardwareMask = true;
             else if (!strcmp(opt, "enable-xe-foreach-varying"))

--- a/src/opt/XeGatherCoalescePass.cpp
+++ b/src/opt/XeGatherCoalescePass.cpp
@@ -530,16 +530,9 @@ void XeGatherCoalescing::optimizePtr(llvm::Value *Ptr, PtrData &PD, llvm::Instru
         llvm::Instruction *Addr = llvm::BinaryOperator::CreateAdd(PtrToInt, Offset, "vectorized_address", InsertPoint);
         llvm::Type *RetType = llvm::FixedVectorType::get(LargestType, ReqSize / LargestTypeSize);
         llvm::Instruction *LD = nullptr;
-        if (g->opt.buildLLVMLoadsOnXeGatherCoalescing) {
-            // Experiment: build standard llvm load instead of block ld
-            llvm::IntToPtrInst *PtrForLd =
-                new llvm::IntToPtrInst(Addr, llvm::PointerType::get(RetType, 0), "vectorized_address_ptr", InsertPoint);
-            LD = new llvm::LoadInst(RetType, PtrForLd, "vectorized_ld_exp", InsertPoint);
-        } else {
-            llvm::Function *Fn = llvm::GenXIntrinsic::getGenXDeclaration(
-                m->module, llvm::GenXIntrinsic::genx_svm_block_ld_unaligned, {RetType, Addr->getType()});
-            LD = llvm::CallInst::Create(Fn, {Addr}, "vectorized_ld", InsertPoint);
-        }
+        llvm::IntToPtrInst *PtrForLd =
+            new llvm::IntToPtrInst(Addr, llvm::PointerType::get(RetType, 0), "vectorized_address_ptr", InsertPoint);
+        LD = new llvm::LoadInst(RetType, PtrForLd, "vectorized_ld_exp", InsertPoint);
         BlockLDs.push_back(LD);
     }
 

--- a/src/target_enums.cpp
+++ b/src/target_enums.cpp
@@ -28,8 +28,6 @@ Arch ParseArch(std::string arch) {
         return Arch::aarch64;
     } else if (arch == "wasm32") {
         return Arch::wasm32;
-    } else if (arch == "xe32") {
-        return Arch::xe32;
     } else if (arch == "xe64") {
         return Arch::xe64;
     }
@@ -50,8 +48,6 @@ std::string ArchToString(Arch arch) {
         return "aarch64";
     case Arch::wasm32:
         return "wasm32";
-    case Arch::xe32:
-        return "xe32";
     case Arch::xe64:
         return "xe64";
     case Arch::error:

--- a/src/target_enums.h
+++ b/src/target_enums.h
@@ -24,7 +24,7 @@ std::string OSToString(TargetOS os);
 std::string OSToLowerString(TargetOS os);
 TargetOS GetHostOS();
 
-enum class Arch { none, x86, x86_64, arm, aarch64, wasm32, xe32, xe64, error };
+enum class Arch { none, x86, x86_64, arm, aarch64, wasm32, xe64, error };
 
 Arch ParseArch(std::string arch);
 std::string ArchToString(Arch arch);

--- a/superbuild/14_0_15_0-ld-symlink-lld.patch
+++ b/superbuild/14_0_15_0-ld-symlink-lld.patch
@@ -1,0 +1,29 @@
+From c8bc14609bc2e4a5f153ce92e4a251ba88f4821e Mon Sep 17 00:00:00 2001
+From: Aleksei Nurmukhametov <aleksei.nurmukhametov@intel.com>
+Date: Wed, 22 Mar 2023 06:13:14 -0700
+Subject: [PATCH] Create ld -> lld symlink
+
+Symlink is needed to be sure that all linking is done via lld not
+system-wide ld (literally always).
+lld allows us to use same linker options across all platforms (LTO
+included).
+---
+ lld/tools/lld/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lld/tools/lld/CMakeLists.txt b/lld/tools/lld/CMakeLists.txt
+index 12628395680b..bfaff2e1f2f7 100644
+--- a/lld/tools/lld/CMakeLists.txt
++++ b/lld/tools/lld/CMakeLists.txt
+@@ -33,7 +33,7 @@ install(TARGETS lld
+ 
+ if(NOT LLD_SYMLINKS_TO_CREATE)
+   set(LLD_SYMLINKS_TO_CREATE
+-      lld-link ld.lld ld64.lld wasm-ld)
++      lld-link ld.lld ld64.lld wasm-ld ld)
+ endif()
+ 
+ foreach(link ${LLD_SYMLINKS_TO_CREATE})
+-- 
+2.25.1
+

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -1,0 +1,1056 @@
+#
+#  Copyright (c) 2023, Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.23)
+
+project(SUPERBUILD NONE)
+
+include(ExternalProject)
+include(FetchContent)
+
+# Checks that VAR_NAME has been declared. HELP_MESSAGE is just information.
+# There are two ways of declaring options. In command line with -DVAR_NAME=value,
+# or in CMakePresets.json creating new preset or changing a existing one.
+# Note: command line -D values should override values from CMakePresets.json.
+function(check_cache_var_declaration VAR_NAME HELP_MESSAGE)
+    if (NOT ${VAR_NAME})
+        message(FATAL_ERROR
+            "${VAR_NAME} is not defined. You have to set that with -D${VAR_NAME} or use --preset option.")
+    endif()
+endfunction()
+
+check_cache_var_declaration(LLVM_VERSION "LLVM version to build with")
+check_cache_var_declaration(LLVM_URL "LLVM url")
+check_cache_var_declaration(VC_INTRINSICS_URL "vc-intrinsics url")
+check_cache_var_declaration(VC_INTRINSICS_SHA "vc-intrinsics hash commit to checkout")
+check_cache_var_declaration(SPIRV_TRANSLATOR_URL "SPIRV-LLVM-Translator url")
+check_cache_var_declaration(SPIRV_TRANSLATOR_SHA "SPIRV-LLVM-Translator hash commit to checkout")
+check_cache_var_declaration(L0_URL "Level Zero url")
+check_cache_var_declaration(L0_TAG "Level Zero url")
+check_cache_var_declaration(ISPC_CORPUS_URL "ispc-corpus url")
+
+set(GNUWIN32 "c:/gnuwin32" CACHE STRING "Set path to gnuwin32 root dir (Windows only)")
+set(CCACHE_VERSION "4.7.4" CACHE STRING "ccache version ")
+set(CCACHE_DIR "default" CACHE STRING "ccache cache directory")
+set(PREBUILT_STAGE2 "NO" CACHE STRING "Provide pre-built stage2 archive to skip pre ispc-stage2 jobs")
+set(PREBUILT_STAGE2_PATH "NO" CACHE STRING "Provide pre-built stage2 toolchain path")
+set(STAGE2_TOOLCHAIN_INSTALL_PREFIX "NO" CACHE STRING "Path to install stage2 Clang/LLVM to")
+option(LLVM_DISABLE_ASSERTIONS "Enable LLVM build without assertions" ON)
+option(EXTERNAL_VERBOSE "Enable verbose for external project build and install commands" OFF)
+option(CCACHE "Enable ccache to speed up repetitive builds" OFF)
+option(FULL_STAGE2_LLVM "Enable full llvm stage2 build" OFF)
+option(LTO "Enable LTO" OFF)
+option(PGO "Enale PGO (implicitly enable LTO)" OFF)
+option(BUILD_STAGE2_TOOLCHAIN_ONLY "Enable build of stage2 toolchain only, i.e., skip ispc building and stage3." OFF)
+option(BUILD_SPIRV_TRANSLATOR_ONLY "Enable only build of SPIRV-LLVM-Translator" OFF)
+option(BUILD_VC_INTRINSICS_ONLY "Enable only build of vc-intrinsics" OFF)
+option(BUILD_L0_LOADER_ONLY "Enable only build of level-zero loader" OFF)
+option(XE_DEPS "Enable build of XE dependencies (L0 loader, vc-intrinsics, SPIRV-LLVM-Translator" ON)
+
+# Force LTO when PGO enabled to the sake of simplicity and less number of
+# possible build variants.
+if (PGO)
+    set(LTO ON)
+endif()
+
+if (NOT PREBUILT_STAGE2 STREQUAL "NO" OR NOT PREBUILT_STAGE2_PATH STREQUAL "NO")
+    set(SKIP_STAGE2_DEPS ON)
+endif()
+
+if (NOT PREBUILT_STAGE2 STREQUAL "NO" AND NOT PREBUILT_STAGE2_PATH STREQUAL "NO")
+    message(FATAL_ERROR "Provide only one source of stage2 toolchain.")
+endif()
+
+set(STAGE2_PATH "${CMAKE_BINARY_DIR}/stage2")
+if (NOT PREBUILT_STAGE2_PATH STREQUAL "NO")
+    set(STAGE2_PATH "${PREBUILT_STAGE2_PATH}")
+endif()
+
+string(APPEND LIT_TOOLS_DIR ${GNUWIN32} "/bin")
+
+unset(LLVM_TAG)
+unset(LLVM_VERSION_DOTTED)
+string(REPLACE "." "_" LLVM_VERSION "${LLVM_VERSION}")
+if     (${LLVM_VERSION} STREQUAL 16_0)
+    set(LLVM_TAG    llvmorg-16.0.1)
+    set(LLVM_VERSION_DOTTED 16.0.1)
+elseif (${LLVM_VERSION} STREQUAL 15_0)
+    set(LLVM_TAG    llvmorg-15.0.7)
+    set(LLVM_VERSION_DOTTED 15.0.7)
+elseif (${LLVM_VERSION} STREQUAL 14_0)
+    set(LLVM_TAG    llvmorg-14.0.6)
+    set(LLVM_VERSION_DOTTED 14.0.6)
+elseif (${LLVM_VERSION} STREQUAL 13_0)
+    set(LLVM_TAG    llvmorg-13.0.1)
+    set(LLVM_VERSION_DOTTED 13.0.1)
+elseif (${LLVM_VERSION} STREQUAL 12_0)
+    set(LLVM_TAG    llvmorg-12.0.1)
+    set(LLVM_VERSION_DOTTED 12.0.1)
+elseif (${LLVM_VERSION} STREQUAL 11_1)
+    set(LLVM_TAG    llvmorg-11.1.0)
+    set(LLVM_VERSION_DOTTED 11.1.0)
+elseif (${LLVM_VERSION} STREQUAL 11_0)
+    set(LLVM_TAG    llvmorg-11.0.1)
+    set(LLVM_VERSION_DOTTED 11.0.1)
+elseif (${LLVM_VERSION} STREQUAL 10_0)
+    set(LLVM_TAG    llvmorg-10.0.1)
+    set(LLVM_VERSION_DOTTED 10.0.1)
+elseif (${LLVM_VERSION} STREQUAL 9_0)
+    set(LLVM_TAG    llvmorg-9.0.1)
+    set(LLVM_VERSION_DOTTED 9.0.1)
+elseif (${LLVM_VERSION} STREQUAL 8_0)
+    set(LLVM_TAG    llvmorg-8.0.1)
+    set(LLVM_VERSION_DOTTED 8.0.1)
+elseif (${LLVM_VERSION} STREQUAL 7_1)
+    set(LLVM_TAG    llvmorg-7.1.0)
+    set(LLVM_VERSION_DOTTED 7.1.0)
+elseif (${LLVM_VERSION} STREQUAL 7_0)
+    set(LLVM_TAG    llvmorg-7.0.1)
+    set(LLVM_VERSION_DOTTED 7.0.1)
+elseif (${LLVM_VERSION} STREQUAL 6_0)
+    set(LLVM_TAG    llvmorg-6.0.1)
+    set(LLVM_VERSION_DOTTED 6.0.1)
+elseif (${LLVM_VERSION} STREQUAL trunk)
+    set(LLVM_TAG main)
+    set(LLVM_VERSION_DOTTED main)
+else()
+    message(FATAL_ERROR "Incorrect LLVM version")
+endif()
+
+set(EXTERNAL_VERBOSE_FLAG "")
+if (EXTERNAL_VERBOSE)
+    set(EXTERNAL_VERBOSE_FLAG "-v")
+endif()
+
+message(STATUS "LLVM_VERSION is ${LLVM_VERSION}")
+message(STATUS "LLVM_URL is ${LLVM_URL}")
+message(STATUS "VC_INTRINSICS_URL is ${VC_INTRINSICS_URL}")
+message(STATUS "VC_INTRINSICS_SHA is ${VC_INTRINSICS_SHA}")
+message(STATUS "SPIRV_TRANSLATOR_URL is ${SPIRV_TRANSLATOR_URL}")
+message(STATUS "SPIRV_TRANSLATOR_SHA is ${SPIRV_TRANSLATOR_SHA}")
+message(STATUS "L0_URL is ${L0_URL}")
+message(STATUS "L0_TAG is ${L0_TAG}")
+message(STATUS "GNUWIN32 is ${GNUWIN32}")
+message(STATUS "LIT_TOOLS_DIR is ${LIT_TOOLS_DIR}")
+message(STATUS "ISPC_CORPUS_URL is ${ISPC_CORPUS_URL}")
+message(STATUS "CCACHE_VERSION is ${CCACHE_VERSION}")
+message(STATUS "CCACHE_DIR is ${CCACHE_DIR}")
+message(STATUS "CCACHE is ${CCACHE}")
+message(STATUS "PREBUILT_STAGE2 is ${PREBUILT_STAGE2}")
+message(STATUS "PREBUILT_STAGE2_PATH is ${PREBUILT_STAGE2_PATH}")
+message(STATUS "EXTERNAL_VERBOSE is ${EXTERNAL_VERBOSE}")
+message(STATUS "FULL_STAGE2_LLVM is ${FULL_STAGE2_LLVM}")
+message(STATUS "STAGE2_TOOLCHAIN_INSTALL_PREFIX is ${STAGE2_TOOLCHAIN_INSTALL_PREFIX}")
+message(STATUS "LLVM_DISABLE_ASSERTIONS is ${LLVM_DISABLE_ASSERTIONS}")
+message(STATUS "LTO is ${LTO}")
+message(STATUS "PGO is ${PGO}")
+message(STATUS "BUILD_STAGE2_TOOLCHAIN_ONLY is ${BUILD_STAGE2_TOOLCHAIN_ONLY}")
+message(STATUS "BUILD_SPIRV_TRANSLATOR_ONLY is ${BUILD_SPIRV_TRANSLATOR_ONLY}")
+message(STATUS "BUILD_VC_INTRINSICS_ONLY is ${BUILD_VC_INTRINSICS_ONLY}")
+message(STATUS "BUILD_L0_LOADER_ONLY is ${BUILD_L0_LOADER_ONLY}")
+message(STATUS "XE_DEPS is ${XE_DEPS}")
+message(STATUS "LLVM_TAG is ${LLVM_TAG}")
+message(STATUS "LLVM_VERSION_DOTTED is ${LLVM_VERSION_DOTTED}")
+message(STATUS "SKIP_STAGE2_DEPS is ${SKIP_STAGE2_DEPS}")
+message(STATUS "STAGE2_BIN is ${STAGE2_BIN}")
+message(STATUS "CMAKE_INSTALL_PREFIX is ${CMAKE_INSTALL_PREFIX}")
+
+
+# Ninja is hard-coded for two reasons:
+# 1. It looks like that only ninja is able out-of-box properly utilize all CPUs.
+# 2. Some LLVM stage2 install targets are ninja specific, e.g., genx, spirv, openmp.
+find_program(NINJA_EXE NAMES ninja)
+if (NOT NINJA_EXE)
+    message(FATAL_ERROR "ninja not found.")
+endif()
+
+
+# Get list of patches needed to apply for the requested LLVM version
+cmake_path(SET LLVM_PATCHES_DIR NORMALIZE ${PROJECT_SOURCE_DIR}/../llvm_patches)
+file(GLOB_RECURSE LLVM_PATCHES_ALL ${LLVM_PATCHES_DIR}/*.patch)
+foreach(patch IN LISTS LLVM_PATCHES_ALL)
+    if (${patch} MATCHES ".*${LLVM_VERSION}.*")
+        list(APPEND LLVM_PATCHES_VER ${patch})
+    endif()
+endforeach()
+file(GLOB_RECURSE SUPERBUILD_LLVM_PATCHES_ALL ${PROJECT_SOURCE_DIR}/*.patch)
+foreach(patch IN LISTS SUPERBUILD_LLVM_PATCHES_ALL)
+    if (${patch} MATCHES ".*${LLVM_VERSION}.*")
+        list(APPEND LLVM_PATCHES_VER ${patch})
+    endif()
+endforeach()
+message(STATUS "For llvm version ${LLVM_VERSION} found patches ${LLVM_PATCHES_VER}")
+
+
+# Set up ccache use to speed up build process.
+# We always include CCACHE_EXE and CCACHE_LAUNCHER_ACTION into *-toolchain.cmake files.
+# To disable CCACHE we define default values.
+set(CCACHE_LAUNCHER_ACTION unset)
+
+# Comment out cache_dir from ccache.conf when CCACHE_DIR not overridden by user.
+set(CCACHE_COMMENT_CACHE_DIR "")
+if (${CCACHE_DIR} STREQUAL default)
+    set(CCACHE_COMMENT_CACHE_DIR "# ")
+endif()
+
+# Default is to check if compiler if up-to-date by size and mtime.
+set(CCACHE_DEFAULT_CONF ${CMAKE_BINARY_DIR}/ccache.conf)
+# Stage1 clang is needed to check better to hit cache.
+set(CCACHE_CLANG_V_CONF ${CMAKE_BINARY_DIR}/ccache-clang.conf)
+
+if (CCACHE)
+    # Not default values with set and actual ccache binary full path.
+    set(CCACHE_LAUNCHER_ACTION set)
+    # cmake_path(CONVERT "${CMAKE_BINARY_DIR}" TO_NATIVE_PATH_LIST CCACHE_BASE_DIR_NATIVE)
+
+    # Configuration file.
+    # Same cache-dir for any job on machine to share cache between different compilations.
+    # Sloppiness to avoid some time/locale specific setting. Probably not important much.
+    # base_dir needed to share cache between compilation in different directories.
+    file(CONFIGURE OUTPUT ccache.conf CONTENT [[
+${CCACHE_COMMENT_CACHE_DIR}cache_dir = ${CCACHE_DIR}
+sloppiness = locale,time_macros
+compiler_check = content
+base_dir = ${CMAKE_BINARY_DIR}
+hash_dir = false
+]])
+
+    # compiler_check -v output is needed to enable caching on freshly built
+    # compiler, i.e., during stage2, otherwise it would be skipped due to mtime
+    # is newer than in the cached command.
+    # Clang has been patched to not contain in -v absolute paths of directories
+    # which would result in caches misses when build directory changed.
+    file(CONFIGURE OUTPUT ccache-clang.conf CONTENT [[
+${CCACHE_COMMENT_CACHE_DIR}cache_dir = ${CCACHE_DIR}
+sloppiness = locale,time_macros
+# compiler_check = %compiler% -v
+base_dir = ${CMAKE_BINARY_DIR}
+hash_dir = false
+]])
+
+    if (WIN32)
+        string(APPEND CCACHE_URL
+            https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}-windows-x86_64.zip)
+    else()
+        string(APPEND CCACHE_URL
+            https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}-linux-x86_64.tar.xz)
+    endif()
+
+    find_program(CCACHE_EXE NAMES ccache)
+    if (NOT CCACHE_EXE)
+        if (APPLE)
+            message(FATAL_ERROR "No ccache found.")
+        endif()
+        # Download and unpack ccache executable when no ccache in system.
+        FetchContent_Populate(ccache
+            URL ${CCACHE_URL}
+            SOURCE_DIR ccache
+            )
+
+        set(CCACHE_EXE "${CMAKE_BINARY_DIR}/ccache/ccache${CMAKE_EXECUTABLE_SUFFIX}")
+    endif()
+    message(STATUS "CCACHE_EXE is ${CCACHE_EXE}")
+endif()
+
+
+if (APPLE)
+    message(STATUS "APPLE CMAKE_SYSTEM_VERSION is ${CMAKE_SYSTEM_VERSION}")
+    # Starting from MacOS 10.9 Maverics which is Darwin 13.0, C and C++ library
+    # headers are part of the SDK, not the OS itself. System root must be
+    # specified during the compiler build, so the compiler knows the default
+    # location to search for headers. C headers are located at system root
+    # location, while C++ headers are part of the toolchain. I.e. specifying
+    # system root solved C header problem. For C++ headers we enable libc++
+    # build as part of clang build (our own toolchain).
+    # Note that on Sierra there's an issue with using C headers from High
+    # Sierra SDK, which instantiates as compile error:
+    #     error: 'utimensat' is only available on macOS 10.13 or newer
+    # This is due to using SDK targeting OS, which is newer than current one.
+    if (CMAKE_SYSTEM_VERSION VERSION_GREATER_EQUAL 13)
+        if (NOT MAC_SYSTEM_ROOT)
+            find_program(XCRUN_EXE NAMES xcrun)
+            if (NOT XCRUN_EXE)
+                message(FATAL_ERROR "xcrun is not found")
+            endif()
+            execute_process(COMMAND ${XCRUN_EXE} --show-sdk-path
+                OUTPUT_VARIABLE MAC_SYSTEM_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+        endif()
+        message(STATUS "MAC_SYSTEM_ROOT (macOS SDK path) is ${MAC_SYSTEM_ROOT}")
+    endif()
+endif()
+
+
+# common LLVM cmake configuration flags.
+list(APPEND LLVM_COMMON_CMAKE_ARGS
+    -DCMAKE_BUILD_TYPE=Release
+    -DLLVM_ENABLE_DUMP=OFF
+    -DLLVM_INSTALL_UTILS=ON
+    -DLLVM_ENABLE_ZLIB=OFF
+    -DLLVM_ENABLE_ZSTD=OFF
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    )
+
+# Disable unneded parts of clang.
+list(APPEND LLVM_COMMON_CMAKE_ARGS
+    -DCLANG_ENABLE_ARCMT=OFF
+    -DCLANG_ENABLE_STATIC_ANALYZER=OFF
+    -DCLANG_INCLUDE_TESTS=OFF
+    )
+
+# Disable extra component in compiler_rt, we only need profile_rt and sanitizers.
+list(APPEND LLVM_COMMON_CMAKE_ARGS
+    -DCOMPILER_RT_BUILD_PROFILE=ON
+    -DCOMPILER_RT_BUILD_SANITIZERS=ON
+    -DCOMPILER_RT_BUILD_BUILTINS=OFF
+    -DCOMPILER_RT_BUILD_CRT=OFF
+    -DCOMPILER_RT_CRT_USE_EH_FRAME_REGISTRY=OFF
+    -DCOMPILER_RT_BUILD_XRAY=OFF
+    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF
+    -DCOMPILER_RT_BUILD_MEMPROF=OFF
+    -DCOMPILER_RT_BUILD_ORC=OFF
+    -DCOMPILER_RT_BUILD_GWP_ASAN=OFF
+    )
+
+# Enable or disable assertions.
+if (LLVM_DISABLE_ASSERTIONS)
+    list(APPEND LLVM_COMMON_CMAKE_ARGS
+        -DLLVM_ENABLE_ASSERTIONS=OFF
+        )
+else()
+    list(APPEND LLVM_COMMON_CMAKE_ARGS
+        -DLLVM_ENABLE_ASSERTIONS=ON
+        )
+endif()
+
+# Targets to build.
+# It is possible to build for stage1 only X86 if we build only on x86 platforms.
+list(APPEND LLVM_COMMON_CMAKE_ARGS
+    -DLLVM_TARGETS_TO_BUILD=X86$<SEMICOLON>AArch64$<SEMICOLON>ARM
+    -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly
+    )
+
+# Enable LLVM subprojects.
+set(LLVM_PROJECTS clang$<SEMICOLON>lld$<SEMICOLON>compiler-rt)
+if (NOT WIN32)
+    set(LLVM_PROJECTS ${LLVM_PROJECTS}$<SEMICOLON>openmp)
+endif()
+list(APPEND LLVM_COMMON_CMAKE_ARGS
+    -DLLVM_ENABLE_PROJECTS=${LLVM_PROJECTS}
+    )
+
+# Install symlinks, nm -> llvm-nm is required for building ISPC.
+# Unfortunately, this options doesn't force ld -> lld symlink creation, so
+# patch for LLVM tree resolves that (13_0_14_0_15_0-ld-symlink-lld.patch).
+list(APPEND LLVM_COMMON_CMAKE_ARGS
+    -DLLVM_INSTALL_BINUTILS_SYMLINKS=ON
+    )
+
+if (WIN32)
+    list(APPEND LLVM_COMMON_CMAKE_ARGS
+        -DLLVM_LIT_TOOLS_DIR=${LIT_TOOLS_DIR}
+        )
+endif()
+
+if (APPLE AND CMAKE_SYSTEM_VERSION VERSION_GREATER_EQUAL 13)
+    list(APPEND LLVM_COMMON_CMAKE_ARGS
+        -DDEFAULT_SYSROOT=${MAC_SYSTEM_ROOT}
+        )
+    # Starting with MacOS 10.9 Maverics, the system doesn't contain headers for
+    # standard C++ library and the default library is libc++, bit libstdc++. The
+    # headers are part of XCode now. But we are checking out headers as part of
+    # LLVM source tree, so they will be installed in clang location and clang
+    # will be able to find them. Though they may not match to the library
+    # installed in the system, but seems that this should not happen.  Note, that
+    # we can also build a libc++ library, but it must be on system default
+    # location or should be passed to the linker explicitly (either through
+    # command line or environment variables). So we are not doing it currently to
+    # make the build process easier.
+
+    # We either need to explicitly opt-out from using libcxxabi from this repo,
+    # or build and use it, otherwise a build error will occure (attempt to use
+    # just built libcxxabi, which was not built).  An option to build seems to be
+    # a better one.
+    list(APPEND LLVM_COMMON_CMAKE_ARGS
+        -DLLVM_ENABLE_RUNTIMES=libcxx$<SEMICOLON>libcxxabi
+        )
+endif()
+
+# stage1 specific LLVM cmake arguments.
+list(APPEND LLVM_STAGE1_CMAKE_ARGS
+    ${LLVM_COMMON_CMAKE_ARGS}
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_BINARY_DIR}/stage1-toolchain.cmake
+    )
+message(STATUS "LLVM stage1 cmake arguments ${LLVM_STAGE1_CMAKE_ARGS}")
+
+
+# LLVM stage2 install targets.
+if (FULL_STAGE2_LLVM)
+    list(APPEND LLVM_STAGE2_INSTALL_TARGETS install)
+else()
+    list(APPEND LLVM_STAGE2_INSTALL_TARGETS
+        install-clang-headers
+        install-clangFrontend
+        install-clangBasic
+        install-clangEdit
+        install-clangLex
+        )
+    list(APPEND LLVM_STAGE2_INSTALL_TARGETS
+        install-llvm-headers
+        install-llvm-libraries
+        install-llvm-config
+        )
+
+    if (XE_DEPS)
+        list(APPEND LLVM_STAGE2_INSTALL_TARGETS
+            tools/vc-intrinsics/install
+            tools/SPIRV-LLVM-Translator/install
+            )
+    endif()
+
+    if (NOT WIN32)
+        list(APPEND LLVM_STAGE2_INSTALL_TARGETS
+            projects/openmp/runtime/install
+            )
+    endif()
+endif()
+message(STATUS "LLVM stage2 install targets ${LLVM_STAGE2_INSTALL_TARGETS}")
+
+# stage2 cmake arguments common for both LTO and not LTO build.
+# Build stage2 clang/LLVM libraries with XE deps as external LLVM projects
+list(APPEND LLVM_STAGE2_COMMON_CMAKE_ARGS
+    ${LLVM_COMMON_CMAKE_ARGS}
+    )
+
+if (XE_DEPS)
+    List(APPEND LLVM_STAGE2_COMMON_CMAKE_ARGS
+        -DLLVM_EXTERNAL_PROJECTS=vc-intrinsics$<SEMICOLON>SPIRV-LLVM-Translator
+        -DLLVM_EXTERNAL_VC_INTRINSICS_SOURCE_DIR=${CMAKE_BINARY_DIR}/vc-intrinsics
+        -DLLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR=${CMAKE_BINARY_DIR}/spirv-translator
+        )
+endif()
+
+if (LTO)
+    list(APPEND LLVM_STAGE2_CMAKE_ARGS
+        ${LLVM_STAGE2_COMMON_CMAKE_ARGS}
+        -DLLVM_ENABLE_LTO=Thin
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_BINARY_DIR}/stage2-lto-toolchain.cmake
+        )
+else()
+    list(APPEND LLVM_STAGE2_CMAKE_ARGS
+        ${LLVM_STAGE2_COMMON_CMAKE_ARGS}
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_BINARY_DIR}/stage2-toolchain.cmake
+        )
+endif()
+message(STATUS "LLVM stage2 cmake arguments ${LLVM_STAGE2_CMAKE_ARGS}")
+
+
+# ISPC cmake arguments.
+list(APPEND ISPC_COMMON_CMAKE_ARGS
+    -DCMAKE_BUILD_TYPE=Release
+    -DISPC_CROSS=ON
+    -DXE_ENABLED=ON
+    -DISPC_PREPARE_PACKAGE=ON
+    )
+if (WIN32)
+    # XPU examples are not buildable on windows, issue: TODO!
+    list(APPEND ISPC_COMMON_CMAKE_ARGS
+        -DISPC_GNUWIN32_PATH=${GNUWIN32}
+        -DISPC_INCLUDE_EXAMPLES=OFF
+        -DISPC_INCLUDE_XE_EXAMPLES=OFF
+        )
+endif()
+
+list(APPEND ISPC_STAGE2_CMAKE_ARGS
+    ${ISPC_COMMON_CMAKE_ARGS}
+    -DXE_DEPS_DIR=${STAGE2_PATH}
+    -DLEVEL_ZERO_ROOT=${STAGE2_PATH}
+    )
+if (WIN32)
+    list(APPEND ISPC_STAGE2_CMAKE_ARGS
+        -DLLVM_DIR=${STAGE2_PATH}/lib/cmake/llvm
+        )
+endif()
+
+# LTO specific compiler flags are specified in corresponding toolchain file.
+if (LTO)
+    list(APPEND ISPC_STAGE2_CMAKE_ARGS
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_BINARY_DIR}/stage2-lto-toolchain.cmake
+        )
+else()
+    list(APPEND ISPC_STAGE2_CMAKE_ARGS
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_BINARY_DIR}/stage2-toolchain.cmake
+        )
+endif()
+message(STATUS ISPC_STAGE2_CMAKE_ARGS "ISPC stage2 cmake arguments ${ISPC_STAGE2_CMAKE_ARGS}")
+
+
+# LLVM stage3 specific cmake arguments, here we imply that PGO always works with LTO.
+# PGO specific compiler flags is inside toolchain file.
+if (PGO)
+    list(APPEND LLVM_STAGE3_CMAKE_ARGS
+        ${LLVM_STAGE2_COMMON_CMAKE_ARGS}
+        -DLLVM_ENABLE_LTO=Thin
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_BINARY_DIR}/stage3-pgo-toolchain.cmake
+        )
+    message(STATUS "LLVM stage3 cmake arguments ${LLVM_STAGE3_CMAKE_ARGS}")
+
+    list(APPEND ISPC_STAGE3_CMAKE_ARGS
+        ${ISPC_COMMON_CMAKE_ARGS}
+        -DXE_DEPS_DIR=${CMAKE_BINARY_DIR}/stage3
+        -DLEVEL_ZERO_ROOT=${CMAKE_BINARY_DIR}/stage3
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_BINARY_DIR}/stage3-pgo-toolchain.cmake
+        )
+    if (WIN32)
+        list(APPEND ISPC_STAGE3_CMAKE_ARGS
+            -DLLVM_DIR=${CMAKE_BINARY_DIR}/stage3/lib/cmake/llvm
+            )
+    endif()
+    message(STATUS "ISPC stage3 cmake arguments ${ISPC_STAGE3_CMAKE_ARGS}")
+endif()
+
+
+set(PGO_FLAGS "")
+if (PGO)
+    set(PGO_FLAGS -fprofile-instr-generate)
+endif()
+
+set(CODE_PROFDATA ${CMAKE_BINARY_DIR}/code.profdata)
+# MSVC has an outdated clang_rt.profile lib in its SDK.
+# We need to enforce explicitly our freshly built library to avoid profile mismatch errors.
+set(CLANG_RT_PROFLIB ${STAGE2_PATH}/lib/clang/${LLVM_VERSION_DOTTED}/lib/windows/clang_rt.profile-x86_64.lib)
+
+# Generate value for ENV{PATH} with the corresponding stage toolchain.
+# _ESC_SEM is needed because of list expansion in ExternalProject_Add.
+function(gen_env_path OUT_VAR OUT_VAR_ESC_SEM STAGE_PATH)
+    list(APPEND ENV_PATH
+        ${STAGE_PATH}
+        "$ENV{PATH}"
+        )
+    cmake_path(CONVERT "${ENV_PATH}" TO_NATIVE_PATH_LIST ENV_PATH)
+    string(REPLACE "\\" "\\\\" ENV_PATH "${ENV_PATH}")
+    string(REPLACE ";" "$<SEMICOLON>" ENV_PATH_ESC_SEM "${ENV_PATH}")
+    set(${OUT_VAR} ${ENV_PATH} PARENT_SCOPE)
+    set(${OUT_VAR_ESC_SEM} ${ENV_PATH_ESC_SEM} PARENT_SCOPE)
+endfunction()
+
+gen_env_path(ENV_PATH_STAGE2 ENV_PATH_STAGE2_ESC_SEM "${STAGE2_PATH}/bin")
+gen_env_path(ENV_PATH_STAGE3 ENV_PATH_STAGE3_ESC_SEM "${CMAKE_BINARY_DIR}/stage3/bin")
+message(STATUS "ENV_PATH_STAGE2 is ${ENV_PATH_STAGE2}")
+message(STATUS "ENV_PATH_STAGE3 is ${ENV_PATH_STAGE3}")
+
+
+# Generate toolchain files regardless current platform and configuration
+# because it is easier to check them.
+# The stage1 compiler are built with system toolchain.
+file(CONFIGURE OUTPUT stage1-toolchain.cmake CONTENT [[
+${CCACHE_LAUNCHER_ACTION}(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_EXE})
+${CCACHE_LAUNCHER_ACTION}(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_EXE})
+if (WIN32)
+    set(CMAKE_C_COMPILER   cl)
+    set(CMAKE_CXX_COMPILER cl)
+    set(CMAKE_ASM_COMPILER ml64)
+else()
+    set(CMAKE_C_COMPILER   cc)
+    set(CMAKE_CXX_COMPILER c++)
+endif()
+]])
+
+# Base toolchain file for building ISPC and LLVM dependencies.
+file(CONFIGURE OUTPUT stage2-toolchain.cmake CONTENT [[
+@CCACHE_LAUNCHER_ACTION@(CMAKE_C_COMPILER_LAUNCHER   @CCACHE_EXE@)
+@CCACHE_LAUNCHER_ACTION@(CMAKE_CXX_COMPILER_LAUNCHER @CCACHE_EXE@)
+set(ENV{PATH} "@ENV_PATH_STAGE2@")
+set(WIN_C_FLAGS     "-fuse-ld=lld-link /EHa")
+if (WIN32)
+    set(CMAKE_C_COMPILER   clang-cl)
+    set(CMAKE_CXX_COMPILER clang-cl)
+    set(CMAKE_LINKER       lld-link)
+    set(CMAKE_AR           llvm-lib)
+    set(CMAKE_RC_COMPILER  llvm-rc)
+    set(CMAKE_MT           mt)
+    set(CMAKE_C_FLAGS      "${WIN_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS    "${WIN_C_FLAGS}")
+else()
+    set(CMAKE_C_COMPILER   clang)
+    set(CMAKE_CXX_COMPILER clang++)
+    set(CMAKE_LINKER       lld)
+endif()
+]] @ONLY)
+
+# Toolchain file for LTO build or PGO stage instrumenting LLVM libraries.
+file(CONFIGURE OUTPUT stage2-lto-toolchain.cmake CONTENT [[
+@CCACHE_LAUNCHER_ACTION@(CMAKE_C_COMPILER_LAUNCHER   @CCACHE_EXE@)
+@CCACHE_LAUNCHER_ACTION@(CMAKE_CXX_COMPILER_LAUNCHER @CCACHE_EXE@)
+set(ENV{PATH} "@ENV_PATH_STAGE2@")
+set(COMMON_FLAGS    "-flto=thin @PGO_FLAGS@")
+set(COMMON_C_FLAGS  "")
+# Note: -O3 --lto-O3 --icf=...  that these flags lld specific
+set(COMMON_LD_FLAGS "-Wl,-O3 -Wl,--lto-O3 -Wl,--icf=all")
+set(WIN_C_FLAGS     "-fuse-ld=lld-link /EHa")
+set(WIN_LD_FLAGS    "@CLANG_RT_PROFLIB@")
+if (WIN32)
+    set(CMAKE_C_COMPILER   clang-cl)
+    set(CMAKE_CXX_COMPILER clang-cl)
+    set(CMAKE_LINKER       lld-link)
+    set(CMAKE_AR           llvm-lib)
+    set(CMAKE_RC_COMPILER  llvm-rc)
+    set(CMAKE_MT           mt)
+    set(CMAKE_C_FLAGS             "${COMMON_FLAGS} ${COMMON_C_FLAGS} ${WIN_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS           "${COMMON_FLAGS} ${COMMON_C_FLAGS} ${WIN_C_FLAGS}")
+    set(CMAKE_MODULE_LINKER_FLAGS "${COMMON_FLAGS} ${COMMON_LD_FLAGS} ${WIN_LD_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${COMMON_FLAGS} ${COMMON_LD_FLAGS} ${WIN_LD_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS    "${COMMON_FLAGS} ${COMMON_LD_FLAGS} ${WIN_LD_FLAGS}")
+else()
+    set(CMAKE_C_COMPILER   clang)
+    set(CMAKE_CXX_COMPILER clang++)
+    set(CMAKE_LINKER       lld)
+    set(CMAKE_C_FLAGS             "${COMMON_FLAGS} ${COMMON_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS           "${COMMON_FLAGS} ${COMMON_C_FLAGS}")
+    set(CMAKE_MODULE_LINKER_FLAGS "${COMMON_FLAGS} ${COMMON_LD_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${COMMON_FLAGS} ${COMMON_LD_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS    "${COMMON_FLAGS} ${COMMON_LD_FLAGS}")
+endif()
+]] @ONLY)
+
+# Special toolchain file for building level-zero.
+# Primarily needed because if warning suppression for windows.
+# https://github.com/oneapi-src/level-zero/issues/83
+file(CONFIGURE OUTPUT stage2-l0-toolchain.cmake CONTENT [[
+@CCACHE_LAUNCHER_ACTION@(CMAKE_C_COMPILER_LAUNCHER   @CCACHE_EXE@)
+@CCACHE_LAUNCHER_ACTION@(CMAKE_CXX_COMPILER_LAUNCHER @CCACHE_EXE@)
+set(ENV{PATH} "@ENV_PATH_STAGE2@")
+set(WIN_C_FLAGS "-Wno-error=unused-command-line-argument -Wno-error=unused-but-set-variable")
+if (WIN32)
+    set(CMAKE_C_COMPILER   clang-cl)
+    set(CMAKE_CXX_COMPILER clang-cl)
+    set(CMAKE_LINKER       lld-link)
+    set(CMAKE_AR           llvm-lib)
+    set(CMAKE_RC_COMPILER  llvm-rc)
+    set(CMAKE_MT           mt)
+    set(CMAKE_C_FLAGS      "${WIN_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS    "${WIN_C_FLAGS}")
+else()
+    set(CMAKE_C_COMPILER   clang)
+    set(CMAKE_CXX_COMPILER clang++)
+    set(CMAKE_LINKER       lld)
+endif()
+]] @ONLY)
+
+# Stage3 to optimize with the collected profile.
+file(CONFIGURE OUTPUT stage3-pgo-toolchain.cmake CONTENT [[
+set(ENV{PATH} "@ENV_PATH_STAGE3@")
+set(COMMON_FLAGS    "-flto=thin -fprofile-instr-use=@CODE_PROFDATA@")
+set(COMMON_C_FLAGS  "")
+# Note: -O3 --lto-O3 --icf=...  that these flags lld specific
+set(COMMON_LD_FLAGS "-Wl,-O3 -Wl,--lto-O3 -Wl,--icf=all")
+set(WIN_C_FLAGS     "-fuse-ld=lld-link /EHa")
+set(WIN_LD_FLAGS    "")
+if (WIN32)
+    set(CMAKE_C_COMPILER   clang-cl)
+    set(CMAKE_CXX_COMPILER clang-cl)
+    set(CMAKE_LINKER       lld-link)
+    set(CMAKE_AR           llvm-lib)
+    set(CMAKE_RC_COMPILER  llvm-rc)
+    set(CMAKE_MT           mt)
+    set(CMAKE_C_FLAGS             "${COMMON_FLAGS} ${COMMON_C_FLAGS} ${WIN_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS           "${COMMON_FLAGS} ${COMMON_C_FLAGS} ${WIN_C_FLAGS}")
+    set(CMAKE_MODULE_LINKER_FLAGS "${COMMON_FLAGS} ${COMMON_LD_FLAGS} ${WIN_LD_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${COMMON_FLAGS} ${COMMON_LD_FLAGS} ${WIN_LD_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS    "${COMMON_FLAGS} ${COMMON_LD_FLAGS} ${WIN_LD_FLAGS}")
+else()
+    set(CMAKE_C_COMPILER   clang)
+    set(CMAKE_CXX_COMPILER clang++)
+    set(CMAKE_LINKER       lld)
+    set(CMAKE_C_FLAGS             "${COMMON_FLAGS} ${COMMON_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS           "${COMMON_FLAGS} ${COMMON_C_FLAGS}")
+    set(CMAKE_MODULE_LINKER_FLAGS "${COMMON_FLAGS} ${COMMON_LD_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${COMMON_FLAGS} ${COMMON_LD_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS    "${COMMON_FLAGS} ${COMMON_LD_FLAGS}")
+endif()
+]] @ONLY)
+
+
+# Fetch source code of dependencies. They fetched during cmake configuration run.
+# Patch command applies LLVM version specific patches.
+if (PGO OR NOT SKIP_STAGE2_DEPS)
+    FetchContent_Populate(llvm-source
+        GIT_REPOSITORY ${LLVM_URL}
+        GIT_TAG ${LLVM_TAG}
+        GIT_SHALLOW ON
+        GIT_PROGRESS ON
+        UPDATE_COMMAND git checkout .
+        PATCH_COMMAND git apply ${LLVM_PATCHES_VER}
+        SOURCE_DIR llvm-source
+        )
+
+    if (XE_DEPS)
+        # Checkout level-zero needed for XE
+        FetchContent_Populate(l0-source
+            GIT_REPOSITORY ${L0_URL}
+            GIT_TAG ${L0_TAG}
+            GIT_SHALLOW ON
+            GIT_PROGRESS ON
+            SOURCE_DIR l0-source
+            )
+
+        # Checkout LLVM-SPIRV-Translator needed for XE
+        FetchContent_Populate(spirv-translator
+            GIT_REPOSITORY ${SPIRV_TRANSLATOR_URL}
+            GIT_TAG ${SPIRV_TRANSLATOR_SHA}
+            GIT_SHALLOW OFF
+            GIT_PROGRESS ON
+            SOURCE_DIR spirv-translator
+            )
+
+        # Checkout vc-intrinsics needed for XE
+        FetchContent_Populate(vc-intrinsics
+            GIT_REPOSITORY ${VC_INTRINSICS_URL}
+            GIT_TAG ${VC_INTRINSICS_SHA}
+            GIT_SHALLOW OFF
+            GIT_PROGRESS ON
+            SOURCE_DIR vc-intrinsics
+            UPDATE_COMMAND git checkout .
+            PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/vc_intrinsics.patch
+            )
+    endif()
+
+    if (NOT BUILD_STAGE2_TOOLCHAIN_ONLY)
+        # May be profiles from examples or less set of programs just enough?
+        FetchContent_Populate(ispc-corpus
+            GIT_REPOSITORY ${ISPC_CORPUS_URL}
+            GIT_TAG main
+            GIT_SHALLOW ON
+            GIT_PROGRESS ON
+            UPDATE_COMMAND git clean -f -d
+            SOURCE_DIR ispc-corpus
+            )
+    endif()
+endif()
+
+if (SKIP_STAGE2_DEPS AND BUILD_SPIRV_TRANSLATOR_ONLY)
+    # Checkout LLVM-SPIRV-Translator needed for XE
+    FetchContent_Populate(spirv-translator
+        GIT_REPOSITORY ${SPIRV_TRANSLATOR_URL}
+        GIT_TAG ${SPIRV_TRANSLATOR_SHA}
+        GIT_SHALLOW OFF
+        GIT_PROGRESS ON
+        SOURCE_DIR spirv-translator
+        )
+endif()
+
+if (SKIP_STAGE2_DEPS AND BUILD_VC_INTRINSICS_ONLY)
+    # Checkout vc-intrinsics needed for XE
+    FetchContent_Populate(vc-intrinsics
+        GIT_REPOSITORY ${VC_INTRINSICS_URL}
+        GIT_TAG ${VC_INTRINSICS_SHA}
+        GIT_SHALLOW OFF
+        GIT_PROGRESS ON
+        SOURCE_DIR vc-intrinsics
+        UPDATE_COMMAND git checkout .
+        PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/vc_intrinsics.patch
+        )
+endif()
+
+if (SKIP_STAGE2_DEPS AND BUILD_L0_LOADER_ONLY)
+    # Checkout level-zero needed for XE
+    FetchContent_Populate(l0-source
+        GIT_REPOSITORY ${L0_URL}
+        GIT_TAG ${L0_TAG}
+        GIT_SHALLOW ON
+        GIT_PROGRESS ON
+        SOURCE_DIR l0-source
+        )
+endif()
+
+
+# Run build and install commands in required environment.
+# It is needed to find ccache.conf files and to properly locate all needed tools during build.
+list(APPEND NINJA_COMMAND_WITH_ENV_STAGE1
+    ${CMAKE_COMMAND}
+    -E
+    env
+    "CCACHE_CONFIGPATH=${CCACHE_DEFAULT_CONF}"
+    ${NINJA_EXE}
+    ${EXTERNAL_VERBOSE_FLAG}
+    )
+list(APPEND NINJA_COMMAND_WITH_ENV_STAGE2
+    ${CMAKE_COMMAND}
+    -E
+    env
+    "CCACHE_CONFIGPATH=${CCACHE_CLANG_V_CONF}"
+    "PATH=${ENV_PATH_STAGE2_ESC_SEM}"
+    ${NINJA_EXE}
+    ${EXTERNAL_VERBOSE_FLAG}
+    )
+list(APPEND NINJA_COMMAND_WITH_ENV_STAGE3
+    ${CMAKE_COMMAND}
+    -E
+    env
+    "CCACHE_CONFIGPATH=${CCACHE_CLANG_V_CONF}"
+    "PATH=${ENV_PATH_STAGE3_ESC_SEM}"
+    ${NINJA_EXE}
+    ${EXTERNAL_VERBOSE_FLAG}
+    )
+
+if (BUILD_SPIRV_TRANSLATOR_ONLY)
+    message(STATUS "BUILD SPIRV-LLVM-Translator only")
+    ExternalProject_Add(spirv-translator
+        DOWNLOAD_COMMAND ""
+        UPDATE_COMMAND ""
+        SOURCE_DIR spirv-translator
+        PREFIX bspirv
+        STAMP_DIR bspirv/s
+        BINARY_DIR bspirv/b
+        TMP_DIR bspirv/t
+        INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+        CMAKE_GENERATOR Ninja
+        CMAKE_ARGS
+            -DLLVM_DIR=${PREBUILT_STAGE2_PATH}/lib/cmake/llvm
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_BINARY_DIR}/stage2-toolchain.cmake
+            -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+        BUILD_IN_SOURCE OFF
+        BUILD_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE2}
+        INSTALL_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE2} install
+        )
+    return()
+endif()
+
+if (BUILD_VC_INTRINSICS_ONLY)
+    message(STATUS "BUILD vc-intrinsics only")
+    ExternalProject_Add(vc-intrinsics
+        DOWNLOAD_COMMAND ""
+        UPDATE_COMMAND ""
+        SOURCE_DIR vc-intrinsics
+        PREFIX bvcint
+        STAMP_DIR bvcint/s
+        BINARY_DIR bvcint/b
+        TMP_DIR bvcint/t
+        INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+        CMAKE_GENERATOR Ninja
+        CMAKE_ARGS
+            -DLLVM_DIR=${PREBUILT_STAGE2_PATH}/lib/cmake/llvm
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_BINARY_DIR}/stage2-toolchain.cmake
+            -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+        BUILD_IN_SOURCE OFF
+        BUILD_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE2}
+        INSTALL_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE2} install
+        )
+    return()
+endif()
+
+if (BUILD_L0_LOADER_ONLY)
+    # Level-zero
+    ExternalProject_Add(l0
+        DOWNLOAD_COMMAND ""
+        SOURCE_DIR l0-source
+        BUILD_IN_SOURCE OFF
+        PREFIX bl0
+        STAMP_DIR bl0/s
+        BINARY_DIR bl0/b
+        TMP_DIR bl0/t
+        INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+        CMAKE_GENERATOR Ninja
+        CMAKE_ARGS
+            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_BINARY_DIR}/stage2-l0-toolchain.cmake
+            -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+            -DCMAKE_BUILD_TYPE=Release
+        BUILD_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE2}
+        INSTALL_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE2} install
+        )
+    return()
+endif()
+
+
+# Stage1 job to build bootstrap compiler for building required Clang/LLVM libraries and ISPC itself.
+if (PGO OR NOT SKIP_STAGE2_DEPS)
+    ExternalProject_Add(stage1
+        DOWNLOAD_COMMAND ""
+        UPDATE_COMMAND ""
+        SOURCE_DIR llvm-source
+        SOURCE_SUBDIR llvm
+        PREFIX bstage1
+        STAMP_DIR bstage1/s
+        BINARY_DIR bstage1/b
+        TMP_DIR bstage1/t
+        INSTALL_DIR stage2
+        CMAKE_GENERATOR Ninja
+        CMAKE_ARGS ${LLVM_STAGE1_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/stage2
+        BUILD_IN_SOURCE OFF
+        BUILD_COMMAND ""
+        BUILD_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE1}
+        INSTALL_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE1} install
+        )
+    # Note: We may rebuild instead stage2 clang/lld with stage1 toolchain to
+    # generate more performant stage2 compiler.
+
+
+    list(APPEND L0_DEPS)
+    if (XE_DEPS)
+        # Level-zero
+        ExternalProject_Add(l0
+            DEPENDS stage1
+            DOWNLOAD_COMMAND ""
+            CMAKE_GENERATOR Ninja
+            CMAKE_ARGS
+                -DCMAKE_TOOLCHAIN_FILE=${CMAKE_BINARY_DIR}/stage2-l0-toolchain.cmake
+                -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/stage2
+                -DCMAKE_BUILD_TYPE=Release
+            SOURCE_DIR l0-source
+            BUILD_IN_SOURCE OFF
+            PREFIX bl0
+            STAMP_DIR bl0/s
+            BINARY_DIR bl0/b
+            TMP_DIR bl0/t
+            INSTALL_DIR stage2
+            BUILD_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE2}
+            INSTALL_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE2} install
+            )
+        list(APPEND L0_DEPS l0)
+    endif()
+
+    if (PGO)
+        # Copy stage1 compiler to stage3 install dir.
+        add_custom_command(OUTPUT stage3-copied.stamp
+            DEPENDS stage1 ${L0_DEPS}
+            COMMENT "Copy stage2 to stage3"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory stage2 stage3
+            COMMAND ${CMAKE_COMMAND} -E touch stage3-copied.stamp
+            )
+        add_custom_target(pre-stage3
+            DEPENDS stage3-copied.stamp
+            )
+    endif()
+
+    # Build Clang/LLVM static libraries required for ISPC.
+    # It is rather important to build only them as much as possible, because under
+    # LTO/PGO linking extra stuff may take long time.
+    # On that step, we build external LLVM projects together with LLVM.
+    # When LTO, this stage has barely only -flto extra flag comparing with base build.
+    # When PGO, this step produces instrumented Clang/LLVM static libraries.
+    ExternalProject_Add(stage2
+        DEPENDS stage1 ${L0_DEPS}
+        DOWNLOAD_COMMAND ""
+        UPDATE_COMMAND ""
+        SOURCE_DIR llvm-source
+        SOURCE_SUBDIR llvm
+        PREFIX bstage2
+        STAMP_DIR bstage2/s
+        BINARY_DIR bstage2/b
+        TMP_DIR bstage2/t
+        INSTALL_DIR stage2
+        CMAKE_GENERATOR Ninja
+        CMAKE_ARGS ${LLVM_STAGE2_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/stage2
+        BUILD_IN_SOURCE OFF
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE2} ${LLVM_STAGE2_INSTALL_TARGETS}
+        )
+
+
+    # Custom target to install stage2 toolchain with libraries in the user-provided directory.
+    if (NOT STAGE2_TOOLCHAIN_INSTALL_PREFIX STREQUAL "NO")
+        add_custom_target(install-stage2-toolchain
+            COMMENT "Install stage2 to ${STAGE2_TOOLCHAIN_INSTALL_PREFIX}"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory stage2 ${STAGE2_TOOLCHAIN_INSTALL_PREFIX}
+            )
+    endif()
+
+    # Custom target to package stage2 tooclhain to use after skipping its repetitive build.
+    add_custom_target(package-stage2
+        DEPENDS stage2
+        COMMENT "Packaging stage2 archive to llvm-stage2-${LLVM_VERSION_DOTTED}.tgz"
+        COMMAND ${CMAKE_COMMAND} -E tar cfvz "llvm-stage2-${LLVM_VERSION_DOTTED}.tgz" stage2
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+endif()
+
+list(APPEND ISPC_STAGE2_DEPS)
+if (SKIP_STAGE2_DEPS)
+    if (NOT PREBUILT_STAGE2 STREQUAL "NO")
+        # Extract pre-built stage2, path should be provided in PREBUILT_STAGE2.
+        ExternalProject_Add(stage2
+            URL ${PREBUILT_STAGE2}
+            DOWNLOAD_EXTRACT_TIMESTAMP OFF
+            UPDATE_COMMAND ""
+            SOURCE_DIR stage2
+            CONFIGURE_COMMAND ""
+            BUILD_COMMAND ""
+            INSTALL_COMMAND ""
+            )
+        list(APPEND ISPC_STAGE2_DEPS stage2)
+    endif()
+else()
+    list(APPEND ISPC_STAGE2_DEPS ${L0_DEPS} stage2)
+endif()
+
+if (NOT BUILD_STAGE2_TOOLCHAIN_ONLY)
+    # Build ispc first time with stage2 compiler/libraries.
+    # For LTO only build, this ispc is final artifact.
+    ExternalProject_Add(ispc-stage2
+        DEPENDS ${ISPC_STAGE2_DEPS}
+        DOWNLOAD_COMMAND ""
+        UPDATE_COMMAND ""
+        PREFIX build-ispc-stage2
+        SOURCE_DIR ${PROJECT_SOURCE_DIR}/..
+        INSTALL_DIR ispc-stage2
+        BUILD_IN_SOURCE OFF
+        CMAKE_GENERATOR Ninja
+        CMAKE_ARGS ${ISPC_STAGE2_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/ispc-stage2
+        BUILD_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE2}
+        INSTALL_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE2} install package
+        )
+
+    # The following steps applicable only for PGO type build.
+    if (PGO)
+        find_package(Python3 COMPONENTS Interpreter)
+
+        # Collect and merge profiles.
+        add_custom_command(OUTPUT ${CODE_PROFDATA}
+            DEPENDS ispc-stage2 stage2 ispc-corpus/profile.py
+            COMMAND ${Python3_EXECUTABLE}
+                ispc-corpus/profile.py
+                    --ispc ${CMAKE_BINARY_DIR}/ispc-stage2/bin/ispc${CMAKE_EXECUTABLE_SUFFIX}
+                    --llvm-profdata ${STAGE2_PATH}/bin/llvm-profdata${CMAKE_EXECUTABLE_SUFFIX}
+                    --output ${CODE_PROFDATA}
+            COMMENT "Collecting profile on ispc-corpus"
+            )
+        add_custom_target(generate-profdata
+            DEPENDS ${CODE_PROFDATA}
+            )
+
+        # Build LLVM with PGO optimizations.
+        ExternalProject_Add(stage3
+            DEPENDS pre-stage3 ${L0_DEPS} generate-profdata
+            DOWNLOAD_COMMAND ""
+            UPDATE_COMMAND ""
+            PREFIX build-llvm-stage3
+            SOURCE_DIR llvm-source
+            SOURCE_SUBDIR llvm
+            INSTALL_DIR stage3
+            CMAKE_GENERATOR Ninja
+            CMAKE_ARGS ${LLVM_STAGE3_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/stage3
+            BUILD_IN_SOURCE OFF
+            BUILD_COMMAND ""
+            INSTALL_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE3} ${LLVM_STAGE2_INSTALL_TARGETS}
+            )
+
+        # Finally, build ISPC with PGO based on the collected profile.
+        # For PGO build, this ispc is final artifact.
+        ExternalProject_Add(ispc-stage3
+            DEPENDS stage3
+            DOWNLOAD_COMMAND ""
+            UPDATE_COMMAND ""
+            PREFIX build-ispc-stage3
+            SOURCE_DIR ${PROJECT_SOURCE_DIR}/..
+            INSTALL_DIR ispc-stage3
+            BUILD_IN_SOURCE OFF
+            CMAKE_GENERATOR Ninja
+            CMAKE_ARGS ${ISPC_STAGE3_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/ispc-stage3
+            BUILD_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE3}
+            INSTALL_COMMAND ${NINJA_COMMAND_WITH_ENV_STAGE3} install package
+            )
+    endif()
+endif()

--- a/superbuild/CMakePresets.json
+++ b/superbuild/CMakePresets.json
@@ -1,0 +1,24 @@
+{
+  "vendor": {
+    "ispc.github.io" : {
+      "license_comment1": "Copyright (c) 2023, Intel Corporation",
+      "license_comment2": "SPDX-License-Identifier: BSD-3-Clause"
+    }
+  },
+  "version": 4,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 23
+  },
+  "include": [
+    "intPresets.json",
+    "osPresets.json",
+    "os-intPresets.json"
+  ],
+  "configurePresets": [
+    {
+      "name": "os",
+      "inherits": "dependency-versions-os"
+    }
+  ]
+}

--- a/superbuild/README.md
+++ b/superbuild/README.md
@@ -1,0 +1,67 @@
+# Superbuild
+
+It may be used to build ISPC with dependencies (LLVM, L0, vc-intrinsics,
+SPIRV-Translator), as well as it can produce an archive with dependencies or
+consume a pre-built archive to build ISPC only. It also allows to generate LTO
+or LTO+PGO enabled build of LLVM and ISPC.
+
+# Use Cases
+
+Typical use cases:
+
+```bash
+# Basic configuration.
+$ cmake ${ISPC}/superbuild --preset os
+$ cmake --build .
+# Produce an archive with dependencies.
+$ cmake --build . --target package-stage2
+# On Windows, one may want to use nmake generators
+$ cmake ${ISPC}/superbuild --preset os -G "NMake Makefiles"
+
+# Enable LTO.
+$ cmake ${ISPC}/superbuild --preset os -DLTO=ON
+# Enable LTO and PGO.
+$ cmake ${ISPC}/superbuild --preset os -DPGO=ON
+# Provide LLVM version and source url or directory (same for other dependencies).
+$ cmake ${ISPC}/superbuild --preset os -DLLVM_VERSION=15.0 -DLLVM_URL=/home/llvm-project
+$ cmake ${ISPC}/superbuild --preset os -DLLVM_VERSION=13_0
+# Enable cache using.
+$ cmake ${ISPC}/superbuild --preset os -DCCACHE=ON
+# Enable cache using where cache located in not default directory.
+$ cmake ${ISPC}/superbuild --preset os -DCCACHE=ON -DCCACHE_DIR=/tmp/shared-ispc-ccache
+# Consume pre-built dependencies as archive.
+$ cmake ${ISPC}/superbuild --preset os -DPREBUILT_STAGE2=/path/to/stage2-archive.tgz
+
+# Build and install only stage2 toolchain
+$ cmake ${ISPC}/superbuild --preset os -DSTAGE2_TOOLCHAIN_INSTALL_PREFIX=/tmp/stage2-path -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON
+$ cmake --build .
+$ cmake --buidl . --target install-stage2-toolchain
+# Consume pre-build dependencies as path with installed stage2 toolchain and libs.
+$ cmake ${ISPC}/superbuild --preset os -DPREBUILT_STAGE2_PATH=/tmp/stage2-path
+```
+
+# Building Process.
+
+The building process consists of several stages.
+Base and LTO build consists of two stages. The only difference between them
+is that we pass -flto flags to compiler and linker on the second stage. The
+first stage creates a minimal compiler toolchain (clang, lld, llvm-dis,
+llvm-as) to build LLVM/ISPC.  On the second stage, stage1 compiler builds clang
+and LLVM libraries needed for building ISPC. They are combined together with
+stage1 clang to become stage2 toolchain, i.e., stage1 and stage2 clangs are
+literally same. We may build the stage2 clang by the stage1 clang, but it takes
+time especially with LTO/PGO enabled, whereas time profit from better
+performant compiler for building ISPC/stage3 is not comparable with LTO/PGO
+overhead in the case when system compiler is not ancient. Stage2 compiler is
+used to build ISPC.
+
+PGO build has one more stage (3 stages overall). On the first stage, we
+additionally build a compiler runtime library needed for profiling and
+llvm-profdata tool utilized to merging profiles. During stage2, we generate
+instrumented stage2 LLVM libraries and ISPC. That ISPC binary generates
+profile files upon every execution. Profile collection happens on source
+files from `ispc-corpus`. `ispc-corpus` is the collection of ISPC preprocessed
+real world source codes complemented with scripts to build them. It allows us
+to collect profile meaningful from the customer point of view. On the last
+third stage, stage1 compiler uses that profile to optimize LLVM and ISPC code
+with PGO.

--- a/superbuild/osPresets.json
+++ b/superbuild/osPresets.json
@@ -1,0 +1,30 @@
+{
+  "vendor": {
+    "ispc.github.io" : {
+      "license_comment1": "Copyright (c) 2023, Intel Corporation",
+      "license_comment2": "SPDX-License-Identifier: BSD-3-Clause"
+    }
+  },
+  "version": 4,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 23
+  },
+  "configurePresets": [
+    {
+      "name": "dependency-versions-os",
+      "cacheVariables": {
+        "LLVM_VERSION": "15.0",
+        "LLVM_URL": "https://github.com/llvm/llvm-project.git",
+        "VC_INTRINSICS_URL": "https://github.com/intel/vc-intrinsics.git",
+        "VC_INTRINSICS_SHA": "fe92a377338258b725cfbd0a1bd49a9cf5e2864c",
+        "SPIRV_TRANSLATOR_URL": "https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",
+        "SPIRV_TRANSLATOR_BRANCH": "llvm_release_150",
+        "SPIRV_TRANSLATOR_SHA": "e82ecc2bd7295604fcf1824e47c95fa6a09c6e63",
+        "L0_URL": "https://github.com/oneapi-src/level-zero.git",
+        "L0_TAG": "v1.11.0",
+        "ISPC_CORPUS_URL": "null"
+      }
+    }
+  ]
+}

--- a/superbuild/vc_intrinsics.patch
+++ b/superbuild/vc_intrinsics.patch
@@ -1,0 +1,31 @@
+From eb055d19a932940616568a3abfa1375e90d61efa Mon Sep 17 00:00:00 2001
+From: Aleksei Nurmukhametov <aleksei.nurmukhametov@intel.com>
+Date: Sat, 4 Mar 2023 05:24:18 -0800
+Subject: [PATCH] Enable install headers target for external project LLVM build
+
+It is needed to actually install all required to ISPC headers by target
+tools/vc-intrinsics/install.
+
+It is kind of bug of vc-intrinsics cmake because no headers actually
+installed when building as external project with LLVM
+(-DLLVM_EXTERNAL_PROJECT...), i.e., files llvm/GenXIntrinsics/GenXI*.h
+are misisng.
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a04f4b1..e20f883 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -48,6 +48,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+   message(STATUS "Found LLVM: ${LLVM_VERSION}")
+ else(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+   set(BUILD_EXTERNAL NO)
++  set(INSTALL_REQUIRED YES)
+ 
+   # LLVM_CMAKE_DIR is not set for non-standalone builds. Use LLVM_CMAKE_PATH
+   # instead. (see clang/CMakeLists.txt)
+-- 
+2.25.1
+

--- a/tests/FNeg-uniform.ispc
+++ b/tests/FNeg-uniform.ispc
@@ -1,6 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on cpu=tgllp
-// rule: skip on cpu=dg2
 uniform float Neg(uniform float inVal) {
     return -inVal;
 }
@@ -31,42 +29,8 @@ void test_uni(uniform float RET[]) {
 
 }
 
-float Neg(float inVal) {
-    return -inVal;
-}
-
-
-void test_vary(uniform float RET[]) {
-    double val;
-    unsigned int signBit;
-    double retval;
-    RET[programIndex] = 0;
-
-    val = 0.0;
-    signBit = signbits(val);
-    if (signBit != 0)
-        RET[programIndex] = 1;
-    retval = Neg(val);
-    signBit = signbits(retval);
-    if (signBit == 0)
-        RET[programIndex] = 1;
-
-    val = -0.0;
-    signBit = signbits(val);
-    if (signBit == 0)
-        RET[programIndex] = 1;
-    retval = Neg(val);
-    signBit = signbits(retval);
-    if (signBit != 0)
-        RET[programIndex] = 1;
-
-}
-
 task void f_v(uniform float RET[]) {
-
-    test_vary(RET);
     test_uni(RET);
-
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/FNeg-varying.ispc
+++ b/tests/FNeg-varying.ispc
@@ -1,0 +1,37 @@
+#include "../test_static.isph"
+
+float Neg(float inVal) {
+    return -inVal;
+}
+
+void test_vary(uniform float RET[]) {
+    float val;
+    unsigned int signBit;
+    float retval;
+    RET[programIndex] = 0;
+
+    val = 0.0;
+    signBit = signbits(val);
+    if (signBit != 0)
+        RET[programIndex] = 1;
+    retval = Neg(val);
+    signBit = signbits(retval);
+    if (signBit == 0)
+        RET[programIndex] = 1;
+
+    val = -0.0;
+    signBit = signbits(val);
+    if (signBit == 0)
+        RET[programIndex] = 1;
+    retval = Neg(val);
+    signBit = signbits(retval);
+    if (signBit != 0)
+        RET[programIndex] = 1;
+
+}
+
+task void f_v(uniform float RET[]) {
+    test_vary(RET);
+}
+
+task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/FNeg.ispc
+++ b/tests/FNeg.ispc
@@ -1,4 +1,6 @@
 #include "../test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
 uniform float Neg(uniform float inVal) {
     return -inVal;
 }

--- a/tests/align1.ispc
+++ b/tests/align1.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 struct InnerUniform {
     uniform int i;

--- a/tests/align2.ispc
+++ b/tests/align2.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 struct InnerVec {
     int i;

--- a/tests/aossoa-12.ispc
+++ b/tests/aossoa-12.ispc
@@ -1,4 +1,6 @@
 #include "../test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
 task void f_v(uniform float RET[]) {
 #define width 4
 //CO    const uniform int width = 4;

--- a/tests/aossoa-16.ispc
+++ b/tests/aossoa-16.ispc
@@ -1,4 +1,6 @@
 #include "../test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
 task void f_v(uniform float RET[]) {
 #define width 3
 //CO    const uniform int width = 4;

--- a/tests/coalesce-1.ispc
+++ b/tests/coalesce-1.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/coalesce-2.ispc
+++ b/tests/coalesce-2.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/coalesce-3.ispc
+++ b/tests/coalesce-3.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/coalesce-4.ispc
+++ b/tests/coalesce-4.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/coalesce-5.ispc
+++ b/tests/coalesce-5.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/coalesce-6.ispc
+++ b/tests/coalesce-6.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/coalesce-7.ispc
+++ b/tests/coalesce-7.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/coalesce-8.ispc
+++ b/tests/coalesce-8.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/foreach-double-1.ispc
+++ b/tests/foreach-double-1.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 uniform double one = 1;

--- a/tests/frexp-double-1.ispc
+++ b/tests/frexp-double-1.ispc
@@ -1,4 +1,6 @@
 #include "../test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
 task void f_f(uniform float RET[], uniform float aFOO[]) {
     double a = (1ul<< (programIndex % 28)) * 1.5;
     if (programIndex & 1)

--- a/tests/frexp-double.ispc
+++ b/tests/frexp-double.ispc
@@ -1,4 +1,6 @@
 #include "../test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
 task void f_f(uniform float RET[], uniform float aFOO[]) {
     double a = (1ul << (programIndex%28)) * 1.5;
     if (programIndex & 1)

--- a/tests/launch-1.ispc
+++ b/tests/launch-1.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 static uniform float array[10000];

--- a/tests/launch-10.ispc
+++ b/tests/launch-10.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 typedef task void (*TaskFn)(float i);
 

--- a/tests/launch-11.ispc
+++ b/tests/launch-11.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 typedef task void (*TaskFn)(uniform int i, float i);

--- a/tests/launch-2.ispc
+++ b/tests/launch-2.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 static uniform float array[10000];

--- a/tests/launch-3.ispc
+++ b/tests/launch-3.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 static float array[6];

--- a/tests/launch-4.ispc
+++ b/tests/launch-4.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 static float array[6];

--- a/tests/launch-5.ispc
+++ b/tests/launch-5.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 static uniform float array[10000];

--- a/tests/launch-6.ispc
+++ b/tests/launch-6.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 static uniform float array[10];

--- a/tests/launch-7.ispc
+++ b/tests/launch-7.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 static uniform float array[10];

--- a/tests/launch-8.ispc
+++ b/tests/launch-8.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 #define N0 12

--- a/tests/launch-9.ispc
+++ b/tests/launch-9.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 #define N0 12

--- a/tests/ldexp-double.ispc
+++ b/tests/ldexp-double.ispc
@@ -1,4 +1,6 @@
 #include "../test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
 task void f_f(uniform float RET[], uniform float aFOO[]) {
     double a = 1ul << (programIndex % 28);
     if (programIndex & 1)

--- a/tests/lit-tests/fp16_support.ispc
+++ b/tests/lit-tests/fp16_support.ispc
@@ -1,6 +1,5 @@
 // This test checks that ISPC_FP16_SUPPORTED macro is ON for XE and ARM platforms only.
 
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 --emit-llvm-text -o - | FileCheck %s --check-prefixes=CHECK_FP_16,CHECK
 // RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 --emit-llvm-text -o - | FileCheck %s --check-prefixes=CHECK_FP_16,CHECK
 // RUN: %{ispc} %s --target=neon-i8x16 --arch=arm --emit-llvm-text -o - | FileCheck %s --check-prefixes=CHECK_FP_16,CHECK
 // RUN: %{ispc} %s --target=neon-i32x4 --arch=aarch64 --emit-llvm-text -o - | FileCheck %s --check-prefixes=CHECK_FP_16,CHECK

--- a/tests/lit-tests/fp64_support.ispc
+++ b/tests/lit-tests/fp64_support.ispc
@@ -1,15 +1,23 @@
 // RUN: %{ispc} %s --target=gen9-x16 --device=skl -h %t.h --emit-llvm-text -o %t.ll
-// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_FP64_SUPPORTED %s
+// RUN: FileCheck --input-file=%t.ll -check-prefixes=CHECK_ALL,CHECK_FP64_SUPPORTED %s
 // RUN: %{ispc} %s --target=xelp-x16 --device=tgllp -h %t.h --emit-llvm-text -o %t.ll
-// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_FP64_NOT_SUPPORTED %s
+// RUN: FileCheck --input-file=%t.ll -check-prefixes=CHECK_ALL,CHECK_FP64_NOT_SUPPORTED %s
+
 // REQUIRES: XE_ENABLED
-// CHECK_FP64_SUPPORTED: call void @llvm.genx.svm.block.st.i64.v16f64
+
+// CHECK_ALL-LABEL:       @test
+
 #ifdef ISPC_FP64_SUPPORTED
+
+// CHECK_FP64_SUPPORTED:  store <16 x double> %a_load_broadcast{{[0-9]*}}
 export void test(uniform double out[], uniform double a) {
+
 #else
-// CHECK_FP64_NOT_SUPPORTED: call void @llvm.genx.svm.block.st.i64.v16f32
+
+// CHECK_FP64_NOT_SUPPORTED:  store <16 x float> %a_load_broadcast{{[0-9]*}}
 export void test(uniform float out[], uniform float a) {
+
 #endif
+
   out[programIndex] = a;
 }
-

--- a/tests/lit-tests/load_store_vectorizer_loopunroll.ispc
+++ b/tests/lit-tests/load_store_vectorizer_loopunroll.ispc
@@ -12,11 +12,6 @@
 // RUN: FileCheck --input-file %t/ir_325_GPULoadandStoreVectorizer.ll %s --check-prefixes CHECK_ALL,CHECK
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -h %t.h --emit-llvm-text --debug-phase=325:325 --dump-file=%t -o /dev/null
 // RUN: FileCheck --input-file %t/ir_325_GPULoadandStoreVectorizer.ll %s --check-prefixes CHECK_ALL,CHECK
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=325:325 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_325_GPULoadandStoreVectorizer.ll %s --check-prefixes CHECK_ALL,CHECK
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=325:325 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_325_GPULoadandStoreVectorizer.ll %s --check-prefixes CHECK_ALL,CHECK
-
 
 // REQUIRES: XE_ENABLED
 

--- a/tests/lit-tests/xe_gather_coalescing.ispc
+++ b/tests/lit-tests/xe_gather_coalescing.ispc
@@ -9,11 +9,6 @@
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD_INLINE4,CHECK_LOAD_INLINE16
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD_INLINE4,CHECK_LOAD_INLINE16
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD_INLINE4,CHECK_LOAD_INLINE16
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD_INLINE4,CHECK_LOAD_INLINE16
-
 
 // REQUIRES:  XE_ENABLED
 

--- a/tests/lit-tests/xe_gather_coalescing.ispc
+++ b/tests/lit-tests/xe_gather_coalescing.ispc
@@ -16,7 +16,6 @@
 
 
 // REQUIRES:  XE_ENABLED
-// XFAIL:     XE_ENABLED
 
 #define LOAD(n)   \
     a[n] = _in[n]

--- a/tests/lit-tests/xe_gather_coalescing_loop.ispc
+++ b/tests/lit-tests/xe_gather_coalescing_loop.ispc
@@ -7,11 +7,6 @@
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK
-
 
 // REQUIRES:  XE_ENABLED
 

--- a/tests/lit-tests/xe_gather_coalescing_loopunroll.ispc
+++ b/tests/lit-tests/xe_gather_coalescing_loopunroll.ispc
@@ -11,11 +11,6 @@
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD_PRAGMA4,CHECK_LOAD_INLINE4,CHECK_LOAD_INLINE8
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD_PRAGMA4,CHECK_LOAD_INLINE4,CHECK_LOAD_INLINE8
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD_PRAGMA4,CHECK_LOAD_INLINE4,CHECK_LOAD_INLINE8
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD_PRAGMA4,CHECK_LOAD_INLINE4,CHECK_LOAD_INLINE8
-
 
 // REQUIRES: XE_ENABLED
 // XFAIL:    XE_ENABLED

--- a/tests/lit-tests/xe_gather_coalescing_ptr.ispc
+++ b/tests/lit-tests/xe_gather_coalescing_ptr.ispc
@@ -16,11 +16,6 @@
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 --emit-llvm-text -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s
 
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 --emit-llvm-text -o %t.ll --opt=build-llvm-loads-on-xe-gather-coalescing
-// RUN: FileCheck --input-file=%t.ll %s
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 --emit-llvm-text -o %t.ll --opt=build-llvm-loads-on-xe-gather-coalescing
-// RUN: FileCheck --input-file=%t.ll %s
-
 // REQUIRES: XE_ENABLED
 // XFAIL: XE_ENABLED
 

--- a/tests/lit-tests/xe_gather_coalescing_ptr_alloca.ispc
+++ b/tests/lit-tests/xe_gather_coalescing_ptr_alloca.ispc
@@ -22,10 +22,6 @@
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD
 
 // REQUIRES:  XE_ENABLED
 

--- a/tests/lit-tests/xe_gather_coalescing_ptr_alloca.ispc
+++ b/tests/lit-tests/xe_gather_coalescing_ptr_alloca.ispc
@@ -28,7 +28,6 @@
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD
 
 // REQUIRES:  XE_ENABLED
-// XFAIL:     XE_ENABLED
 
 
 struct vec3f {

--- a/tests/lit-tests/xe_gather_coalescing_ptr_indvar.ispc
+++ b/tests/lit-tests/xe_gather_coalescing_ptr_indvar.ispc
@@ -22,10 +22,6 @@
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD,CHECK_VARYING
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD,CHECK_VARYING
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD,CHECK_VARYING
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK_LOAD,CHECK_VARYING
 
 // REQUIRES: XE_ENABLED
 // XFAIL:    XE_ENABLED

--- a/tests/lit-tests/xe_gather_coalescing_varying.ispc
+++ b/tests/lit-tests/xe_gather_coalescing_varying.ispc
@@ -12,11 +12,6 @@
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
 // RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -h %t.h --emit-llvm-text --debug-phase=321:321 --dump-file=%t -o /dev/null
-// RUN: FileCheck --input-file %t/ir_321_XeGatherCoalescing.ll %s --check-prefixes CHECK_ALL,CHECK
-
 
 // REQUIRES:  XE_ENABLED
 // XFAIL:     XE_ENABLED

--- a/tests/lit-tests/xe_gather_test.ispc
+++ b/tests/lit-tests/xe_gather_test.ispc
@@ -2,6 +2,7 @@
 // RUN: FileCheck --input-file=%t.ll %s
 // RUN: %{ispc} %s --target=gen9-x16 --no-discard-value-names --arch=xe32 -h %t.h --emit-llvm-text -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s
+
 // REQUIRES: XE_ENABLED
 
 struct vec3f {
@@ -11,9 +12,8 @@ struct vec3f {
 };
 
 // CHECK: alloca [3 x %v16_varying_vec3f]
-// CHECK: load float, float* %{{.*}}
 // CHECK: load <16 x float>, <16 x float>* %ptr_cast_for_load
-// CHECK: call void @llvm.genx.svm.block.st.i64.v16f32(i64 %svm_st_ptrtoint
+// CHECK: store <16 x float> %
 export void checkAddrSpace(uniform float _out[], uniform float _in[]) {
     float a = _in[programIndex];
     vec3f myFoo[3] = { { -1, -2, -3 }, {a, -3, 0}, {-4, -5, -6} };

--- a/tests/lit-tests/xe_gather_test.ispc
+++ b/tests/lit-tests/xe_gather_test.ispc
@@ -1,7 +1,5 @@
 // RUN: %{ispc} %s --target=gen9-x16 --no-discard-value-names --arch=xe64 -h %t.h --emit-llvm-text -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s
-// RUN: %{ispc} %s --target=gen9-x16 --no-discard-value-names --arch=xe32 -h %t.h --emit-llvm-text -o %t.ll
-// RUN: FileCheck --input-file=%t.ll %s
 
 // REQUIRES: XE_ENABLED
 

--- a/tests/lit-tests/xe_invoke_sycl.ispc
+++ b/tests/lit-tests/xe_invoke_sycl.ispc
@@ -59,7 +59,8 @@
 // CHECK_GPU: call x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl(<8 x i64> %{{.*}}, <8 x i32> {{.*}})
 // @llvm.genx.simdcf.join
 
-// CHECK_GPU: @llvm.genx.svm.block.st
+// CHECK_GPU: store <8 x float>
+// CHECK_GPU: store float
 // CHECK_GPU: call x86_regcallcc void @__regcall3__extern_sycl_decl_void(<8 x i64> {{.*}})
 // CHECK_GPU: call x86_regcallcc void @__regcall3__extern_sycl_decl_noarg()
 // CHECK_GPU: call x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl_ptr(<8 x i64> {{.*}})

--- a/tests/lit-tests/xe_regcall-1.ispc
+++ b/tests/lit-tests/xe_regcall-1.ispc
@@ -104,7 +104,7 @@ extern "C" __regcall uniform EndsWithFlexArray foo7(uniform int b) {
   return f;
 }
 
-// CHECK: define x86_regcallcc <16 x float> @__regcall3__foo8(float addrspace(4)* noalias %A, <16 x float> %b, i32 %I, <16 x i1> %mask)
+// CHECK: define x86_regcallcc <16 x float> @__regcall3__foo8(float addrspace(4)* noalias nocapture {{(readonly)?}} %A, <16 x float> %b, i32 %I, <16 x i1> %mask)
 extern "C" __regcall float foo8(uniform float A[], float b, uniform int I, bool mask) {
   return A[programIndex+I];
 }

--- a/tests/lit-tests/xe_vec_add.ispc
+++ b/tests/lit-tests/xe_vec_add.ispc
@@ -1,81 +1,83 @@
 // This test is checking correct svm.ld/st svm.gather/scatter generation for different types and SIMD width.
 
 // RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DUNIFORM --emit-llvm-text --nowrap -o %t.ll
-// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_UNIFORM %s
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DVARYING --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_VARYING_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_VARYING
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DMASKED_ST --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DMASKED_ST --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST_UNSAFE
+// RUN: FileCheck --input-file=%t.ll -check-prefixes=CHECK_ALL,CHECK_UNIFORM %s
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DVARYING --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_VARYING_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_VARYING
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DMASKED_ST --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DMASKED_ST --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_UNSAFE
 
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DUNIFORM --emit-llvm-text --nowrap -o %t.ll
-// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_UNIFORM %s
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DVARYING --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_VARYING_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_VARYING
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST_UNSAFE
+// RUN: FileCheck --input-file=%t.ll -check-prefixes=CHECK_ALL,CHECK_UNIFORM %s
+// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DVARYING --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_VARYING_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_VARYING
+// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST
+// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_UNSAFE
 
 // RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -DUNIFORM --emit-llvm-text --nowrap -o %t.ll 2>&1
-// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_UNIFORM %s
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -DVARYING --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_VARYING_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_VARYING
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -DMASKED_ST --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -DMASKED_ST --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST_UNSAFE
+// RUN: FileCheck --input-file=%t.ll -check-prefixes=CHECK_ALL,CHECK_UNIFORM %s
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -DVARYING --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_VARYING_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_VARYING
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -DMASKED_ST --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -DMASKED_ST --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_UNSAFE
 
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -DUNIFORM --emit-llvm-text --nowrap -o %t.ll 2>&1
-// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_UNIFORM %s
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -DVARYING --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_VARYING_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_VARYING
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -DMASKED_ST --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -DMASKED_ST --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST_UNSAFE
+// RUN: FileCheck --input-file=%t.ll -check-prefixes=CHECK_ALL,CHECK_UNIFORM %s
+// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -DVARYING --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_VARYING_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_VARYING
+// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -DMASKED_ST --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST
+// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -DMASKED_ST --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_UNSAFE
 
 // Now process special cases
 // i8 simd16
 // RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DUNIFORM -DTEST_I8 --emit-llvm-text --nowrap -o %t.ll
-// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_UNIFORM %s
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DVARYING -DTEST_I8 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_VARYING_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_VARYING_I8_SIMD16
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DMASKED_ST -DTEST_I8 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST_I8_SIMD16
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DMASKED_ST -DTEST_I8 --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST_UNSAFE_I8_SIMD16
+// RUN: FileCheck --input-file=%t.ll -check-prefixes=CHECK_ALL,CHECK_UNIFORM %s
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DVARYING -DTEST_I8 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_VARYING_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_VARYING_I8_SIMD16
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DMASKED_ST -DTEST_I8 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_I8_SIMD16
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DMASKED_ST -DTEST_I8 --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_UNSAFE_I8_SIMD16
 
 // for i8 we always generate gathers/scatters since i8x8 is too small for svm ld/st
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DUNIFORM -DTEST_I8 --emit-llvm-text --nowrap -o %t.ll
-// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_UNIFORM_I8_SIMD8 %s
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DVARYING -DTEST_I8 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_VARYING_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_VARYING_I8_SIMD8
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST -DTEST_I8 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST_I8_SIMD8
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST -DTEST_I8 --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST_UNSAFE_I8_SIMD8
+// RUN: FileCheck --input-file=%t.ll -check-prefixes=CHECK_ALL,CHECK_UNIFORM %s
+// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DVARYING -DTEST_I8 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_VARYING_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_VARYING_I8_SIMD8
+// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST -DTEST_I8 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_I8_SIMD8
+// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST -DTEST_I8 --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_UNSAFE_I8_SIMD8
 
 // i16 simd16
 // RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DUNIFORM -DTEST_I16 --emit-llvm-text --nowrap -o %t.ll
-// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_UNIFORM %s
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DVARYING -DTEST_I16 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_VARYING_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_VARYING_I16_SIMD16
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DMASKED_ST -DTEST_I16 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST_I16_SIMD16
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DMASKED_ST -DTEST_I16 --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST_UNSAFE_I16_SIMD16
+// RUN: FileCheck --input-file=%t.ll -check-prefixes=CHECK_ALL,CHECK_UNIFORM %s
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DVARYING -DTEST_I16 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_VARYING_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_VARYING_I16_SIMD16
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DMASKED_ST -DTEST_I16 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_I16_SIMD16
+// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DMASKED_ST -DTEST_I16 --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_UNSAFE_I16_SIMD16
 
 // i16 simd8
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DUNIFORM -DTEST_I16 --emit-llvm-text --nowrap -o %t.ll
-// RUN: FileCheck --input-file=%t.ll -check-prefix=CHECK_UNIFORM %s
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DVARYING -DTEST_I16 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_VARYING_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_VARYING_I16_SIMD8
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST -DTEST_I16 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST_I16_SIMD8
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST -DTEST_I16 --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefix=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=CHECK_MASKED_ST_UNSAFE_I16_SIMD8
+// RUN: FileCheck --input-file=%t.ll -check-prefixes=CHECK_ALL,CHECK_UNIFORM %s
+// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DVARYING -DTEST_I16 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_VARYING_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_VARYING_I16_SIMD8
+// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST -DTEST_I16 --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_I16_SIMD8
+// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST -DTEST_I16 --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_UNSAFE_I16_SIMD8
+
+// CHECK_ALL-LABEL: @vadd(
 
 // REQUIRES: XE_ENABLED
 #ifdef TEST_I8
@@ -89,17 +91,11 @@ typedef float T;
 export void vadd(uniform int n, uniform T aIN[], uniform T bIN[], uniform T cOUT[]) {
 #ifdef UNIFORM
   for (uniform int i = 0; i < n; i += programCount) {
-// CHECK_UNIFORM: @llvm.genx.svm.block.ld.unaligned
-// CHECK_UNIFORM_I8_SIMD8: call <32 x i8> @llvm.genx.svm.gather.v32i8.v8i1.v8i64(<8 x i1> {{.*}}, i32 0, {{.*}})
-// CHECK_UNIFORM_I8_SIMD8-NEXT: call <8 x i8> @llvm.genx.rdregioni.v8i8.v32i8.i16(<32 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 undef)
+// CHECK_UNIFORM:               %{{.*}} = load <{{(8|16)}} x {{(i8|i16|float)}}
     T a = aIN[i + programIndex];
-// CHECK_UNIFORM: @llvm.genx.svm.block.ld.unaligned
-// CHECK_UNIFORM_I8_SIMD8: call <32 x i8> @llvm.genx.svm.gather.v32i8.v8i1.v8i64(<8 x i1> {{.*}}, i32 0, {{.*}})
-// CHECK_UNIFORM_I8_SIMD8-NEXT: call <8 x i8> @llvm.genx.rdregioni.v8i8.v32i8.i16(<32 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 undef)
+// CHECK_UNIFORM:               %{{.*}} = load <{{(8|16)}} x {{(i8|i16|float)}}
     T b = bIN[i + programIndex];
-// CHECK_UNIFORM: @llvm.genx.svm.block.st
-// CHECK_UNIFORM_I8_SIMD8: call <32 x i8> @llvm.genx.wrregioni.v32i8.v8i8.i16.v8i1(<32 x i8> undef, <8 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 0, <8 x i1> {{.*}})
-// CHECK_UNIFORM_I8_SIMD8-NEXT: call void @llvm.genx.svm.scatter.v8i1.v8i64.v32i8(<8 x i1> {{.*}}, i32 0, {{.*}})
+// CHECK_UNIFORM:               store <{{(8|16)}} x {{(i8|i16|float)}}> %add_a_load_b_load
     cOUT[i + programIndex] = a + b;
   }
 #elif defined VARYING

--- a/tests/lit-tests/xe_vec_add.ispc
+++ b/tests/lit-tests/xe_vec_add.ispc
@@ -18,24 +18,6 @@
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 -DMASKED_ST --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
 // RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_UNSAFE
 
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -DUNIFORM --emit-llvm-text --nowrap -o %t.ll 2>&1
-// RUN: FileCheck --input-file=%t.ll -check-prefixes=CHECK_ALL,CHECK_UNIFORM %s
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -DVARYING --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_VARYING_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_VARYING
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -DMASKED_ST --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe32 -DMASKED_ST --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_UNSAFE
-
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -DUNIFORM --emit-llvm-text --nowrap -o %t.ll 2>&1
-// RUN: FileCheck --input-file=%t.ll -check-prefixes=CHECK_ALL,CHECK_UNIFORM %s
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -DVARYING --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_VARYING_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_VARYING
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -DMASKED_ST --emit-llvm-text --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe32 -DMASKED_ST --emit-llvm-text --opt=enable-xe-unsafe-masked-load --nowrap -o %t.ll 2>&1 | FileCheck %s -check-prefixes=CHECK_MASKED_ST_WARN
-// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=CHECK_ALL,CHECK_MASKED_ST_UNSAFE
-
 // Now process special cases
 // i8 simd16
 // RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 -DUNIFORM -DTEST_I8 --emit-llvm-text --nowrap -o %t.ll

--- a/tests/lit-tests/xe_yarpgen_3330730858.ispc
+++ b/tests/lit-tests/xe_yarpgen_3330730858.ispc
@@ -9,8 +9,6 @@ Invocation: ../../build/yarpgen --std=ispc
 // RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 --emit-spirv -o %t.spv
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 --emit-spirv --opt=disable-xe-gather-coalescing -o %t.spv
 // RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 --emit-spirv --opt=disable-xe-gather-coalescing -o %t.spv
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 --emit-spirv --opt=build-llvm-loads-on-xe-gather-coalescing -o %t.spv
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 --emit-spirv --opt=build-llvm-loads-on-xe-gather-coalescing -o %t.spv
 
 // REQUIRES: XE_ENABLED
 

--- a/tests/lit-tests/xe_yarpgen_4096674170.ispc
+++ b/tests/lit-tests/xe_yarpgen_4096674170.ispc
@@ -9,8 +9,6 @@ Invocation: ../../build/yarpgen --std=ispc
 // RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 --emit-spirv -o %t.spv
 // RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 --emit-spirv --opt=disable-xe-gather-coalescing -o %t.spv
 // RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 --emit-spirv --opt=disable-xe-gather-coalescing -o %t.spv
-// RUN: %{ispc} %s --target=gen9-x8 --arch=xe64 --emit-spirv --opt=build-llvm-loads-on-xe-gather-coalescing -o %t.spv
-// RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 --emit-spirv --opt=build-llvm-loads-on-xe-gather-coalescing -o %t.spv
 
 // REQUIRES: XE_ENABLED
 

--- a/tests/lit-tests/xehpc_vec_add.ispc
+++ b/tests/lit-tests/xehpc_vec_add.ispc
@@ -30,20 +30,14 @@ typedef float T;
 task void vadd(uniform int n, uniform T aIN[], uniform T bIN[], uniform T cOUT[]) {
 #ifdef UNIFORM
   for (uniform int i = 0; i < n; i += programCount) {
-// CHECK_UNIFORM_DOUBLE: call <16 x double> @llvm.genx.svm.gather.v16f64.v16i1.v16i64
-// CHECK_UNIFORM_DOUBLE-NEXT: call <16 x double> @llvm.genx.svm.gather.v16f64.v16i1.v16i64
-// CHECK_UNIFORM_I64: call <16 x i64> @llvm.genx.svm.gather.v16i64.v16i1.v16i64
-// CHECK_UNIFORM_I64-NEXT: call <16 x i64> @llvm.genx.svm.gather.v16i64.v16i1.v16i64
+// CHECK_UNIFORM_DOUBLE:  %{{.*}} = load <32 x double>
+// CHECK_UNIFORM_I64:     %{{.*}} = load <32 x i64>
     T a = aIN[i + programIndex];
-// CHECK_UNIFORM_DOUBLE: call <16 x double> @llvm.genx.svm.gather.v16f64.v16i1.v16i64
-// CHECK_UNIFORM_DOUBLE-NEXT: call <16 x double> @llvm.genx.svm.gather.v16f64.v16i1.v16i64
-// CHECK_UNIFORM_I64: call <16 x i64> @llvm.genx.svm.gather.v16i64.v16i1.v16i64
-// CHECK_UNIFORM_I64-NEXT: call <16 x i64> @llvm.genx.svm.gather.v16i64.v16i1.v16i64
+// CHECK_UNIFORM_DOUBLE:  %{{.*}} = load <32 x double>
+// CHECK_UNIFORM_I64:     %{{.*}} = load <32 x i64>
     T b = bIN[i + programIndex];
-// CHECK_UNIFORM_DOUBLE: call void @llvm.genx.svm.scatter.v16i1.v16i64.v16f64
-// CHECK_UNIFORM_DOUBLE-NEXT: call void @llvm.genx.svm.scatter.v16i1.v16i64.v16f64
-// CHECK_UNIFORM_I64: call void @llvm.genx.svm.scatter.v16i1.v16i64.v16i64
-// CHECK_UNIFORM_I64-NEXT: call void @llvm.genx.svm.scatter.v16i1.v16i64.v16i64
+// CHECK_UNIFORM_DOUBLE:  store <32 x double> %add_a_load_b_load
+// CHECK_UNIFORM_I64:     store <32 x i64> %add_a_load_b_load
     cOUT[i + programIndex] = a + b;
   }
 #elif defined VARYING

--- a/tests/memcpy-uniform.ispc
+++ b/tests/memcpy-uniform.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/memcpy-varying.ispc
+++ b/tests/memcpy-varying.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/memmove-uniform.ispc
+++ b/tests/memmove-uniform.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/memmove-varying.ispc
+++ b/tests/memmove-varying.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/memset-uniform.ispc
+++ b/tests/memset-uniform.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/memset-varying.ispc
+++ b/tests/memset-varying.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/new-delete-1.ispc
+++ b/tests/new-delete-1.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {

--- a/tests/new-delete-2.ispc
+++ b/tests/new-delete-2.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {

--- a/tests/new-delete-3.ispc
+++ b/tests/new-delete-3.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {

--- a/tests/new-delete-4.ispc
+++ b/tests/new-delete-4.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {

--- a/tests/new-delete-5.ispc
+++ b/tests/new-delete-5.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 struct Point {

--- a/tests/new-delete-6.ispc
+++ b/tests/new-delete-6.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 struct Point {

--- a/tests/ref-overloads.ispc
+++ b/tests/ref-overloads.ispc
@@ -1,4 +1,6 @@
 #include "../test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
 /////////////////////////VARYING
 //int A011(varying float f){return 0;}  int A011(varying float& f){return 1;}       int A011(varying const float& f){return 2;}
 //int A011(varying double f){return 3;} int A011(varying int f){return 4;}          int A011(uniform float f){return 5;}

--- a/tests/ref-overloads1.ispc
+++ b/tests/ref-overloads1.ispc
@@ -1,4 +1,6 @@
 #include "../test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
 void A1(float f)               {}
 void A2(float& f)              {}
 void A3(const float& f)        {} 

--- a/tests/soa-14.ispc
+++ b/tests/soa-14.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 struct Point { float x, y, z; };
 

--- a/tests/soa-21.ispc
+++ b/tests/soa-21.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 struct Point { float x, y, z; };
 

--- a/tests/soa-22.ispc
+++ b/tests/soa-22.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 struct Point { float x, y, z; };
 

--- a/tests/soa-23.ispc
+++ b/tests/soa-23.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 struct Point { float x, y, z; };
 

--- a/tests/soa-24.ispc
+++ b/tests/soa-24.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 struct Point { float x, y, z; };
 

--- a/tests/soa-25.ispc
+++ b/tests/soa-25.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 struct Point { float x, y, z; };
 

--- a/tests/soa-26.ispc
+++ b/tests/soa-26.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 struct Point { float x, y, z; };
 

--- a/tests/soa-29.ispc
+++ b/tests/soa-29.ispc
@@ -1,4 +1,6 @@
 #include "../test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
 struct Point { float x, y; int8 zzz0; float z; double aa[3]; int8 zzz; };
 
 

--- a/tests/struct-zero-len-array-member.ispc
+++ b/tests/struct-zero-len-array-member.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 struct Foo {
     float x;

--- a/tests/uniform-1.ispc
+++ b/tests/uniform-1.ispc
@@ -1,5 +1,4 @@
 #include "../test_static.isph"
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 #define THREADS 4

--- a/tests/xe-task-count.ispc
+++ b/tests/xe-task-count.ispc
@@ -1,6 +1,5 @@
 #include "../test_static.isph"
 // rule: skip on arch=*
-// rule: run on arch=xe32
 // rule: run on arch=xe64
 
 task void f_t(uniform float RET[]) {

--- a/tests/xe-task-index-1.ispc
+++ b/tests/xe-task-index-1.ispc
@@ -1,6 +1,5 @@
 #include "../test_static.isph"
 // rule: skip on arch=*
-// rule: run on arch=xe32
 // rule: run on arch=xe64
 
 task void f_t(uniform float RET[]) {

--- a/tests/xe-task-index.ispc
+++ b/tests/xe-task-index.ispc
@@ -1,6 +1,5 @@
 #include "../test_static.isph"
 // rule: skip on arch=*
-// rule: run on arch=xe32
 // rule: run on arch=xe64
 // TODO: the test should be reworked when atomic operation on Xe are available.
 // It is hard to check taskIndex now.

--- a/tests_errors/new-delete-1.ispc
+++ b/tests_errors/new-delete-1.ispc
@@ -1,5 +1,4 @@
 // Illegal to delete non-pointer type
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 void func(int a) {
     delete a;

--- a/tests_errors/new-delete-2.ispc
+++ b/tests_errors/new-delete-2.ispc
@@ -1,5 +1,4 @@
 // syntax error, unexpected 'const'.
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 int * func(int a) {

--- a/tests_errors/new-delete-3.ispc
+++ b/tests_errors/new-delete-3.ispc
@@ -1,5 +1,4 @@
 // syntax error, unexpected '\('
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 int * func(int a) {

--- a/tests_errors/new-delete-4.ispc
+++ b/tests_errors/new-delete-4.ispc
@@ -1,5 +1,4 @@
 // Type conversion from "varying struct P" to "varying unsigned int32" for item count is not possible
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 struct P { int x; };

--- a/tests_errors/new-delete-5.ispc
+++ b/tests_errors/new-delete-5.ispc
@@ -1,5 +1,4 @@
 // Illegal to provide "varying" allocation count with "uniform new" expression
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 int * func(int x) {

--- a/tests_errors/new-delete-6.ispc
+++ b/tests_errors/new-delete-6.ispc
@@ -1,5 +1,4 @@
 // Can't convert from type "uniform int32 \* varying" to type "uniform int32 \* uniform" for return
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 int * uniform func(int x) {

--- a/tests_errors/new-delete-7.ispc
+++ b/tests_errors/new-delete-7.ispc
@@ -1,5 +1,4 @@
 // Can't convert from type "varying float" to type "uniform float" for initializer
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 struct Point {

--- a/tests_errors/undef-struct-new.ispc
+++ b/tests_errors/undef-struct-new.ispc
@@ -1,5 +1,4 @@
 // Can't dynamically allocate storage for declared but not defined type
-// rule: skip on arch=xe32
 // rule: skip on arch=xe64
 
 struct Foo;


### PR DESCRIPTION
This PR introduces ISPC `superbuild`. It may be used to build ISPC with Xe dependencies (LLVM, L0, vc-intrinsics, SPIRV-Translator), as well as it can produce an archive with dependencies or consume a pre-built archive to build ISPC only. It also allows to generate LTO or LTO+PGO enabled build of LLVM and ISPC.
The PR also have some Xe-related minor changes:
- produce llvm loads/stores instead of svm block load/stores
- fixed order of commands for ISPC/SYCL interop
- removed `xe32` architecture
- tests updates