### PR TITLE
LLVM 17.0 fixes and LLVM 18.0 definiton

### DIFF
--- a/alloy.py
+++ b/alloy.py
@@ -93,6 +93,8 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     # git: "release/16.x"
     if  version_LLVM == "trunk":
         GIT_TAG="main"
+    elif  version_LLVM == "17_0":
+        GIT_TAG="release/17.x"
     elif  version_LLVM == "16_0":
         GIT_TAG="llvmorg-16.0.6"
     elif  version_LLVM == "15_0":
@@ -600,7 +602,7 @@ def validation_run(only, only_targets, reference_branch, number, update, speed_n
             archs.append("x86-64")
         if "native" in only:
             sde_targets_t = []
-        for i in ["6.0", "7.0", "8.0", "9.0", "10.0", "11.0", "12.0", "13.0", "14.0", "15.0", "16.0", "trunk"]:
+        for i in ["6.0", "7.0", "8.0", "9.0", "10.0", "11.0", "12.0", "13.0", "14.0", "15.0", "16.0", "17.0", "trunk"]:
             if i in only:
                 LLVM.append(i)
         if "current" in only:
@@ -806,7 +808,7 @@ def Main():
     if os.environ.get("ISPC_HOME") == None:
         alloy_error("you have no ISPC_HOME", 1)
     if options.only != "":
-        test_only_r = " 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0 14.0 15.0 16.0 trunk current build stability performance x86 x86-64 x86_64 -O0 -O1 -O2 native debug nodebug "
+        test_only_r = " 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0 14.0 15.0 16.0 17.0 trunk current build stability performance x86 x86-64 x86_64 -O0 -O1 -O2 native debug nodebug "
         test_only = options.only.split(" ")
         for iterator in test_only:
             if not (" " + iterator + " " in test_only_r):
@@ -929,7 +931,7 @@ if __name__ == '__main__':
     llvm_group = OptionGroup(parser, "Options for building LLVM",
                     "These options must be used with -b option.")
     llvm_group.add_option('--version', dest='version',
-        help='version of llvm to build: 6.0-16.0 trunk. Default: trunk', default="trunk")
+        help='version of llvm to build: 6.0-17.0 trunk. Default: trunk', default="trunk")
     llvm_group.add_option('--full-checkout', dest='full_checkout', action='store_true', default=False,
         help=('Disable a shallow clone and checkout a whole LLVM repository.\n'
               'By default it clones LLVM with --depth=1 to save space and time'))
@@ -980,7 +982,7 @@ if __name__ == '__main__':
     run_group.add_option('--only', dest='only',
         help='set types of tests. Possible values:\n' +
             '-O0, -O1, -O2, x86, x86-64, stability (test only stability), performance (test only performance),\n' +
-            'build (only build with different LLVM), 6.0-16.0, trunk, native (do not use SDE),\n' +
+            'build (only build with different LLVM), 6.0-17.0, trunk, native (do not use SDE),\n' +
             'current (do not rebuild ISPC), debug (only with debug info), nodebug (only without debug info, default).',
             default="")
     run_group.add_option('--perf_LLVM', dest='perf_llvm',

--- a/ispcrt/CMakeLists.txt
+++ b/ispcrt/CMakeLists.txt
@@ -1,7 +1,7 @@
 ## Copyright 2020-2023 Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 ## Global setup ##
 

--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -21,7 +21,6 @@
 #include <math.h>
 #include <stdlib.h>
 
-#include <llvm/ADT/Triple.h>
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/IR/Attributes.h>
 #include <llvm/IR/DerivedTypes.h>
@@ -33,6 +32,11 @@
 #include <llvm/Linker/Linker.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Target/TargetMachine.h>
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_17_0
+#include <llvm/TargetParser/Triple.h>
+#else
+#include <llvm/ADT/Triple.h>
+#endif
 
 #ifdef ISPC_XE_ENABLED
 #include <llvm/GenXIntrinsics/GenXIntrinsics.h>

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -1685,6 +1685,17 @@ llvm::Value *FunctionEmitContext::NotOperator(llvm::Value *v, const llvm::Twine 
     }
 }
 
+llvm::Value *FunctionEmitContext::FNegInst(llvm::Value *v, const llvm::Twine &name) {
+    if (v == nullptr) {
+        AssertPos(currentPos, m->errorCount > 0);
+        return nullptr;
+    }
+
+    llvm::Instruction *fneg = llvm::UnaryOperator::CreateFNeg(v, name.isTriviallyEmpty() ? "fneg" : name, bblock);
+    AddDebugPos(fneg);
+    return fneg;
+}
+
 // Given the llvm Type that represents an ispc VectorType, return an
 // equally-shaped type with boolean elements.  (This is the type that will
 // be returned from CmpInst with ispc VectorTypes).

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -404,6 +404,9 @@ class FunctionEmitContext {
         a VectorType-based operand. */
     llvm::Value *NotOperator(llvm::Value *v, const llvm::Twine &name = "");
 
+    /** Emit FNeg instruction. */
+    llvm::Value *FNegInst(llvm::Value *v, const llvm::Twine &name = "");
+
     /** Emit a comparison instruction.  If the operands are VectorTypes,
         then a value for the corresponding boolean VectorType is
         returned. */

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1106,8 +1106,7 @@ static llvm::Value *lEmitNegate(Expr *arg, SourcePos pos, FunctionEmitContext *c
     // Negate by subtracting from zero...
     ctx->SetDebugPos(pos);
     if (type->IsFloatType()) {
-        llvm::Value *zero = llvm::ConstantFP::getZeroValueForNegation(type->LLVMType(g->ctx));
-        return ctx->BinaryOperator(llvm::Instruction::FSub, zero, argVal, llvm::Twine(argVal->getName()) + "_negate");
+        return ctx->FNegInst(argVal, llvm::Twine(argVal->getName()) + "_negate");
     } else {
         llvm::Value *zero = lLLVMConstantValue(type, g->ctx, 0.);
         AssertPos(pos, type->IsIntType());

--- a/src/ispc_version.h
+++ b/src/ispc_version.h
@@ -20,9 +20,10 @@
 #define ISPC_LLVM_15_0 150000
 #define ISPC_LLVM_16_0 160000
 #define ISPC_LLVM_17_0 170000
+#define ISPC_LLVM_18_0 180000
 
 #define OLDEST_SUPPORTED_LLVM ISPC_LLVM_13_0
-#define LATEST_SUPPORTED_LLVM ISPC_LLVM_17_0
+#define LATEST_SUPPORTED_LLVM ISPC_LLVM_18_0
 
 #ifdef __ispc__xstr
 #undef __ispc__xstr
@@ -34,7 +35,7 @@
     __ispc__xstr(LLVM_VERSION_MAJOR) "." __ispc__xstr(LLVM_VERSION_MINOR) "." __ispc__xstr(LLVM_VERSION_PATCH)
 
 #if ISPC_LLVM_VERSION < OLDEST_SUPPORTED_LLVM || ISPC_LLVM_VERSION > LATEST_SUPPORTED_LLVM
-#error "Only LLVM 13.0 - 16.0 and 17.0 development branch are supported"
+#error "Only LLVM 13.0 - 17.0 and 18.0 development branch are supported"
 #endif
 
 #define ISPC_VERSION_STRING                                                                                            \

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -72,12 +72,16 @@
 #include <llvm/Support/DynamicLibrary.h>
 #include <llvm/Support/FileUtilities.h>
 #include <llvm/Support/FormattedStream.h>
-#include <llvm/Support/Host.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/ToolOutputFile.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_17_0
+#include <llvm/TargetParser/Host.h>
+#else
+#include <llvm/Support/Host.h>
+#endif
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/Utils/ValueMapper.h>
 

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -23,7 +23,6 @@
 #include <stdio.h>
 
 #include <llvm/ADT/SmallSet.h>
-#include <llvm/ADT/Triple.h>
 #include <llvm/Analysis/BasicAliasAnalysis.h>
 #include <llvm/Analysis/ConstantFolding.h>
 #include <llvm/Analysis/GlobalsModRef.h>
@@ -46,6 +45,11 @@
 #include <llvm/Passes/StandardInstrumentations.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_17_0
+#include <llvm/TargetParser/Triple.h>
+#else
+#include <llvm/ADT/Triple.h>
+#endif
 #include <llvm/Transforms/IPO/ArgumentPromotion.h>
 #include <llvm/Transforms/IPO/ConstantMerge.h>
 #include <llvm/Transforms/IPO/DeadArgumentElimination.h>

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -141,7 +141,11 @@ class DebugModulePassManager {
         pb.registerLoopAnalyses(lam);
         pb.crossRegisterProxies(lam, fam, cgam, mam);
 
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_17_0
+        SI.registerCallbacks(PIC, &mam);
+#else
         SI.registerCallbacks(PIC, &fam);
+#endif
 
         // Register all the analysis passes
         fam.registerPass([&] { return targetMachine->getTargetIRAnalysis(); });

--- a/tests/lit-tests/1470.ispc
+++ b/tests/lit-tests/1470.ispc
@@ -4,53 +4,34 @@
 // The test also checks that inserts are transformed to shuffles during
 // optimization when vector size equals number of program instances.
 
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=sse2-i32x4 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=sse2-i32x8 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-asm -h %t.h --target=sse2-i32x4 -o - | FileCheck %s -check-prefix=CHECK_SSE
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=sse2-i32x4    -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=sse2-i32x8    -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-asm       -h %t.h --nostdlib --target=sse2-i32x4    -o - | FileCheck %s -check-prefix=CHECK_SSE
 
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=sse4-i32x4 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=sse4-i32x8 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=sse4-i16x8 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=sse4-i8x16 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-asm -h %t.h --target=sse4-i32x4 -o - | FileCheck %s -check-prefix=CHECK_SSE
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=sse4-i32x4    -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=sse4-i32x8    -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=sse4-i16x8    -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=sse4-i8x16    -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-asm       -h %t.h --nostdlib --target=sse4-i32x4    -o - | FileCheck %s -check-prefix=CHECK_SSE
 
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=sse4.1-i32x4 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=sse4.1-i32x8 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=sse4.1-i16x8 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=sse4.1-i8x16 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-asm -h %t.h --target=sse4.1-i32x4 -o - | FileCheck %s -check-prefix=CHECK_SSE
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=sse4.1-i32x4  -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=sse4.1-i32x8  -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=sse4.1-i16x8  -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=sse4.1-i8x16  -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-asm       -h %t.h --nostdlib --target=sse4.1-i32x4  -o - | FileCheck %s -check-prefix=CHECK_SSE
 
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=avx1-i32x4 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=avx1-i32x8 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=avx1-i32x16 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=avx1-i64x4 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-asm -h %t.h --target=avx1-i32x4 -o - | FileCheck %s -check-prefix=CHECK_AVX
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx1-i32x4    -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx1-i32x8    -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx1-i32x16   -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx1-i64x4    -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-asm       -h %t.h --nostdlib --target=avx1-i32x4    -o - | FileCheck %s -check-prefix=CHECK_AVX
 
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=avx2-i32x8 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=avx2-i32x16 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=avx2-i64x4 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx2-i32x8    -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx2-i32x16   -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx2-i64x4    -o - | FileCheck %s
 
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=avx512knl-x16 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
-// RUN: %{ispc}  %s --emit-llvm -h %t.h --target=avx512skx-x16 -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx512knl-x16 -o - | FileCheck %s
+// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx512skx-x16 -o - | FileCheck %s
 
 // REQUIRES: X86_ENABLED
 

--- a/tests/lit-tests/1470.ispc
+++ b/tests/lit-tests/1470.ispc
@@ -1,4 +1,4 @@
-// This test checks that swizzle operation does not cause any compiler 
+// This test checks that swizzle operation does not cause any compiler
 // internal error when it is applied to binary expression.
 // Swizzle operation is implemented through memory using insert instructions.
 // The test also checks that inserts are transformed to shuffles during
@@ -82,7 +82,7 @@ unmasked vec4 test_shuffle(uniform vec4 offs0) {
 // CHECK_SSE-COUNT-3: shufps {{.*#+}}
 
 // CHECK_AVX: test_shuffle
-// CHECK_AVX-COUNT-3: vpermilps {{.*#+}}
+// CHECK_AVX-COUNT-3: {{(vpermilps|vshufps)}} {{.*#+}}
 
     return (uv.xyxy + offs0).xwwz;
 }


### PR DESCRIPTION
- Add `LLVM 17.0` support to `alloy.py`
- Add `LLVM 18.0` definition to ISPC sources
- Bump required CMake version in `ispcrt` to make newest CMake version (3.27) happy
- Fix compile and test problems with LLVM 17.0

This is not all the changes that are required to fully enable LLVM 17.0+. Starting 17.0 opaque pointers must be enabled.