### PR TITLE
Enable more compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,7 +521,7 @@ if (MSVC)
     set_source_files_properties(${FLEX_OUTPUT} PROPERTIES COMPILE_FLAGS "/wd4005 /wd4003")
     set_source_files_properties(${BISON_OUTPUT} PROPERTIES COMPILE_FLAGS "/wd4005 /wd4065")
 else()
-    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wno-sign-compare -Wno-unused-function ${LLVM_CPP_FLAGS})
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-unused-function ${LLVM_CPP_FLAGS})
     # Security options
     target_compile_options(${PROJECT_NAME} PRIVATE -fstack-protector-strong
                            -fdata-sections -ffunction-sections -fno-delete-null-pointer-checks

--- a/ispcrt/CMakeLists.txt
+++ b/ispcrt/CMakeLists.txt
@@ -108,6 +108,7 @@ else()
     # Assume that signed overflow always wraps
     target_compile_options(ispcrt_interface_lib INTERFACE
                            -fstack-protector-strong -fno-delete-null-pointer-checks -fwrapv)
+    target_compile_options(ispcrt_interface_lib INTERFACE -Wall -Wextra -Wno-unused-private-field)
     target_compile_definitions(ispcrt_interface_lib INTERFACE "_FORTIFY_SOURCE=2")
     if (NOT APPLE)
         target_link_options(ispcrt_interface_lib INTERFACE

--- a/ispcrt/detail/cpu/CPUDevice.cpp
+++ b/ispcrt/detail/cpu/CPUDevice.cpp
@@ -416,7 +416,7 @@ struct TaskQueue : public ispcrt::base::TaskQueue {
 
 uint32_t deviceCount() { return 1; }
 
-ISPCRTDeviceInfo deviceInfo(uint32_t deviceIdx) {
+ISPCRTDeviceInfo deviceInfo([[maybe_unused]] uint32_t deviceIdx) {
     ISPCRTDeviceInfo info;
     info.deviceId = 0; // for CPU we don't support it yet
     info.vendorId = 0;
@@ -430,7 +430,9 @@ ispcrt::base::MemoryView *CPUDevice::newMemoryView(void *appMem, size_t numBytes
     return new cpu::MemoryView(appMem, numBytes, flags->allocType == ISPCRT_ALLOC_TYPE_SHARED);
 }
 
-ispcrt::base::CommandQueue *CPUDevice::newCommandQueue(uint32_t ordinal) const { return new cpu::CommandQueueImpl(); }
+ispcrt::base::CommandQueue *CPUDevice::newCommandQueue([[maybe_unused]] uint32_t ordinal) const {
+    return new cpu::CommandQueueImpl();
+}
 
 ispcrt::base::TaskQueue *CPUDevice::newTaskQueue() const { return new cpu::TaskQueue(); }
 
@@ -442,11 +444,12 @@ ispcrt::base::ModuleOptions *CPUDevice::newModuleOptions(ISPCRTModuleType module
 }
 
 ispcrt::base::Module *CPUDevice::newModule(const char *moduleFile,
-                                           const ispcrt::base::ModuleOptions &moduleOpts) const {
+                                           [[maybe_unused]] const ispcrt::base::ModuleOptions &moduleOpts) const {
     return new cpu::Module(moduleFile);
 }
 
-void CPUDevice::dynamicLinkModules(base::Module **modules, const uint32_t numModules) const {}
+void CPUDevice::dynamicLinkModules([[maybe_unused]] base::Module **modules,
+                                   [[maybe_unused]] const uint32_t numModules) const {}
 
 ispcrt::base::Module *CPUDevice::staticLinkModules(base::Module **modules, const uint32_t numModules) const {
     return new cpu::Module((cpu::Module **)modules, numModules);
@@ -464,7 +467,9 @@ void *CPUDevice::contextNativeHandle() const { return nullptr; }
 
 ISPCRTDeviceType CPUDevice::getType() const { return ISPCRT_DEVICE_TYPE_CPU; }
 
-ISPCRTAllocationType CPUDevice::getMemAllocType(void *appMemory) const { return ISPCRT_ALLOC_TYPE_UNKNOWN; }
+ISPCRTAllocationType CPUDevice::getMemAllocType([[maybe_unused]] void *appMemory) const {
+    return ISPCRT_ALLOC_TYPE_UNKNOWN;
+}
 
 ispcrt::base::MemoryView *CPUContext::newMemoryView(void *appMem, size_t numBytes,
                                                     const ISPCRTNewMemoryViewFlags *flags) const {

--- a/ispcrt/detail/cpu/CPUDevice.cpp
+++ b/ispcrt/detail/cpu/CPUDevice.cpp
@@ -64,7 +64,7 @@ using CPUKernelEntryPoint = void (*)(void *, size_t, size_t, size_t);
 
 struct MemoryView : public ispcrt::base::MemoryView {
     MemoryView(void *appMem, size_t numBytes, bool shared)
-        : m_hostPtr(appMem), m_devicePtr(appMem), m_size(numBytes), m_shared(shared) {}
+        : m_shared(shared), m_hostPtr(appMem), m_devicePtr(appMem), m_size(numBytes) {}
 
     ~MemoryView() {
         if (!m_external_alloc && m_devicePtr)
@@ -119,9 +119,9 @@ struct ModuleOptions : public ispcrt::base::ModuleOptions {
     void setModuleType(ISPCRTModuleType type) { m_moduleType = type; }
 
   private:
-    uint32_t m_stackSize{0};
-    bool m_libraryCompilation{false};
     ISPCRTModuleType m_moduleType{ISPCRTModuleType::ISPCRT_VECTOR_MODULE};
+    bool m_libraryCompilation{false};
+    uint32_t m_stackSize{0};
 };
 
 struct Module : public ispcrt::base::Module {

--- a/ispcrt/detail/cpu/ispc_tasking.cpp
+++ b/ispcrt/detail/cpu/ispc_tasking.cpp
@@ -316,7 +316,7 @@ static void *lAtomicCompareAndSwapPointer(void **v, void *newValue, void *oldVal
 #endif // ISPC_IS_WINDOWS
 }
 
-static int32_t lAtomicCompareAndSwap32(volatile int32_t *v, int32_t newValue, int32_t oldValue) {
+[[maybe_unused]] static int32_t lAtomicCompareAndSwap32(volatile int32_t *v, int32_t newValue, int32_t oldValue) {
 #ifdef ISPC_IS_WINDOWS
     return InterlockedCompareExchange((volatile LONG *)v, newValue, oldValue);
 #else
@@ -326,7 +326,7 @@ static int32_t lAtomicCompareAndSwap32(volatile int32_t *v, int32_t newValue, in
 #endif // ISPC_IS_WINDOWS
 }
 
-static inline int32_t lAtomicAdd(volatile int32_t *v, int32_t delta) {
+[[maybe_unused]] static inline int32_t lAtomicAdd(volatile int32_t *v, int32_t delta) {
 #ifdef ISPC_IS_WINDOWS
     return InterlockedExchangeAdd((volatile LONG *)v, delta) + delta;
 #else

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -480,8 +480,8 @@ struct CommandList {
 
   private:
     ze_command_list_handle_t m_handle{nullptr};
-    ze_context_handle_t m_context{nullptr};
     ze_device_handle_t m_device{nullptr};
+    ze_context_handle_t m_context{nullptr};
     const uint32_t m_ordinal{0};
     bool m_submitted{false};
     uint32_t m_numCommands{0};
@@ -680,8 +680,8 @@ class Bulk {
   private:
     char *m_memPtr{nullptr};
 
-    size_t m_size{0};
     size_t m_chunkSize{0};
+    size_t m_size{0};
     size_t m_numChunks{0};
 
     // Index of free chunk during initial linear allocation.
@@ -926,19 +926,20 @@ struct MemoryView : public ispcrt::base::MemoryView {
         }
     }
 
-    ISPCRTSharedMemoryAllocationHint m_smhint{ISPCRT_SM_HOST_DEVICE_READ_WRITE};
-    bool m_shared{false};
-    bool m_useMemPool{false};
-
     void *m_hostPtr{nullptr};
-    void *m_devicePtr{nullptr};
     size_t m_size{0};
     size_t m_requestedSize{0};
 
-    ze_device_handle_t m_device{nullptr};
     ze_context_handle_t m_context{nullptr};
+    ze_device_handle_t m_device{nullptr};
 
+    void *m_devicePtr{nullptr};
+
+    bool m_shared{false};
+    ISPCRTSharedMemoryAllocationHint m_smhint{ISPCRT_SM_HOST_DEVICE_READ_WRITE};
     const GPUContext *m_ctxtGPU{nullptr};
+
+    bool m_useMemPool{false};
     ChunkedPool *m_memPool{nullptr};
 };
 
@@ -956,9 +957,9 @@ struct ModuleOptions : public ispcrt::base::ModuleOptions {
     void setModuleType(ISPCRTModuleType type) { m_moduleType = type; }
 
   private:
-    uint32_t m_stackSize{0};
-    bool m_libraryCompilation{false};
     ISPCRTModuleType m_moduleType{ISPCRTModuleType::ISPCRT_VECTOR_MODULE};
+    bool m_libraryCompilation{false};
+    uint32_t m_stackSize{0};
 };
 
 struct Module : public ispcrt::base::Module {

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -153,7 +153,7 @@ static size_t round_up_pow2(size_t x) {
 namespace ispcrt {
 namespace gpu {
 
-static const ISPCRTError getIspcrtError(ze_result_t err) {
+static ISPCRTError getIspcrtError(ze_result_t err) {
     auto res = ISPCRT_UNKNOWN_ERROR;
     switch (err) {
     case ZE_RESULT_SUCCESS:

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -1025,7 +1025,6 @@ struct Module : public ispcrt::base::Module {
         if (opts.libraryCompilation()) {
             m_igc_options += " -library-compilation";
         }
-        constexpr auto MAX_ISPCRT_IGC_OPTIONS = 2000UL;
         const char *userIgcOptionsEnv = getenv_wr(ISPCRT_IGC_OPTIONS);
         if (userIgcOptionsEnv) {
             // Copy at most MAX_ISPCRT_IGC_OPTIONS characters from the env - just to be safe

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -757,7 +757,7 @@ class ChunkedPool {
 
         bool allFull = true;
         Bulk *blk = bulks.front();
-        for (int i = 0; i < bulks.size(); i++) {
+        for (size_t i = 0; i < bulks.size(); i++) {
             if (blk->full()) {
                 bulks.pop_front();
                 bulks.push_back(blk);
@@ -1088,7 +1088,7 @@ struct Module : public ispcrt::base::Module {
         std::vector<const char *> buildFlags;
         std::vector<size_t> inputSizes;
         std::vector<const uint8_t *> inputModules;
-        for (int i = 0; i < numModules; i++) {
+        for (uint32_t i = 0; i < numModules; i++) {
             buildFlags.push_back(modules[i]->m_module_desc.pBuildFlags);
             inputSizes.push_back(modules[i]->m_module_desc.inputSize);
             inputModules.push_back(modules[i]->m_module_desc.pInputModule);
@@ -1774,13 +1774,13 @@ ISPCRTDeviceInfo deviceInfo(uint32_t deviceIdx) {
 
 void dynamicLinkModules(gpu::Module **modules, const uint32_t numModules) {
     std::vector<ze_module_handle_t> moduleHandles;
-    for (int i = 0; i < numModules; i++) {
+    for (uint32_t i = 0; i < numModules; i++) {
         moduleHandles.push_back(modules[i]->handle());
     }
 
     if (UNLIKELY(is_verbose)) {
         std::cout << "Binary linking of " << numModules << " modules: ";
-        for (int i = 0; i < numModules; i++) {
+        for (uint32_t i = 0; i < numModules; i++) {
             std::cout << modules[i]->filename() << " ";
         }
         std::cout << std::endl;
@@ -1803,13 +1803,13 @@ void dynamicLinkModules(gpu::Module **modules, const uint32_t numModules) {
 base::Module *staticLinkModules(gpu::Module **modules, const uint32_t numModules, ze_device_handle_t device,
                                 ze_context_handle_t context) {
     std::vector<ze_module_handle_t> moduleHandles;
-    for (int i = 0; i < numModules; i++) {
+    for (uint32_t i = 0; i < numModules; i++) {
         moduleHandles.push_back(modules[i]->handle());
     }
 
     if (UNLIKELY(is_verbose)) {
         std::cout << "vISA linking of " << numModules << " modules: ";
-        for (int i = 0; i < numModules; i++) {
+        for (uint32_t i = 0; i < numModules; i++) {
             std::cout << modules[i]->filename() << " ";
         }
         std::cout << std::endl;

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -724,6 +724,9 @@ class Bulk {
 class ChunkedPool {
   public:
     ChunkedPool(ISPCRTSharedMemoryAllocationHint type, ze_context_handle_t ctxt) : m_type(type), m_ctxt(ctxt) {
+        if (UNLIKELY(is_verbose)) {
+            std::cout << "ChunkedPool for " << m_type << " shared memory allocation hint created." << std::endl;
+        }
         m_minPow2 = get_number_envvar(ISPCRT_MEM_POOL_MIN_CHUNK_POW2, m_minPow2);
         if (!(m_minPow2 >= 1 && m_minPow2 <= 30)) {
             throw std::runtime_error("ISPCRT_MEM_POOL_MIN_CHUNK_POW2 is beyond reasonable limits");

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -127,7 +127,8 @@ static OBJECT_T &referenceFromHandle(HANDLE_T handle) {
 #endif
 
 // OS agnostic function to dynamically load a shared library.
-void *dyn_load_lib(const char *name, const char *name_major_version, const char *name_full_version) {
+void *dyn_load_lib(const char *name, [[maybe_unused]] const char *name_major_version,
+                   [[maybe_unused]] const char *name_full_version) {
 #if defined(_WIN32) || defined(_WIN64)
     // Removes CWD from the search path to reduce the risk of DLL injection.
     SetDllDirectory("");
@@ -386,7 +387,7 @@ uint32_t gpuDeviceCount() {
 #endif
 }
 
-ISPCRTDeviceInfo gpuDeviceInfo(uint32_t idx) {
+ISPCRTDeviceInfo gpuDeviceInfo([[maybe_unused]] uint32_t idx) {
 #ifdef ISPCRT_BUILD_STATIC
 #ifdef ISPCRT_BUILD_GPU
     return ispcrt::gpu::deviceInfo(idx);
@@ -429,7 +430,8 @@ ispcrt::base::Device *loadGPUDevice() {
 #endif
 }
 
-ispcrt::base::Device *loadGPUDevice(void *ctx, void *dev, uint32_t idx) {
+ispcrt::base::Device *loadGPUDevice([[maybe_unused]] void *ctx, [[maybe_unused]] void *dev,
+                                    [[maybe_unused]] uint32_t idx) {
 #ifdef ISPCRT_BUILD_STATIC
 #ifdef ISPCRT_BUILD_GPU
     return new ispcrt::GPUDevice(ctx, dev, idx);
@@ -473,7 +475,7 @@ ispcrt::base::Context *loadGPUContext() {
 #endif
 }
 
-ispcrt::base::Context *loadGPUContext(void *ctx) {
+ispcrt::base::Context *loadGPUContext([[maybe_unused]] void *ctx) {
 #ifdef ISPCRT_BUILD_STATIC
 #ifdef ISPCRT_BUILD_GPU
     return new ispcrt::GPUContext(ctx);
@@ -528,11 +530,12 @@ ISPCRT_CATCH_END_NO_RETURN()
 ///////////////////////////////////////////////////////////////////////////////
 // Device initialization //////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
-static ISPCRTDevice getISPCRTDevice(ISPCRTDeviceType type, ISPCRTContext context, ISPCRTGenericHandle d,
-                                    uint32_t deviceIdx) ISPCRT_CATCH_BEGIN {
+static ISPCRTDevice getISPCRTDevice(ISPCRTDeviceType type, ISPCRTContext context,
+                                    [[maybe_unused]] ISPCRTGenericHandle d,
+                                    [[maybe_unused]] uint32_t deviceIdx) ISPCRT_CATCH_BEGIN {
     ispcrt::base::Device *device = nullptr;
 
-    void *nativeContext = nullptr;
+    [[maybe_unused]] void *nativeContext = nullptr;
     if (context) {
         auto &c = referenceFromHandle<ispcrt::base::Context>(context);
         nativeContext = c.contextNativeHandle();
@@ -656,7 +659,8 @@ ISPCRT_CATCH_END_NO_RETURN()
 ///////////////////////////////////////////////////////////////////////////////
 // Context initialization //////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
-static ISPCRTContext getISPCRTContext(ISPCRTDeviceType type, ISPCRTGenericHandle c) ISPCRT_CATCH_BEGIN {
+static ISPCRTContext getISPCRTContext(ISPCRTDeviceType type,
+                                      [[maybe_unused]] ISPCRTGenericHandle c) ISPCRT_CATCH_BEGIN {
     ispcrt::base::Context *context = nullptr;
 
     switch (type) {

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -678,7 +678,7 @@ static ISPCRTContext getISPCRTContext(ISPCRTDeviceType type, ISPCRTGenericHandle
     }
     case ISPCRT_DEVICE_TYPE_GPU:
 #ifdef ISPCRT_BUILD_GPU
-        context = loadGPUContext();
+        context = loadGPUContext(c);
 #else
         throw std::runtime_error("GPU support not enabled");
 #endif

--- a/src/bitcode_lib.cpp
+++ b/src/bitcode_lib.cpp
@@ -56,7 +56,7 @@ void BitcodeLib::print() const {
 
 BitcodeLib::BitcodeLibType BitcodeLib::getType() const { return m_type; }
 const unsigned char *BitcodeLib::getLib() const { return m_lib; }
-const size_t BitcodeLib::getSize() const { return m_size; }
-const TargetOS BitcodeLib::getOS() const { return m_os; }
-const Arch BitcodeLib::getArch() const { return m_arch; }
-const ISPCTarget BitcodeLib::getISPCTarget() const { return m_target; }
+size_t BitcodeLib::getSize() const { return m_size; }
+TargetOS BitcodeLib::getOS() const { return m_os; }
+Arch BitcodeLib::getArch() const { return m_arch; }
+ISPCTarget BitcodeLib::getISPCTarget() const { return m_target; }

--- a/src/bitcode_lib.h
+++ b/src/bitcode_lib.h
@@ -42,10 +42,10 @@ class BitcodeLib {
 
     BitcodeLibType getType() const;
     const unsigned char *getLib() const;
-    const size_t getSize() const;
-    const TargetOS getOS() const;
-    const Arch getArch() const;
-    const ISPCTarget getISPCTarget() const;
+    size_t getSize() const;
+    TargetOS getOS() const;
+    Arch getArch() const;
+    ISPCTarget getISPCTarget() const;
 };
 
 } // namespace ispc

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -223,7 +223,7 @@ static ISPCTarget lGetSystemISA() {
 #endif
 }
 
-static const bool lIsTargetValidforArch(ISPCTarget target, Arch arch) {
+static bool lIsTargetValidforArch(ISPCTarget target, Arch arch) {
     bool ret = true;
     // If target name starts with sse or avx, has to be x86 or x86-64.
     if (ISPCTargetIsX86(target)) {

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -47,8 +47,6 @@
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 
-#define UNUSED(x) (void)(x)
-
 using namespace ispc;
 
 Globals *ispc::g;
@@ -182,14 +180,12 @@ static ISPCTarget lGetSystemISA() {
         bool knl = avx512_pf && avx512_er && avx512_cd;
         bool skx = avx512_dq && avx512_cd && avx512_bw && avx512_vl;
         bool clx = skx && avx512_vnni;
-        bool cpx = clx && avx512_bf16;
+        [[maybe_unused]] bool cpx = clx && avx512_bf16;
         bool icl =
             clx && avx512_vbmi2 && avx512_gfni && avx512_vaes && avx512_vpclmulqdq && avx512_bitalg && avx512_vpopcntdq;
-        bool tgl = icl && avx512_vp2intersect;
+        [[maybe_unused]] bool tgl = icl && avx512_vp2intersect;
         bool spr =
             icl && avx512_bf16 && avx512_amx_bf16 && avx512_amx_tile && avx512_amx_int8 && avx_vnni && avx512_fp16;
-        UNUSED(cpx);
-        UNUSED(tgl);
         if (spr) {
             // We don't care if AMX is enabled or not here, as AMX support is not implemented yet.
             return ISPCTarget::avx512spr_x16;

--- a/src/lex.ll
+++ b/src/lex.ll
@@ -320,6 +320,7 @@ inline int ispcRand() {
 }
 
 #define RT \
+    do { \
     if (g->enableFuzzTest) { \
         int r = ispcRand() % 40; \
         if (r == 0) { \
@@ -342,7 +343,7 @@ inline int ispcRand() {
             } \
         } \
         /*  TOKEN_TYPE_NAME */ \
-     } else /* swallow semicolon */
+     } } while(0)
 
 %}
 

--- a/src/opt/ISPCPass.h
+++ b/src/opt/ISPCPass.h
@@ -59,24 +59,28 @@ namespace ispc {
 enum { BYTE = 1, WORD = 2, DWORD = 4, QWORD = 8, OWORD = 16, GRF = 32 };
 
 #define DEBUG_START_BB(NAME)                                                                                           \
-    if (g->debugPrint && (getenv("FUNC") == nullptr ||                                                                 \
-                          (getenv("FUNC") != nullptr && !strncmp(bb.getParent()->getName().str().c_str(),              \
-                                                                 getenv("FUNC"), strlen(getenv("FUNC")))))) {          \
-        fprintf(stderr, "Start of " NAME "\n");                                                                        \
-        fprintf(stderr, "---------------\n");                                                                          \
-        bb.print(llvm::errs());                                                                                        \
-        fprintf(stderr, "---------------\n\n");                                                                        \
-    } else /* eat semicolon */
+    do {                                                                                                               \
+        if (g->debugPrint && (getenv("FUNC") == nullptr ||                                                             \
+                              (getenv("FUNC") != nullptr && !strncmp(bb.getParent()->getName().str().c_str(),          \
+                                                                     getenv("FUNC"), strlen(getenv("FUNC")))))) {      \
+            fprintf(stderr, "Start of " NAME "\n");                                                                    \
+            fprintf(stderr, "---------------\n");                                                                      \
+            bb.print(llvm::errs());                                                                                    \
+            fprintf(stderr, "---------------\n\n");                                                                    \
+        }                                                                                                              \
+    } while (0)
 
 #define DEBUG_END_BB(NAME)                                                                                             \
-    if (g->debugPrint && (getenv("FUNC") == nullptr ||                                                                 \
-                          (getenv("FUNC") != nullptr && !strncmp(bb.getParent()->getName().str().c_str(),              \
-                                                                 getenv("FUNC"), strlen(getenv("FUNC")))))) {          \
-        fprintf(stderr, "End of " NAME " %s\n", modifiedAny ? "** CHANGES **" : "");                                   \
-        fprintf(stderr, "---------------\n");                                                                          \
-        bb.print(llvm::errs());                                                                                        \
-        fprintf(stderr, "---------------\n\n");                                                                        \
-    } else /* eat semicolon */
+    do {                                                                                                               \
+        if (g->debugPrint && (getenv("FUNC") == nullptr ||                                                             \
+                              (getenv("FUNC") != nullptr && !strncmp(bb.getParent()->getName().str().c_str(),          \
+                                                                     getenv("FUNC"), strlen(getenv("FUNC")))))) {      \
+            fprintf(stderr, "End of " NAME " %s\n", modifiedAny ? "** CHANGES **" : "");                               \
+            fprintf(stderr, "---------------\n");                                                                      \
+            bb.print(llvm::errs());                                                                                    \
+            fprintf(stderr, "---------------\n\n");                                                                    \
+        }                                                                                                              \
+    } while (0)
 
 /** A helper that reduced LLVM versioning in the code. */
 inline void ReplaceInstWithValueWrapper(llvm::BasicBlock::iterator &BI, llvm::Value *V) {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -3017,7 +3017,7 @@ llvm::FunctionType *FunctionType::LLVMFunctionType(llvm::LLVMContext *ctx, bool 
     return llvm::FunctionType::get(llvmReturnType, callTypes, false);
 }
 
-const unsigned int FunctionType::GetCallingConv() const {
+unsigned int FunctionType::GetCallingConv() const {
     // Default calling convention on CPU targets is CallingConv::C.
     // If __vectorcall or __regcall is specified explicitly, corresponding
     // llvm::CallingConv will be used.

--- a/src/type.h
+++ b/src/type.h
@@ -978,7 +978,7 @@ class FunctionType : public Type {
     llvm::FunctionType *LLVMFunctionType(llvm::LLVMContext *ctx, bool disableMask = false) const;
 
     /* This method returns appropriate llvm::CallingConv for the function*/
-    const unsigned int GetCallingConv() const;
+    unsigned int GetCallingConv() const;
 
     /* Get string representation of calling convention */
     const std::string GetNameForCallConv() const;


### PR DESCRIPTION
Enables `-Wextra` that helps to uncover the real bug that has been introduced in https://github.com/nurmukhametov/ispc/commit/e4ea6d7e285d93a690a1bb36ad15c14999f14a61 and fixed in this PR in the commit https://github.com/ispc/ispc/pull/2600/commits/a73bc2b4cd1f62c66bac69542e2210ca60933467

It also contains some fixes to suppress compiler warnings. Most of them look harmless but clean report and enabling `-Wextra` may help fix some problems earlier in the future.