### PR TITLE
Clean up symbol table to avoid assertion in destructor

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3180,6 +3180,10 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
         }
 
         int errorCount = m->errorCount;
+        // In case of error, clean up symbolTable
+        if (errorCount > 0) {
+            m->symbolTable->PopInnerScopes();
+        }
         delete m;
         m = nullptr;
 

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -67,6 +67,12 @@ void SymbolTable::PopScope() {
     types.pop_back();
 }
 
+void SymbolTable::PopInnerScopes() {
+    while (variables.size() > 1) {
+        PopScope();
+    }
+}
+
 bool SymbolTable::AddVariable(Symbol *symbol) {
     Assert(symbol != nullptr);
 

--- a/src/sym.h
+++ b/src/sym.h
@@ -134,6 +134,10 @@ class SymbolTable {
         that scope. */
     void PopScope();
 
+    /** Pop all scopes except the outermost scope. It's needed to clean up SymbolTable in case of any error during
+        parsing to avoid assertion in destructor. */
+    void PopInnerScopes();
+
     /** Adds the given variable symbol to the symbol table.
         @param symbol The symbol to be added
 

--- a/tests/lit-tests/2523.ispc
+++ b/tests/lit-tests/2523.ispc
@@ -1,0 +1,7 @@
+// Check that ISPC produces error for incorrect code and does not crash. ISPC issue #2523.
+// RUN: not %{ispc} %s --nowrap --nostdlib --target=host 2>&1 | FileCheck %s
+
+// CHECK: Error: Premature end of file: syntax error
+// CHECK-NOT: FATAL ERROR: Unhandled signal sent to process
+void foobar() { {
+}


### PR DESCRIPTION
This is a fix for #2523. Thanks @mingodad for the idea of the fix.