### PR TITLE
Fix GCC warnings and MSVC /WX build into CI

### DIFF
--- a/.github/workflows/compiler-warnings.yml
+++ b/.github/workflows/compiler-warnings.yml
@@ -67,3 +67,33 @@ jobs:
       run: |
           cmake -B build -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror"
           cmake --build build --target ispc -j4
+
+  msvc-2022:
+    runs-on: windows-2022
+    env:
+      LLVM_VERSION: "15.0"
+      LLVM_TAR: llvm-15.0.7-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_HOME: "C:\\projects\\llvm"
+      CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
+      BUILD_TYPE: "Release"
+      ISPC_OPAQUE_PTR_MODE: "ON"
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Install dependencies
+      run: |
+        .github/workflows/scripts/install-build-deps.ps1
+
+    - name: Check environment
+      shell: cmd
+      run: |
+        wmic cpu get caption, deviceid, name, numberofcores, maxclockspeed, status
+
+    - name: Build ISPC with MSVC in -Werror mode
+      shell: cmd
+      run: |
+        cmake -B build -DCMAKE_C_FLAGS="/WX" -DCMAKE_CXX_FLAGS="/WX" -DISPC_CROSS=ON -DCMAKE_BUILD_TYPE=Release -DISPC_GNUWIN32_PATH=%CROSS_TOOLS_GNUWIN32% -DISPC_OPAQUE_PTR_MODE=%ISPC_OPAQUE_PTR_MODE%
+        cmake --build build --target ispc -j4 --config Release

--- a/.github/workflows/compiler-warnings.yml
+++ b/.github/workflows/compiler-warnings.yml
@@ -65,5 +65,5 @@ jobs:
 
     - name: Build ISPC with gcc in -Werror mode
       run: |
-          cmake -B build -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=gcc++-11 -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror"
+          cmake -B build -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror"
           cmake --build build --target ispc -j4

--- a/.github/workflows/compiler-warnings.yml
+++ b/.github/workflows/compiler-warnings.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Build ISPC with clang in -Werror mode
       run: |
           cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror"
-          cmake --build build --target ispc -j4
+          cmake --build build --target all -j4
 
   gcc-11:
     runs-on: ubuntu-latest
@@ -66,7 +66,7 @@ jobs:
     - name: Build ISPC with gcc in -Werror mode
       run: |
           cmake -B build -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror"
-          cmake --build build --target ispc -j4
+          cmake --build build --target all -j4
 
   msvc-2022:
     runs-on: windows-2022
@@ -95,5 +95,5 @@ jobs:
     - name: Build ISPC with MSVC in -Werror mode
       shell: cmd
       run: |
-        cmake -B build -DCMAKE_C_FLAGS="/WX" -DCMAKE_CXX_FLAGS="/WX" -DISPC_CROSS=ON -DCMAKE_BUILD_TYPE=Release -DISPC_GNUWIN32_PATH=%CROSS_TOOLS_GNUWIN32% -DISPC_OPAQUE_PTR_MODE=%ISPC_OPAQUE_PTR_MODE%
-        cmake --build build --target ispc -j4 --config Release
+        cmake -B build -DISPC_PREPARE_PACKAGE=ON -DCMAKE_C_FLAGS="/WX" -DCMAKE_CXX_FLAGS="/WX" -DISPC_CROSS=ON -DCMAKE_BUILD_TYPE=Release -DISPC_GNUWIN32_PATH=%CROSS_TOOLS_GNUWIN32% -DISPC_OPAQUE_PTR_MODE=%ISPC_OPAQUE_PTR_MODE%
+        cmake --build build --target package -j4 --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,6 +539,9 @@ if (NOT MSVC)
     target_compile_options(${PROJECT_NAME} PRIVATE -fno-rtti)
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         target_compile_options(${PROJECT_NAME} PRIVATE -Wno-register -Wno-error=comment)
+        # The GCC warning issues false positives when one of the allocation and
+        # deallocation functions is inlined into its caller but not the other.
+        target_compile_options(${PROJECT_NAME} PRIVATE -Wno-mismatched-new-delete)
     else()
         target_compile_options(${PROJECT_NAME} PRIVATE -Wno-c99-extensions -Wno-deprecated-register)
     endif()

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -47,6 +47,8 @@
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 
+#define UNUSED(x) (void)(x)
+
 using namespace ispc;
 
 Globals *ispc::g;
@@ -186,7 +188,8 @@ static ISPCTarget lGetSystemISA() {
         bool tgl = icl && avx512_vp2intersect;
         bool spr =
             icl && avx512_bf16 && avx512_amx_bf16 && avx512_amx_tile && avx512_amx_int8 && avx_vnni && avx512_fp16;
-#pragma unused(cpx, tgl)
+        UNUSED(cpx);
+        UNUSED(tgl);
         if (spr) {
             // We don't care if AMX is enabled or not here, as AMX support is not implemented yet.
             return ISPCTarget::avx512spr_x16;

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -243,7 +243,7 @@ template <typename T> void DebugModulePassManager::addModulePass(T &&P, int stag
     Assert(!m_isFPMOpen && "FunctionPassManager must be committed before adding module passes.");
     Assert(!m_isLPMOpen && "LoopPassManager must be committed before adding module passes.");
     // taking number of optimization
-    m_passNumber = (stage == -1) ? ++m_passNumber : stage;
+    m_passNumber = (stage == -1) ? (m_passNumber + 1) : stage;
     if (g->off_stages.find(m_passNumber) == g->off_stages.end()) {
         mpm.addPass(std::move(P));
         addPassAndDebugPrint(T::name().str(), DebugModulePassManager::Passes::Module);
@@ -254,7 +254,7 @@ template <typename T> void DebugModulePassManager::addPostOrderCGSCCPass(T &&P, 
     Assert(!m_isFPMOpen && "FunctionPassManager must be committed before adding PostOrderCGSCC passes.");
     Assert(!m_isLPMOpen && "LoopPassManager must be committed before adding PostOrderCGSCC passes.");
     // taking number of optimization
-    m_passNumber = (stage == -1) ? ++m_passNumber : stage;
+    m_passNumber = (stage == -1) ? (m_passNumber + 1) : stage;
     if (g->off_stages.find(m_passNumber) == g->off_stages.end()) {
         // Add PostOrderCGSCC pass to the ModulePassManager directly through adaptor
         mpm.addPass(llvm::createModuleToPostOrderCGSCCPassAdaptor(std::move(P)));
@@ -265,7 +265,7 @@ template <typename T> void DebugModulePassManager::addPostOrderCGSCCPass(T &&P, 
 template <typename T> void DebugModulePassManager::addFunctionPass(T &&P, int stage) {
     Assert(m_isFPMOpen && "FunctionPassManager must be initialized before adding function passes");
     // taking number of optimization
-    m_passNumber = (stage == -1) ? ++m_passNumber : stage;
+    m_passNumber = (stage == -1) ? (m_passNumber + 1) : stage;
     if (g->off_stages.find(m_passNumber) == g->off_stages.end()) {
         fpmVec.back()->addPass(std::move(P));
         addPassAndDebugPrint(T::name().str(), DebugModulePassManager::Passes::Function);
@@ -275,7 +275,7 @@ template <typename T> void DebugModulePassManager::addFunctionPass(T &&P, int st
 template <typename T> void DebugModulePassManager::addLoopPass(T &&P, int stage) {
     Assert(m_isLPMOpen && "LoopPassManager must be initialized before adding function passes");
     // taking number of optimization
-    m_passNumber = (stage == -1) ? ++m_passNumber : stage;
+    m_passNumber = (stage == -1) ? (m_passNumber + 1) : stage;
     if (g->off_stages.find(m_passNumber) == g->off_stages.end()) {
         // if not debug stage, add pass to loop pass manager
         lpmVec.back()->addPass(std::move(P));


### PR DESCRIPTION
This fixes and suppresses GCC warnings, so it is green (https://github.com/nurmukhametov/ispc/actions/runs/5613763085/job/15210488452).

MSVC job with /WX (analogue of -Werror) flag was added also.