### PR TITLE
Fix function specifiers for templates

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -8523,7 +8523,8 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
             // Easy, we have all template arguments specified explicitly, no deduction is needed.
             Symbol *funcSym = templSym->functionTemplate->LookupInstantiation(templateArgs);
             if (funcSym == nullptr) {
-                funcSym = templSym->functionTemplate->AddInstantiation(templateArgs);
+                funcSym =
+                    templSym->functionTemplate->AddInstantiation(templateArgs, TemplateInstantiationKind::Implicit);
             }
             AssertPos(pos, funcSym);
             // Success
@@ -8535,7 +8536,7 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
         }
 
         // Create substitution map for specified template parameters
-        TemplateInstantiation inst(*templateParms, templateArgs);
+        TemplateInstantiation inst(*templateParms, templateArgs, TemplateInstantiationKind::Implicit);
 
         std::vector<const Type *> substitutedParamTypes;
         // Instantiate function parameter types with explicitly specified template arguments
@@ -8646,7 +8647,7 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
         // All template arguments were either explicitly specified or deduced, now get the instantiation.
         Symbol *funcSym = templSym->functionTemplate->LookupInstantiation(deducedArgs);
         if (funcSym == nullptr) {
-            funcSym = templSym->functionTemplate->AddInstantiation(deducedArgs);
+            funcSym = templSym->functionTemplate->AddInstantiation(deducedArgs, TemplateInstantiationKind::Implicit);
         }
         AssertPos(pos, funcSym);
         // Success

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -1082,7 +1082,7 @@ Symbol *TemplateInstantiation::InstantiateTemplateSymbol(TemplateSymbol *sym) {
     const Type *instType = sym->type->ResolveDependenceForTopType(*this);
 
     // Create a function symbol
-    Symbol *instSym = new Symbol(sym->name, sym->pos, instType, SC_STATIC);
+    Symbol *instSym = new Symbol(sym->name, sym->pos, instType, sym->storageClass);
     functionSym = instSym;
 
     // Create llvm::Function and attach to the symbol, so the symbol is complete and ready for use.

--- a/src/func.h
+++ b/src/func.h
@@ -73,6 +73,7 @@ class TemplateArgs {
     std::vector<std::pair<const Type *, SourcePos>> args;
 };
 
+enum class TemplateInstantiationKind { Implicit, Explicit, Specialization };
 class FunctionTemplate {
   public:
     FunctionTemplate(TemplateSymbol *sym, Stmt *code);
@@ -82,7 +83,8 @@ class FunctionTemplate {
     const FunctionType *GetFunctionType() const;
 
     Symbol *LookupInstantiation(const std::vector<std::pair<const Type *, SourcePos>> &types);
-    Symbol *AddInstantiation(const std::vector<std::pair<const Type *, SourcePos>> &types);
+    Symbol *AddInstantiation(const std::vector<std::pair<const Type *, SourcePos>> &types,
+                             TemplateInstantiationKind kind);
     Symbol *AddSpecialization(const FunctionType *ftype, const std::vector<std::pair<const Type *, SourcePos>> &types,
                               SourcePos pos);
 
@@ -108,7 +110,8 @@ class FunctionTemplate {
 class TemplateInstantiation {
   public:
     TemplateInstantiation(const TemplateParms &typeParms,
-                          const std::vector<std::pair<const Type *, SourcePos>> &typeArgs);
+                          const std::vector<std::pair<const Type *, SourcePos>> &typeArgs,
+                          TemplateInstantiationKind kind);
     const Type *InstantiateType(const std::string &name);
     Symbol *InstantiateSymbol(Symbol *sym);
     Symbol *InstantiateTemplateSymbol(TemplateSymbol *sym);
@@ -125,6 +128,8 @@ class TemplateInstantiation {
     std::unordered_map<std::string, const Type *> argsMap;
     // Template arguments in the order of the template parameters.
     std::vector<const Type *> templateArgs;
+    // Kind of instantiation (explicit, implicit, specialization).
+    TemplateInstantiationKind kind;
 
     llvm::Function *createLLVMFunction(Symbol *functionSym, bool isInline, bool isNoInline);
 };

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1070,7 +1070,7 @@ void Module::AddFunctionDefinition(const std::string &name, const FunctionType *
 //
 void Module::AddFunctionTemplateDeclaration(const TemplateParms *templateParmList, const std::string &name,
                                             const FunctionType *ftype, StorageClass sc, bool isInline, bool isNoInline,
-                                            bool isVectorCall, SourcePos pos) {
+                                            SourcePos pos) {
     Assert(ftype != nullptr);
     Assert(templateParmList != nullptr);
 
@@ -1118,7 +1118,7 @@ void Module::AddFunctionTemplateDeclaration(const TemplateParms *templateParmLis
 
     // ...
 
-    TemplateSymbol *funcTemplSym = new TemplateSymbol(templateParmList, name, ftype, pos, isInline, isNoInline);
+    TemplateSymbol *funcTemplSym = new TemplateSymbol(templateParmList, name, ftype, sc, pos, isInline, isNoInline);
     symbolTable->AddFunctionTemplate(funcTemplSym);
 }
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1108,8 +1108,6 @@ void Module::AddFunctionTemplateDeclaration(const TemplateParms *templateParmLis
         }
     }
 
-    // TODO: extern "C" - do we allow it?
-
     // TODO: Xe adjust linkage
 
     // No mangling for template, only instantiations.

--- a/src/module.h
+++ b/src/module.h
@@ -79,7 +79,7 @@ class Module {
         symbol to the module. */
     void AddFunctionTemplateDeclaration(const TemplateParms *templateParmList, const std::string &name,
                                         const FunctionType *ftype, StorageClass sc, bool isInline, bool isNoInline,
-                                        bool isVectorCall, SourcePos pos);
+                                        SourcePos pos);
 
     /** Add the function described by the declaration information and the
         provided statements to the module. */

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -2470,12 +2470,6 @@ template_declaration
           lAddTemplateDeclaration($1, $3, $4);
           lAddFunctionParams($4);
           lAddMaskToSymbolTable(@4);
-          if ($3->typeQualifiers & TYPEQUAL_TASK) {
-              Error(@3, "'task' not supported for templates.");
-          }
-          if ($3->typeQualifiers & TYPEQUAL_EXPORT) {
-              Error(@3, "'export' not supported for templates.");
-          }
           const FunctionType *ft = CastType<FunctionType>($4->type);
           // Creating a new TemplateSymbol just to pass it further seems to be a waste
           $$ = new TemplateSymbol($1, $4->name, ft, $3->storageClass, @4, false /*not used*/, false /*not used*/);

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -2829,26 +2829,33 @@ lAddTemplateDeclaration(TemplateParms *templateParmList, DeclSpecs *ds, Declarat
         // FIXME: source position
         Error(decl->pos, "Illegal \"typedef\" provided with function template.");
         return;
-    } else {
-        if (decl->type == nullptr) {
-            Assert(m->errorCount > 0);
-            return;
-        }
-
-        //decl->type = decl->type->ResolveUnboundVariability(Variability::Varying);
-
-        const FunctionType *ft = CastType<FunctionType>(decl->type);
-        if (ft != nullptr) {
-            bool isInline = (ds->typeQualifiers & TYPEQUAL_INLINE);
-            bool isNoInline = (ds->typeQualifiers & TYPEQUAL_NOINLINE);
-            bool isVectorCall = (ds->typeQualifiers & TYPEQUAL_VECTORCALL);
-            m->AddFunctionTemplateDeclaration(templateParmList, decl->name, ft, ds->storageClass,
-                                              isInline, isNoInline, isVectorCall, decl->pos);
-        }
-        else {
-            Error(decl->pos, "Only function templates are supported.");
-        }
     }
+    // We can't support extern "C"/extern "SYCL" for templates because
+    // we need mangling information.
+    if (ds->storageClass == SC_EXTERN_C || ds->storageClass == SC_EXTERN_SYCL) {
+        Error(decl->pos, "Illegal linkage provided with function template.");
+        return;
+    }
+
+    if (decl->type == nullptr) {
+        Assert(m->errorCount > 0);
+        return;
+    }
+
+    //decl->type = decl->type->ResolveUnboundVariability(Variability::Varying);
+
+    const FunctionType *ft = CastType<FunctionType>(decl->type);
+    if (ft != nullptr) {
+        bool isInline = (ds->typeQualifiers & TYPEQUAL_INLINE);
+        bool isNoInline = (ds->typeQualifiers & TYPEQUAL_NOINLINE);
+        bool isVectorCall = (ds->typeQualifiers & TYPEQUAL_VECTORCALL);
+        m->AddFunctionTemplateDeclaration(templateParmList, decl->name, ft, ds->storageClass,
+                                            isInline, isNoInline, isVectorCall, decl->pos);
+    }
+    else {
+        Error(decl->pos, "Only function templates are supported.");
+    }
+
 }
 
 static void

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -31,9 +31,10 @@ Symbol::Symbol(const std::string &n, SourcePos p, const Type *t, StorageClass sc
 ///////////////////////////////////////////////////////////////////////////
 // TemplateSymbol
 
-TemplateSymbol::TemplateSymbol(const TemplateParms *parms, const std::string &n, const FunctionType *t,
+TemplateSymbol::TemplateSymbol(const TemplateParms *parms, const std::string &n, const FunctionType *t, StorageClass sc,
                                const SourcePos p, bool inl, bool noinl)
-    : pos(p), name(n), type(t), templateParms(parms), functionTemplate(nullptr), isInline(inl), isNoInline(noinl) {}
+    : pos(p), name(n), type(t), storageClass(sc), templateParms(parms), functionTemplate(nullptr), isInline(inl),
+      isNoInline(noinl) {}
 
 ///////////////////////////////////////////////////////////////////////////
 // SymbolTable

--- a/src/sym.h
+++ b/src/sym.h
@@ -91,12 +91,13 @@ class Symbol : public Traceable {
  */
 class TemplateSymbol {
   public:
-    TemplateSymbol(const TemplateParms *parms, const std::string &n, const FunctionType *t, const SourcePos p,
-                   bool isInline, bool inNoInline);
+    TemplateSymbol(const TemplateParms *parms, const std::string &n, const FunctionType *t, StorageClass sc,
+                   const SourcePos p, bool isInline, bool inNoInline);
 
     SourcePos pos;
     const std::string name;
     const FunctionType *type;
+    StorageClass storageClass;
     const TemplateParms *templateParms;
     FunctionTemplate *functionTemplate;
 

--- a/tests/lit-tests/func_template_1.ispc
+++ b/tests/lit-tests/func_template_1.ispc
@@ -5,16 +5,16 @@
 // RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
 
 // CHECK-LABEL: define <{{[0-9]*}} x float> @foo0
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyfvyi___vyfuni(<{{[0-9]*}} x float>
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyiuni(<{{[0-9]*}} x i32>
+// CHECK: call <{{[0-9]*}} x i32> @goo___vyfvyi___vyfuni(<{{[0-9]*}} x float>
+// CHECK: call <{{[0-9]*}} x i32> @goo___vyivyi___vyiuni(<{{[0-9]*}} x i32>
 
 // CHECK-LABEL: define <{{[0-9]*}} x float> @foo1___uniuni
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyiuni(<{{[0-9]*}} x i32>
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___univyi___uniuni(i32
+// CHECK: call <{{[0-9]*}} x i32> @goo___vyivyi___vyiuni(<{{[0-9]*}} x i32>
+// CHECK: call <{{[0-9]*}} x i32> @goo___univyi___uniuni(i32
 
 // CHECK-LABEL: define <{{[0-9]*}} x float> @foo2___uniuni
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyiuni(<{{[0-9]*}} x i32>
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyfvyi___vyfuni(<{{[0-9]*}} x float>
+// CHECK: call <{{[0-9]*}} x i32> @goo___vyivyi___vyiuni(<{{[0-9]*}} x i32>
+// CHECK: call <{{[0-9]*}} x i32> @goo___vyfvyi___vyfuni(<{{[0-9]*}} x float>
 
 template <typename T, typename C> noinline int goo(T argGooOne, uniform int argGooTwo) {
     C val = argGooTwo;

--- a/tests/lit-tests/func_template_11.ispc
+++ b/tests/lit-tests/func_template_11.ispc
@@ -1,0 +1,102 @@
+// Check different function specifiers with templates.
+
+// RUN: %{ispc} -DNONE %s --nostdlib --target=host --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_NONE
+// RUN: %{ispc} -DEXTERN %s --nostdlib --target=host --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_EXTERN
+// RUN: %{ispc} -DSTATIC %s --nostdlib --target=host --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_STATIC
+// RUN: %{ispc} -DUNMASKED %s --nostdlib --target=host --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_UNMASKED
+// RUN: %{ispc} -DINLINE %s --nostdlib --target=host --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_INLINE
+// RUN: not %{ispc} -DTYPEDEF %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_TYPEDEF
+// RUN: not %{ispc} -DEXTERN_C %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXTERN_C
+// RUN: not %{ispc} -DEXTERN_SYCL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXTERN_SYCL
+// RUN: not %{ispc} -DEXPORT %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXPORT
+// RUN: not %{ispc} -DTASK %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_TASK
+// RUN: not %{ispc} -DVECTORCALL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_VECTORCALL
+// RUN: not %{ispc} -DREGCALL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_REGCALL
+
+// CHECK_NONE: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyf___vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+#ifdef NONE
+template <typename T> noinline int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_EXTERN: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyf___vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+#ifdef EXTERN
+template <typename T> noinline extern int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_STATIC: define internal <{{[0-9]*}} x i32> @goo___vyf___vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+#ifdef STATIC
+template <typename T> noinline static int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_UNMASKED: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyf___UM_vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo)
+#ifdef UNMASKED
+template <typename T> unmasked noinline int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_INLINE-NOT: @goo___vyf___UM_vyfvyf
+#ifdef INLINE
+template <typename T> inline int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_TYPEDEF: Illegal "typedef" provided with function template.
+#ifdef TYPEDEF
+template <typename T> noinline typedef int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_EXTERN_C: Error: Illegal linkage provided with function template.
+#ifdef EXTERN_C
+template <typename T> noinline extern "C" int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_EXTERN_SYCL: Error: Illegal linkage provided with function template.
+#ifdef EXTERN_SYCL
+template <typename T> noinline extern "SYCL" int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_EXPORT: Error: 'export' not supported for templates.
+#ifdef EXPORT
+template <typename T> noinline export int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_TASK: Error: 'task' not supported for templates.
+#ifdef TASK
+template <typename T> noinline task int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_VECTORCALL: Illegal to use "__vectorcall" qualifier on non-extern function
+#ifdef VECTORCALL
+template <typename T> noinline __vectorcall int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_REGCALL: Illegal to use "__regcall" qualifier on non-extern function
+#ifdef REGCALL
+template <typename T> noinline __regcall int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+float foo(int argFoo0, float argFoo1) {
+    return goo<float>(argFoo0, argFoo1);
+}

--- a/tests/lit-tests/func_template_2.ispc
+++ b/tests/lit-tests/func_template_2.ispc
@@ -4,8 +4,8 @@
 // RUN: %{ispc}  %s --emit-llvm-text --target=host -o - | FileCheck %s
 
 // CHECK: define void @foo
-// CHECK: call {{.*}} void @aos_to_soa2_ispc___vyivyi___un_3C_uni_3E_un_3C_vyi_3E_un_3C_vyi_3E_REFCvyi({{(i32*|ptr)}}
-// CHECK: call {{.*}} void @aos_to_soa2_ispc___vyfvyi___un_3C_unf_3E_un_3C_vyf_3E_un_3C_vyf_3E_REFCvyi({{(float*|ptr)}}
+// CHECK: call void @aos_to_soa2_ispc___vyivyi___un_3C_uni_3E_un_3C_vyi_3E_un_3C_vyi_3E_REFCvyi({{(i32*|ptr)}}
+// CHECK: call void @aos_to_soa2_ispc___vyfvyi___un_3C_unf_3E_un_3C_vyf_3E_un_3C_vyf_3E_REFCvyi({{(float*|ptr)}}
 
 template <typename T, typename C>
 noinline void aos_to_soa2_ispc(uniform T src[], varying T *uniform v0, varying T *uniform v1, const C &ind) {

--- a/tests/lit-tests/func_template_6.ispc
+++ b/tests/lit-tests/func_template_6.ispc
@@ -13,8 +13,8 @@ template <typename T> noinline void goo() {
 // CHECK: call void @goo___vyi___
 // CHECK: call void @goo___vys___
 
-// CHECK: define internal void @goo___vyi___
-// CHECK: define internal void @goo___vys___
+// CHECK: define linkonce_odr void @goo___vyi___
+// CHECK: define linkonce_odr void @goo___vys___
 void foo() {
     goo<int>();
     goo<int16>();

--- a/tests/lit-tests/func_template_spec_1.ispc
+++ b/tests/lit-tests/func_template_spec_1.ispc
@@ -5,16 +5,16 @@
 // CHECK-LABEL: define <{{[0-9]*}} x i32> @goo___vyivyf(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
 
 // Specialized function
-// CHECK-LABEL: define {{.*}} <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x float> %argGooTwo)
+// CHECK-LABEL: define <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
 // Check that implementation of specialized function is generated from specialization
 // CHECK: fmul
 
 // CHECK-LABEL: define <{{[0-9]*}} x float> @foo
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x float> %argFoo1)
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x i32> %argFoo0)
+// CHECK: call <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x float> %argFoo1, <{{[0-9]*}} x {{.*}}> {{.*}})
+// CHECK: call <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x {{.*}}> {{.*}})
 
 // Instantiated function
-// CHECK-LABEL: define {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo)
+// CHECK-LABEL: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
 // Check that implementation of instantiated function is generated from primary template
 // CHECK: add
 

--- a/tests/lit-tests/func_template_spec_2.ispc
+++ b/tests/lit-tests/func_template_spec_2.ispc
@@ -2,16 +2,16 @@
 // RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
 
 // Specialized function
-// CHECK-LABEL: define {{.*}} <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x float> %argGooTwo)
+// CHECK-LABEL: define <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
 // Check that implementation of specialized function is generated from specialization
 // CHECK: fmul
 
 // CHECK-LABEL: define <{{[0-9]*}} x float> @foo
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x float> %argFoo1)
-// CHECK: call {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x i32> %argFoo0)
+// CHECK: call <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x float> %argFoo1, <{{[0-9]*}} x {{.*}}> {{.*}})
+// CHECK: call <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x {{.*}}> {{.*}})
 
 // Instantiated function
-// CHECK-LABEL: define {{.*}} <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo)
+// CHECK-LABEL: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
 // Check that implementation of instantiated function is generated from primary template
 // CHECK: add
 


### PR DESCRIPTION
- Produce error when template is used with `extern "C"`/ `extern "SYCL"`
- Fixed storage class for templates, so it's now extern by default as for regular ISPC functions
- Fixed linkage for different types of template instantiations (aligned with Clang behavior)