### PR TITLE
Sanitize MSVC builds and enable compiler-warnings job in CI

### DIFF
--- a/.github/workflows/compiler-warnings.yml
+++ b/.github/workflows/compiler-warnings.yml
@@ -4,8 +4,7 @@
 name: Compiler Warnings
 
 on:
-# Turned off until all jobs are green.
-#  pull_request:
+  pull_request:
   workflow_dispatch:
 
 env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,11 +549,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 # Compile options
 if (MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE /W3 /wd4018 /wd4065 /wd4141 /wd4146 /wd4244 /wd4267 /wd4291 /wd4355 /wd4624 /wd4800 /wd4996)
+    target_compile_options(${PROJECT_NAME} PRIVATE /W3 /wd4018 /wd4146 /wd4244 /wd4267 /wd4624 /wd4996)
     # Security options
     target_compile_options(${PROJECT_NAME} PRIVATE /GS)
-    set_source_files_properties(${FLEX_OUTPUT} PROPERTIES COMPILE_FLAGS "/wd4005 /wd4003")
-    set_source_files_properties(${BISON_OUTPUT} PROPERTIES COMPILE_FLAGS "/wd4005 /wd4065")
+    set_source_files_properties(${FLEX_OUTPUT} PROPERTIES COMPILE_FLAGS /wd4005)
+    set_source_files_properties(${BISON_OUTPUT} PROPERTIES COMPILE_FLAGS /wd4005)
 else()
     target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-unused-function ${LLVM_CPP_FLAGS})
     # Security options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,22 @@
 #
 # ispc CMakeLists.txt
 #
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+
+# Set C++ standard to C++17.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+
+# Set C standard to C11
+set(CMAKE_C_STANDARD   11)
+set(CMAKE_C_STANDARD_REQUIRED   ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
 
 if (UNIX)
     if (NOT CMAKE_C_COMPILER)
@@ -557,10 +570,6 @@ else()
     endif()
 endif()
 
-# Set C++ standard to C++17.
-set_target_properties(${PROJECT_NAME} PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED YES)
 
 # Set hidden visibility for inline functions.
 # This is needed to be in sync with LLVM libraries, we do include some template code from LLVM that requires

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ option(ISPC_INCLUDE_TESTS "Generate build targets for the ISPC tests." ON)
 option(ISPC_INCLUDE_BENCHMARKS "Generate build targets for the ISPC tests." OFF)
 option(ISPC_INCLUDE_RT "Generate build targets for ISPC runtime." ON)
 option(ISPC_INCLUDE_UTILS "Generate build targets for the utils." ON)
+option(ISPC_INCLUDE_UTILS_ONLY "Generate build targets only for the utils." OFF)
 option(ISPC_PREPARE_PACKAGE "Generate build targets for ispc package" OFF)
 
 option(ISPC_OPAQUE_PTR_MODE "Build ISPC with usage of opaque pointers" OFF)
@@ -233,6 +234,22 @@ else(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
     message(STATUS "Build type not specified: Use Release by default.")
 endif(CMAKE_BUILD_TYPE)
+
+
+# Build target for utility checking host ISA
+if (ISPC_INCLUDE_UTILS)
+    add_executable(check_isa "")
+    target_sources(check_isa PRIVATE check_isa.cpp)
+    set_target_properties(check_isa PROPERTIES FOLDER "Utils")
+    if (NOT ISPC_PREPARE_PACKAGE)
+        install (TARGETS check_isa DESTINATION bin)
+    endif()
+    if (ISPC_INCLUDE_UTILS_ONLY)
+        # Skip the below part of CMake. It is useful when only check_isa compiling is needed.
+        return()
+    endif()
+endif()
+
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/ispcrt/cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/FixWindowsPath.cmake)
@@ -643,16 +660,6 @@ else()
             target_link_libraries(${PROJECT_NAME} ${CURSES_EXTRA_LIBRARY})
         endif()
         target_link_libraries(${PROJECT_NAME} pthread ${CURSES_CURSES_LIBRARY})
-    endif()
-endif()
-
-# Build target for utility checking host ISA
-if (ISPC_INCLUDE_UTILS)
-    add_executable(check_isa "")
-    target_sources(check_isa PRIVATE check_isa.cpp)
-    set_target_properties(check_isa PROPERTIES FOLDER "Utils")
-    if (NOT ISPC_PREPARE_PACKAGE)
-        install (TARGETS check_isa DESTINATION bin)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,7 +551,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 if (MSVC)
     target_compile_options(${PROJECT_NAME} PRIVATE /W3 /wd4018 /wd4146 /wd4244 /wd4267 /wd4624 /wd4996)
     # Security options
-    target_compile_options(${PROJECT_NAME} PRIVATE /GS)
+    target_compile_options(${PROJECT_NAME} PRIVATE /GS /EHsc)
     set_source_files_properties(${FLEX_OUTPUT} PROPERTIES COMPILE_FLAGS /wd4005)
     set_source_files_properties(${BISON_OUTPUT} PROPERTIES COMPILE_FLAGS /wd4005)
 else()

--- a/check_isa.cpp
+++ b/check_isa.cpp
@@ -154,13 +154,12 @@ static const char *lGetSystemISA() {
         bool knl = avx512_pf && avx512_er && avx512_cd;
         bool skx = avx512_dq && avx512_cd && avx512_bw && avx512_vl;
         bool clx = skx && avx512_vnni;
-        bool cpx = clx && avx512_bf16;
+        [[maybe_unused]] bool cpx = clx && avx512_bf16;
         bool icl =
             clx && avx512_vbmi2 && avx512_gfni && avx512_vaes && avx512_vpclmulqdq && avx512_bitalg && avx512_vpopcntdq;
-        bool tgl = icl && avx512_vp2intersect;
+        [[maybe_unused]] bool tgl = icl && avx512_vp2intersect;
         bool spr =
             icl && avx512_bf16 && avx512_amx_bf16 && avx512_amx_tile && avx512_amx_int8 && avx_vnni && avx512_fp16;
-#pragma unused(cpx, tgl)
         if (spr) {
             if (__os_enabled_amx_support()) {
                 return "SPR (AMX on)";

--- a/ispcrt/CMakeLists.txt
+++ b/ispcrt/CMakeLists.txt
@@ -99,7 +99,7 @@ endif()
 # Security options
 if (MSVC)
     # Stack canaries
-    target_compile_options(ispcrt_interface_lib INTERFACE /GS)
+    target_compile_options(ispcrt_interface_lib INTERFACE /GS /EHsc)
     # Control flow guard
     target_link_options(ispcrt_interface_lib INTERFACE /GUARD:CF)
 else()

--- a/ispcrt/CMakeLists.txt
+++ b/ispcrt/CMakeLists.txt
@@ -1,7 +1,7 @@
 ## Copyright 2020-2023 Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 ## Global setup ##
 

--- a/ispcrt/CMakeLists.txt
+++ b/ispcrt/CMakeLists.txt
@@ -98,6 +98,7 @@ endif()
 
 # Security options
 if (MSVC)
+    target_compile_options(ispcrt_interface_lib INTERFACE /W3)
     # Stack canaries
     target_compile_options(ispcrt_interface_lib INTERFACE /GS /EHsc)
     # Control flow guard

--- a/ispcrt/detail/gpu/GPUDevice.cpp
+++ b/ispcrt/detail/gpu/GPUDevice.cpp
@@ -535,7 +535,7 @@ struct EventPool {
             throw std::runtime_error(ss.str());
         }
         // Put all event ids into a freelist
-        for (uint32_t i = 0; i < m_poolSize; i++) {
+        for (size_t i = 0; i < m_poolSize; i++) {
             m_freeList.push_back(i);
         }
     }
@@ -607,8 +607,8 @@ struct EventPool {
     ze_event_pool_handle_t m_pool{nullptr};
     uint64_t m_timestampFreq;
     uint64_t m_timestampMaxValue;
-    uint32_t m_poolSize;
-    std::deque<uint32_t> m_freeList;
+    size_t m_poolSize;
+    std::deque<size_t> m_freeList;
     // Events pool for reuse
     std::vector<Event *> m_events_pool;
 };

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -843,7 +843,7 @@ void ispcrtDynamicLinkModules(ISPCRTDevice d, ISPCRTModule *modules, const uint3
     const auto &device = referenceFromHandle<ispcrt::base::Device>(d);
     device.dynamicLinkModules((ispcrt::base::Module **)modules, numModules);
 }
-ISPCRT_CATCH_END()
+ISPCRT_CATCH_END_NO_RETURN()
 
 ISPCRTModule ispcrtStaticLinkModules(ISPCRTDevice d, ISPCRTModule *modules,
                                      const uint32_t numModules) ISPCRT_CATCH_BEGIN {

--- a/ispcrt/ispcrt.cpp
+++ b/ispcrt/ispcrt.cpp
@@ -182,7 +182,8 @@ void ISPCLaunch(void **handlePtr, void *f, void *data, int countx, int county, i
         return ispc_launch_fptr(handlePtr, f, data, countx, county, countz);
     }
     // TODO: this code can be called directly from ISPC code. Not sure how to exit error safely.
-    throw std::runtime_error("Missing ISPCLaunch symbol");
+    fprintf(stderr, "Missing ISPCLaunch symbol");
+    abort();
 }
 
 void *ISPCAlloc(void **handlePtr, int64_t size, int32_t alignment) {
@@ -190,7 +191,8 @@ void *ISPCAlloc(void **handlePtr, int64_t size, int32_t alignment) {
         return ispc_alloc_fptr(handlePtr, size, alignment);
     }
     // TODO: this code can be called directly from ISPC code. Not sure how to exit error safely.
-    throw std::runtime_error("Missing ISPCAlloc symbol");
+    fprintf(stderr, "Missing ISPCAlloc symbol");
+    abort();
 }
 
 void ISPCSync(void *handle) {
@@ -198,7 +200,8 @@ void ISPCSync(void *handle) {
         return ispc_sync_fptr(handle);
     }
     // TODO: this code can be called directly from ISPC code. Not sure how to exit error safely.
-    throw std::runtime_error("Missing ISPCSync symbol");
+    fprintf(stderr, "Missing ISPCSync symbol");
+    abort();
 }
 }
 #endif


### PR DESCRIPTION
This change enforces `c++17` standard for all projects including `check_isa.cpp`. It also specifies `/EHsc` for MSVC builds to properly enable exception handling. It fixes macro catching invocation in `ispcrt.cpp` and some minor warnings.

This change makes [compiler-warnings](https://github.com/ispc/ispc/actions/workflows/compiler-warnings.yml) green and enables it for pull requests.