### PR TITLE
Function specifiers for template specializations and instantiations 

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -3848,6 +3848,23 @@ template function specializations is not yet supported. Consider the following e
     }
 
 
+You can use limited number of function specifiers with function templates:
+
+* The keywords ``export``, ``task``, ``typedef``, ``extern "C"`` and ``extern "SYCL"``
+  are not allowed.
+* Calling conventions such as ``__vectorcall`` and ``__regcall`` must be used in conjunction
+  with ``extern "C"`` or ``extern "SYCL"``, so they are not allowed as well.
+* Performance hints like ``inline`` and ``noinline`` are allowed. Primary template, template
+  specializations and explicit instantiations may have different ``inline`` hints.
+* Storage types ``extern`` and ``static`` are allowed. Template specializations and explicit
+  instantiations must share the same storage type as the primary template.
+  If not specified, the storage type will be inherited from the primary template.
+* ``unmasked`` specifier is allowed. Template specializations and explicit instantiations
+  must maintain consistency with the primary template regarding the ``unmasked`` specifier.
+  You cannot specify ``unmasked`` for a template specialization if it was not previously
+  specified for the primary template. If unspecified, it will be inherited from the
+  primary template.
+
 The ISPC Standard Library
 =========================
 

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -8541,8 +8541,8 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
             // Easy, we have all template arguments specified explicitly, no deduction is needed.
             Symbol *funcSym = templSym->functionTemplate->LookupInstantiation(templateArgs);
             if (funcSym == nullptr) {
-                funcSym =
-                    templSym->functionTemplate->AddInstantiation(templateArgs, TemplateInstantiationKind::Implicit);
+                funcSym = templSym->functionTemplate->AddInstantiation(
+                    templateArgs, TemplateInstantiationKind::Implicit, templSym->isInline, templSym->isNoInline);
             }
             AssertPos(pos, funcSym);
             // Success
@@ -8554,7 +8554,8 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
         }
 
         // Create substitution map for specified template parameters
-        TemplateInstantiation inst(*templateParms, templateArgs, TemplateInstantiationKind::Implicit);
+        TemplateInstantiation inst(*templateParms, templateArgs, TemplateInstantiationKind::Implicit,
+                                   templSym->isInline, templSym->isNoInline);
 
         std::vector<const Type *> substitutedParamTypes;
         // Instantiate function parameter types with explicitly specified template arguments
@@ -8665,7 +8666,8 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
         // All template arguments were either explicitly specified or deduced, now get the instantiation.
         Symbol *funcSym = templSym->functionTemplate->LookupInstantiation(deducedArgs);
         if (funcSym == nullptr) {
-            funcSym = templSym->functionTemplate->AddInstantiation(deducedArgs, TemplateInstantiationKind::Implicit);
+            funcSym = templSym->functionTemplate->AddInstantiation(deducedArgs, TemplateInstantiationKind::Implicit,
+                                                                   templSym->isInline, templSym->isNoInline);
         }
         AssertPos(pos, funcSym);
         // Success

--- a/src/func.h
+++ b/src/func.h
@@ -81,12 +81,13 @@ class FunctionTemplate {
     std::string GetName() const;
     const TemplateParms *GetTemplateParms() const;
     const FunctionType *GetFunctionType() const;
+    StorageClass GetStorageClass();
 
     Symbol *LookupInstantiation(const std::vector<std::pair<const Type *, SourcePos>> &types);
     Symbol *AddInstantiation(const std::vector<std::pair<const Type *, SourcePos>> &types,
-                             TemplateInstantiationKind kind);
+                             TemplateInstantiationKind kind, bool isInline, bool isNoInline);
     Symbol *AddSpecialization(const FunctionType *ftype, const std::vector<std::pair<const Type *, SourcePos>> &types,
-                              SourcePos pos);
+                              bool isInline, bool isNoInline, SourcePos pos);
 
     // Generate code for instantiations and specializations.
     void GenerateIR() const;
@@ -111,7 +112,7 @@ class TemplateInstantiation {
   public:
     TemplateInstantiation(const TemplateParms &typeParms,
                           const std::vector<std::pair<const Type *, SourcePos>> &typeArgs,
-                          TemplateInstantiationKind kind);
+                          TemplateInstantiationKind kind, bool IsInline, bool IsNoInline);
     const Type *InstantiateType(const std::string &name);
     Symbol *InstantiateSymbol(Symbol *sym);
     Symbol *InstantiateTemplateSymbol(TemplateSymbol *sym);
@@ -131,7 +132,10 @@ class TemplateInstantiation {
     // Kind of instantiation (explicit, implicit, specialization).
     TemplateInstantiationKind kind;
 
-    llvm::Function *createLLVMFunction(Symbol *functionSym, bool isInline, bool isNoInline);
+    bool isInline;
+    bool isNoInline;
+
+    llvm::Function *createLLVMFunction(Symbol *functionSym);
 };
 
 } // namespace ispc

--- a/src/module.h
+++ b/src/module.h
@@ -88,11 +88,12 @@ class Module {
 
     void AddFunctionTemplateInstantiation(const std::string &name,
                                           const std::vector<std::pair<const Type *, SourcePos>> &types,
-                                          const FunctionType *ftype, SourcePos pos);
+                                          const FunctionType *ftype, StorageClass sc, bool isInline, bool isNoInline,
+                                          SourcePos pos);
 
     void AddFunctionTemplateSpecializationDeclaration(const std::string &name, const FunctionType *ftype,
                                                       const std::vector<std::pair<const Type *, SourcePos>> &types,
-                                                      SourcePos pos);
+                                                      StorageClass sc, bool isInline, bool isNoInline, SourcePos pos);
 
     void AddFunctionTemplateSpecializationDefinition(const std::string &name, const FunctionType *ftype,
                                                      const std::vector<std::pair<const Type *, SourcePos>> &types,

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -2572,8 +2572,9 @@ template_function_instantiation
           d->InitFromDeclSpecs($2);
           lCheckTemplateDeclSpecs($2, d->pos, TemplateType::Instantiation, $3->first->name.c_str());
           const FunctionType *ftype = CastType<FunctionType>(d->type);
-
-          m->AddFunctionTemplateInstantiation($3->first->name, *$3->second, ftype, Union(@1, @6));
+          bool isInline = ($2->typeQualifiers & TYPEQUAL_INLINE);
+          bool isNoInline = ($2->typeQualifiers & TYPEQUAL_NOINLINE);
+          m->AddFunctionTemplateInstantiation($3->first->name, *$3->second, ftype, $2->storageClass, isInline, isNoInline, Union(@1, @6));
 
           // deallocate SimpleTemplateIDType returned by simple_template_id
           lFreeSimpleTemplateID(simpleTemplID);
@@ -2589,8 +2590,9 @@ template_function_instantiation
           d->InitFromDeclSpecs($2);
           lCheckTemplateDeclSpecs($2, d->pos, TemplateType::Instantiation, $3->first->name.c_str());
           const FunctionType *ftype = CastType<FunctionType>(d->type);
-
-          m->AddFunctionTemplateInstantiation($3->first->name, *$3->second, ftype, Union(@1, @5));
+          bool isInline = ($2->typeQualifiers & TYPEQUAL_INLINE);
+          bool isNoInline = ($2->typeQualifiers & TYPEQUAL_NOINLINE);
+          m->AddFunctionTemplateInstantiation($3->first->name, *$3->second, ftype, $2->storageClass, isInline, isNoInline, Union(@1, @5));
 
           // deallocate SimpleTemplateIDType returned by simple_template_id
           lFreeSimpleTemplateID(simpleTemplID);
@@ -2912,7 +2914,10 @@ lAddTemplateSpecialization(const std::vector<std::pair<const Type *, SourcePos>>
 
     const FunctionType *ftype = CastType<FunctionType>(decl->type);
     if (ftype != nullptr) {
-        m->AddFunctionTemplateSpecializationDeclaration(decl->name, ftype, types, decl->pos);
+        bool isInline = (ds->typeQualifiers & TYPEQUAL_INLINE);
+        bool isNoInline = (ds->typeQualifiers & TYPEQUAL_NOINLINE);
+        m->AddFunctionTemplateSpecializationDeclaration(decl->name, ftype, types, ds->storageClass, 
+                                                        isInline, isNoInline, decl->pos);
     }
     else {
         Error(decl->pos, "Only function template specializations are supported.");

--- a/src/sym.h
+++ b/src/sym.h
@@ -106,7 +106,6 @@ class TemplateSymbol {
     // The reason to keep them here for now is that for regular functions it's not stored anywhere in AST,
     // but attached as attrubutes to llvm::Function when it's created. For templates we need to store this
     // information in here and use later when the template is instantiated.
-    // These attributes will be inherited by template functions specializations.
     bool isInline;
     bool isNoInline;
 };

--- a/src/type.h
+++ b/src/type.h
@@ -947,6 +947,9 @@ class FunctionType : public Type {
     const Type *GetAsConstType() const;
     const Type *GetAsNonConstType() const;
 
+    const Type *GetAsUnmaskedType() const;
+    const Type *GetAsNonUnmaskedType() const;
+
     std::string GetString() const;
     std::string Mangle() const;
     std::string GetCDeclaration(const std::string &fname) const;
@@ -1041,6 +1044,8 @@ class FunctionType : public Type {
         and the like and so not affect testing function types for equality,
         etc. */
     const llvm::SmallVector<SourcePos, 8> paramPositions;
+
+    mutable const FunctionType *asMaskedType, *asUnmaskedType;
 };
 
 /* Efficient dynamic casting of Types.  First, we specify a default

--- a/tests/lit-tests/func_template_inst_1.ispc
+++ b/tests/lit-tests/func_template_inst_1.ispc
@@ -1,0 +1,73 @@
+// Check different function specifiers with template explicit instantiations.
+
+// RUN: not %{ispc} -DTYPEDEF %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_TYPEDEF
+// RUN: not %{ispc} -DEXTERN_C %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXTERN_C
+// RUN: not %{ispc} -DEXTERN_SYCL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXTERN_SYCL
+// RUN: not %{ispc} -DEXPORT %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXPORT
+// RUN: not %{ispc} -DTASK %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_TASK
+// RUN: not %{ispc} -DVECTORCALL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_VECTORCALL
+// RUN: not %{ispc} -DREGCALL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_REGCALL
+
+// Primary template
+template <typename T> noinline int goo(T argGooOne, T argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+
+// CHECK_EXTERN: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyf___vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+#ifdef EXTERN
+template noinline extern int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_STATIC: define internal <{{[0-9]*}} x i32> @goo___vyf___vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+#ifdef STATIC
+template noinline static int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_UNMASKED: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyf___UM_vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo)
+#ifdef UNMASKED
+template noinline unmasked int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_INLINE-NOT: @goo___vyf___UM_vyfvyf
+#ifdef INLINE
+template inline int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_TYPEDEF: Illegal "typedef" provided with template instantiation.
+#ifdef TYPEDEF
+template noinline typedef int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_EXTERN_C: Error: Illegal linkage provided with template instantiation.
+#ifdef EXTERN_C
+template noinline extern "C" int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_EXTERN_SYCL: Error: Illegal linkage provided with template instantiation.
+#ifdef EXTERN_SYCL
+template noinline extern "SYCL" int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_EXPORT: Error: 'export' not supported for template instantiation.
+#ifdef EXPORT
+template noinline export int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_TASK: Error: 'task' not supported for template instantiation.
+#ifdef TASK
+template noinline task int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_VECTORCALL: Illegal to use "__vectorcall" qualifier on non-extern function
+#ifdef VECTORCALL
+template noinline __vectorcall int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_REGCALL: Illegal to use "__regcall" qualifier on non-extern function
+#ifdef REGCALL
+template noinline __regcall int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+float foo(int argFoo0, float argFoo1) {
+    return goo<int>(argFoo0, argFoo1);
+}

--- a/tests/lit-tests/func_template_inst_1.ispc
+++ b/tests/lit-tests/func_template_inst_1.ispc
@@ -1,5 +1,14 @@
 // Check different function specifiers with template explicit instantiations.
 
+// RUN: %{ispc} -DEXTERN %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_EXTERN
+// RUN: %{ispc} -DSTATIC %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_STATIC
+// RUN: %{ispc} -DUNMASKED %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_UNMASKED
+// RUN: %{ispc} -DEXTERN_INHERIT %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_EXTERN_INHERIT
+// RUN: %{ispc} -DSTATIC_INHERIT %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_STATIC_INHERIT
+// RUN: %{ispc} -DUNMASKED_INHERIT %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_UNMASKED_INHERIT
+// RUN: %{ispc} -DINLINE %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_INLINE
+// RUN: not %{ispc} -DEXTERN_ERROR %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXTERN_ERROR
+// RUN: not %{ispc} -DSTATIC_ERROR %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_STATIC_ERROR
 // RUN: not %{ispc} -DTYPEDEF %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_TYPEDEF
 // RUN: not %{ispc} -DEXTERN_C %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXTERN_C
 // RUN: not %{ispc} -DEXTERN_SYCL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXTERN_SYCL
@@ -9,26 +18,56 @@
 // RUN: not %{ispc} -DREGCALL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_REGCALL
 
 // Primary template
-template <typename T> noinline int goo(T argGooOne, T argGooTwo) {
-    return argGooOne + argGooTwo;
+template <typename T> noinline
+#if defined(EXTERN) || defined(EXTERN_INHERIT)
+    extern
+#elif defined(STATIC) || defined(STATIC_INHERIT)
+    static
+#elif defined(UNMASKED) || defined(UNMASKED_INHERIT)
+    unmasked
+#endif
+    int goo(T argGooOne, T argGooTwo) {
+    return argGooOne - argGooTwo;
 }
 
-// CHECK_EXTERN: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyf___vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+// CHECK_EXTERN_INHERIT: define weak_odr <{{[0-9]*}} x i32> @goo___vyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+// CHECK_STATIC_INHERIT: define internal <{{[0-9]*}} x i32> @goo___vyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+// CHECK_UNMASKED_INHERIT: define weak_odr <{{[0-9]*}} x i32> @goo___vyi___UM_vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo)
+#if defined(EXTERN_INHERIT) || defined(STATIC_INHERIT) || defined(UNMASKED_INHERIT)
+template noinline int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_EXTERN: define weak_odr <{{[0-9]*}} x i32> @goo___vyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
 #ifdef EXTERN
 template noinline extern int goo<int>(int argGooOne, int argGooTwo);
 #endif
 
-// CHECK_STATIC: define internal <{{[0-9]*}} x i32> @goo___vyf___vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+// CHECK_STATIC: define internal <{{[0-9]*}} x i32> @goo___vyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
 #ifdef STATIC
 template noinline static int goo<int>(int argGooOne, int argGooTwo);
 #endif
 
-// CHECK_UNMASKED: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyf___UM_vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo)
+// CHECK_EXTERN_ERROR: Template instantiation has inconsistent storage class. Consider assigning it to the primary template to inherit it's signature.
+#ifdef EXTERN_ERROR
+template noinline extern int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_STATIC_ERROR: Template instantiation has inconsistent storage class. Consider assigning it to the primary template to inherit it's signature.
+#ifdef STATIC_ERROR
+template noinline static int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_UNMASKED: define weak_odr <{{[0-9]*}} x i32> @goo___vyi___UM_vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo)
 #ifdef UNMASKED
 template noinline unmasked int goo<int>(int argGooOne, int argGooTwo);
 #endif
 
-// CHECK_INLINE-NOT: @goo___vyf___UM_vyfvyf
+// CHECK_UNMASKED_ERROR: Template instantiation has inconsistent "unmasked" specifier. Consider moving the specifier inside the function or assigning it to the primary template to inherit it's signature.
+#ifdef UNMASKED_ERROR
+template noinline unmasked int goo<int>(int argGooOne, int argGooTwo);
+#endif
+
+// CHECK_INLINE-NOT: @goo___vyi___vyivyi
 #ifdef INLINE
 template inline int goo<int>(int argGooOne, int argGooTwo);
 #endif

--- a/tests/lit-tests/func_template_spec_7.ispc
+++ b/tests/lit-tests/func_template_spec_7.ispc
@@ -1,5 +1,15 @@
 // Check different function specifiers with template specializations.
 
+// RUN: %{ispc} -DEXTERN %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_EXTERN
+// RUN: %{ispc} -DSTATIC %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_STATIC
+// RUN: %{ispc} -DUNMASKED %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_UNMASKED
+// RUN: %{ispc} -DEXTERN_INHERIT %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_EXTERN_INHERIT
+// RUN: %{ispc} -DSTATIC_INHERIT %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_STATIC_INHERIT
+// RUN: %{ispc} -DUNMASKED_INHERIT %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_UNMASKED_INHERIT
+// RUN: %{ispc} -DINLINE %s --nostdlib --target=host --nowrap --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_INLINE
+// RUN: not %{ispc} -DEXTERN_ERROR %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXTERN_ERROR
+// RUN: not %{ispc} -DSTATIC_ERROR %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_STATIC_ERROR
+// RUN: not %{ispc} -DUNMASKED_ERROR %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_UNMASKED_ERROR
 // RUN: not %{ispc} -DTYPEDEF %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_TYPEDEF
 // RUN: not %{ispc} -DEXTERN_C %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXTERN_C
 // RUN: not %{ispc} -DEXTERN_SYCL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXTERN_SYCL
@@ -9,32 +19,70 @@
 // RUN: not %{ispc} -DREGCALL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_REGCALL
 
 // Primary template
-template <typename T> noinline int goo(T argGooOne, T argGooTwo) {
-    return argGooOne + argGooTwo;
+template <typename T> noinline
+#if defined(EXTERN) || defined(EXTERN_INHERIT)
+    extern
+#elif defined(STATIC) || defined(STATIC_INHERIT)
+    static
+#elif defined(UNMASKED) || defined(UNMASKED_INHERIT)
+    unmasked
+#endif
+    int goo(T argGooOne, T argGooTwo) {
+    return argGooOne - argGooTwo;
 }
 
-// CHECK_EXTERN: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyf___vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+// CHECK_EXTERN_INHERIT: define <{{[0-9]*}} x i32> @goo___vyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+// CHECK_STATIC_INHERIT: define internal <{{[0-9]*}} x i32> @goo___vyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+// CHECK_UNMASKED_INHERIT: define <{{[0-9]*}} x i32> @goo___vyi___UM_vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo)
+#if defined(EXTERN_INHERIT) || defined(STATIC_INHERIT) || defined(UNMASKED_INHERIT)
+template <> noinline int goo<int>(int argGooOne, int argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_EXTERN: define <{{[0-9]*}} x i32> @goo___vyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
 #ifdef EXTERN
 template <> noinline extern int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
-// CHECK_STATIC: define internal <{{[0-9]*}} x i32> @goo___vyf___vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
+// CHECK_STATIC: define internal <{{[0-9]*}} x i32> @goo___vyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
 #ifdef STATIC
 template <> noinline static int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
-// CHECK_UNMASKED: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyf___UM_vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo)
+// CHECK_EXTERN_ERROR: Template specialization has inconsistent storage class. Consider assigning it to the primary template to inherit it's signature.
+#ifdef EXTERN_ERROR
+template <> noinline extern int goo<int>(int argGooOne, int argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_STATIC_ERROR: Template specialization has inconsistent storage class. Consider assigning it to the primary template to inherit it's signature.
+#ifdef STATIC_ERROR
+template <> noinline static int goo<int>(int argGooOne, int argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_UNMASKED: define <{{[0-9]*}} x i32> @goo___vyi___UM_vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo)
 #ifdef UNMASKED
 template <> noinline unmasked int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
-// CHECK_INLINE-NOT: @goo___vyf___UM_vyfvyf
+// CHECK_UNMASKED_ERROR: Template specialization has inconsistent "unmasked" specifier. Consider moving the specifier inside the function or assigning it to the primary template to inherit it's signature.
+#ifdef UNMASKED_ERROR
+template <> noinline unmasked int goo<int>(int argGooOne, int argGooTwo) {
+    return argGooOne + argGooTwo;
+}
+#endif
+
+// CHECK_INLINE-NOT: @goo___vyi___vyivyi
 #ifdef INLINE
 template <> inline int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
@@ -91,5 +139,5 @@ template <> noinline __regcall int goo<int>(int argGooOne, int argGooTwo) {
 #endif
 
 float foo(int argFoo0, float argFoo1) {
-    return goo<int>(argFoo0, argFoo1);
+    return goo<int>(argFoo0, argFoo1) + goo<float>(argFoo0, argFoo1);
 }

--- a/tests/lit-tests/func_template_spec_7.ispc
+++ b/tests/lit-tests/func_template_spec_7.ispc
@@ -1,10 +1,5 @@
-// Check different function specifiers with templates.
+// Check different function specifiers with template specializations.
 
-// RUN: %{ispc} -DNONE %s --nostdlib --target=host --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_NONE
-// RUN: %{ispc} -DEXTERN %s --nostdlib --target=host --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_EXTERN
-// RUN: %{ispc} -DSTATIC %s --nostdlib --target=host --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_STATIC
-// RUN: %{ispc} -DUNMASKED %s --nostdlib --target=host --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_UNMASKED
-// RUN: %{ispc} -DINLINE %s --nostdlib --target=host --emit-llvm-text -O0 --nowrap -o - | FileCheck %s --check-prefixes=CHECK_INLINE
 // RUN: not %{ispc} -DTYPEDEF %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_TYPEDEF
 // RUN: not %{ispc} -DEXTERN_C %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXTERN_C
 // RUN: not %{ispc} -DEXTERN_SYCL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_EXTERN_SYCL
@@ -13,90 +8,88 @@
 // RUN: not %{ispc} -DVECTORCALL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_VECTORCALL
 // RUN: not %{ispc} -DREGCALL %s --nostdlib --target=host --nowrap 2>&1 | FileCheck %s --check-prefixes=CHECK_REGCALL
 
-// CHECK_NONE: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyf___vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
-#ifdef NONE
+// Primary template
 template <typename T> noinline int goo(T argGooOne, T argGooTwo) {
     return argGooOne + argGooTwo;
 }
-#endif
 
 // CHECK_EXTERN: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyf___vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
 #ifdef EXTERN
-template <typename T> noinline extern int goo(T argGooOne, T argGooTwo) {
+template <> noinline extern int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
 // CHECK_STATIC: define internal <{{[0-9]*}} x i32> @goo___vyf___vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
 #ifdef STATIC
-template <typename T> noinline static int goo(T argGooOne, T argGooTwo) {
+template <> noinline static int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
 // CHECK_UNMASKED: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyf___UM_vyfvyf(<{{[0-9]*}} x float> %argGooOne, <{{[0-9]*}} x float> %argGooTwo)
 #ifdef UNMASKED
-template <typename T> unmasked noinline int goo(T argGooOne, T argGooTwo) {
+template <> noinline unmasked int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
 // CHECK_INLINE-NOT: @goo___vyf___UM_vyfvyf
 #ifdef INLINE
-template <typename T> inline int goo(T argGooOne, T argGooTwo) {
+template <> inline int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
-// CHECK_TYPEDEF: Illegal "typedef" provided with function template.
+// CHECK_TYPEDEF: Illegal "typedef" provided with template specialization.
 #ifdef TYPEDEF
-template <typename T> noinline typedef int goo(T argGooOne, T argGooTwo) {
+template <> noinline typedef int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
-// CHECK_EXTERN_C: Error: Illegal linkage provided with function template.
+// CHECK_EXTERN_C: Error: Illegal linkage provided with template specialization.
 #ifdef EXTERN_C
-template <typename T> noinline extern "C" int goo(T argGooOne, T argGooTwo) {
+template <> noinline extern "C" int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
-// CHECK_EXTERN_SYCL: Error: Illegal linkage provided with function template.
+// CHECK_EXTERN_SYCL: Error: Illegal linkage provided with template specialization.
 #ifdef EXTERN_SYCL
-template <typename T> noinline extern "SYCL" int goo(T argGooOne, T argGooTwo) {
+template <> noinline extern "SYCL" int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
-// CHECK_EXPORT: Error: 'export' not supported for function template.
+// CHECK_EXPORT: Error: 'export' not supported for template specialization.
 #ifdef EXPORT
-template <typename T> noinline export int goo(T argGooOne, T argGooTwo) {
+template <> noinline export int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
-// CHECK_TASK: Error: 'task' not supported for function template.
+// CHECK_TASK: Error: 'task' not supported for template specialization.
 #ifdef TASK
-template <typename T> noinline task int goo(T argGooOne, T argGooTwo) {
+template <> noinline task int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
 // CHECK_VECTORCALL: Illegal to use "__vectorcall" qualifier on non-extern function
 #ifdef VECTORCALL
-template <typename T> noinline __vectorcall int goo(T argGooOne, T argGooTwo) {
+template <> noinline __vectorcall int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
 // CHECK_REGCALL: Illegal to use "__regcall" qualifier on non-extern function
 #ifdef REGCALL
-template <typename T> noinline __regcall int goo(T argGooOne, T argGooTwo) {
+template <> noinline __regcall int goo<int>(int argGooOne, int argGooTwo) {
     return argGooOne + argGooTwo;
 }
 #endif
 
 float foo(int argFoo0, float argFoo1) {
-    return goo<float>(argFoo0, argFoo1);
+    return goo<int>(argFoo0, argFoo1);
 }


### PR DESCRIPTION
This PR fixes and aligns usage of different function specifiers (storage class, inline hints, unmasked keyword etc) for template specializations and instantiations.  
* The keywords ``export``, ``task``, ``typedef``, ``extern "C"`` and ``extern "SYCL"``
  are not allowed.
* Calling conventions such as ``__vectorcall`` and ``__regcall`` must be used in conjunction
  with ``extern "C"`` or ``extern "SYCL"``, so they are not allowed as well.
* Performance hints like ``inline`` and ``noinline`` are allowed. Primary template, template
  specializations and explicit instantiations may have different ``inline`` hints.
* Storage types ``extern`` and ``static`` are allowed. Template specializations and explicit
  instantiations must share the same storage type as the primary template.
  If not specified, the storage type will be inherited from the primary template.
* ``unmasked`` specifier is allowed. Template specializations and explicit instantiations
  must maintain consistency with the primary template regarding the ``unmasked`` specifier.
  You cannot specify ``unmasked`` for a template specialization if it was not previously
  specified for the primary template. If unspecified, it will be inherited from the
  primary template.
Fixes https://github.com/ispc/ispc/issues/2635