### PR TITLE
Deallocate memory and enable ASAN for examples

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -44,7 +44,7 @@ jobs:
     # So, we disable leaks detection to have clean report.
     - name: Build examples with ASAN
       run: |
-          ASAN_OPTIONS=detect_leaks=0 cmake --build build --target ispc_cpu_examples -j4
+          ASAN_OPTIONS=detect_leaks=1 cmake --build build --target ispc_cpu_examples -j4
 
     - name: Build LIT tests with ASAN
       run: |
@@ -52,4 +52,4 @@ jobs:
 
     - name: Build runtime tests with ASAN
       run: |
-          ASAN_OPTIONS=detect_leaks=0 PATH=`pwd`/build/bin:$PATH ./run_tests.py --target=avx2-i32x8 --arch=x86-64 ./tests/*.ispc
+          ASAN_OPTIONS=detect_leaks=0 PATH=`pwd`/build/bin:$PATH ./run_tests.py --target=avx2-i32x8 --arch=x86-64

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -111,6 +111,15 @@ void ASTNode::Print() const {
 ///////////////////////////////////////////////////////////////////////////
 // AST
 
+AST::~AST() {
+    for (auto p : functions) {
+        delete p;
+    }
+    for (auto p : functionTemplates) {
+        delete p;
+    }
+}
+
 void AST::AddFunction(Symbol *sym, Stmt *code) {
     if (sym == nullptr)
         return;

--- a/src/ast.h
+++ b/src/ast.h
@@ -183,6 +183,8 @@ class ASTNode : public Traceable {
 
 class AST {
   public:
+    ~AST();
+
     /** Add the AST for a function described by the given declaration
         information and source code. */
     void AddFunction(Symbol *sym, Stmt *code);

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -500,7 +500,7 @@ void FunctionEmitContext::StartVaryingIf(llvm::Value *oldMask) {
 }
 
 void FunctionEmitContext::EndIf() {
-    CFInfo *ci = popCFState();
+    std::unique_ptr<CFInfo> ci(popCFState());
     // Make sure we match up with a Start{Uniform,Varying}If().
     AssertPos(currentPos, ci->IsIf());
 
@@ -583,7 +583,7 @@ void FunctionEmitContext::StartLoop(llvm::BasicBlock *bt, llvm::BasicBlock *ct, 
 }
 
 void FunctionEmitContext::EndLoop() {
-    CFInfo *ci = popCFState();
+    std::unique_ptr<CFInfo> ci(popCFState());
     AssertPos(currentPos, ci->IsLoop());
 
     if (!ci->IsUniform())
@@ -632,7 +632,7 @@ void FunctionEmitContext::StartForeach(ForeachType ft, bool isEmulatedUniform) {
 }
 
 void FunctionEmitContext::EndForeach() {
-    CFInfo *ci = popCFState();
+    std::unique_ptr<CFInfo> ci(popCFState());
     AssertPos(currentPos, ci->IsForeach());
 }
 
@@ -885,7 +885,7 @@ void FunctionEmitContext::StartSwitch(bool cfIsUniform, llvm::BasicBlock *bbBrea
 void FunctionEmitContext::EndSwitch() {
     AssertPos(currentPos, bblock != nullptr);
 
-    CFInfo *ci = popCFState();
+    std::unique_ptr<CFInfo> ci(popCFState());
     if (ci->IsVarying() && bblock != nullptr)
         restoreMaskGivenReturns(ci->savedMask);
 }

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -809,6 +809,10 @@ class FunctionEmitContext {
     bool inSwitchStatement() const;
     llvm::Value *getMaskAtSwitchEntry();
 
+    // Returns pointer to CFInfo object allocated on heap. This function
+    // doesn't create or allocate this object. It removes CFInfo object from
+    // controlFlowInfo vector and passes the ownership to the outer context.
+    // The outer context should deconstruct this object.
     CFInfo *popCFState();
 
     void scatter(llvm::Value *value, llvm::Value *ptr, const Type *valueType, const Type *ptrType, llvm::Value *mask);

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1724,6 +1724,13 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, MCM
     return;
 }
 
+Target::~Target() {
+    if (m_dataLayout)
+        delete m_dataLayout;
+    if (m_tf_attributes)
+        delete m_tf_attributes;
+}
+
 bool Target::checkIntrinsticSupport(llvm::StringRef name, SourcePos pos) {
     if (name.consume_front("llvm.") == false) {
         return false;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -215,6 +215,8 @@ class Target {
         target was initialized and false if the name is unknown. */
     Target(Arch arch, const char *cpu, ISPCTarget isa, bool pic, MCModel code_model, bool printTarget);
 
+    ~Target();
+
     /** Check if LLVM intrinsic is supported for the current target. */
     bool checkIntrinsticSupport(llvm::StringRef name, SourcePos pos);
 
@@ -351,6 +353,8 @@ class Target {
         Module::CompileAndOutput() uses TargetMachines after Target is destroyed.
         This needs to be changed. */
     llvm::TargetMachine *m_targetMachine;
+
+    /** This is deconstructed in ~Target. */
     llvm::DataLayout *m_dataLayout;
 
     /** flag to report invalid state after construction

--- a/src/lex.ll
+++ b/src/lex.ll
@@ -29,7 +29,7 @@ static bool lConsumePragma(YYSTYPE *, SourcePos *);
 static void lHandleCppHash(SourcePos *);
 static void lStringConst(YYSTYPE *, SourcePos *);
 static double lParseHexFloat(const char *ptr);
-extern void RegisterDependency(const std::string &fileName);
+extern const char *RegisterDependency(const std::string &fileName);
 
 #define YY_USER_ACTION \
     yylloc.first_line = yylloc.last_line; \
@@ -1004,8 +1004,7 @@ static void lHandleCppHash(SourcePos *pos) {
         filename.push_back(*src);
         ++src;
     }
-    pos->name = strdup(filename.c_str());
-    RegisterDependency(filename);
+    pos->name = RegisterDependency(filename);
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -244,7 +244,9 @@ class ArgFactory {
   private:
     char *AllocateString(std::string string) {
         int len = string.length();
-        char *ptr = new char[len + 1];
+        // We use malloc here because of strdup in lAddSingleArg
+        char *ptr = (char *)malloc(len + 1);
+        memset(ptr, 0, len + 1);
         strncpy(ptr, string.c_str(), len);
         ptr[len] = '\0';
         return ptr;
@@ -328,7 +330,7 @@ class StringArgFactory : public ArgFactory {
 };
 
 // Forward reference
-static void lAddSingleArg(char *arg, std::vector<char *> &argv);
+static void lAddSingleArg(char *arg, std::vector<char *> &argv, bool duplicate);
 
 /** Add all args from a given factory to the argv passed as parameters, which could
  *  include recursing into another ArgFactory.
@@ -338,7 +340,7 @@ static void lAddArgsFromFactory(ArgFactory &Args, std::vector<char *> &argv) {
         char *NextArg = Args.GetNextArg();
         if (NextArg == nullptr)
             break;
-        lAddSingleArg(NextArg, argv);
+        lAddSingleArg(NextArg, argv, false);
     }
 }
 
@@ -358,7 +360,7 @@ static void lAddArgsFromString(const char *string, std::vector<char *> &argv) {
  *  form @<filename> and <filename> exists and is readable, the arguments in the file will be
  *  inserted into argv in place of the original argument.
  */
-static void lAddSingleArg(char *arg, std::vector<char *> &argv) {
+static void lAddSingleArg(char *arg, std::vector<char *> &argv, bool duplicate) {
     if (arg[0] == '@') {
         char *filename = &arg[1];
         FILE *file = fopen(filename, "r");
@@ -369,7 +371,12 @@ static void lAddSingleArg(char *arg, std::vector<char *> &argv) {
         }
     }
     if (arg != nullptr) {
-        argv.push_back(arg);
+        if (duplicate) {
+            // duplicate arg from main argv to make deallocation straightforward.
+            argv.push_back(strdup(arg));
+        } else {
+            argv.push_back(arg);
+        }
     }
 }
 
@@ -381,7 +388,7 @@ static void lAddSingleArg(char *arg, std::vector<char *> &argv) {
 static void lGetAllArgs(int Argc, char *Argv[], std::vector<char *> &argv) {
     // Copy over the command line arguments (passed in)
     for (int i = 0; i < Argc; ++i)
-        lAddSingleArg(Argv[i], argv);
+        lAddSingleArg(Argv[i], argv, true);
 
     // See if we have any set via the environment variable
     const char *env = getenv("ISPC_ARGS");
@@ -545,6 +552,15 @@ static void lParseInclude(const char *path) {
     } while (pos_end != std::string::npos);
 }
 
+void lFreeArgv(std::vector<char *> &argv) {
+    // argv vector consists of pointers to arguments as C strings alloced on
+    // heap and collected form three source:  environment variable ISPC_ARGS,
+    // @filename, inputs argv. They are needed to be deallocated.
+    for (auto p : argv) {
+        free(p);
+    }
+}
+
 extern int yydebug;
 
 int main(int Argc, char *Argv[]) {
@@ -661,7 +677,9 @@ int main(int Argc, char *Argv[]) {
                                  "be issued, but no output will be generated.");
         }
 
-        return Module::LinkAndOutput(linkFileNames, ot, outFileName);
+        int ret = Module::LinkAndOutput(linkFileNames, ot, outFileName);
+        lFreeArgv(argv);
+        return ret;
     }
 
     for (int i = 1; i < argc; ++i) {
@@ -1031,6 +1049,7 @@ int main(int Argc, char *Argv[]) {
 #endif
         } else if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--version")) {
             lPrintVersion();
+            lFreeArgv(argv);
             return 0;
         } else if (argv[i][0] == '-') {
             errorHandler.AddError("Unknown option \"%s\".", argv[i]);
@@ -1219,5 +1238,6 @@ int main(int Argc, char *Argv[]) {
     // Free all bookkeeped objects.
     BookKeeper::in().freeAll();
 
+    lFreeArgv(argv);
     return ret;
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3117,6 +3117,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             target = targets[0];
         }
         g->target = new Target(arch, cpu, target, outputFlags.isPIC(), outputFlags.getMCModel(), g->printTarget);
+        llvm::TargetMachine *targetMachine = g->target->GetTargetMachine();
         if (!g->target->isValid())
             return 1;
 
@@ -3185,6 +3186,8 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
 
         delete g->target;
         g->target = nullptr;
+
+        delete targetMachine;
 
         return errorCount > 0;
     } else {
@@ -3402,6 +3405,12 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
 
         delete g->target;
         g->target = nullptr;
+
+        for (int i = 0; i < Target::NUM_ISAS; ++i) {
+            if (targetMachines[i] != nullptr)
+                delete targetMachines[i];
+        }
+
         return errorCount > 0;
     }
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -146,11 +146,20 @@ static bool lIsSpirVBitcode(std::ifstream &is) {
     the module file's dependencies via the -MMM option */
 std::set<std::string> registeredDependencies;
 
+/* This set is used to store strings that is referenced in yylloc (SourcePos)
+   in lexer once and not to lost memory via just strduping them. */
+std::set<std::string> pseudoDependencies;
+
 /*! this is where the parser tells us that it has seen the given file
     name in the CPP hash */
-void RegisterDependency(const std::string &fileName) {
-    if (fileName[0] != '<' && fileName != "stdlib.ispc")
-        registeredDependencies.insert(fileName);
+const char *RegisterDependency(const std::string &fileName) {
+    if (fileName[0] != '<' && fileName != "stdlib.ispc") {
+        auto res = registeredDependencies.insert(fileName);
+        return res.first->c_str();
+    } else {
+        auto res = pseudoDependencies.insert(fileName);
+        return res.first->c_str();
+    }
 }
 
 static void lDeclareSizeAndPtrIntTypes(SymbolTable *symbolTable) {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3356,6 +3356,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
         Assert(firstTargetMachine != nullptr);
 
         g->target = new Target(arch, cpu, firstTarget, outputFlags.isPIC(), outputFlags.getMCModel(), false);
+        llvm::TargetMachine *targetMachine = g->target->GetTargetMachine();
         if (!g->target->isValid()) {
             return 1;
         }
@@ -3419,6 +3420,8 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             if (targetMachines[i] != nullptr)
                 delete targetMachines[i];
         }
+
+        delete targetMachine;
 
         return errorCount > 0;
     }

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -106,7 +106,7 @@ class DebugModulePassManager {
     DebugModulePassManager(llvm::Module &M, int optLevel) : m_passNumber(0), m_optLevel(optLevel) {
         m = &M;
         llvm::Triple targetTriple = llvm::Triple(m->getTargetTriple());
-        llvm::TargetLibraryInfoImpl *targetLibraryInfo = new llvm::TargetLibraryInfoImpl(targetTriple);
+        llvm::TargetLibraryInfoImpl targetLibraryInfo(targetTriple);
         targetMachine = g->target->GetTargetMachine();
 
         // We have to register an llvm::OptNoneInstrumentation with a llvm::PassInstrumentationCallbacks,
@@ -132,7 +132,7 @@ class DebugModulePassManager {
 
         // Register all the analysis passes
         fam.registerPass([&] { return targetMachine->getTargetIRAnalysis(); });
-        fam.registerPass([&] { return llvm::TargetLibraryAnalysis(*targetLibraryInfo); });
+        fam.registerPass([&] { return llvm::TargetLibraryAnalysis(targetLibraryInfo); });
 
         // Add alias analysis for more aggressive optimizations
         if (m_optLevel != 0) {

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1350,22 +1350,32 @@ enum_specifier
     : TOKEN_ENUM '{' enumerator_list '}'
       {
           $$ = lCreateEnumType(nullptr, $3, @1);
+          // enumerator_list returns aux vector that is not needed anymore.
+          delete $3;
       }
     | TOKEN_ENUM enum_identifier '{' enumerator_list '}'
       {
           $$ = lCreateEnumType($2, $4, @2);
           // allocated by strdup in enum_identifier
           free((char*)$2);
+
+          // enumerator_list returns aux vector that is not needed anymore.
+          delete $4;
       }
     | TOKEN_ENUM '{' enumerator_list ',' '}'
       {
           $$ = lCreateEnumType(nullptr, $3, @1);
+          // enumerator_list returns aux vector that is not needed anymore.
+          delete $3;
       }
     | TOKEN_ENUM enum_identifier '{' enumerator_list ',' '}'
       {
           $$ = lCreateEnumType($2, $4, @2);
           // allocated by strdup in enum_identifier
           free((char*)$2);
+
+          // enumerator_list returns aux vector that is not needed anymore.
+          delete $4;
       }
     | TOKEN_ENUM enum_identifier
       {

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1893,6 +1893,8 @@ labeled_statement
     : goto_identifier ':' attributed_statement
     {
         $$ = new LabeledStmt($1, $3, @1);
+        // allocated by strdup in goto_identifier
+        free((char*)$1);
     }
     | TOKEN_CASE constant_expression ':' attributed_statement
       {
@@ -2189,7 +2191,11 @@ goto_identifier
 
 jump_statement
     : TOKEN_GOTO goto_identifier ';'
-      { $$ = new GotoStmt($2, @1, @2); }
+      {
+          $$ = new GotoStmt($2, @1, @2);
+          // allocated by strdup in goto_identifier
+          free((char*)$2);
+      }
     | TOKEN_CONTINUE ';'
       { $$ = new ContinueStmt(@1); }
     | TOKEN_BREAK ';'

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -2178,6 +2178,9 @@ iteration_statement
      {
          $$ = new ForeachUniqueStmt($3, $5, $8, @1);
          m->symbolTable->PopScope();
+
+         // allocated by strdup in foreach_unique_identifier
+         free((char*)$3);
      }
     ;
 

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1121,6 +1121,8 @@ struct_or_union_and_name
               else
                   $$ = st;
          }
+         // allocated by strdup in struct_or_union_name
+         free((char*)$2);
       }
     ;
 

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1354,6 +1354,8 @@ enum_specifier
     | TOKEN_ENUM enum_identifier '{' enumerator_list '}'
       {
           $$ = lCreateEnumType($2, $4, @2);
+          // allocated by strdup in enum_identifier
+          free((char*)$2);
       }
     | TOKEN_ENUM '{' enumerator_list ',' '}'
       {
@@ -1362,6 +1364,8 @@ enum_specifier
     | TOKEN_ENUM enum_identifier '{' enumerator_list ',' '}'
       {
           $$ = lCreateEnumType($2, $4, @2);
+          // allocated by strdup in enum_identifier
+          free((char*)$2);
       }
     | TOKEN_ENUM enum_identifier
       {
@@ -1382,6 +1386,8 @@ enum_specifier
               else
                   $$ = enumType;
           }
+          // allocated by strdup in enum_identifier
+          free((char*)$2);
       }
     ;
 
@@ -1413,6 +1419,8 @@ enumerator
     : enum_identifier
       {
           $$ = new Symbol($1, @1);
+          // allocated by strdup in enum_identifier
+          free((char*)$1);
       }
     | enum_identifier '=' constant_expression
       {
@@ -1426,6 +1434,9 @@ enumerator
           }
           else
               $$ = nullptr;
+
+          // allocated by strdup in enum_identifier
+          free((char*)$1);
       }
     ;
 

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -2451,6 +2451,8 @@ simple_template_id
           // Template ID declartor
           Declarator *d = new Declarator(DK_BASE, @1);
           d->name = $1;
+          // allocated by strdup in template_identifier
+          free((char*)$1);
           // Arguments vector
           std::vector<std::pair<const Type *, SourcePos>> *vec = (std::vector<std::pair<const Type *, SourcePos>> *) $3;
           // Bundle template ID declarator and type list.
@@ -2461,6 +2463,8 @@ simple_template_id
           // Template ID declartor
           Declarator *d = new Declarator(DK_BASE, @1);
           d->name = $1;
+          // allocated by strdup in template_identifier
+          free((char*)$1);
           // Arguments vector
           std::vector<std::pair<const Type *, SourcePos>> *vec = new std::vector<std::pair<const Type *, SourcePos>>;
           // Bundle template ID declarator and empty type list.

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -2121,6 +2121,13 @@ iteration_statement
          }
          $$ = new ForeachStmt(syms, begins, ends, $6, false, @1);
          m->symbolTable->PopScope();
+
+         // deallocate ForeachDimension elements allocated in foreach_dimension_specifier
+         for (unsigned int i = 0; i < dims->size(); ++i)
+             delete (*dims)[i];
+
+         // deallocate std::vector<ForeachDimension*> allocated in foreach_dimension_list
+         delete dims;
      }
     | foreach_tiled_scope '(' foreach_dimension_list ')'
      {
@@ -2150,6 +2157,13 @@ iteration_statement
          }
          $$ = new ForeachStmt(syms, begins, ends, $6, true, @1);
          m->symbolTable->PopScope();
+
+         // deallocate ForeachDimension elements allocated in foreach_dimension_specifier
+         for (unsigned int i = 0; i < dims->size(); ++i)
+             delete (*dims)[i];
+
+         // deallocate std::vector<ForeachDimension*> allocated in foreach_dimension_list
+         delete dims;
      }
     | foreach_active_scope '(' foreach_active_identifier ')'
      {

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -44,6 +44,10 @@ SymbolTable::~SymbolTable() {
     // Otherwise we have mismatched push/pop scopes
     Assert(variables.size() == 1);
     PopScope();
+
+    for (auto p : freeSymbolMaps) {
+        delete p;
+    }
 }
 
 void SymbolTable::PushScope() {


### PR DESCRIPTION
This change let us enable ASAN with leak sanitizer on examples. There are still a few deallocations detected by LSAN On LIT tests and runtime tests.