### PR TITLE
Force DWARF generation on windows with --dwarf-version

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -1008,8 +1008,10 @@ Debugging
 The ``-g`` command-line flag can be supplied to the compiler, which causes
 it to generate debugging symbols.  The debug info is emitted in DWARF format
 on Linux\* and macOS\*.  The version of the DWARF can be controlled by
-command-line switch ``--dwarf-version={2,3,4}``.  On Windows\* CodeView format
-is used (not PDB), it's natively supported by Microsoft Visual Studio\*.
+command-line switch ``--dwarf-version={2,3,4,5}``.  On Windows\* CodeView format
+is used by default (it's natively supported by Microsoft Visual Studio\*) but
+this switch can force the generation of DWARF format that can be used, e.g.,
+together with MinGW generated code.
 Running ``ispc`` programs in the debugger, setting breakpoints, printing out
 variables is just the same as debugging C/C++ programs.  Similarly, you can
 directly step up and down the call stack between ``ispc`` code and C/C++

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1714,7 +1714,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, bool pic, MCM
             m_targetMachine->Options.MCOptions.AsmVerbose = true;
 
             // Change default version of generated DWARF.
-            if (g->generateDWARFVersion != 0) {
+            if (g->generateDWARFVersion) {
                 m_targetMachine->Options.MCOptions.DwarfVersion = g->generateDWARFVersion;
             }
         }
@@ -2303,6 +2303,7 @@ Globals::Globals() {
     emitInstrumentation = false;
     noPragmaOnce = false;
     generateDebuggingSymbols = false;
+    debugInfoType = Globals::DebugInfoType::None;
     generateDWARFVersion = 3;
     enableFuzzTest = false;
     enableLLVMIntrinsics = false;
@@ -2350,6 +2351,12 @@ Globals::Globals() {
 
     // Target OS defaults to host OS.
     target_os = GetHostOS();
+
+    if (target_os == TargetOS::windows) {
+        debugInfoType = Globals::DebugInfoType::CodeView;
+    } else {
+        debugInfoType = Globals::DebugInfoType::DWARF;
+    }
 
     // Set calling convention to 'uninitialized'.
     // This needs to be set once target OS is decided.

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -780,7 +780,7 @@ struct Globals {
     enum class DebugInfoType { None = 0, DWARF, CodeView };
     DebugInfoType debugInfoType;
 
-    /** Require generation of DWARF of certain version (2, 3, 4). For
+    /** Require generation of DWARF of certain version (2, 3, 4, 5). For
         default version, this field is set to 3. */
     // Hint: to verify dwarf version in the object file, run on Linux:
     // readelf --debug-dump=info object.o | grep -A 2 'Compilation Unit @'

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -776,8 +776,12 @@ struct Globals {
         program in its output. */
     bool generateDebuggingSymbols;
 
+    /** Debug info type to generate. */
+    enum class DebugInfoType { None = 0, DWARF, CodeView };
+    DebugInfoType debugInfoType;
+
     /** Require generation of DWARF of certain version (2, 3, 4). For
-        default version, this field is set to 0. */
+        default version, this field is set to 3. */
     // Hint: to verify dwarf version in the object file, run on Linux:
     // readelf --debug-dump=info object.o | grep -A 2 'Compilation Unit @'
     // on Mac:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,7 +76,7 @@ static void lPrintVersion() {
     PrintWithWordBreaks(cpuHelp, 16, TerminalWidth(), stdout);
     printf("    [--dllexport]\t\t\tMake non-static functions DLL exported.  Windows target only\n");
     printf("    [--dwarf-version={2,3,4}]\t\tGenerate source-level debug information with given DWARF version "
-           "(triggers -g).  Ignored for Windows target\n");
+           "(triggers -g).  It forces the usage of DWARF debug info on Windows target\n");
     printf("    [-E]\t\t\t\tRun only the preprocessor\n");
     printf("    [--emit-asm]\t\t\tGenerate assembly language file as output\n");
     printf("    [--emit-llvm]\t\t\tEmit LLVM bitcode file as output\n");
@@ -782,6 +782,7 @@ int main(int Argc, char *Argv[]) {
             if (2 <= val && val <= 4) {
                 g->generateDebuggingSymbols = true;
                 g->generateDWARFVersion = val;
+                g->debugInfoType = Globals::DebugInfoType::DWARF;
             } else {
                 errorHandler.AddError("Invalid value for DWARF version: \"%s\" -- "
                                       "only 2, 3 and 4 are allowed.",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,7 @@ static void lPrintVersion() {
              Target::SupportedCPUs().c_str());
     PrintWithWordBreaks(cpuHelp, 16, TerminalWidth(), stdout);
     printf("    [--dllexport]\t\t\tMake non-static functions DLL exported.  Windows target only\n");
-    printf("    [--dwarf-version={2,3,4}]\t\tGenerate source-level debug information with given DWARF version "
+    printf("    [--dwarf-version={2,3,4,5}]\t\tGenerate source-level debug information with given DWARF version "
            "(triggers -g).  It forces the usage of DWARF debug info on Windows target\n");
     printf("    [-E]\t\t\t\tRun only the preprocessor\n");
     printf("    [--emit-asm]\t\t\tGenerate assembly language file as output\n");
@@ -779,13 +779,13 @@ int main(int Argc, char *Argv[]) {
             g->dllExport = true;
         else if (!strncmp(argv[i], "--dwarf-version=", 16)) {
             int val = atoi(argv[i] + 16);
-            if (2 <= val && val <= 4) {
+            if (2 <= val && val <= 5) {
                 g->generateDebuggingSymbols = true;
                 g->generateDWARFVersion = val;
                 g->debugInfoType = Globals::DebugInfoType::DWARF;
             } else {
                 errorHandler.AddError("Invalid value for DWARF version: \"%s\" -- "
-                                      "only 2, 3 and 4 are allowed.",
+                                      "only 2, 3, 4 and 5 are allowed.",
                                       argv[i] + 16);
             }
         } else if (!strcmp(argv[i], "--print-target"))

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -247,10 +247,17 @@ Module::Module(const char *fn) : filename(fn) {
         llvm::TimeTraceScope TimeScope("Create Debug Data");
         // To enable debug information on Windows, we have to let llvm know, that
         // debug information should be emitted in CodeView format.
-        if (g->target_os == TargetOS::windows) {
+
+        switch (g->debugInfoType) {
+        case Globals::DebugInfoType::CodeView:
             module->addModuleFlag(llvm::Module::Warning, "CodeView", 1);
-        } else {
+            break;
+        case Globals::DebugInfoType::DWARF:
             module->addModuleFlag(llvm::Module::Warning, "Dwarf Version", g->generateDWARFVersion);
+            break;
+        default:
+            FATAL("Incorrect debugInfoType");
+            break;
         }
         diBuilder = new llvm::DIBuilder(*module);
 

--- a/tests/lit-tests/arg_parsing_errors.ispc
+++ b/tests/lit-tests/arg_parsing_errors.ispc
@@ -37,7 +37,7 @@
 //; CHECK_ERROR_1: Error: Invalid value for --x86-asm-syntax: "amd" -- only intel and att are allowed.
 //; CHECK_ERROR_1: Error: --fast-math option has been renamed to --opt=fast-math!
 //; CHECK_ERROR_1: Error: --fast-masked-vload option has been renamed to --opt=fast-masked-vload!
-//; CHECK_ERROR_1: Error: Invalid value for DWARF version: "15" -- only 2, 3 and 4 are allowed.
+//; CHECK_ERROR_1: Error: Invalid value for DWARF version: "15" -- only 2, 3, 4 and 5 are allowed.
 //; CHECK_ERROR_1: Error: Unknown --math-lib= option "fast2".
 //; CHECK_ERROR_1: Error: Unknown option "-opt=make_me_happy".
 //; CHECK_ERROR_1: Error: Unknown option "-not-existing-opt".

--- a/tests/lit-tests/debug_type_dwarf.ispc
+++ b/tests/lit-tests/debug_type_dwarf.ispc
@@ -1,0 +1,11 @@
+// RUN: %{ispc} --target-os=windows --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --implicit-check-not "llvm.dbg.cu"
+// RUN: %{ispc} -g --target-os=windows --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s -check-prefix=CHECK_CODEVIEW
+// RUN: %{ispc} --dwarf-version=3 --target-os=windows --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s -check-prefix=CHECK_DWARF
+// RUN: %{ispc} -g --dwarf-version=3 --target-os=windows --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s -check-prefix=CHECK_DWARF
+// RUN: %{ispc} --dwarf-version=3 -g --target-os=windows --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s -check-prefix=CHECK_DWARF
+// RUN: %{ispc} --dwarf-version=3 --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s -check-prefix=CHECK_DWARF
+
+// REQUIRES: WINDOWS_ENABLED
+// CHECK_DWARF: Dwarf Version
+// CHECK_CODEVIEW: CodeView
+void foo() { return; }

--- a/tests/lit-tests/debug_type_dwarf_2.ispc
+++ b/tests/lit-tests/debug_type_dwarf_2.ispc
@@ -1,0 +1,7 @@
+// RUN: %{ispc} --target-os=linux --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --implicit-check-not "llvm.dbg.cu"
+// RUN: %{ispc} -g --target-os=linux --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s -check-prefix=CHECK_DWARF
+// RUN: %{ispc} -g --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s -check-prefix=CHECK_DWARF
+
+// REQUIRES: LINUX_HOST
+// CHECK_DWARF: Dwarf Version
+void foo() { return; }

--- a/tests/lit-tests/dwarf_version.ispc
+++ b/tests/lit-tests/dwarf_version.ispc
@@ -1,0 +1,11 @@
+// RUN: %{ispc} --dwarf-version=2 --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s -check-prefix=CHECK_DWARF_V2
+// RUN: %{ispc} --dwarf-version=3 --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s -check-prefix=CHECK_DWARF_V3
+// RUN: %{ispc} --dwarf-version=4 --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s -check-prefix=CHECK_DWARF_V4
+// RUN: %{ispc} --dwarf-version=5 --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s -check-prefix=CHECK_DWARF_V5
+
+// CHECK_DWARF_V2: Dwarf Version", i32 2
+// CHECK_DWARF_V3: Dwarf Version", i32 3
+// CHECK_DWARF_V4: Dwarf Version", i32 4
+// CHECK_DWARF_V5: Dwarf Version", i32 5
+void foo() { return; }
+


### PR DESCRIPTION
This change lets `--dwarf-version=<n>` to force DWARF format debug info generation on Windows. It may be useful when ISPC code is linked with MINGW generated code. In that case, usual DWARF debug section (_debug_info, _debug_line, and etc.) are generated in PE files. This information is used by MINGW GDB during debug on Windows.

It fixes/implements #2129