### PR TITLE
Fixed vector_type_convert.ispc lit test

### DIFF
--- a/tests/lit-tests/2514.ispc
+++ b/tests/lit-tests/2514.ispc
@@ -1,4 +1,4 @@
-// RUN: not %{ispc} --nostdlib --nowrap --target=avx1-i32x4 %s > %t 2>&1
+// RUN: not %{ispc} --nostdlib --nowrap --target=host %s > %t 2>&1
 // RUN: FileCheck --input-file=%t %s
 
 // CHECK-NOT: FATAL ERROR: Unhandled signal sent to process

--- a/tests/lit-tests/vector_type_convert.ispc
+++ b/tests/lit-tests/vector_type_convert.ispc
@@ -1,9 +1,10 @@
 // This test checks that uniform vectors convertion is perfomed using vector instructions.
 // RUN: %{ispc} %s --target=host --emit-llvm-text -o - | FileCheck %s
+
 // CHECK: fpext <4 x float>
 // CHECK-NOT: fpext float
-void test(uniform float RET[], uniform float b) {
-    uniform float<3> x = {1,2,3};
-    uniform double<3> z = x+b;
+void test(uniform double RET[], uniform float b) {
+    uniform float<3> x = {1.0f, 2.0f, 3.0f};
+    uniform double<3> z = x + b;
     RET[programIndex] = z[programIndex];
 }


### PR DESCRIPTION
Fix for #2605 
The test was too aggressively optimized on some targets.
