### PR TITLE
Fix missing copy constructor warnings

### DIFF
--- a/src/decl.h
+++ b/src/decl.h
@@ -184,6 +184,11 @@ struct StructDeclaration : public Traceable {
     StructDeclaration(const Type *t, std::vector<Declarator *> *d) : type(t), declarators(d) {}
     ~StructDeclaration() { delete declarators; }
 
+    // We don't copy these objects at the moment. If we will then proper
+    // implementations are needed considering the ownership of declarators.
+    StructDeclaration(const StructDeclaration &) = delete;
+    StructDeclaration &operator=(const StructDeclaration &) = delete;
+
     const Type *type;
     std::vector<Declarator *> *declarators;
 };

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -219,6 +219,12 @@ class Target {
 
     ~Target();
 
+    // We don't copy Target objects at the moment. If we will then proper
+    // implementations are needed considering the ownership of heap-allocated
+    // fields like m_dataLayout.
+    Target(const Target &) = delete;
+    Target &operator=(const Target &) = delete;
+
     /** Check if LLVM intrinsic is supported for the current target. */
     bool checkIntrinsticSupport(llvm::StringRef name, SourcePos pos);
 

--- a/src/module.h
+++ b/src/module.h
@@ -46,6 +46,12 @@ class Module {
 
     ~Module();
 
+    // We don't copy Module objects at the moment. If we will then proper
+    // implementations are needed considering the ownership of heap-allocated
+    // fields like symbolTable.
+    Module(const Module &) = delete;
+    Module &operator=(const Module &) = delete;
+
     /** Compiles the source file passed to the Module constructor, adding
         its global variables and functions to both the llvm::Module and
         SymbolTable.  Returns the number of errors during compilation.  */
@@ -119,6 +125,15 @@ class Module {
         OutputFlags(OutputFlags &o)
             : pic(o.pic), flatDeps(o.flatDeps), makeRuleDeps(o.makeRuleDeps), depsToStdout(o.depsToStdout),
               mcModel(o.mcModel) {}
+
+        OutputFlags &operator=(const OutputFlags &o) {
+            pic = o.pic;
+            flatDeps = o.flatDeps;
+            makeRuleDeps = o.makeRuleDeps;
+            depsToStdout = o.depsToStdout;
+            mcModel = o.mcModel;
+            return *this;
+        };
 
         void setPIC(bool v = true) { pic = v; }
         bool isPIC() const { return pic; }


### PR DESCRIPTION
Some objects (`Target`, `Module`, `StructDeclaration`) own heap-allocated memory. The absence of user-defined copy constructor and assignment operator may lead to memory leak. At the moment, we do not copy them at all, so I think it is just better to delete them. 