### PR TITLE
Xe: Remove unused emitXeHardwareMask option

### DIFF
--- a/src/ctx.h
+++ b/src/ctx.h
@@ -587,14 +587,6 @@ class FunctionEmitContext {
                                 const std::vector<llvm::Value *> &args);
 
 #ifdef ISPC_XE_ENABLED
-    /** Emit genx_simdcf_any intrinsic.
-        Required when Xe hardware mask is emitted. */
-    llvm::Value *XeSimdCFAny(llvm::Value *value);
-
-    /** Emit genx_simdcf_predicate intrinsic
-        Required when Xe hardware mask is emitted. */
-    llvm::Value *XeSimdCFPredicate(llvm::Value *values, llvm::Value *defaults = nullptr);
-
     /** Start unmasked region. Sets execution mask to all-active, and return the old mask.*/
     llvm::Value *XeStartUnmaskedRegion();
 
@@ -613,20 +605,10 @@ class FunctionEmitContext {
         and returns pointer to its first element. */
     llvm::Constant *XeGetOrCreateConstantString(llvm::StringRef str, llvm::StringRef name);
 
-    /** Change scalar condition to vector condition before branching if
-        emulated uniform condition was found in external scopes and start SIMD control
-        flow with simdcf.any intrinsic.
-        Required when Xe hardware mask is emitted. */
-    llvm::Value *XePrepareVectorBranch(llvm::Value *value);
-
     /** Emit ISPC-Uniform metadata to llvm instruction. Instruction with
         such metadata will not be predicated in ISPCSIMDCFLowering pass.
         Required when Xe hardware mask is emitted. */
     void XeUniformMetadata(llvm::Value *v);
-
-    /** Check if current control flow block is inside Xe SIND CF
-        Required when Xe hardware mask is emitted. */
-    bool inXeSimdCF() const;
 
     /** This function checks addrspace of function parameter on paramIndex and returns
         val with casted addrspace if required. If cast is not required, original val is returned*/
@@ -634,10 +616,6 @@ class FunctionEmitContext {
                                            const unsigned int paramIndex, bool atEntryBlock = false);
 
 #endif
-    /** Enables emitting of genx.any intrinsics and the control flow which is
-        based on impliit hardware mask. Forces generation of goto/join instructions
-        in assembly. */
-    bool emitXeHardwareMask();
 
     /** @} */
 
@@ -704,12 +682,6 @@ class FunctionEmitContext {
     /** If we're inside a loop, this gives the block to jump to if all of
         the running lanes have executed a 'continue' statement. */
     llvm::BasicBlock *continueTarget;
-
-#ifdef ISPC_XE_ENABLED
-    /** Final basic block of the function. It is used for Xe to
-        disable returned lanes until return point is reached. */
-    llvm::BasicBlock *returnPoint;
-#endif
 
     /** @name Switch statement state
 

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1907,13 +1907,8 @@ llvm::Value *lEmitLogicalOp(BinaryExpr::Op op, Expr *arg0, Expr *arg1, FunctionE
             llvm::Value *equalsMask = ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_EQ, value0AndMask,
                                                    oldFullMask, "value0&mask==mask");
             equalsMask = ctx->I1VecToBoolVec(equalsMask);
-            if (!ctx->emitXeHardwareMask()) {
-                llvm::Value *allMatch = ctx->All(equalsMask);
-                ctx->BranchInst(bbSkipEvalValue1, bbEvalValue1, allMatch);
-            } else {
-                // If uniform CF is emulated, pass vector value to BranchInst
-                ctx->BranchInst(bbSkipEvalValue1, bbEvalValue1, equalsMask);
-            }
+            llvm::Value *allMatch = ctx->All(equalsMask);
+            ctx->BranchInst(bbSkipEvalValue1, bbEvalValue1, allMatch);
 
             // value0 is true for all running lanes, so it can be used for
             // the final result
@@ -1956,13 +1951,8 @@ llvm::Value *lEmitLogicalOp(BinaryExpr::Op op, Expr *arg0, Expr *arg1, FunctionE
             llvm::Value *equalsMask = ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_EQ, notValue0AndMask,
                                                    oldFullMask, "not_value0&mask==mask");
             equalsMask = ctx->I1VecToBoolVec(equalsMask);
-            if (!ctx->emitXeHardwareMask()) {
-                llvm::Value *allMatch = ctx->All(equalsMask);
-                ctx->BranchInst(bbSkipEvalValue1, bbEvalValue1, allMatch);
-            } else {
-                // If uniform CF is emulated, pass vector value to BranchInst
-                ctx->BranchInst(bbSkipEvalValue1, bbEvalValue1, equalsMask);
-            }
+            llvm::Value *allMatch = ctx->All(equalsMask);
+            ctx->BranchInst(bbSkipEvalValue1, bbEvalValue1, allMatch);
 
             // value0 was false for all running lanes, so use its value as
             // the overall result.
@@ -8108,13 +8098,6 @@ llvm::Value *SymbolExpr::GetValue(FunctionEmitContext *ctx) const {
     ctx->SetDebugPos(pos);
 
     std::string loadName = symbol->name + std::string("_load");
-#ifdef ISPC_XE_ENABLED
-    // TODO: this is a temporary workaround and will be changed as part
-    // of SPIR-V emitting solution
-    if (ctx->emitXeHardwareMask() && symbol->name == "__mask") {
-        return ctx->XeSimdCFPredicate(LLVMMaskAllOn);
-    }
-#endif
     return ctx->LoadInst(symbol->storageInfo, symbol->type, loadName.c_str());
 }
 

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -409,17 +409,7 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
             argIter->setName("__mask");
             Assert(argIter->getType() == LLVMTypes::MaskType);
 
-            if (ctx->emitXeHardwareMask()) {
-                // We should not create explicit predication
-                // to avoid EM usage duplication. All stuff
-                // will be done by SIMD CF Lowering
-                // TODO: temporary workaround that will be changed
-                // as part of SPIR-V emitting solution
-                ctx->SetFunctionMask(LLVMMaskAllOn);
-            } else {
-                ctx->SetFunctionMask(&*argIter);
-            }
-
+            ctx->SetFunctionMask(&*argIter);
             ++argIter;
             Assert(argIter == function->arg_end());
         }

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2193,7 +2193,6 @@ Opt::Opt() {
     disableXeGatherCoalescing = false;
     thresholdForXeGatherCoalescing = 0;
     enableForeachInsideVarying = false;
-    emitXeHardwareMask = false;
     enableXeUnsafeMaskedLoad = false;
 #endif
 }

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -599,11 +599,6 @@ struct Opt {
         implementation of unmasked.*/
     bool enableForeachInsideVarying;
 
-    /** Enables emitting of genx.any intrinsics and the control flow which is
-        based on impliit hardware mask. Forces generation of goto/join instructions
-        in assembly.*/
-    bool emitXeHardwareMask;
-
     /** Enables generation of masked loads implemented using svm loads which
      * may lead to out of bound reads but bring prformance improvement in
      * most of the cases.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,7 +132,6 @@ static void lPrintVersion() {
         "        disable-zmm\t\t\tDisable using zmm registers for avx512 targets in favour of ymm. This also affects "
         "ABI\n");
 #ifdef ISPC_XE_ENABLED
-    printf("        emit-xe-hardware-mask\t\tEnable emitting of Xe implicit hardware mask\n");
     printf("        enable-xe-foreach-varying\t\tEnable experimental foreach support inside varying control flow\n");
 #endif
     printf("        fast-masked-vload\t\tFaster masked vector loads on SSE (may go past end of array)\n");
@@ -886,8 +885,6 @@ int main(int Argc, char *Argv[]) {
                 g->opt.disableXeGatherCoalescing = true;
             else if (!strncmp(opt, "threshold-for-xe-gather-coalescing=", 37))
                 g->opt.thresholdForXeGatherCoalescing = atoi(opt + 37);
-            else if (!strcmp(opt, "emit-xe-hardware-mask"))
-                g->opt.emitXeHardwareMask = true;
             else if (!strcmp(opt, "enable-xe-foreach-varying"))
                 g->opt.enableForeachInsideVarying = true;
             else if (!strcmp(opt, "enable-xe-unsafe-masked-load"))

--- a/src/stmt.h
+++ b/src/stmt.h
@@ -234,9 +234,6 @@ class ForeachStmt : public Stmt {
     static inline bool classof(ForeachStmt const *) { return true; }
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ForeachStmtID; }
 
-#ifdef ISPC_XE_ENABLED
-    void EmitCodeForXe(FunctionEmitContext *ctx) const;
-#endif
     void EmitCode(FunctionEmitContext *ctx) const;
     void Print(Indent &indent) const;
 


### PR DESCRIPTION
Changes:
*   Remove `--emit-xe-hardware-mask` flag.
    Remove `emitXeHardwareMask` code paths.
    See [discussion](https://github.com/ispc/ispc/pull/2494#discussion_r1267393765).
    | `src/ctx.cpp`,  `src/ctx.h`,
    | `src/expr.cpp`,
    | `src/func.cpp`,
    | `src/ispc.cpp`, `src/ispc.h`,
    | `src/main.cpp`,
    | `src/stmt.cpp`, `src/stmt.h`