### PR TITLE
Fix emission code for FNeg instruction

### DIFF
--- a/tests/lit-tests/2628.ispc
+++ b/tests/lit-tests/2628.ispc
@@ -1,0 +1,9 @@
+// RUN: %{ispc} --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+
+// CHECK: extractvalue [2 x <[[#]] x float>]
+// CHECK:  fneg <[[#]] x float>
+typedef float<2> float2;
+
+float2 TestFunc(float2 x) {
+    return -x;
+}


### PR DESCRIPTION
The case of input ISPC vector is needed to be supported likewise it is done in, e.g., in NotOperator.

It fixes #2628 