### PR TITLE
Updates for Xe targets (20)

### DIFF
--- a/benchmarks/01_trivial/07_loop_unroll_varying.cpp
+++ b/benchmarks/01_trivial/07_loop_unroll_varying.cpp
@@ -1,7 +1,6 @@
 #include <benchmark/benchmark.h>
 #include <iostream>
 
-#include "../../ispcrt/ispcrt.hpp"
 #include "../common.h"
 
 #include "07_loop_unroll_varying_ispc.h"

--- a/examples/xpu/CMakeLists.txt
+++ b/examples/xpu/CMakeLists.txt
@@ -37,6 +37,12 @@ if (ISPC_BUILD)
     include_directories_ispc(${ISPCRT_INCLUDE_DIR})
 else()
     find_package(ispcrt REQUIRED)
+
+    # L0 is required, e.g., for sgemm
+    set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../ispcrt/cmake)
+    find_package(level_zero REQUIRED)
+    message(STATUS "LEVEL_ZERO_INCLUDE_DIR is ${LEVEL_ZERO_INCLUDE_DIR}")
+    message(STATUS "LEVEL_ZERO_LIB_LOADER is ${LEVEL_ZERO_LIB_LOADER}")
 endif()
 if (NOT ISPC_EXECUTABLE)
     message(FATAL_ERROR "Failed to find ispc")

--- a/examples/xpu/aobench/ao.cpp
+++ b/examples/xpu/aobench/ao.cpp
@@ -123,8 +123,7 @@ static int run() {
         auto p_dev = ispcrtNewMemoryView(device, &p, sizeof(p), &flags);
 
         // Create module and kernel to execute
-        ISPCRTModuleOptions options = {};
-        auto module = ispcrtLoadModule(device, "xe_aobench", options);
+        auto module = ispcrtLoadModule(device, "xe_aobench");
         auto kernel = ispcrtNewKernel(device, module, "ao_ispc");
         // Create task queue and execute kernel
         auto queue = ispcrtNewTaskQueue(device);

--- a/examples/xpu/cmake/AddPerfExample.cmake
+++ b/examples/xpu/cmake/AddPerfExample.cmake
@@ -4,7 +4,7 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 
 function(add_perf_example)
-    set(options GBENCH)
+    set(options GBENCH LINK_L0)
     set(oneValueArgs ISPC_SRC_NAME ISPC_TARGET_XE TEST_NAME GBENCH_TEST_NAME)
     set(multiValueArgs ISPC_XE_ADDITIONAL_ARGS HOST_SOURCES DPCPP_HOST_SOURCES GBENCH_SRC_NAME)
     cmake_parse_arguments("parsed" "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
@@ -55,6 +55,11 @@ function(add_perf_example)
     if (DPCPP_HOST_SOURCES)
         target_compile_options(${HOST_EXECUTABLE} PRIVATE "-fsycl")
         target_link_options(${HOST_EXECUTABLE} PRIVATE "-fsycl")
+    endif()
+
+    if (parsed_LINK_L0)
+        target_include_directories(${HOST_EXECUTABLE} PUBLIC ${LEVEL_ZERO_INCLUDE_DIR})
+        target_link_libraries(${HOST_EXECUTABLE} PRIVATE ${LEVEL_ZERO_LIB_LOADER})
     endif()
 
     target_compile_definitions(${HOST_EXECUTABLE} PRIVATE ISPCRT)

--- a/examples/xpu/common/L0_helpers.h
+++ b/examples/xpu/common/L0_helpers.h
@@ -120,7 +120,7 @@ void L0InitContext(ze_driver_handle_t &hDriver, ze_device_handle_t &hDevice, ze_
     moduleDesc.format = use_zebin ? ZE_MODULE_FORMAT_NATIVE : ZE_MODULE_FORMAT_IL_SPIRV;
     moduleDesc.inputSize = codeSize;
     moduleDesc.pInputModule = codeBin;
-    moduleDesc.pBuildFlags = "-vc-codegen -no-optimize -Xfinalizer '-presched'";
+    moduleDesc.pBuildFlags = "-vc-codegen -no-optimize -Xfinalizer '-presched' -Xfinalizer '-newspillcostispc'";
     L0_SAFE_CALL(zeModuleCreate(hContext, hDevice, &moduleDesc, &hModule, nullptr));
 
     delete[] codeBin;

--- a/examples/xpu/pipeline-dpcpp/CMakeLists.txt
+++ b/examples/xpu/pipeline-dpcpp/CMakeLists.txt
@@ -20,5 +20,6 @@ if(UNIX)
         TEST_NAME ${TEST_NAME}
         ISPC_TARGET_XE ${ISPC_TARGET_XE}
         DPCPP_HOST_SOURCES ${DPCPP_HOST_SOURCES}
+        LINK_L0
     )
 endif()

--- a/examples/xpu/sgemm/CMakeLists.txt
+++ b/examples/xpu/sgemm/CMakeLists.txt
@@ -22,4 +22,5 @@ add_perf_example(
     GBENCH
     GBENCH_TEST_NAME bench-sgemm
     GBENCH_SRC_NAME bench.cpp sgemm.cpp
+    LINK_L0
 )

--- a/examples/xpu/sgemm/sgemm.cpp
+++ b/examples/xpu/sgemm/sgemm.cpp
@@ -148,9 +148,9 @@ void SGEMMApp::run(SGEMMApp::RunResult &result, int m, int niter, int gx, int gy
 
     ze_device_mem_alloc_desc_t alloc_desc = {};
 
-    L0_SAFE_CALL(zeMemAllocDevice(m_context, &alloc_desc, mtA_size * sizeof(float), 0, m_device, &a_buf));
-    L0_SAFE_CALL(zeMemAllocDevice(m_context, &alloc_desc, mtB_size * sizeof(float), 0, m_device, &b_buf));
-    L0_SAFE_CALL(zeMemAllocDevice(m_context, &alloc_desc, mtC_size * sizeof(float), 0, m_device, &c_buf));
+    L0_SAFE_CALL(zeMemAllocDevice(m_context, &alloc_desc, mtA_size * sizeof(float), 64, m_device, &a_buf));
+    L0_SAFE_CALL(zeMemAllocDevice(m_context, &alloc_desc, mtB_size * sizeof(float), 64, m_device, &b_buf));
+    L0_SAFE_CALL(zeMemAllocDevice(m_context, &alloc_desc, mtC_size * sizeof(float), 64, m_device, &c_buf));
 
     L0_SAFE_CALL(zeCommandListReset(m_command_list));
     L0_SAFE_CALL(

--- a/examples/xpu/simple-dpcpp-l0/CMakeLists.txt
+++ b/examples/xpu/simple-dpcpp-l0/CMakeLists.txt
@@ -20,5 +20,6 @@ if(UNIX)
         TEST_NAME ${TEST_NAME}
         ISPC_TARGET_XE ${ISPC_TARGET_XE}
         DPCPP_HOST_SOURCES ${DPCPP_HOST_SOURCES}
+        LINK_L0
     )
 endif()

--- a/examples/xpu/simple-dpcpp-l0/simple-dpcpp-l0.cpp
+++ b/examples/xpu/simple-dpcpp-l0/simple-dpcpp-l0.cpp
@@ -63,9 +63,9 @@ std::vector<float> DpcppApp::transformIspc(const std::vector<float> &in) {
     ze_device_mem_alloc_desc_t alloc_desc = {};
 
     // Allocate memory on the device
-    L0_SAFE_CALL(zeMemAllocDevice(m_context, &alloc_desc, count * sizeof(float), 0, m_device, &in_dev));
-    L0_SAFE_CALL(zeMemAllocDevice(m_context, &alloc_desc, count * sizeof(float), 0, m_device, &out_dev));
-    L0_SAFE_CALL(zeMemAllocDevice(m_context, &alloc_desc, sizeof(Parameters), 0, m_device, &params_dev));
+    L0_SAFE_CALL(zeMemAllocDevice(m_context, &alloc_desc, count * sizeof(float), 64, m_device, &in_dev));
+    L0_SAFE_CALL(zeMemAllocDevice(m_context, &alloc_desc, count * sizeof(float), 64, m_device, &out_dev));
+    L0_SAFE_CALL(zeMemAllocDevice(m_context, &alloc_desc, sizeof(Parameters), 64, m_device, &params_dev));
 
     params.in = reinterpret_cast<float *>(in_dev);
     params.out = reinterpret_cast<float *>(out_dev);

--- a/ispcrt/cmake/ispcrtConfig.cmake.in
+++ b/ispcrt/cmake/ispcrtConfig.cmake.in
@@ -1,4 +1,4 @@
-## Copyright 2020-2022 Intel Corporation
+## Copyright 2020-2023 Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 
 @PACKAGE_INIT@
@@ -20,21 +20,6 @@ if (@ISPCRT_BUILD_TASKING@)
   set(ISPCRT_TASKING_MODEL @ISPCRT_BUILD_TASK_MODEL@)
 else()
   set(ISPCRT_TASKING_ENABLED FALSE)
-endif()
-
-## Find level_zero if required ##
-
-if(@ISPCRT_BUILD_GPU@)
-  include(CMakeFindDependencyMacro)
-
-  set(OLD_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
-
-  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-
-  find_dependency(level_zero)
-
-  set(CMAKE_MODULE_PATH ${OLD_CMAKE_MODULE_PATH})
-  unset(OLD_CMAKE_MODULE_PATH)
 endif()
 
 ## Print info about found ISPCRT version

--- a/ispcrt/detail/Device.h
+++ b/ispcrt/detail/Device.h
@@ -9,6 +9,7 @@
 #include "CommandQueue.h"
 #include "Kernel.h"
 #include "Module.h"
+#include "ModuleOptions.h"
 #include "TaskQueue.h"
 
 namespace ispcrt {
@@ -26,7 +27,11 @@ struct Device : public RefCounted {
 
     virtual TaskQueue *newTaskQueue() const = 0;
 
-    virtual Module *newModule(const char *moduleFile, const ISPCRTModuleOptions &opts) const = 0;
+    virtual ModuleOptions *newModuleOptions() const = 0;
+    virtual ModuleOptions *newModuleOptions(ISPCRTModuleType moduleType, bool libraryCompilation,
+                                            uint32_t stackSize) const = 0;
+
+    virtual Module *newModule(const char *moduleFile, const ModuleOptions &opts) const = 0;
 
     virtual void dynamicLinkModules(Module **modules, uint32_t numModules) const = 0;
     virtual Module *staticLinkModules(Module **modules, uint32_t numModules) const = 0;

--- a/ispcrt/detail/ModuleOptions.h
+++ b/ispcrt/detail/ModuleOptions.h
@@ -1,0 +1,26 @@
+// Copyright 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+// public
+#include "../ispcrt.h"
+// internal
+#include "IntrusivePtr.h"
+
+namespace ispcrt {
+namespace base {
+
+struct ModuleOptions : public RefCounted {
+    ModuleOptions() = default;
+    virtual ~ModuleOptions() = default;
+    virtual uint32_t stackSize() const = 0;
+    virtual bool libraryCompilation() const = 0;
+    virtual ISPCRTModuleType moduleType() const = 0;
+    virtual void setStackSize(uint32_t) = 0;
+    virtual void setLibraryCompilation(bool) = 0;
+    virtual void setModuleType(ISPCRTModuleType) = 0;
+};
+
+} // namespace base
+} // namespace ispcrt

--- a/ispcrt/detail/cpu/CPUDevice.cpp
+++ b/ispcrt/detail/cpu/CPUDevice.cpp
@@ -105,6 +105,25 @@ struct MemoryView : public ispcrt::base::MemoryView {
     size_t m_size{0};
 };
 
+struct ModuleOptions : public ispcrt::base::ModuleOptions {
+    ModuleOptions() = default;
+    ModuleOptions(ISPCRTModuleType moduleType, bool libraryCompilation, uint32_t stackSize)
+        : m_moduleType{moduleType}, m_libraryCompilation{libraryCompilation}, m_stackSize{stackSize} {}
+
+    uint32_t stackSize() const { return m_stackSize; }
+    bool libraryCompilation() const { return m_libraryCompilation; }
+    ISPCRTModuleType moduleType() const { return m_moduleType; }
+
+    void setStackSize(uint32_t size) { m_stackSize = size; }
+    void setLibraryCompilation(bool isLibraryCompilation) { m_libraryCompilation = isLibraryCompilation; }
+    void setModuleType(ISPCRTModuleType type) { m_moduleType = type; }
+
+  private:
+    uint32_t m_stackSize{0};
+    bool m_libraryCompilation{false};
+    ISPCRTModuleType m_moduleType{ISPCRTModuleType::ISPCRT_VECTOR_MODULE};
+};
+
 struct Module : public ispcrt::base::Module {
     Module(const char *moduleFile) : m_file(moduleFile) {
         if (!m_file.empty()) {
@@ -413,7 +432,15 @@ ispcrt::base::CommandQueue *CPUDevice::newCommandQueue(uint32_t ordinal) const {
 
 ispcrt::base::TaskQueue *CPUDevice::newTaskQueue() const { return new cpu::TaskQueue(); }
 
-ispcrt::base::Module *CPUDevice::newModule(const char *moduleFile, const ISPCRTModuleOptions &moduleOpts) const {
+ispcrt::base::ModuleOptions *CPUDevice::newModuleOptions() const { return new cpu::ModuleOptions(); }
+
+ispcrt::base::ModuleOptions *CPUDevice::newModuleOptions(ISPCRTModuleType moduleType, bool libraryCompilation,
+                                                         uint32_t stackSize) const {
+    return new cpu::ModuleOptions(moduleType, libraryCompilation, stackSize);
+}
+
+ispcrt::base::Module *CPUDevice::newModule(const char *moduleFile,
+                                           const ispcrt::base::ModuleOptions &moduleOpts) const {
     return new cpu::Module(moduleFile);
 }
 

--- a/ispcrt/detail/cpu/CPUDevice.h
+++ b/ispcrt/detail/cpu/CPUDevice.h
@@ -6,6 +6,7 @@
 #include "../CommandQueue.h"
 #include "../Device.h"
 #include "../Future.h"
+#include "../ModuleOptions.h"
 
 namespace ispcrt {
 
@@ -26,7 +27,11 @@ struct CPUDevice : public base::Device {
 
     base::TaskQueue *newTaskQueue() const override;
 
-    base::Module *newModule(const char *moduleFile, const ISPCRTModuleOptions &moduleOpts) const override;
+    base::ModuleOptions *newModuleOptions() const override;
+    base::ModuleOptions *newModuleOptions(ISPCRTModuleType moduleType, bool libraryCompilation,
+                                          uint32_t stackSize) const override;
+
+    base::Module *newModule(const char *moduleFile, const base::ModuleOptions &moduleOpts) const override;
 
     void dynamicLinkModules(base::Module **modules, const uint32_t numModules) const override;
     base::Module *staticLinkModules(base::Module **modules, const uint32_t numModules) const override;

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -1009,12 +1009,7 @@ struct Module : public ispcrt::base::Module {
         // If scalar module is passed to ISPC Runtime, do not use VC backend
         // options on it
         if (opts.moduleType() != ISPCRTModuleType::ISPCRT_SCALAR_MODULE) {
-            m_igc_options += "-vc-codegen -no-optimize -Xfinalizer '-presched'";
-#if defined(__linux__)
-            // `newspillcost` is not yet supported on Windows in open source
-            // TODO: use `newspillcost` for all platforms as soon as it available
-            m_igc_options += " -Xfinalizer '-newspillcost'";
-#endif
+            m_igc_options += "-vc-codegen -no-optimize -Xfinalizer '-presched' -Xfinalizer '-newspillcostispc'";
         }
         // If stackSize has default value 0, do not set -stateless-stack-mem-size,
         // it will be set to 8192 in VC backend by default.

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -876,7 +876,7 @@ struct MemoryView : public ispcrt::base::MemoryView {
             throw std::runtime_error("Device handle is NULL!");
 
         ze_device_mem_alloc_desc_t allocDesc = {};
-        ze_result_t status = zeMemAllocDevice(m_context, &allocDesc, m_size, m_size, m_device, &m_devicePtr);
+        ze_result_t status = zeMemAllocDevice(m_context, &allocDesc, m_size, 64, m_device, &m_devicePtr);
 
         if (status != ZE_RESULT_SUCCESS)
             m_devicePtr = nullptr;

--- a/ispcrt/detail/gpu/GPUDevice.h
+++ b/ispcrt/detail/gpu/GPUDevice.h
@@ -37,7 +37,11 @@ struct GPUDevice : public base::Device {
 
     base::TaskQueue *newTaskQueue() const override;
 
-    base::Module *newModule(const char *moduleFile, const ISPCRTModuleOptions &opts) const override;
+    base::ModuleOptions *newModuleOptions() const override;
+    base::ModuleOptions *newModuleOptions(ISPCRTModuleType moduleType, bool libraryCompilation,
+                                          uint32_t stackSize) const override;
+
+    base::Module *newModule(const char *moduleFile, const base::ModuleOptions &opts) const override;
 
     void dynamicLinkModules(base::Module **modules, const uint32_t numModules) const override;
     base::Module *staticLinkModules(base::Module **modules, const uint32_t numModules) const override;

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -17,6 +17,7 @@
 // ispcrt
 #include "detail/Exception.h"
 #include "detail/Module.h"
+#include "detail/ModuleOptions.h"
 #include "detail/TaskQueue.h"
 
 #ifdef ISPCRT_BUILD_CPU
@@ -765,11 +766,70 @@ ISPCRT_CATCH_END(nullptr)
 // Modules ////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 
-ISPCRTModule ispcrtLoadModule(ISPCRTDevice d, const char *moduleFile,
-                              ISPCRTModuleOptions moduleOpts) ISPCRT_CATCH_BEGIN {
+ISPCRTModuleOptions ispcrtNewModuleOptionsEmpty(ISPCRTDevice d) ISPCRT_CATCH_BEGIN {
     const auto &device = referenceFromHandle<ispcrt::base::Device>(d);
-    auto module = (ISPCRTModule)device.newModule(moduleFile, moduleOpts);
+    return (ISPCRTModuleOptions)device.newModuleOptions();
+}
+ISPCRT_CATCH_END(nullptr)
+
+ISPCRTModuleOptions ispcrtNewModuleOptions(ISPCRTDevice d, ISPCRTModuleType moduleType, bool libraryCompilation,
+                                           uint32_t stackSize) ISPCRT_CATCH_BEGIN {
+    const auto &device = referenceFromHandle<ispcrt::base::Device>(d);
+    return (ISPCRTModuleOptions)device.newModuleOptions(moduleType, libraryCompilation, stackSize);
+}
+ISPCRT_CATCH_END(nullptr)
+
+uint32_t ispcrtModuleOptionsGetStackSize(ISPCRTModuleOptions o) ISPCRT_CATCH_BEGIN {
+    const auto &opts = referenceFromHandle<ispcrt::base::ModuleOptions>(o);
+    return opts.stackSize();
+}
+ISPCRT_CATCH_END(0)
+
+bool ispcrtModuleOptionsGetLibraryCompilation(ISPCRTModuleOptions o) ISPCRT_CATCH_BEGIN {
+    const auto &opts = referenceFromHandle<ispcrt::base::ModuleOptions>(o);
+    return opts.libraryCompilation();
+}
+ISPCRT_CATCH_END(false)
+
+ISPCRTModuleType ispcrtModuleOptionsGetModuleType(ISPCRTModuleOptions o) ISPCRT_CATCH_BEGIN {
+    const auto &opts = referenceFromHandle<ispcrt::base::ModuleOptions>(o);
+    return opts.moduleType();
+}
+ISPCRT_CATCH_END(ISPCRTModuleType::ISPCRT_VECTOR_MODULE)
+
+void ispcrtModuleOptionsSetStackSize(ISPCRTModuleOptions o, uint32_t size) ISPCRT_CATCH_BEGIN {
+    auto &opts = referenceFromHandle<ispcrt::base::ModuleOptions>(o);
+    opts.setStackSize(size);
+}
+ISPCRT_CATCH_END_NO_RETURN()
+
+void ispcrtModuleOptionsSetLibraryCompilation(ISPCRTModuleOptions o, bool isLibraryCompilation) ISPCRT_CATCH_BEGIN {
+    auto &opts = referenceFromHandle<ispcrt::base::ModuleOptions>(o);
+    opts.setLibraryCompilation(isLibraryCompilation);
+}
+ISPCRT_CATCH_END_NO_RETURN()
+
+void ispcrtModuleOptionsSetModuleType(ISPCRTModuleOptions o, ISPCRTModuleType type) ISPCRT_CATCH_BEGIN {
+    auto &opts = referenceFromHandle<ispcrt::base::ModuleOptions>(o);
+    opts.setModuleType(type);
+}
+ISPCRT_CATCH_END_NO_RETURN()
+
+ISPCRTModule ispcrtLoadModule(ISPCRTDevice d, const char *moduleFile) ISPCRT_CATCH_BEGIN {
+    ISPCRTModule module;
+    const auto &device = referenceFromHandle<ispcrt::base::Device>(d);
+    const auto &o = (ISPCRTModuleOptions)device.newModuleOptions();
+    module = ispcrtLoadModuleWithOptions(d, moduleFile, o);
+    ispcrtRelease(o);
     return module;
+}
+ISPCRT_CATCH_END(nullptr)
+
+ISPCRTModule ispcrtLoadModuleWithOptions(ISPCRTDevice d, const char *moduleFile,
+                                         ISPCRTModuleOptions o) ISPCRT_CATCH_BEGIN {
+    const auto &device = referenceFromHandle<ispcrt::base::Device>(d);
+    const auto &opts = referenceFromHandle<ispcrt::base::ModuleOptions>(o);
+    return (ISPCRTModule)device.newModule(moduleFile, opts);
 }
 ISPCRT_CATCH_END(nullptr)
 

--- a/ispcrt/ispcrt.h
+++ b/ispcrt/ispcrt.h
@@ -18,6 +18,7 @@ struct _ISPCRTDevice;
 struct _ISPCRTMemoryView;
 struct _ISPCRTTaskQueue;
 struct _ISPCRTModule;
+struct _ISPCRTModuleOptions;
 struct _ISPCRTKernel;
 struct _ISPCRTFuture;
 struct _ISPCRTFence;
@@ -29,6 +30,7 @@ typedef _ISPCRTDevice *ISPCRTDevice;
 typedef _ISPCRTMemoryView *ISPCRTMemoryView;
 typedef _ISPCRTTaskQueue *ISPCRTTaskQueue;
 typedef _ISPCRTModule *ISPCRTModule;
+typedef _ISPCRTModuleOptions *ISPCRTModuleOptions;
 typedef _ISPCRTKernel *ISPCRTKernel;
 typedef _ISPCRTFuture *ISPCRTFuture;
 typedef _ISPCRTFence *ISPCRTFence;
@@ -40,6 +42,7 @@ typedef void *ISPCRTDevice;
 typedef void *ISPCRTMemoryView;
 typedef void *ISPCRTTaskQueue;
 typedef void *ISPCRTModule;
+typedef void *ISPCRTModuleOptions;
 typedef void *ISPCRTKernel;
 typedef void *ISPCRTFuture;
 typedef void *ISPCRTFence;
@@ -168,14 +171,18 @@ typedef enum {
     ISPCRT_SCALAR_MODULE,
 } ISPCRTModuleType;
 
-struct ISPCRTModuleOptions_ {
-    uint32_t stackSize{0};
-    bool libraryCompilation{false};
-    ISPCRTModuleType moduleType{ISPCRTModuleType::ISPCRT_VECTOR_MODULE};
-};
-typedef struct ISPCRTModuleOptions_ ISPCRTModuleOptions;
+ISPCRTModuleOptions ispcrtNewModuleOptionsEmpty(ISPCRTDevice);
+ISPCRTModuleOptions ispcrtNewModuleOptions(ISPCRTDevice, ISPCRTModuleType moduleType, bool libraryCompilation = false,
+                                           uint32_t stackSize = 0);
+uint32_t ispcrtModuleOptionsGetStackSize(ISPCRTModuleOptions);
+bool ispcrtModuleOptionsGetLibraryCompilation(ISPCRTModuleOptions);
+ISPCRTModuleType ispcrtModuleOptionsGetModuleType(ISPCRTModuleOptions);
+void ispcrtModuleOptionsSetStackSize(ISPCRTModuleOptions, uint32_t);
+void ispcrtModuleOptionsSetLibraryCompilation(ISPCRTModuleOptions, bool);
+void ispcrtModuleOptionsSetModuleType(ISPCRTModuleOptions, ISPCRTModuleType);
 
-ISPCRTModule ispcrtLoadModule(ISPCRTDevice, const char *moduleFile, ISPCRTModuleOptions);
+ISPCRTModule ispcrtLoadModule(ISPCRTDevice, const char *moduleFile);
+ISPCRTModule ispcrtLoadModuleWithOptions(ISPCRTDevice, const char *moduleFile, ISPCRTModuleOptions);
 void ispcrtDynamicLinkModules(ISPCRTDevice, ISPCRTModule *modules, uint32_t numModules);
 ISPCRTModule ispcrtStaticLinkModules(ISPCRTDevice, ISPCRTModule *modules, uint32_t numModules);
 void *ispcrtFunctionPtr(ISPCRTModule, const char *name);

--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -357,17 +357,33 @@ TEST_F(MockTestWithDevice, Module_Constructor) {
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
+TEST_F(MockTestWithDevice, Module_Constructor_zeModuleCreateWithOptionsEmpty) {
+    // Create module with options
+    ispcrt::ModuleOptions opts{m_device};
+    ispcrt::Module m(m_device, "", opts);
+    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
+}
+
 TEST_F(MockTestWithDevice, Module_Constructor_zeModuleCreateWithOptions) {
     // Create module with options
-    ISPCRTModuleOptions opts = {};
+    ispcrt::ModuleOptions opts{m_device, ISPCRTModuleType::ISPCRT_VECTOR_MODULE, false, 0};
     ispcrt::Module m(m_device, "", opts);
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
 
 TEST_F(MockTestWithDevice, Module_Constructor_zeModuleCreateWithStackSize) {
     // Create module with stack size
-    ISPCRTModuleOptions opts;
-    opts.stackSize = 32000;
+    ispcrt::ModuleOptions opts{m_device, ISPCRTModuleType::ISPCRT_VECTOR_MODULE, false, 32000};
+    ispcrt::Module m(m_device, "", opts);
+    ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
+}
+
+TEST_F(MockTestWithDevice, Module_Constructor_zeModuleCreateWithOptionsSetters) {
+    // Create module with stack size
+    ispcrt::ModuleOptions opts{m_device};
+    opts.setStackSize(32000);
+    opts.setLibraryCompilation(true);
+    opts.setModuleType(ISPCRTModuleType::ISPCRT_SCALAR_MODULE);
     ispcrt::Module m(m_device, "", opts);
     ASSERT_EQ(sm_rt_error, ISPCRT_NO_ERROR);
 }
@@ -1478,8 +1494,7 @@ TEST_F(MockTest, C_API_ispcrtCommandListBarrierCloseSubmitReset) {
 TEST_F(MockTest, C_API_ispcrtCommandListCopyLaunchSyncQueue) {
     ISPCRTContext ctx = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
     ISPCRTDevice dev = ispcrtGetDeviceFromContext(ctx, 0);
-    ISPCRTModuleOptions opts;
-    ISPCRTModule m = ispcrtLoadModule(dev, "", opts);
+    ISPCRTModule m = ispcrtLoadModule(dev, "");
     ISPCRTKernel k = ispcrtNewKernel(dev, m, "");
     ISPCRTNewMemoryViewFlags flags = {ISPCRT_ALLOC_TYPE_SHARED};
     char mem[100] = {0};
@@ -1526,8 +1541,7 @@ TEST_F(MockTest, C_API_ispcrtCommandListCopyLaunchSyncQueue) {
 TEST_F(MockTest, C_API_ispcrtCommandListCopyLaunchFence) {
     ISPCRTContext ctx = ispcrtNewContext(ISPCRT_DEVICE_TYPE_GPU);
     ISPCRTDevice dev = ispcrtGetDeviceFromContext(ctx, 0);
-    ISPCRTModuleOptions opts;
-    ISPCRTModule m = ispcrtLoadModule(dev, "", opts);
+    ISPCRTModule m = ispcrtLoadModule(dev, "");
     ISPCRTKernel k = ispcrtNewKernel(dev, m, "");
     ISPCRTNewMemoryViewFlags flags = {ISPCRT_ALLOC_TYPE_SHARED};
     char mem[100] = {0};

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1435,12 +1435,7 @@ bool Module::writeZEBin(llvm::Module *module, const char *outFileName) {
         return false;
     }
 
-    std::string options{"-vc-codegen -no-optimize -Xfinalizer '-presched'"};
-#ifdef ISPC_IS_LINUX
-    // `newspillcost` is not yet supported on Windows in open source
-    // TODO: use `newspillcost` for all platforms as soon as it available
-    options += " -Xfinalizer '-newspillcost'";
-#endif
+    std::string options{"-vc-codegen -no-optimize -Xfinalizer '-presched' -Xfinalizer '-newspillcostispc'"};
     // Add debug option to VC backend of "-g" is set to ISPC
     if (g->generateDebuggingSymbols) {
         options.append(" -g");

--- a/superbuild/osPresets.json
+++ b/superbuild/osPresets.json
@@ -1,6 +1,6 @@
 {
   "vendor": {
-    "ispc.github.io" : {
+    "ispc.github.io": {
       "license_comment1": "Copyright (c) 2023, Intel Corporation",
       "license_comment2": "SPDX-License-Identifier: BSD-3-Clause"
     }
@@ -22,7 +22,7 @@
         "SPIRV_TRANSLATOR_BRANCH": "llvm_release_150",
         "SPIRV_TRANSLATOR_SHA": "e82ecc2bd7295604fcf1824e47c95fa6a09c6e63",
         "L0_URL": "https://github.com/oneapi-src/level-zero.git",
-        "L0_TAG": "v1.11.0",
+        "L0_TAG": "v1.12.0",
         "ISPC_CORPUS_URL": "null"
       }
     }

--- a/superbuild/osPresets.json
+++ b/superbuild/osPresets.json
@@ -17,7 +17,7 @@
         "LLVM_VERSION": "15.0",
         "LLVM_URL": "https://github.com/llvm/llvm-project.git",
         "VC_INTRINSICS_URL": "https://github.com/intel/vc-intrinsics.git",
-        "VC_INTRINSICS_SHA": "fe92a377338258b725cfbd0a1bd49a9cf5e2864c",
+        "VC_INTRINSICS_SHA": "910db4801d4a029834606e3e42a8d60358e74fdf",
         "SPIRV_TRANSLATOR_URL": "https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",
         "SPIRV_TRANSLATOR_BRANCH": "llvm_release_150",
         "SPIRV_TRANSLATOR_SHA": "e82ecc2bd7295604fcf1824e47c95fa6a09c6e63",

--- a/test_static_l0.cpp
+++ b/test_static_l0.cpp
@@ -162,12 +162,7 @@ static void L0InitContext(ze_device_handle_t &hDevice, ze_module_handle_t &hModu
     is.read((char *)codeBin, codeSize);
     is.close();
 
-    std::string igcOptions = "-vc-codegen -no-optimize -Xfinalizer '-presched'";
-#ifdef ISPC_IS_LINUX
-    // `newspillcost` is not yet supported on Windows in open source
-    // TODO: use `newspillcost` for all platforms as soon as it available
-    igcOptions += " -Xfinalizer '-newspillcost'";
-#endif
+    std::string igcOptions = "-vc-codegen -no-optimize -Xfinalizer '-presched' -Xfinalizer '-newspillcostispc'";
     const char *userIgcOptionsEnv = getenv("ISPCRT_IGC_OPTIONS");
     if (userIgcOptionsEnv) {
         std::string userIgcOptions(userIgcOptionsEnv);

--- a/test_static_l0.cpp
+++ b/test_static_l0.cpp
@@ -260,7 +260,7 @@ static void L0Launch_F_V(ze_device_handle_t &hDevice, ze_module_handle_t &hModul
     // allocate buffers
     ze_device_mem_alloc_desc_t allocDesc = {};
     void *OUTBuff = nullptr;
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &OUTBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &OUTBuff));
     // copy buffers to device
     L0_SAFE_CALL(
         zeCommandListAppendMemoryCopy(hCommandList, OUTBuff, return_data, N * sizeof(float), nullptr, 0, nullptr));
@@ -283,7 +283,7 @@ static void L0Launch_F_Threads(ze_device_handle_t &hDevice, ze_module_handle_t &
     // allocate buffers
     ze_device_mem_alloc_desc_t allocDesc = {};
     void *OUTBuff = nullptr;
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &OUTBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &OUTBuff));
     // copy buffers to device
     L0_SAFE_CALL(
         zeCommandListAppendMemoryCopy(hCommandList, OUTBuff, return_data, N * sizeof(float), nullptr, 0, nullptr));
@@ -305,8 +305,8 @@ static void L0Launch_F_F(ze_device_handle_t &hDevice, ze_module_handle_t &hModul
     // allocate buffers
     ze_device_mem_alloc_desc_t allocDesc = {};
     void *OUTBuff = nullptr, *INBuff = nullptr;
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &OUTBuff));
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &INBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &OUTBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &INBuff));
     // copy buffers to device
     L0_SAFE_CALL(
         zeCommandListAppendMemoryCopy(hCommandList, OUTBuff, return_data, N * sizeof(float), nullptr, 0, nullptr));
@@ -335,9 +335,9 @@ static void L0Launch_F_FI(ze_device_handle_t &hDevice, ze_module_handle_t &hModu
     // allocate buffers
     ze_device_mem_alloc_desc_t allocDesc = {};
     void *OUTBuff = nullptr, *INBuff = nullptr, *IN1Buff = nullptr;
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &OUTBuff));
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &INBuff));
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(int), N * sizeof(int), hDevice, &IN1Buff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &OUTBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &INBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(int), 64, hDevice, &IN1Buff));
     // copy buffers to device
     L0_SAFE_CALL(
         zeCommandListAppendMemoryCopy(hCommandList, OUTBuff, return_data, N * sizeof(float), nullptr, 0, nullptr));
@@ -368,8 +368,8 @@ static void L0Launch_F_FU(ze_device_handle_t &hDevice, ze_module_handle_t &hModu
     // allocate buffers
     ze_device_mem_alloc_desc_t allocDesc = {};
     void *OUTBuff = nullptr, *INBuff = nullptr;
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &OUTBuff));
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &INBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &OUTBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &INBuff));
     // copy buffers to device
     L0_SAFE_CALL(
         zeCommandListAppendMemoryCopy(hCommandList, OUTBuff, return_data, N * sizeof(float), nullptr, 0, nullptr));
@@ -398,8 +398,8 @@ static void L0Launch_F_DU(ze_device_handle_t &hDevice, ze_module_handle_t &hModu
     // allocate buffers
     ze_device_mem_alloc_desc_t allocDesc = {};
     void *OUTBuff = nullptr, *INBuff = nullptr;
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &OUTBuff));
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(double), N * sizeof(double), hDevice, &INBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &OUTBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(double), 64, hDevice, &INBuff));
     // copy buffers to device
     L0_SAFE_CALL(
         zeCommandListAppendMemoryCopy(hCommandList, OUTBuff, return_data, N * sizeof(float), nullptr, 0, nullptr));
@@ -428,8 +428,8 @@ static void L0Launch_F_DUF(ze_device_handle_t &hDevice, ze_module_handle_t &hMod
     // allocate buffers
     ze_device_mem_alloc_desc_t allocDesc = {};
     void *OUTBuff = nullptr, *INBuff = nullptr;
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &OUTBuff));
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(double), N * sizeof(double), hDevice, &INBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &OUTBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(double), 64, hDevice, &INBuff));
     // copy buffers to device
     L0_SAFE_CALL(
         zeCommandListAppendMemoryCopy(hCommandList, OUTBuff, return_data, N * sizeof(float), nullptr, 0, nullptr));
@@ -459,9 +459,9 @@ static void L0Launch_F_DI(ze_device_handle_t &hDevice, ze_module_handle_t &hModu
     // allocate buffers
     ze_device_mem_alloc_desc_t allocDesc = {};
     void *OUTBuff = nullptr, *INBuff = nullptr, *IN1Buff = nullptr;
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &OUTBuff));
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(double), N * sizeof(double), hDevice, &INBuff));
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(int), N * sizeof(int), hDevice, &IN1Buff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &OUTBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(double), 64, hDevice, &INBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(int), 64, hDevice, &IN1Buff));
 
     // copy buffers to device
     L0_SAFE_CALL(
@@ -509,7 +509,7 @@ static void L0Launch_Print_F(ze_device_handle_t &hDevice, ze_module_handle_t &hM
     // allocate buffers
     ze_device_mem_alloc_desc_t allocDesc = {};
     void *INBuff = nullptr;
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &INBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &INBuff));
     // copy buffers to device
     L0_SAFE_CALL(
         zeCommandListAppendMemoryCopy(hCommandList, INBuff, vfloat_data, N * sizeof(float), nullptr, 0, nullptr));
@@ -533,7 +533,7 @@ static void L0Launch_Print_FUF(ze_device_handle_t &hDevice, ze_module_handle_t &
     // allocate buffers
     ze_device_mem_alloc_desc_t allocDesc = {};
     void *INBuff = nullptr;
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &INBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &INBuff));
     // copy buffers to device
     L0_SAFE_CALL(
         zeCommandListAppendMemoryCopy(hCommandList, INBuff, vfloat_data, N * sizeof(float), nullptr, 0, nullptr));
@@ -570,7 +570,7 @@ static void L0Launch_Result(ze_device_handle_t &hDevice, ze_module_handle_t &hMo
     // allocate buffers
     ze_device_mem_alloc_desc_t allocDesc = {};
     void *OUTBuff = nullptr;
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &OUTBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &OUTBuff));
     // copy buffers to device
     L0_SAFE_CALL(
         zeCommandListAppendMemoryCopy(hCommandList, OUTBuff, return_data, N * sizeof(float), nullptr, 0, nullptr));
@@ -604,7 +604,7 @@ static void L0Launch_Result_Threads(ze_device_handle_t &hDevice, ze_module_handl
     // allocate buffers
     ze_device_mem_alloc_desc_t allocDesc = {};
     void *OUTBuff = nullptr;
-    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), N * sizeof(float), hDevice, &OUTBuff));
+    L0_SAFE_CALL(zeMemAllocDevice(hContext, &allocDesc, N * sizeof(float), 64, hDevice, &OUTBuff));
     // copy buffers to device
     L0_SAFE_CALL(
         zeCommandListAppendMemoryCopy(hCommandList, OUTBuff, return_data, N * sizeof(float), nullptr, 0, nullptr));


### PR DESCRIPTION
ISPC for Xe update including:
1. updated ISPCRT API in regards to `ISPCRTModuleOptions` structure. Now it's a generic object as other ISPC objects like `Module` or `Future`.
2. removed compile-time level-zero dependency from ISPCRT which is not needed anymore after the ISPCRT split to CPU and GPU parts.
3. fixed alignment for device allocations made using `zwMemAllocDevice` L0 API
4. enabled 'newspillcostispc' IGC finalizer option on Windows reducing spill size on Xe targets which leads to up to 70% performance improvement on our target workloads on DG2.