### PR TITLE
Support of template operators

### DIFF
--- a/tests/lit-tests/func_template_operator_1.ispc
+++ b/tests/lit-tests/func_template_operator_1.ispc
@@ -1,0 +1,35 @@
+// Basic check of template operators (issue #2634)
+// RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
+
+// CHECK-LABEL: define <{{[0-9]*}} x double> @DoMath___
+// CHECK: call %v{{[0-9]*}}_varying_FMatrix @"operator*___{{.*}}"({{.*}} %A, {{.*}} %B, <{{[0-9]*}} x {{.*}}> %__mask)
+
+// CHECK-LABEL: define linkonce_odr %v{{[0-9]*}}_varying_FMatrix @"operator*___{{.*}}"({{.*}} %A, {{.*}} %B, <{{[0-9]*}} x {{.*}}> %__mask)
+struct FMatrix {
+    double M[16];
+};
+
+template <typename T> noinline FMatrix operator*(const FMatrix &A, const T &B) {
+    FMatrix Result;
+
+    for (uniform unsigned int m = 0; m < 4; m++) {
+        varying double Sum;
+        for (uniform unsigned int k = 0; k < 4; k++) {
+            Sum = 0;
+            for (uniform unsigned int n = 0; n < 4; n++) {
+                Sum += A.M[m * 4 + n] * B.M[n * 4 + k];
+            }
+
+            Result.M[m * 4 + k] = Sum;
+        }
+    }
+
+    return A;
+}
+
+double DoMath() {
+    FMatrix A;
+    FMatrix B;
+    FMatrix result = A * B;
+    return result.M[0];
+}

--- a/tests/lit-tests/func_template_operator_not_supported_1.ispc
+++ b/tests/lit-tests/func_template_operator_not_supported_1.ispc
@@ -1,0 +1,15 @@
+// Operators are not supported with explicit template instantiations yet.
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap  2>&1 | FileCheck %s
+
+// CHECK-NOT: Please file a bug report
+
+// CHECK: Error: syntax error, unexpected identifier, expecting TOKEN_TEMPLATE_NAME
+struct FMatrix {
+    double M[16];
+};
+
+template <typename T> noinline FMatrix operator*(const FMatrix &A, const T &B) {
+    return A;
+}
+
+template noinline FMatrix operator*(const FMatrix &A, const int &B)

--- a/tests/lit-tests/func_template_operator_not_supported_2.ispc
+++ b/tests/lit-tests/func_template_operator_not_supported_2.ispc
@@ -1,0 +1,33 @@
+// Operators are not supported with templates specializations yet.
+// Need to support function templates with implicit template parameters first.
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap  2>&1 | FileCheck %s
+
+// CHECK-NOT: Please file a bug report
+
+// CHECK: Error: syntax error, unexpected identifier, expecting TOKEN_TEMPLATE_NAME
+struct FMatrix {
+    double M[16];
+};
+
+template <typename T> noinline FMatrix operator*(const FMatrix &A, const T &B) {
+    return A;
+}
+
+template <>
+noinline FMatrix operator*(const FMatrix &A, const int &B) {
+    FMatrix Result;
+
+    for (uniform unsigned int m = 0; m < 4; m++) {
+        varying double Sum;
+        for (uniform unsigned int k = 0; k < 4; k++) {
+            Sum = 0;
+            for (uniform unsigned int n = 0; n < 4; n++) {
+                Sum += A.M[m * 4 + n] * B;
+            }
+
+            Result.M[m * 4 + k] = Sum;
+        }
+    }
+
+    return Result;
+}


### PR DESCRIPTION
Depends on https://github.com/ispc/ispc/pull/2641.
Introduces basic template support for operators.
Explicit instantiations and specializations are not supported yet.
Fixes #2634 .