### PR TITLE
Check rvalue before assign operation

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -3069,6 +3069,8 @@ static llvm::Value *lEmitOpAssign(AssignExpr::Op op, Expr *arg0, Expr *arg1, con
     // Get the value on the right-hand side of the assignment+operation
     // operator and load the current value on the left-hand side.
     llvm::Value *rvalue = arg1->GetValue(ctx);
+    if (rvalue == nullptr)
+        return nullptr;
     llvm::Value *mask = lMaskForSymbol(baseSym, ctx);
     ctx->SetDebugPos(arg0->pos);
     llvm::Value *oldLHS = ctx->LoadInst(lv, mask, lvalueType);

--- a/tests/lit-tests/2341.ispc
+++ b/tests/lit-tests/2341.ispc
@@ -1,0 +1,11 @@
+// Check that ISPC produces error for incorrect code and does not crash. ISPC issue #2341.
+// RUN: not %{ispc} %s --nowrap --nostdlib --target=host 2>&1 | FileCheck %s
+
+// CHECK: Error: Can't convert from type "const varying int32" to type "uniform unsigned int16" for initializer
+// CHECK-NOT: FATAL ERROR: Unhandled signal sent to process
+void test_func(uniform uint16 start_index) {
+    uniform uint16 step = 4 * programIndex;
+    uniform uint16 vertex_id = start_index;
+    vertex_id += step;
+}
+


### PR DESCRIPTION
This fixes #2341.