### PR TITLE
Deallocate memory allocated in parser

### DIFF
--- a/src/decl.h
+++ b/src/decl.h
@@ -100,7 +100,7 @@ enum DeclaratorKind { DK_BASE, DK_POINTER, DK_REFERENCE, DK_ARRAY, DK_FUNCTION }
     In conjunction with an instance of the DeclSpecs, this gives us
     everything we need for a full variable declaration.
  */
-class Declarator {
+class Declarator : public Traceable {
   public:
     Declarator(DeclaratorKind dk, SourcePos p);
 

--- a/src/decl.h
+++ b/src/decl.h
@@ -180,8 +180,9 @@ class Declaration : public Traceable {
 
 /** The parser creates instances of StructDeclaration for the members of
     structs as it's parsing their declarations. */
-struct StructDeclaration {
+struct StructDeclaration : public Traceable {
     StructDeclaration(const Type *t, std::vector<Declarator *> *d) : type(t), declarators(d) {}
+    ~StructDeclaration() { delete declarators; }
 
     const Type *type;
     std::vector<Declarator *> *declarators;

--- a/src/decl.h
+++ b/src/decl.h
@@ -60,7 +60,7 @@ class Declarator;
     In other words, this represents all of the stuff that applies to all of
     the (possibly multiple) variables in a declaration.
  */
-class DeclSpecs {
+class DeclSpecs : public Traceable {
   public:
     DeclSpecs(const Type *t = nullptr, StorageClass sc = SC_NONE, int tq = TYPEQUAL_NONE);
 

--- a/src/decl.h
+++ b/src/decl.h
@@ -155,7 +155,7 @@ class Declarator {
 /** @brief Representation of a full declaration of one or more variables,
     including the shared DeclSpecs as well as the per-variable Declarators.
  */
-class Declaration {
+class Declaration : public Traceable {
   public:
     Declaration(DeclSpecs *ds, std::vector<Declarator *> *dlist = nullptr);
     Declaration(DeclSpecs *ds, Declarator *d);

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -845,6 +845,9 @@ declaration
     | declaration_specifiers init_declarator_list ';'
       {
           $$ = new Declaration($1, $2);
+          // init_declarator_list returns vector of declarators, its copy is
+          // saved in Declaration constructor, so it is not needed anymore.
+          delete $2;
       }
     ;
 

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1531,8 +1531,11 @@ direct_declarator
           if ($1 != nullptr) {
               Declarator *d = new Declarator(DK_FUNCTION, Union(@1, @4));
               d->child = $1;
-              if ($3 != nullptr)
+              if ($3 != nullptr) {
                   d->functionParams = *$3;
+                  // parameter_type_list returns vector of Declarations that is not needed anymore.
+                  delete $3;
+              }
               $$ = d;
           }
           else
@@ -1760,7 +1763,11 @@ direct_abstract_declarator
     | '(' parameter_type_list ')'
       {
           Declarator *d = new Declarator(DK_FUNCTION, Union(@1, @3));
-          if ($2 != nullptr) d->functionParams = *$2;
+          if ($2 != nullptr) {
+              d->functionParams = *$2;
+              // parameter_type_list returns vector of Declarations that is not needed anymore.
+              delete $2;
+          }
           $$ = d;
       }
     | direct_abstract_declarator '(' ')'
@@ -1780,7 +1787,11 @@ direct_abstract_declarator
           else {
               Declarator *d = new Declarator(DK_FUNCTION, Union(@1, @4));
               d->child = $1;
-              if ($3 != nullptr) d->functionParams = *$3;
+              if ($3 != nullptr) {
+                  d->functionParams = *$3;
+                  // parameter_type_list returns vector of Declarations that is not needed anymore.
+                  delete $3;
+              }
               $$ = d;
           }
       }
@@ -2434,6 +2445,8 @@ template_function_instantiation
           d->child = simpleTemplID->first;
           if ($5 != nullptr) {
               d->functionParams = *$5;
+              // parameter_type_list returns vector of Declarations that is not needed anymore.
+              delete $5;
           }
 
           d->InitFromDeclSpecs($2);

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -872,11 +872,16 @@ declspec_list
     {
         $$ = new std::vector<std::pair<std::string, SourcePos> >;
         $$->push_back(*$1);
+        // declspec_item returns pair that was copied so it is not needed anymore.
+        delete $1;
     }
     | declspec_list ',' declspec_item
     {
-        if ($1 != nullptr)
+        if ($1 != nullptr) {
             $1->push_back(*$3);
+            // declspec_item returns pair that was copied so it is not needed anymore.
+            delete $3;
+        }
         $$ = $1;
     }
     ;
@@ -884,6 +889,7 @@ declspec_list
 declspec_specifier
     : TOKEN_DECLSPEC '(' declspec_list ')'
     {
+        // declspec_list returns heap allocated vector that passed up here.
         $$ = $3;
     }
     ;
@@ -910,8 +916,11 @@ declaration_specifiers
     | declspec_specifier
       {
           $$ = new DeclSpecs;
-          if ($1 != nullptr)
+          if ($1 != nullptr) {
               $$->declSpecList = *$1;
+              // declspec_specifier returns a vector that was copied and it is not needed anymore.
+              delete $1;
+          }
       }
     | declspec_specifier declaration_specifiers
       {
@@ -920,6 +929,9 @@ declaration_specifiers
           if (ds != nullptr && declSpecList != nullptr) {
               for (int i = 0; i < (int)declSpecList->size(); ++i)
                   ds->declSpecList.push_back((*declSpecList)[i]);
+
+              // declspec_specifier returns a vector that was copied and it is not needed anymore.
+              delete declSpecList;
           }
           $$ = ds;
       }

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1142,6 +1142,8 @@ struct_or_union_specifier
                                               Variability::Unbound, false, @1);
               m->symbolTable->AddType(name.c_str(), st, @1);
               $$ = st;
+              // struct_declaration_list returns a vector that is not needed anymore.
+              delete $3;
           }
           else
               $$ = nullptr;
@@ -1156,6 +1158,8 @@ struct_or_union_specifier
                                            &elementPositions);
               $$ = new StructType("", elementTypes, elementNames, elementPositions,
                                   false, Variability::Unbound, true, @1);
+              // struct_declaration_list returns a vector that is not needed anymore.
+              delete $3;
           }
           else
               $$ = nullptr;

--- a/src/sym.h
+++ b/src/sym.h
@@ -36,7 +36,7 @@ class ConstExpr;
    function symbols (and vice versa, for non-function symbols)?
  */
 
-class Symbol {
+class Symbol : public Traceable {
   public:
     /** The Symbol constructor takes the name of the symbol, its
         position in a source file, and its type (if known). */


### PR DESCRIPTION
After that change, no memory leaks left originated from `parse.yy` on trivial example with stdlib. The fixed allocation is cause of around 2MB in32k allocations. The left part after the fix is around 0.2MB in 2600 allocations.

`Symbol`, `Declaration`, `DeclSpec`, `Declarator`, `StructDeclaration` is freed via bookkeeping (`Tracable`). 

There are also quite a few auxiliary vectors created during parsing that deallocated directly after usage.