### PR TITLE
Deallocate memory allocated in lexer

### DIFF
--- a/src/lex.ll
+++ b/src/lex.ll
@@ -453,13 +453,13 @@ while { RT; return TOKEN_WHILE; }
 \"SYCL\" { RT; return TOKEN_STRING_SYCL_LITERAL; }
 \.\.\. { RT; return TOKEN_DOTDOTDOT; }
 
-"operator*"  { return TOKEN_IDENTIFIER; }
-"operator+"  { return TOKEN_IDENTIFIER; }
-"operator-"  { return TOKEN_IDENTIFIER; }
-"operator<<" { return TOKEN_IDENTIFIER; }
-"operator>>" { return TOKEN_IDENTIFIER; }
-"operator/" { return TOKEN_IDENTIFIER; }
-"operator%" { return TOKEN_IDENTIFIER; }
+"operator*"  { yylval.stringVal = new std::string(yytext); return TOKEN_IDENTIFIER; }
+"operator+"  { yylval.stringVal = new std::string(yytext); return TOKEN_IDENTIFIER; }
+"operator-"  { yylval.stringVal = new std::string(yytext); return TOKEN_IDENTIFIER; }
+"operator<<" { yylval.stringVal = new std::string(yytext); return TOKEN_IDENTIFIER; }
+"operator>>" { yylval.stringVal = new std::string(yytext); return TOKEN_IDENTIFIER; }
+"operator/"  { yylval.stringVal = new std::string(yytext); return TOKEN_IDENTIFIER; }
+"operator%"  { yylval.stringVal = new std::string(yytext); return TOKEN_IDENTIFIER; }
 
 L?\"(\\.|[^\\"])*\" { lStringConst(&yylval, &yylloc); return TOKEN_STRING_LITERAL; }
 

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -268,12 +268,14 @@ struct ForeachDimension {
 %%
 
 string_constant
-    : TOKEN_STRING_LITERAL { $$ = new std::string(*yylval.stringVal); }
+    : TOKEN_STRING_LITERAL { $$ = yylval.stringVal; }
     | string_constant TOKEN_STRING_LITERAL
     {
-        std::string s = *((std::string *)$1);
-        s += *yylval.stringVal;
-        $$ = new std::string(s);
+        std::string *p_str_cst = (std::string *)$1;
+        p_str_cst->append(*yylval.stringVal);
+        $$ = p_str_cst;
+        // Allocated in lStringConst
+        delete yylval.stringVal;
     }
     ;
 
@@ -2178,10 +2180,14 @@ print_statement
     : TOKEN_PRINT '(' string_constant ')' ';'
       {
            $$ = new PrintStmt(*$3, nullptr, @1);
+           // deallocate std::string of string_constant
+           delete $3;
       }
     | TOKEN_PRINT '(' string_constant ',' argument_expression_list ')' ';'
       {
            $$ = new PrintStmt(*$3, $5, @1);
+           // deallocate std::string of string_constant
+           delete $3;
       }
     ;
 
@@ -2189,6 +2195,8 @@ assert_statement
     : TOKEN_ASSERT '(' string_constant ',' expression ')' ';'
       {
           $$ = new AssertStmt(*$3, $5, @1);
+          // deallocate std::string of string_constant
+          delete $3;
       }
     ;
 

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1818,6 +1818,8 @@ attributed_statement
             $2->SetLoopAttribute(unrollVal);
         }
         $$ = $2;
+        // deallocate yylval.pragmaAttributes returned from pragma and allocated in lPragmaUnroll
+        delete $1;
     }
     | statement
     ;

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -332,6 +332,7 @@ primary_expression
     }
     | TOKEN_FLOAT16_CONSTANT {
          std::string sval = *(yylval.stringVal);
+         delete yylval.stringVal;
          llvm::Type *hType = llvm::Type::getHalfTy(*g->ctx);
          const llvm::fltSemantics &FS = hType->getFltSemantics();
          llvm::APFloat f16(FS, sval);

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -519,7 +519,7 @@ intrincall_expression
           if (sym != nullptr)
               fSym = new FunctionSymbolExpr(fname, funcs, @1);
           $$ = new FunctionCallExpr(fSym, $3, Union(@1,@4));
-
+          delete name;
       }
     ;
 


### PR DESCRIPTION
There are a few places in `lex.ll` that allocate memory on heap to pass some values to the parser. It should be deallocated. 

Two fields of `yylval` struct are used to pass heap allocated memory from lexer to parser: `std::string *stringVal` and `PragmaAttributes * pragmaAttributes`. The first one is filled in `TOKEN_IDENTIFIER`, `TOKEN_TEMPLATE_NAME`, `TOKEN_TYPE_NAME`, `TOKEN_FLOAT16_CONSTANT `, `TOKEN_INTRINSIC_CALL`, `TOKEN_STRING_LITERAL`. The second one is allocated in `TOKEN_PRAGMA`.

To make `stringVal` memory management identical for all tokens, `operator` rules are made to allocate string as well.