### PR TITLE
Fix dockers

### DIFF
--- a/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
@@ -77,7 +77,7 @@ ARG LLVM_VERSION
 
 # Install regular ISPC dependencies
 RUN if [[ $(uname -m) =~ "x86" ]]; then export CROSS_LIBS="libc6-dev-i386=2.27-3ubuntu*"; else export CROSS_LIBS="libc6-dev-armhf-cross=2.27-3ubuntu*"; fi && \
-    apt-get -y update && apt-get --no-install-recommends install -y m4 bison flex $CROSS_LIBS && \
+    apt-get -y update && apt-get --no-install-recommends install -y m4 bison flex "$CROSS_LIBS" && \
     rm -rf /var/lib/apt/lists/*
 
 # Configure ISPC build

--- a/docker/ubuntu/20.04/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/20.04/xpu_ispc_build/Dockerfile
@@ -54,14 +54,13 @@ RUN set -eux && wget -qO - https://repositories.intel.com/graphics/intel-graphic
     mesa-vdpau-drivers mesa-vulkan-drivers va-driver-all && \
     rm -rf /var/lib/apt/lists/*
 
-# L0 loaader
-RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/oneapi-src/level-zero/releases/download/v${L0L_VER}/level-zero-devel_${L0L_VER}+u18.04_amd64.deb && \
-    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/oneapi-src/level-zero/releases/download/v${L0L_VER}/level-zero_${L0L_VER}+u18.04_amd64.deb
-
-# Install packages and clean up
-RUN dpkg -i ./*.deb
-WORKDIR /home
-RUN rm -rf packages
+# L0 loader
+WORKDIR /home/src
+RUN git clone https://github.com/oneapi-src/level-zero.git
+WORKDIR /home/src/level-zero
+RUN git checkout v$L0L_VER && mkdir -p build
+WORKDIR /home/src/level-zero/build
+RUN cmake -DCMAKE_INSTALL_PREFIX=/home/deps ../ && make install -j"$(nproc)"
 
 # vc-intrinsics
 WORKDIR /home/src
@@ -84,6 +83,6 @@ ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
 WORKDIR /home/src/ispc
 RUN mkdir -p build
 WORKDIR /home/src/ispc/build
-RUN cmake -DXE_ENABLED=ON -DCMAKE_INSTALL_PREFIX=/home/ispc/ -DXE_DEPS_DIR=/home/deps ../ && make install -j"$(nproc)" && make check-all -j"$(nproc)"
+RUN cmake -DXE_ENABLED=ON -DCMAKE_INSTALL_PREFIX=/home/ispc/ -DXE_DEPS_DIR=/home/deps -DLEVEL_ZERO_ROOT=/home/deps ../ && make install -j"$(nproc)" && make check-all -j"$(nproc)"
 # Add ISPC to PATH
 ENV PATH=/home/ispc/bin:$PATH

--- a/docker/ubuntu/20.04/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/20.04/xpu_ispc_build/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM ubuntu:20.04
 LABEL maintainer="Arina Neshlyaeva <arina.neshlyaeva@intel.com>"
-SHELL ["/bin/bash", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG REPO=ispc/ispc
 ARG SHA=main


### PR DESCRIPTION
This PR fixes two minor hadolint warnings. It also fixes the logic of installing level zero loader of the ubuntu 20.04 docker.  The link to download deb packages of level zero 1.10 for Ubuntu 18.04 doesn't exist, because level zero provides only deb packages for ubuntu 22.04 since around this version. 