### PR TITLE
float/half: Add tests checking conversion correctness

### DIFF
--- a/tests/float-to-half.ispc
+++ b/tests/float-to-half.ispc
@@ -1,10 +1,19 @@
 #include "../test_static.isph"
 task void f_v(uniform float RET[]) {
-    float f = 65535;
-    unsigned int16 h = float_to_half(f);
-    RET[programIndex] = half_to_float(h);
+    RET[programIndex] = 0;
+    RET[programIndex + programCount] = 0;
+
+    float f1 = 65535;
+    unsigned int16 h1 = float_to_half(f1);
+
+    float f2 = 32768;
+    unsigned int16 h2 = float_to_half(f2);
+
+    RET[programIndex] = half_to_float(h1);
+    RET[programIndex + programCount] = half_to_float(h2);
 }
 
 task void result(uniform float RET[]) {
     RET[programIndex] = 65535;
+    RET[programIndex + programCount] = 32768;
 }

--- a/tests/float-to-half.ispc
+++ b/tests/float-to-half.ispc
@@ -1,0 +1,10 @@
+#include "../test_static.isph"
+task void f_v(uniform float RET[]) {
+    float f = 65535;
+    unsigned int16 h = float_to_half(f);
+    RET[programIndex] = half_to_float(h);
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 65535;
+}

--- a/tests/float-to-half_fast.ispc
+++ b/tests/float-to-half_fast.ispc
@@ -1,0 +1,20 @@
+#include "../test_static.isph"
+task void f_v(uniform float RET[]) {
+    RET[programIndex] = 0;
+    RET[programIndex + programCount] = 0;
+
+    float f1 = 65535;
+    unsigned int16 h1 = float_to_half_fast(f1);
+
+    float f2 = 32768;
+    unsigned int16 h2 = float_to_half_fast(f2);
+
+    RET[programIndex] = half_to_float_fast(h1);
+    RET[programIndex + programCount] = half_to_float_fast(h2);
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 65535;
+    RET[programIndex + programCount] = 32768;
+}
+

--- a/tests/half-to-float.ispc
+++ b/tests/half-to-float.ispc
@@ -1,0 +1,10 @@
+#include "../test_static.isph"
+task void f_v(uniform float RET[]) {
+    unsigned int16 h = 65535;
+    float f = half_to_float(h);
+    RET[programIndex] = float_to_half(f);
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 65535;
+}

--- a/tests/half-to-float.ispc
+++ b/tests/half-to-float.ispc
@@ -1,10 +1,19 @@
 #include "../test_static.isph"
 task void f_v(uniform float RET[]) {
-    unsigned int16 h = 65535;
-    float f = half_to_float(h);
-    RET[programIndex] = float_to_half(f);
+    RET[programIndex] = 0;
+    RET[programIndex + programCount] = 0;
+
+    unsigned int16 h1 = 65535;
+    float f1 = half_to_float(h1);
+
+    unsigned int16 h2 = 32768;
+    float f2 = half_to_float(h2);
+
+    RET[programIndex] = float_to_half(f1);
+    RET[programIndex + programCount] = float_to_half(f2);
 }
 
 task void result(uniform float RET[]) {
     RET[programIndex] = 65535;
+    RET[programIndex + programCount] = 32768;
 }

--- a/tests/half-to-float_fast.ispc
+++ b/tests/half-to-float_fast.ispc
@@ -1,0 +1,20 @@
+#include "../test_static.isph"
+task void f_v(uniform float RET[]) {
+    RET[programIndex] = 0;
+    RET[programIndex + programCount] = 0;
+
+    unsigned int16 h1 = 65535;
+    float f1 = half_to_float_fast(h1);
+
+    unsigned int16 h2 = 32768;
+    float f2 = half_to_float_fast(h2);
+
+    RET[programIndex] = float_to_half_fast(f1);
+    RET[programIndex + programCount] = float_to_half_fast(f2);
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 65535;
+    RET[programIndex + programCount] = 32768;
+}
+


### PR DESCRIPTION
Changes:
*   Add test checking float to half conversion.
    | `tests/float-to-half.ispc`
*   Add test checking half to float conversion.
    | `tests/half-to-float.ispc`

Adding these tests to attempt to reproduce [flaky half tests](https://github.com/ispc/ispc/actions/runs/5583770342/jobs/10204561581?pr=2494#step:7:28) from PR #2494 in CI.