### PR TITLE
centos7_oneapi: install oneapi_tbb from oneAPI distro

### DIFF
--- a/docker/v1.21.0/centos7_oneapi/Dockerfile
+++ b/docker/v1.21.0/centos7_oneapi/Dockerfile
@@ -29,11 +29,8 @@ RUN yum install -y libstdc++-static && \
     yum clean -y all
 
 # Install TBB
-RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c95cd995-586b-4688-b7e8-2d4485a1b5bf/l_tbb_oneapi_p_2021.10.0.49543_offline.sh && \
-    chmod u+x ./l_tbb_oneapi_p_2021.10.0.49543_offline.sh && \
-    ./l_tbb_oneapi_p_2021.10.0.49543_offline.sh -s -a --action install --eula accept --intel-sw-improvement-program-consent decline --silent && \
-    source /opt/intel/oneapi/setvars.sh && \
-    rm ./l_tbb_oneapi_p_2021.10.0.49543_offline.sh
+ADD oneAPI.repo /etc/yum.repos.d/oneAPI.repo
+RUN yum -y install intel-oneapi-tbb-devel intel-oneapi-tbb && yum clean -y all
 
 # Download and install required version of CMake. CMake 3.20 is required starting from LLVM 16.0.
 RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.sh && mkdir /opt/cmake && sh cmake-3.20.5-linux-x86_64.sh --prefix=/opt/cmake --skip-license && \

--- a/docker/v1.21.0/centos7_oneapi/oneAPI.repo
+++ b/docker/v1.21.0/centos7_oneapi/oneAPI.repo
@@ -1,0 +1,7 @@
+[oneAPI]
+name=Intel® oneAPI repository
+baseurl=https://yum.repos.intel.com/oneapi
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB


### PR DESCRIPTION
Use Intel® oneAPI repository to install intel-oneapi-tbb package.