### PR TITLE
Fix ICE when undeclared symbol used in initializer expr

### DIFF
--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -262,6 +262,11 @@ static bool checkInit(const Type *type, Expr **init) {
         return false;
     }
 
+    if (*init == nullptr) {
+        // Return error if an initializer expression is malformed, e.g., undeclared symbol is used.
+        return true;
+    }
+
     // get the right type for stuff like const float foo = 2; so that
     // the int->float type conversion is in there and we don't return
     // an int as the constValue later...

--- a/tests/lit-tests/2509.ispc
+++ b/tests/lit-tests/2509.ispc
@@ -1,5 +1,4 @@
-// RUN: not %{ispc} --target=avx1-i32x4 --nowrap %s > %t 2>&1
-// RUN: FileCheck --input-file=%t %s
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s 2>&1 | FileCheck %s
 
 // CHECK-NOT: FATAL ERROR: Unhandled signal sent to process
 struct S

--- a/tests/lit-tests/2509.ispc
+++ b/tests/lit-tests/2509.ispc
@@ -1,0 +1,13 @@
+// RUN: not %{ispc} --target=avx1-i32x4 --nowrap %s > %t 2>&1
+// RUN: FileCheck --input-file=%t %s
+
+// CHECK-NOT: FATAL ERROR: Unhandled signal sent to process
+struct S
+{
+    float x;
+};
+
+void f()
+{
+    S s = { b };
+}

--- a/tests/lit-tests/2544.ispc
+++ b/tests/lit-tests/2544.ispc
@@ -1,5 +1,4 @@
-// RUN: not %{ispc} --arch=x86-64 --target=avx2 --nowrap -o - %s 2>%t
-// RUN: FileCheck --input-file=%t %s
+// RUN: not %{ispc} --target=host --nowrap -o - %s 2>&1 | FileCheck %s
 
 // CHECK: Error: syntax error
 // CHECK-NOT: Please file a bug report


### PR DESCRIPTION
This fixes ICE when an initializer expression is malformed, e.g., because of the usage of undeclared symbols, as reported in the issue #2509.

Thanks @mingodad for the suggested fix (https://github.com/ispc/ispc/issues/2509#issuecomment-1556850627)