### PR TITLE
Function template specialization support

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -3702,12 +3702,14 @@ What is currently supported:
   function call syntax (i.e. ``add(1, 2);``).
 * Explicit template function instantiations (i.e.
   ``template int add<int>(int a, int b);``).
+* Explicit template function specializations (i.e.
+  ``template<> int add<int>(int a, int b) { return a - b;}``).
 
 What is currently not supported, but is planned to be supported:
 
 * Non-type template parameters.
 * Default values for template parameters.
-* Template function specializations.
+* Template arguments deduction in template function specializations.
 
 While template argument deduction rules generally follow C++, there are some
 differences caused by existence of ``uniform``, ``varying`` and ``unbound``
@@ -3757,6 +3759,48 @@ following example:
 
 Note, to get the insight of the results of template argument deduction, it might
 be useful to specify ``--ast-dump`` flag to ``ispc`` compiler.
+
+ISPC supports template function specializations that can be used to provide alternative
+implementations for a specific set of template parameters. To define template function
+specialization, the primary template should be already present in the program. If specialization
+is defined after it was used, the error will be issued. Template arguments deduction in
+template function specializations is not yet supported. Consider the following example:
+
+::
+
+    // primary template
+    template <typename T> int goo(T a1, T a2) {
+      return a1 + a2;
+    }
+
+    // declaration of specialization for int type
+    template <> int goo<int>(int a1, int a2);
+
+    // error: no matching function template found for specialization.
+    template <> int goo<float, int>(float a1, int a2) {
+      return a1 + a2;
+    }
+
+    // error: template arguments deduction is not yet supported in template function specialization.
+    template <> int goo(float a1, float a2) {
+      return a1 + a2;
+    }
+
+    float foo(int a1, float a2) {
+      float a = goo<int>(a1, (int)a2); //specialization for int type will be called
+      double b = goo<double>((double)a1, (double)a2); //primary template will be instantiated for double type
+      return a + b;
+    }
+
+    // definition of specialization for int type
+    template <> int goo<int>(int a1, int a2) {
+      return a1 * a2;
+    }
+
+    // error: template function specialization was already defined
+    template <> int goo<int>(int a1, int a2) {
+      return a1 * a2;
+    }
 
 
 The ISPC Standard Library

--- a/src/func.h
+++ b/src/func.h
@@ -83,8 +83,10 @@ class FunctionTemplate {
 
     Symbol *LookupInstantiation(const std::vector<std::pair<const Type *, SourcePos>> &types);
     Symbol *AddInstantiation(const std::vector<std::pair<const Type *, SourcePos>> &types);
+    Symbol *AddSpecialization(const FunctionType *ftype, const std::vector<std::pair<const Type *, SourcePos>> &types,
+                              SourcePos pos);
 
-    // Generate code for instantiations
+    // Generate code for instantiations and specializations.
     void GenerateIR() const;
 
     void Print() const;

--- a/src/module.h
+++ b/src/module.h
@@ -90,6 +90,14 @@ class Module {
                                           const std::vector<std::pair<const Type *, SourcePos>> &types,
                                           const FunctionType *ftype, SourcePos pos);
 
+    void AddFunctionTemplateSpecializationDeclaration(const std::string &name, const FunctionType *ftype,
+                                                      const std::vector<std::pair<const Type *, SourcePos>> &types,
+                                                      SourcePos pos);
+
+    void AddFunctionTemplateSpecializationDefinition(const std::string &name, const FunctionType *ftype,
+                                                     const std::vector<std::pair<const Type *, SourcePos>> &types,
+                                                     SourcePos pos, Stmt *code);
+
     /** Adds the given type to the set of types that have their definitions
         included in automatically generated header files. */
     void AddExportedTypes(const std::vector<std::pair<const Type *, SourcePos>> &types);
@@ -97,6 +105,14 @@ class Module {
     /** Verify LLVM intrinsic called from ISPC source code is valid and return
         function symbol for it. */
     Symbol *AddLLVMIntrinsicDecl(const std::string &name, ExprList *args, SourcePos po);
+
+    /** Returns pointer to FunctionTemplate based on template name and template argument types provided. Also makes
+       template argument types normalization, i.e apply "varying type default":
+       template <typename T> void foo(T t);
+       foo<int>(1); // T is assumed to be "varying int" here.
+    */
+    FunctionTemplate *MatchFunctionTemplate(const std::string &name, const FunctionType *ftype,
+                                            std::vector<std::pair<const Type *, SourcePos>> &normTypes, SourcePos pos);
 
     /** After a source file has been compiled, output can be generated in a
         number of different formats. */

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -2375,7 +2375,7 @@ template_int_parameter
           $$ = nullptr;
           lCleanUpyylvalStringVal();
           // TODO: implement
-          Error(Union(@1, @2), "Non-type template paramters are not yet supported.");
+          Error(Union(@1, @2), "Non-type template parameters are not yet supported.");
       }
     ;
 

--- a/src/sym.h
+++ b/src/sym.h
@@ -105,6 +105,7 @@ class TemplateSymbol {
     // The reason to keep them here for now is that for regular functions it's not stored anywhere in AST,
     // but attached as attrubutes to llvm::Function when it's created. For templates we need to store this
     // information in here and use later when the template is instantiated.
+    // These attributes will be inherited by template functions specializations.
     bool isInline;
     bool isNoInline;
 };

--- a/tests/func-template-1.ispc
+++ b/tests/func-template-1.ispc
@@ -1,0 +1,31 @@
+#include "../test_static.isph"
+
+template <typename T, typename C> noinline uniform float noinline goo(T argGooOne, C argGooTwo) { return 0; }
+
+template <> noinline uniform float noinline goo<int, int>(int argGooOne, int argGooTwo) { return 1; }
+
+template <> noinline uniform float noinline goo<uniform float, int>(uniform float argGooOne, int argGooTwo) {
+    return argGooOne;
+}
+
+template <typename C> uniform float noinline goo(C argGooOne) { return 2; }
+
+template <> uniform float noinline goo<float>(float argGooOne) { return 3; }
+
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b_val) {
+    int argFoo0 = aFOO[programIndex];
+    int argFoo1 = aFOO[programIndex] / 2;
+    RET[programIndex] = goo<int, uniform float>(argFoo0, b_val); // primary template, return 0
+    RET[0] = goo<float>((float)argFoo0);                         // specialized template, return 3
+    RET[1] = goo<int>(argFoo0, argFoo1);                         // primary template with two args, return 1
+    RET[2] = goo<int, int>(argFoo0, argFoo1);                    // specialized template, return 1
+    RET[3] = goo<uniform float, int>(b_val, argFoo1);            // specialized template, return b_val
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 0;
+    RET[0] = 3;
+    RET[1] = 1;
+    RET[2] = 1;
+    RET[3] = 5;
+}

--- a/tests/lit-tests/func_template_not_supported.ispc
+++ b/tests/lit-tests/func_template_not_supported.ispc
@@ -9,8 +9,8 @@ template <typename T = int, int I> T foo(T t) {
   return tt;
 }
 
-// CHECK: Template function specialization not yet supported.
+// CHECK: Template arguments deduction is not yet supported in template function specialization.
 template <> int foo(int t);
 
-// CHECK: Template function specialization not yet supported.
+// CHECK: Template arguments deduction is not yet supported in template function specialization.
 template <> int foo(int t) { return 1; }

--- a/tests/lit-tests/func_template_not_supported.ispc
+++ b/tests/lit-tests/func_template_not_supported.ispc
@@ -3,7 +3,7 @@
 // CHECK-NOT: Please file a bug report
 
 // CHECK: Default values for template type parameters are not yet supported.
-// CHECK: Non-type template paramters are not yet supported.
+// CHECK: Non-type template parameters are not yet supported.
 template <typename T = int, int I> T foo(T t) {
   T tt = t + 1;
   return tt;

--- a/tests/lit-tests/func_template_spec_1.ispc
+++ b/tests/lit-tests/func_template_spec_1.ispc
@@ -1,0 +1,38 @@
+// Check basic scenario for functions specializations.
+// RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
+
+// Regular function
+// CHECK-LABEL: define <{{[0-9]*}} x i32> @goo___vyivyf(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+
+// Specialized function
+// CHECK-LABEL: define {{.*}} <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x float> %argGooTwo)
+// Check that implementation of specialized function is generated from specialization
+// CHECK: fmul
+
+// CHECK-LABEL: define <{{[0-9]*}} x float> @foo
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x float> %argFoo1)
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x i32> %argFoo0)
+
+// Instantiated function
+// CHECK-LABEL: define {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo)
+// Check that implementation of instantiated function is generated from primary template
+// CHECK: add
+
+template <typename T, typename C> noinline int goo(T argGooOne, C argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+
+noinline int goo(int argGooOne, float argGooTwo) {
+  return argGooOne * argGooTwo;
+}
+
+template <> noinline int goo<int, float>(int argGooOne, float argGooTwo) {
+  return argGooOne * argGooTwo;
+}
+
+float foo(int argFoo0, float argFoo1) {
+    float a = goo<int, float>(argFoo0, argFoo1);
+    int b = goo<int, int>(argFoo0, argFoo0);
+    return a + b;
+}
+

--- a/tests/lit-tests/func_template_spec_2.ispc
+++ b/tests/lit-tests/func_template_spec_2.ispc
@@ -1,0 +1,33 @@
+// Check that function specialization can be declared, then used, then defined.
+// RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
+
+// Specialized function
+// CHECK-LABEL: define {{.*}} <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x float> %argGooTwo)
+// Check that implementation of specialized function is generated from specialization
+// CHECK: fmul
+
+// CHECK-LABEL: define <{{[0-9]*}} x float> @foo
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x float> %argFoo1)
+// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x i32> %argFoo0)
+
+// Instantiated function
+// CHECK-LABEL: define {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo)
+// Check that implementation of instantiated function is generated from primary template
+// CHECK: add
+
+template <typename T, typename C> noinline int goo(T argGooOne, C argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+
+template <> noinline int goo<int, float>(int argGooOne, float argGooTwo);
+
+float foo(int argFoo0, float argFoo1) {
+    float a = goo<int, float>(argFoo0, argFoo1);
+    int b = goo<int, int>(argFoo0, argFoo0);
+    return a + b;
+}
+
+template <> noinline int goo<int, float>(int argGooOne, float argGooTwo) {
+  return argGooOne * argGooTwo;
+}
+

--- a/tests/lit-tests/func_template_spec_3.ispc
+++ b/tests/lit-tests/func_template_spec_3.ispc
@@ -1,0 +1,20 @@
+// Check that error is produced when template function specialization is defined after it was already created through instantiation.
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap  2>&1 | FileCheck %s
+
+// CHECK-NOT: Please file a bug report
+
+// CHECK: Template function specialization was already defined.
+
+template <typename T, typename C> noinline int goo(T argGooOne, C argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+
+float foo(int argFoo0, float argFoo1) {
+    float a = goo<int, float>(argFoo0, argFoo1);
+    int b = goo<int, int>(argFoo0, argFoo0);
+    return a + b;
+}
+
+template <> noinline int goo<int, float>(int argGooOne, float argGooTwo) {
+  return argGooOne * argGooTwo;
+}

--- a/tests/lit-tests/func_template_spec_4.ispc
+++ b/tests/lit-tests/func_template_spec_4.ispc
@@ -1,0 +1,32 @@
+// Check that error is produced when template function specialization is defined several times.
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap  2>&1 | FileCheck %s
+
+// CHECK-NOT: Please file a bug report
+
+template <typename T> noinline int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+
+template <> noinline int goo<int>(int argGooOne, int argGooTwo) {
+  return argGooOne * argGooTwo;
+}
+
+// CHECK: Template function specialization was already defined.
+template <> noinline int goo<int>(int argGooOne, int argGooTwo) {
+  return argGooOne * argGooTwo;
+}
+
+// CHECK: No matching function template found for specialization.
+template <> noinline int goo<float, int>(float argGooOne, float argGooTwo) {
+  return argGooOne + argGooTwo;
+}
+
+// CHECK: Template function specialization was declared but never defined.
+template <> noinline int goo<double>(double argGooOne, double argGooTwo);
+
+float foo(int argFoo0, float argFoo1) {
+    float a = goo<int>(argFoo0, (int)argFoo1);
+    int b = goo<float>((float)argFoo0, argFoo1);
+    double c = goo<double>((double)argFoo0, (double)argFoo1);
+    return a + b;
+}

--- a/tests/lit-tests/func_template_spec_5.ispc
+++ b/tests/lit-tests/func_template_spec_5.ispc
@@ -1,0 +1,21 @@
+// Check that error is produced when template function specialization is defined before primary template.
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap  2>&1 | FileCheck %s
+
+// CHECK-NOT: Please file a bug report
+
+// TODO: better diagnostics is needed here
+// CHECK: syntax error, unexpected identifier, expecting TOKEN_TEMPLATE_NAME
+
+template <> noinline int goo<int, float>(int argGooOne, float argGooTwo) {
+  return argGooOne * argGooTwo;
+}
+
+template <typename T, typename C> noinline int goo(T argGooOne, C argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+
+float foo(int argFoo0, float argFoo1) {
+    float a = goo<int, float>(argFoo0, argFoo1);
+    int b = goo<int, int>(argFoo0, argFoo0);
+    return a + b;
+}

--- a/tests/lit-tests/func_template_spec_6.ispc
+++ b/tests/lit-tests/func_template_spec_6.ispc
@@ -1,0 +1,38 @@
+// Test function template specialization with nested templates.
+
+// RUN: %{ispc}  %s --emit-llvm-text --target=host -O0 -o - | FileCheck %s
+
+float k;
+template <typename T> noinline T add(T A, T B) { return A + B; }
+template <typename T> noinline T mul(T A, T B) { return A * B; }
+template <typename T> noinline T fma(T A, T B, T C) { return add<T>(mul<T>(A, B), C); }
+template <> noinline float fma<float>(float A, float B, float C) {
+    return add<float>(mul<float>(A, B), C * k);
+}
+
+// CHECK: define {{.*}} @fma___vyf___vyfvyfvyf
+// CHECK: call {{.*}} @mul___vyf___vyfvyf(<{{[0-9]*}} x float>
+// CHECK: fmul
+// CHECK: call {{.*}} @add___vyf___vyfvyf(<{{[0-9]*}} x float>
+
+// CHECK: define {{.*}} @mul___vyf___vyfvyf
+
+// CHECK: define {{.*}} @add___vyf___vyfvyf
+
+// CHECK: define <{{[0-9]*}} x float> @foo___vyfvyfvyf
+// CHECK: call {{.*}} @fma___vyf___vyfvyfvyf(<{{[0-9]*}} x float>
+
+// CHECK: define <{{[0-9]*}} x i32> @foo___vyivyivyi
+// CHECK: call {{.*}} @fma___vyi___vyivyivyi(<{{[0-9]*}} x i32>
+
+// CHECK: define {{.*}} @fma___vyi___vyivyivyi
+// CHECK: call {{.*}} @mul___vyi___vyivyi(<{{[0-9]*}} x i32>
+// CHECK-NOT: fmul
+// CHECK: call {{.*}} @add___vyi___vyivyi(<{{[0-9]*}} x i32>
+
+// CHECK: define {{.*}} @mul___vyi___vyivyi
+
+// CHECK: define {{.*}} @add___vyi___vyivyi
+
+float foo(float A, float B, float C) { return fma<varying float>(A, B, C); }
+int foo(int A, int B, int C) { return fma<varying int>(A, B, C); }


### PR DESCRIPTION
Added support of function template specializations with explicit template arguments:
```cpp
// Primary template
template <typename T, typename C> noinline int goo(T argGooOne, C argGooTwo);

// Specialization with explicit template arguments
template <> noinline int goo<int, float>(int argGooOne, float argGooTwo);

// Not supported yet: specialization with implicit template arguments (requires template arguments type deduction)
template <> noinline int goo(int argGooOne, float argGooTwo);
```