### PR TITLE
Treat TOKEN_TYPE_NAME as TOKEN_IDENTIFIER in postfix_expression

### DIFF
--- a/src/parse.yy
+++ b/src/parse.yy
@@ -493,7 +493,31 @@ postfix_expression
           $$ = MemberExpr::create($1, yytext, Union(@1,@3), @3, false);
           lCleanUpyylvalStringVal();
       }
+    /* When we have postfix_expression inside template definition, we need to allow cases when
+       member name equals to template name or template parameter name. */
+    | postfix_expression '.' TOKEN_TYPE_NAME
+      {
+          $$ = MemberExpr::create($1, yytext, Union(@1,@3), @3, false);
+          lCleanUpyylvalStringVal();
+      }
+    | postfix_expression '.' TOKEN_TEMPLATE_NAME
+      {
+          $$ = MemberExpr::create($1, yytext, Union(@1,@3), @3, false);
+          lCleanUpyylvalStringVal();
+      }
     | postfix_expression TOKEN_PTR_OP TOKEN_IDENTIFIER
+      {
+          $$ = MemberExpr::create($1, yytext, Union(@1,@3), @3, true);
+          lCleanUpyylvalStringVal();
+      }
+    /* When we have postfix_expression inside template definition, we need to allow cases when
+       member name equals to template name or template parameter name. */
+    | postfix_expression TOKEN_PTR_OP TOKEN_TYPE_NAME
+      {
+          $$ = MemberExpr::create($1, yytext, Union(@1,@3), @3, true);
+          lCleanUpyylvalStringVal();
+      }
+    | postfix_expression TOKEN_PTR_OP TOKEN_TEMPLATE_NAME
       {
           $$ = MemberExpr::create($1, yytext, Union(@1,@3), @3, true);
           lCleanUpyylvalStringVal();

--- a/tests/lit-tests/2472.ispc
+++ b/tests/lit-tests/2472.ispc
@@ -1,0 +1,40 @@
+// The test is checking that template name is not clashing with struct member names (#2472)
+// RUN: %{ispc} %s --target=host --nostdlib -o %t.o --nowrap 2>&1 | FileCheck %s
+
+// CHECK-NOT: Error: syntax error, unexpected TOKEN_TYPE_NAME
+struct MyStruct {
+    int M;
+    int V;
+    int Res1;
+    int Res2;
+};
+
+template <typename V>
+noinline int Sum1(V* a, V* b) {
+    return a->M + b->V;
+}
+
+template <typename V>
+noinline int Sum2(V& a, V& b) {
+    return a.M + b.V;
+}
+
+template <typename V>
+noinline void Res1(V* a, V* b) {
+    a->Res1 = a->M + b->V;
+    a->Res2 = a->M - b->V;
+}
+
+template <typename V>
+noinline int Res2(V& a, V& b) {
+    b.Res1 = a.M + b.V;
+    b.Res2 = a.M - b.V;
+}
+
+int foo() {
+    MyStruct a = {1, 2, 0};
+    MyStruct b = {3, 4, 0};
+    Res1(&a, &b);
+    Res2(a, b);
+    return Sum1(&a, &b) + Sum2(a, b);
+}


### PR DESCRIPTION
Fixes the problem from #2472 that RHS of "." or "->" expression cannot be a typename and should be treated as field name.