### PR TITLE
Destroy TargetMachine in Target destructor.

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1732,6 +1732,8 @@ Target::~Target() {
         delete m_dataLayout;
     if (m_tf_attributes)
         delete m_tf_attributes;
+    if (m_targetMachine)
+        delete m_targetMachine;
 }
 
 bool Target::checkIntrinsticSupport(llvm::StringRef name, SourcePos pos) {

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -352,10 +352,7 @@ class Target {
     /** llvm Target object representing this target. */
     const llvm::Target *m_target;
 
-    /** llvm TargetMachine.
-        Note that it's not destroyed during Target destruction, as
-        Module::CompileAndOutput() uses TargetMachines after Target is destroyed.
-        This needs to be changed. */
+    /** llvm TargetMachine. Deconstrcted in ~Target. */
     llvm::TargetMachine *m_targetMachine;
 
     /** This is deconstructed in ~Target. */

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3126,7 +3126,6 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             target = targets[0];
         }
         g->target = new Target(arch, cpu, target, outputFlags.isPIC(), outputFlags.getMCModel(), g->printTarget);
-        llvm::TargetMachine *targetMachine = g->target->GetTargetMachine();
         if (!g->target->isValid())
             return 1;
 
@@ -3196,8 +3195,6 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
         delete g->target;
         g->target = nullptr;
 
-        delete targetMachine;
-
         return errorCount > 0;
     } else {
         if (IsStdin(srcFile)) {
@@ -3224,9 +3221,8 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
         // the target ISA appended to them.
         g->mangleFunctionsWithTarget = true;
 
-        llvm::TargetMachine *targetMachines[Target::NUM_ISAS];
-        for (int i = 0; i < Target::NUM_ISAS; ++i)
-            targetMachines[i] = nullptr;
+        // Array initialized with all false
+        bool compiledTargets[Target::NUM_ISAS] = {};
 
         llvm::Module *dispatchModule = nullptr;
 
@@ -3263,13 +3259,13 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             // Issue an error if we've already compiled to a variant of
             // this target ISA.  (It doesn't make sense to compile to both
             // avx and avx-x2, for example.)
-            if (targetMachines[g->target->getISA()] != nullptr ||
-                (targetMachines[Target::SSE41] != nullptr && g->target->getISA() == Target::SSE42) ||
-                (targetMachines[Target::SSE42] != nullptr && g->target->getISA() == Target::SSE41)) {
+            auto targetISA = g->target->getISA();
+            if (compiledTargets[targetISA] || (compiledTargets[Target::SSE41] && targetISA == Target::SSE42) ||
+                (compiledTargets[Target::SSE42] && targetISA == Target::SSE41)) {
                 Error(SourcePos(), "Can't compile to multiple variants of %s target!\n", g->target->GetISAString());
                 return 1;
             }
-            targetMachines[g->target->getISA()] = g->target->GetTargetMachine();
+            compiledTargets[targetISA] = true;
 
             m = new Module(srcFile);
             modules.push_back(m);
@@ -3338,25 +3334,22 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
             // we generate the dispatch module's functions...
         }
 
-        // Find the first non-nullptr target machine from the targets we
+        // Find the first initialized target machine from the targets we
         // compiled to above.  We'll use this as the target machine for
         // compiling the dispatch module--this is safe in that it is the
         // least-common-denominator of all of the targets we compiled to.
-        llvm::TargetMachine *firstTargetMachine = nullptr;
-        int i = 0;
-        const char *firstISA = "";
-        ISPCTarget firstTarget = ISPCTarget::none;
-        while (i < Target::NUM_ISAS && firstTargetMachine == nullptr) {
-            firstISA = Target::ISAToTargetString((Target::ISA)i);
-            firstTarget = ParseISPCTarget(firstISA);
-            firstTargetMachine = targetMachines[i++];
+        int firstTargetISA = 0;
+        while (!compiledTargets[firstTargetISA]) {
+            firstTargetISA++;
         }
+        const char *firstISA = Target::ISAToTargetString((Target::ISA)firstTargetISA);
+        ISPCTarget firstTarget = ParseISPCTarget(firstISA);
         Assert(strcmp(firstISA, "") != 0);
         Assert(firstTarget != ISPCTarget::none);
-        Assert(firstTargetMachine != nullptr);
 
         g->target = new Target(arch, cpu, firstTarget, outputFlags.isPIC(), outputFlags.getMCModel(), false);
-        llvm::TargetMachine *targetMachine = g->target->GetTargetMachine();
+        llvm::TargetMachine *firstTargetMachine = g->target->GetTargetMachine();
+        Assert(firstTargetMachine);
         if (!g->target->isValid()) {
             return 1;
         }
@@ -3415,13 +3408,6 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
 
         delete g->target;
         g->target = nullptr;
-
-        for (int i = 0; i < Target::NUM_ISAS; ++i) {
-            if (targetMachines[i] != nullptr)
-                delete targetMachines[i];
-        }
-
-        delete targetMachine;
 
         return errorCount > 0;
     }


### PR DESCRIPTION
This is a follow up on the review of PR2575 and fixes #2578.

TargetMachine really belongs to the Target and needs to be destroyed in its destructor.

The cases when it escapes Target lifetime are not legitimate. For the dispatch module we create a new Target anyway and it creates a TargetMachine as well - and this one needs to be used.

This should make the design a little cleaner and reduce memory footprint for multi-target compilation because of earlier release of TargetMachine.