### PR TITLE
Updates for Xe targets (22)

### DIFF
--- a/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
+++ b/ispcrt/tests/mock_tests/ispcrt_mock_main.cpp
@@ -154,12 +154,6 @@ class MockTestWithModuleQueueKernel : public MockTestWithModule {
 /////////////////////////////////////////////////////////////////////
 // Device tests
 
-TEST_F(MockTest, Device_Constructor_zeInit) {
-    Config::setRetValue("zeInit", ZE_RESULT_ERROR_DEVICE_LOST);
-    ispcrt::Device d(ISPCRT_DEVICE_TYPE_GPU);
-    ASSERT_EQ(sm_rt_error, ISPCRT_DEVICE_LOST);
-}
-
 TEST_F(MockTest, Device_Constructor_zeDeviceGet) {
     Config::setRetValue("zeDeviceGet", ZE_RESULT_ERROR_DEVICE_LOST);
     ispcrt::Device d(ISPCRT_DEVICE_TYPE_GPU);
@@ -175,12 +169,6 @@ TEST_F(MockTest, Device_Constructor_zeDeviceGetProperties) {
 TEST_F(MockTest, Device_Constructor_zeContextCreate) {
     Config::setRetValue("zeContextCreate", ZE_RESULT_ERROR_DEVICE_LOST);
     ispcrt::Device d(ISPCRT_DEVICE_TYPE_GPU);
-    ASSERT_EQ(sm_rt_error, ISPCRT_DEVICE_LOST);
-}
-
-TEST_F(MockTest, Context_Constructor_zeInit) {
-    Config::setRetValue("zeInit", ZE_RESULT_ERROR_DEVICE_LOST);
-    ispcrt::Context c(ISPCRT_DEVICE_TYPE_GPU);
     ASSERT_EQ(sm_rt_error, ISPCRT_DEVICE_LOST);
 }
 

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -3868,7 +3868,7 @@ llvm::Value *FunctionEmitContext::XeSimdCFAny(llvm::Value *value) {
 }
 
 llvm::Value *FunctionEmitContext::XeSimdCFPredicate(llvm::Value *value, llvm::Value *defaults) {
-    AssertPos(currentPos, llvm::isa<llvm::VectorType>(value->getType()));
+    AssertPos(currentPos, llvm::isa<llvm::FixedVectorType>(value->getType()));
     llvm::FixedVectorType *vt = llvm::dyn_cast<llvm::FixedVectorType>(value->getType());
     if (defaults == nullptr) {
         defaults = llvm::ConstantVector::getSplat(

--- a/src/opt/MangleOpenCLBuiltins.cpp
+++ b/src/opt/MangleOpenCLBuiltins.cpp
@@ -18,7 +18,8 @@ static std::string mangleMathOCLBuiltin(const llvm::Function &func) {
     std::string mangledName;
     llvm::Type *retType = func.getReturnType();
     // spirv OpenCL builtins are used for double types only
-    Assert(retType->isVectorTy() && llvm::dyn_cast<llvm::FixedVectorType>(retType)->getElementType()->isDoubleTy() ||
+    Assert(retType->isVectorTy() && (llvm::isa<llvm::FixedVectorType>(retType) &&
+                                     llvm::dyn_cast<llvm::FixedVectorType>(retType)->getElementType()->isDoubleTy()) ||
            retType->isSingleValueType() && retType->isDoubleTy());
 
     std::string funcName = func.getName().str();

--- a/superbuild/osPresets.json
+++ b/superbuild/osPresets.json
@@ -22,7 +22,7 @@
         "SPIRV_TRANSLATOR_BRANCH": "llvm_release_150",
         "SPIRV_TRANSLATOR_SHA": "e82ecc2bd7295604fcf1824e47c95fa6a09c6e63",
         "L0_URL": "https://github.com/oneapi-src/level-zero.git",
-        "L0_TAG": "v1.13.1",
+        "L0_TAG": "v1.13.5",
         "ISPC_CORPUS_URL": "null"
       }
     }


### PR DESCRIPTION
This PR fixes couple of static analysis issues and updates Level zero loader dependency to [1.13.5](https://github.com/oneapi-src/level-zero/releases/tag/v1.13.5).