### PR TITLE
Fix ICE on invalid print syntax

### DIFF
--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -3745,7 +3745,10 @@ void PrintStmt::EmitCode(FunctionEmitContext *ctx) const {
     }
 #endif /* ISPC_XE_ENABLED */
     auto printImplArgs = getDoPrintArgs(ctx);
-    Assert(!printImplArgs.empty() && "Haven't managed to produce __do_print args");
+    if (printImplArgs.empty()) {
+        AssertPos(pos, m->errorCount > 0);
+        return;
+    }
     auto printImplFunc = getPrintImplFunc();
     AssertPos(pos, printImplFunc);
     ctx->CallInst(printImplFunc, nullptr, printImplArgs, "");

--- a/tests/lit-tests/2544.ispc
+++ b/tests/lit-tests/2544.ispc
@@ -1,0 +1,10 @@
+// RUN: not %{ispc} --arch=x86-64 --target=avx2 --nowrap -o - %s 2>%t
+// RUN: FileCheck --input-file=%t %s
+
+// CHECK: Error: syntax error
+// CHECK-NOT: Please file a bug report
+void sum(int x)
+{
+    print("sum: %", reduce_add(x:1:0));
+}
+


### PR DESCRIPTION
It fixes the issue #2544 where user reported ICE on invalid syntax inside `print` arguments.

Parser encounters a recoverable syntax error and proceeds further. However, it breaks some assumption in an assert statement later during the code emitting of print statement. This assert is raised resulting in `abort` call to terminate program.

In this case, we may terminate the compiler with `exit(yynerrs)` adding message saying that the assert can be triggered by the reported syntax error.

```bash
$ ./bin/ispc  --arch=x86-64 --target=avx2 2544.ispc -o 2544.o
2544.ispc:3:33: Error: syntax error, unexpected ':', expecting ')' or ','.
    print("sum: %", reduce_add(x:1:0));
                                ^

./src/stmt.cpp:3748: Assertion failed: "!printImplArgs.empty() && "Haven't managed to produce __do_print args"".
***
*** Assertion may be caused by syntax error shown above,
*** otherwise follow instructions below.
***
*** Please file a bug report at https://github.com/ispc/ispc/issues
*** (Including as much information as you can about how to reproduce this error).
*** You have apparently encountered a bug in the compiler that we'd like to fix!
***
$ echo $?
1
```