### PR TITLE
Fixes for Xe-enabled build with LLVM 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,12 +393,14 @@ set(LLVM_TOOLS_OPAQUE_FLAGS)
 # Starting LLVM version 17.0 enable opaque pointers by default for CPU build
 if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "17.0.0")
     set(ISPC_OPAQUE_PTR_MODE ON)
+else()
+    # On Xe-enabled build, turn off opaque pointers before 17.0.
+    # IGC software stack is not ready yet.
+    if (XE_ENABLED)
+        set(ISPC_OPAQUE_PTR_MODE OFF)
+    endif()
 endif()
-# On Xe-enabled build, turn off opaque pointers.
-# IGC software stack is not ready yet.
-if (XE_ENABLED)
-    set(ISPC_OPAQUE_PTR_MODE OFF)
-endif()
+
 if (ISPC_OPAQUE_PTR_MODE)
     if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "15.0.0")
     # Do nothing, opaque pointers mode is default

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -2693,11 +2693,7 @@ llvm::Value *FunctionEmitContext::AddrSpaceCastInst(llvm::Value *val, AddressSpa
     if (pt->getAddressSpace() == (unsigned)as) {
         return val;
     }
-#if ISPC_LLVM_VERSION >= ISPC_LLVM_13_0
     llvm::PointerType *newType = llvm::PointerType::getWithSamePointeeType(pt, (unsigned)as);
-#else
-    llvm::PointerType *newType = llvm::PointerType::get(pt->getPointerElementType(), (unsigned)as);
-#endif
     llvm::AddrSpaceCastInst *inst;
     if (atEntryBlock) {
         inst = new llvm::AddrSpaceCastInst(val, newType, val->getName() + "__cast", allocaBlock->getTerminator());

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -2693,7 +2693,11 @@ llvm::Value *FunctionEmitContext::AddrSpaceCastInst(llvm::Value *val, AddressSpa
     if (pt->getAddressSpace() == (unsigned)as) {
         return val;
     }
+#ifdef ISPC_OPAQUE_PTR_MODE
+    llvm::PointerType *newType = llvm::PointerType::get(*g->ctx, (unsigned)as);
+#else
     llvm::PointerType *newType = llvm::PointerType::getWithSamePointeeType(pt, (unsigned)as);
+#endif
     llvm::AddrSpaceCastInst *inst;
     if (atEntryBlock) {
         inst = new llvm::AddrSpaceCastInst(val, newType, val->getName() + "__cast", allocaBlock->getTerminator());

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -6200,11 +6200,6 @@ void ConstExpr::Print(Indent &indent) const {
             break;
         case AtomicType::TYPE_FLOAT16: {
             llvm::APFloat V(fpVal[i]);
-#if ISPC_LLVM_VERSION < ISPC_LLVM_13_0
-            // Starting from LLVM 13, this is done by convertToFloat() implicitly.
-            bool ignored;
-            V.convert(llvm::APFloat::IEEEsingle(), llvm::APFloat::rmNearestTiesToEven, &ignored);
-#endif
             printf("%f", V.convertToFloat());
             break;
         }

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -37,7 +37,11 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/CodeGen.h>
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_17_0
+#include <llvm/TargetParser/Host.h>
+#else
 #include <llvm/Support/Host.h>
+#endif
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_14_0
 #include <llvm/MC/TargetRegistry.h>
 #else

--- a/src/opt/CheckIRForXeTarget.cpp
+++ b/src/opt/CheckIRForXeTarget.cpp
@@ -56,8 +56,13 @@ bool CheckIRForXeTarget::checkAndFixIRForXe(llvm::BasicBlock &bb) {
         if (!g->target->hasFp64Support()) {
             for (int i = 0; i < (int)inst->getNumOperands(); ++i) {
                 llvm::Type *t = inst->getOperand(i)->getType();
+#ifdef ISPC_OPAQUE_PTR_MODE
+                // No need to check for double pointer types in opaque pointers mode.
+                if (t->isDoubleTy()) {
+#else
                 if (t == LLVMTypes::DoubleType || t == LLVMTypes::DoublePointerType ||
                     t == LLVMTypes::DoubleVectorType || t == LLVMTypes::DoubleVectorPointerType) {
+#endif
                     Error(pos, "\'double\' type is not supported by the target\n");
                 }
             }

--- a/src/opt/XeGatherCoalescePass.cpp
+++ b/src/opt/XeGatherCoalescePass.cpp
@@ -547,8 +547,12 @@ void XeGatherCoalescing::optimizePtr(llvm::Value *Ptr, PtrData &PD, llvm::Instru
         //  If the Offset is non-zero, we should re-align the LD based on its value.
         if (Offset != nullptr && !Offset->isZeroValue()) {
             const uint64_t offset{llvm::dyn_cast<llvm::ConstantInt>(Offset)->getZExtValue()};
-            const uint64_t alignment{
-                llvm::MinAlign(offset, std::min(llvm::PowerOf2Floor(offset), static_cast<uint64_t>(OWORD)))};
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_16_0
+            auto aligned_offset = llvm::bit_floor(offset);
+#else
+            auto aligned_offset = llvm::PowerOf2Floor(offset);
+#endif
+            const uint64_t alignment{llvm::MinAlign(offset, std::min(aligned_offset, static_cast<uint64_t>(OWORD)))};
             LD->setAlignment(llvm::Align{alignment});
         }
 

--- a/tests/lit-tests/load_store_vectorizer_loopunroll.ispc
+++ b/tests/lit-tests/load_store_vectorizer_loopunroll.ispc
@@ -23,11 +23,11 @@
 
 // CHECK_ALL-LABEL: @scatter_coalescing_loopunroll4pragma
 
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> {{undef|poison}}, float %_in{{.*}}, i{{(32|64)}} 0
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> %{{[0-9]+}}, float %_in{{.*}}, i{{(32|64)}} 1
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> %{{[0-9]+}}, float %_in{{.*}}, i{{(32|64)}} 2
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> %{{[0-9]+}}, float %_in{{.*}}, i{{(32|64)}} 3
-// CHECK:           store <4 x float> %{{[0-9]+}}, <4 x float>* %{{[0-9]+}}
+// CHECK:           %{{.*}} = insertelement <4 x float> {{undef|poison}}, float %_in{{.*}}, i{{(32|64)}} 0
+// CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 1
+// CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 2
+// CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 3
+// CHECK:           store <4 x float> %{{.*}}, {{(<4 x float>\*)|ptr}} %{{.*}}
 
 task void scatter_coalescing_loopunroll4pragma(uniform float _out[], uniform float _in[]) {
     uniform float a[NUM];
@@ -50,11 +50,11 @@ task void scatter_coalescing_loopunroll4pragma(uniform float _out[], uniform flo
 
 // CHECK_ALL-LABEL: @scatter_coalescing_loopunroll4inline
 
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> {{undef|poison}}, float %_in{{.*}}, i{{(32|64)}} 0
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> %{{[0-9]+}}, float %_in{{.*}}, i{{(32|64)}} 1
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> %{{[0-9]+}}, float %_in{{.*}}, i{{(32|64)}} 2
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> %{{[0-9]+}}, float %_in{{.*}}, i{{(32|64)}} 3
-// CHECK:           store <4 x float> %{{[0-9]+}}, <4 x float>* %{{[0-9]+}}
+// CHECK:           %{{.*}} = insertelement <4 x float> {{undef|poison}}, float %_in{{.*}}, i{{(32|64)}} 0
+// CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 1
+// CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 2
+// CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 3
+// CHECK:           store <4 x float> %{{.*}}, {{(<4 x float>\*)|ptr}} %{{.*}}
 
 task void scatter_coalescing_loopunroll4inline(uniform float _out[], uniform float _in[]) {
     uniform float a[NUM];
@@ -82,16 +82,16 @@ task void scatter_coalescing_loopunroll4inline(uniform float _out[], uniform flo
 
 // CHECK_ALL-LABEL: @scatter_coalescing_loopunroll8inline
 
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> {{undef|poison}}, float %_in{{.*}}, i{{(32|64)}} 0
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> %{{[0-9]+}}, float %_in{{.*}}, i{{(32|64)}} 1
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> %{{[0-9]+}}, float %_in{{.*}}, i{{(32|64)}} 2
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> %{{[0-9]+}}, float %_in{{.*}}, i{{(32|64)}} 3
-// CHECK:           store <4 x float> %{{[0-9]+}}, <4 x float>* %{{[0-9]+}}
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> {{undef|poison}}, float %_in{{.*}}, i{{(32|64)}} 0
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> %{{[0-9]+}}, float %_in{{.*}}, i{{(32|64)}} 1
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> %{{[0-9]+}}, float %_in{{.*}}, i{{(32|64)}} 2
-// CHECK:           %{{[0-9]+}} = insertelement <4 x float> %{{[0-9]+}}, float %_in{{.*}}, i{{(32|64)}} 3
-// CHECK:           store <4 x float> %{{[0-9]+}}, <4 x float>* %{{[0-9]+}}
+// CHECK:           %{{.*}} = insertelement <4 x float> {{undef|poison}}, float %_in{{.*}}, i{{(32|64)}} 0
+// CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 1
+// CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 2
+// CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 3
+// CHECK:           store <4 x float> %{{.*}}, {{(<4 x float>\*)|ptr}} %{{.*}}
+// CHECK:           %{{.*}} = insertelement <4 x float> {{undef|poison}}, float %_in{{.*}}, i{{(32|64)}} 0
+// CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 1
+// CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 2
+// CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 3
+// CHECK:           store <4 x float> %{{.*}}, {{(<4 x float>\*)|ptr}} %{{.*}}
 
 task void scatter_coalescing_loopunroll8inline(uniform float _out[], uniform float _in[]) {
     uniform float a[NUM];

--- a/tests/lit-tests/xe_assert.ispc
+++ b/tests/lit-tests/xe_assert.ispc
@@ -7,7 +7,7 @@
 //CHECK: @lz_format_str = internal unnamed_addr addrspace(2) constant [{{.*}} x i8] c"{{.*}}xe_assert.ispc:13:3: Assertion failed: a > 0 \0A\00", align 1
 task void assert_kernel(uniform float aFOO[]) {
 //CHECK: fail{{.*}}:
-//CHECK-NEXT: call i32 (i8 addrspace(2)*, ...) @_Z18__spirv_ocl_printfPU3AS2c(i8 addrspace(2)* getelementptr inbounds ([{{.*}} x i8], [{{.*}} x i8] addrspace(2)* @lz_format_str, i64 0, i64 0))
+//CHECK-NEXT: call i32 ({{(i8 addrspace\(2\)\*|ptr addrspace\(2\))}}, ...) @_Z18__spirv_ocl_printfPU3AS2c({{.*}} @lz_format_str
 //CHECK-NEXT: call void @llvm.genx.raw.send.noresult.v32i16.v16i1.v32i16(i32 0, <16 x i1> <i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true>, i32 39, i32 33554448, <32 x i16> zeroinitializer)
   float a = aFOO[programIndex];
   assert(a > 0);

--- a/tests/lit-tests/xe_gather_coalescing.ispc
+++ b/tests/lit-tests/xe_gather_coalescing.ispc
@@ -20,10 +20,10 @@
 
 // CHECK_ALL-LABEL:     @gather_coalescing_inline4
 
-// CHECK_LOAD_INLINE4:  %vectorized_ptrtoint = ptrtoint float* %_in to i64
+// CHECK_LOAD_INLINE4:  %vectorized_ptrtoint = ptrtoint {{(float\*)|ptr}} %_in to i64
 // CHECK_LOAD_INLINE4:  %vectorized_address = add i64 %vectorized_ptrtoint, 0
-// CHECK_LOAD_INLINE4:  %vectorized_address_ptr = inttoptr i64 %vectorized_address to <4 x float>*
-// CHECK_LOAD_INLINE4:  %vectorized_ld_exp = load <4 x float>, <4 x float>* %vectorized_address_ptr
+// CHECK_LOAD_INLINE4:  %vectorized_address_ptr = inttoptr i64 %vectorized_address to {{(<4 x float>\*)|ptr}}
+// CHECK_LOAD_INLINE4:  %vectorized_ld_exp = load <4 x float>, {{(<4 x float>\*)|ptr}} %vectorized_address_ptr
 // CHECK_LOAD_INLINE4:  %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 0
 // CHECK_LOAD_INLINE4:  %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 1
 // CHECK_LOAD_INLINE4:  %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 2
@@ -48,13 +48,12 @@ task void gather_coalescing_inline4(uniform float _out[], uniform float _in[]) {
     _out[programIndex] = a[programIndex];
 }
 
-
 // CHECK_ALL-LABEL:       @gather_coalescing_inline16
 
-// CHECK_LOAD_INLINE16:   %vectorized_ptrtoint = ptrtoint float* %_in to i64
+// CHECK_LOAD_INLINE16:   %vectorized_ptrtoint = ptrtoint {{(float\*)|ptr}} %_in to i64
 // CHECK_LOAD_INLINE16:   %vectorized_address = add i64 %vectorized_ptrtoint, 0
-// CHECK_LOAD_INLINE16:   %vectorized_address_ptr = inttoptr i64 %vectorized_address to <16 x float>*
-// CHECK_LOAD_INLINE16:   %vectorized_ld_exp = load <16 x float>, <16 x float>* %vectorized_address_ptr
+// CHECK_LOAD_INLINE16:   %vectorized_address_ptr = inttoptr i64 %vectorized_address to {{(<16 x float>\*)|ptr}}
+// CHECK_LOAD_INLINE16:   %vectorized_ld_exp = load <16 x float>, {{(<16 x float>\*)|ptr}} %vectorized_address_ptr
 // CHECK_LOAD_INLINE16:   %mem_coal_eei{{[0-9]*}} = extractelement <16 x float> %vectorized_ld_exp, i64 0
 // CHECK_LOAD_INLINE16:   %mem_coal_eei{{[0-9]*}} = extractelement <16 x float> %vectorized_ld_exp, i64 1
 // CHECK_LOAD_INLINE16:   %mem_coal_eei{{[0-9]*}} = extractelement <16 x float> %vectorized_ld_exp, i64 2

--- a/tests/lit-tests/xe_gather_coalescing_loop.ispc
+++ b/tests/lit-tests/xe_gather_coalescing_loop.ispc
@@ -18,8 +18,8 @@
 
 // CHECK_ALL-LABEL: @gather_coalescing_loop
 
-// CHECK:           %_in_load_offset = getelementptr float, float* %_in
-// CHECK:           %_in_load_offset_load = load float, float* %_in_load_offset
+// CHECK:           %_in_load_offset = getelementptr float, {{(float\*)|ptr}} %_in
+// CHECK:           %_in_load_offset_load = load float, {{(float\*)|ptr}} %_in_load_offset
 
 task void gather_coalescing_loop(uniform float _out[], uniform float _in[]) {
     uniform float a[NUM];

--- a/tests/lit-tests/xe_gather_coalescing_ptr_alloca.ispc
+++ b/tests/lit-tests/xe_gather_coalescing_ptr_alloca.ispc
@@ -60,10 +60,10 @@ static inline vec3f get_color(const uniform Linear *uniform self, int index) {
 
 // CHECK_ALL-LABEL: @gather_coalescing_i
 
-// CHECK_LOAD:      %vectorized_ptrtoint = ptrtoint float* %_in to i64
+// CHECK_LOAD:      %vectorized_ptrtoint = ptrtoint {{(float\*)|ptr}} %_in to i64
 // CHECK_LOAD:      %vectorized_address = add i64 %vectorized_ptrtoint, 0
-// CHECK_LOAD:      %vectorized_address_ptr = inttoptr i64 %vectorized_address to <4 x float>*
-// CHECK_LOAD:      %vectorized_ld_exp = load <4 x float>, <4 x float>* %vectorized_address_ptr
+// CHECK_LOAD:      %vectorized_address_ptr = inttoptr i64 %vectorized_address to {{(<4 x float>\*)|ptr}}
+// CHECK_LOAD:      %vectorized_ld_exp = load <4 x float>, {{(<4 x float>\*)|ptr}} %vectorized_address_ptr
 // CHECK_LOAD:      %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 0
 // CHECK_LOAD:      %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 1
 // CHECK_LOAD:      %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 2
@@ -79,10 +79,10 @@ task void gather_coalescing_i(uniform float _out[], uniform float _in[], uniform
 
 // CHECK_ALL-LABEL: @gather_coalescing_inogetter
 
-// CHECK_LOAD:      %vectorized_ptrtoint = ptrtoint float* %_in to i64
+// CHECK_LOAD:      %vectorized_ptrtoint = ptrtoint {{(float\*)|ptr}} %_in to i64
 // CHECK_LOAD:      %vectorized_address = add i64 %vectorized_ptrtoint, 0
-// CHECK_LOAD:      %vectorized_address_ptr = inttoptr i64 %vectorized_address to <4 x float>*
-// CHECK_LOAD:      %vectorized_ld_exp = load <4 x float>, <4 x float>* %vectorized_address_ptr
+// CHECK_LOAD:      %vectorized_address_ptr = inttoptr i64 %vectorized_address to {{(<4 x float>\*)|ptr}}
+// CHECK_LOAD:      %vectorized_ld_exp = load <4 x float>, {{(<4 x float>\*)|ptr}} %vectorized_address_ptr
 // CHECK_LOAD:      %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 0
 // CHECK_LOAD:      %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 1
 // CHECK_LOAD:      %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 2
@@ -99,10 +99,10 @@ task void gather_coalescing_inogetter(uniform float _out[], uniform float _in[],
 
 // CHECK_ALL-LABEL: @gather_coalescing_ivarying
 
-// CHECK_LOAD:      %vectorized_ptrtoint = ptrtoint float* %_in to i64
+// CHECK_LOAD:      %vectorized_ptrtoint = ptrtoint {{(float\*)|ptr}} %_in to i64
 // CHECK_LOAD:      %vectorized_address = add i64 %vectorized_ptrtoint, 0
-// CHECK_LOAD:      %vectorized_address_ptr = inttoptr i64 %vectorized_address to <4 x float>*
-// CHECK_LOAD:      %vectorized_ld_exp = load <4 x float>, <4 x float>* %vectorized_address_ptr
+// CHECK_LOAD:      %vectorized_address_ptr = inttoptr i64 %vectorized_address to {{(<4 x float>\*)|ptr}}
+// CHECK_LOAD:      %vectorized_ld_exp = load <4 x float>, {{(<4 x float>\*)|ptr}} %vectorized_address_ptr
 // CHECK_LOAD:      %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 0
 // CHECK_LOAD:      %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 1
 // CHECK_LOAD:      %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 2
@@ -118,10 +118,10 @@ task void gather_coalescing_ivarying(uniform float _out[], uniform float _in[], 
 
 // CHECK_ALL-LABEL: @gather_coalescing_ivaryingnogetter
 
-// CHECK_LOAD:      %vectorized_ptrtoint = ptrtoint float* %_in to i64
+// CHECK_LOAD:      %vectorized_ptrtoint = ptrtoint {{(float\*)|ptr}} %_in to i64
 // CHECK_LOAD:      %vectorized_address = add i64 %vectorized_ptrtoint, 0
-// CHECK_LOAD:      %vectorized_address_ptr = inttoptr i64 %vectorized_address to <4 x float>*
-// CHECK_LOAD:      %vectorized_ld_exp = load <4 x float>, <4 x float>* %vectorized_address_ptr
+// CHECK_LOAD:      %vectorized_address_ptr = inttoptr i64 %vectorized_address to {{(<4 x float>\*)|ptr}}
+// CHECK_LOAD:      %vectorized_ld_exp = load <4 x float>, {{(<4 x float>\*)|ptr}} %vectorized_address_ptr
 // CHECK_LOAD:      %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 0
 // CHECK_LOAD:      %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 1
 // CHECK_LOAD:      %mem_coal_eei{{[0-9]*}} = extractelement <4 x float> %vectorized_ld_exp, i64 2

--- a/tests/lit-tests/xe_gather_test.ispc
+++ b/tests/lit-tests/xe_gather_test.ispc
@@ -10,7 +10,7 @@ struct vec3f {
 };
 
 // CHECK: alloca [3 x %v16_varying_vec3f]
-// CHECK: load <16 x float>, <16 x float>* %ptr_cast_for_load
+// CHECK: load <16 x float>, {{(<16 x float>\*)|ptr}} %
 // CHECK: store <16 x float> %
 export void checkAddrSpace(uniform float _out[], uniform float _in[]) {
     float a = _in[programIndex];

--- a/tests/lit-tests/xe_invoke_sycl.ispc
+++ b/tests/lit-tests/xe_invoke_sycl.ispc
@@ -28,21 +28,21 @@
 // INVOKE_SYCL_NO_REGCALL: "invoke_sycl" expression can be only used with '__regcall'-qualified function.
 // REQUIRES: XE_ENABLED
 
-// CHECK_CPU: x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl(float*, i32)
-// CHECK_CPU: x86_regcallcc i32 @__regcall3__extern_sycl_decl_uniform(float*)
+// CHECK_CPU: x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl({{(float\*)|ptr}}, i32)
+// CHECK_CPU: x86_regcallcc i32 @__regcall3__extern_sycl_decl_uniform({{(float\*)|ptr}})
 
-// CHECK_CPU: call x86_regcallcc i32 @__regcall3__extern_sycl_decl_uniform(float* {{.*}})
-// CHECK_CPU: call x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl(float* {{.*}}, i32 {{.*}})
-// CHECK_CPU: call x86_regcallcc void @__regcall3__extern_sycl_decl_void(float* {{.*}})
+// CHECK_CPU: call x86_regcallcc i32 @__regcall3__extern_sycl_decl_uniform({{(float\*)|ptr}} {{.*}})
+// CHECK_CPU: call x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl({{(float\*)|ptr}} {{.*}}, i32 {{.*}})
+// CHECK_CPU: call x86_regcallcc void @__regcall3__extern_sycl_decl_void({{(float\*)|ptr}} {{.*}})
 // CHECK_CPU: call x86_regcallcc void @__regcall3__extern_sycl_decl_noarg()
-// CHECK_CPU: call x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl_ptr(float* {{.*}})
+// CHECK_CPU: call x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl_ptr({{(float\*)|ptr}} {{.*}})
 
-// CHECK_MULTI_CPU1: declare x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl(float*, i32)
-// CHECK_MULTI_CPU1: declare x86_regcallcc i32 @__regcall3__extern_sycl_decl_uniform(float*)
+// CHECK_MULTI_CPU1: declare x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl({{(float\*)|ptr}}, i32)
+// CHECK_MULTI_CPU1: declare x86_regcallcc i32 @__regcall3__extern_sycl_decl_uniform({{(float\*)|ptr}})
 // CHECK_MULTI_CPU1: declare x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl_ptr(
 
-// CHECK_MULTI_CPU2: declare x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl(float*, i32)
-// CHECK_MULTI_CPU2: declare x86_regcallcc i32 @__regcall3__extern_sycl_decl_uniform(float*)
+// CHECK_MULTI_CPU2: declare x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl({{(float\*)|ptr}}, i32)
+// CHECK_MULTI_CPU2: declare x86_regcallcc i32 @__regcall3__extern_sycl_decl_uniform({{(float\*)|ptr}})
 // CHECK_MULTI_CPU2: declare x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl_ptr(
 
 // CHECK-GPU: x86_regcallcc <8 x i32> @__regcall3__extern_sycl_decl(<8 x i64> %{{.*}}), <8 x i32> %{{.*}})>)

--- a/tests/lit-tests/xe_kernels_spec.ispc
+++ b/tests/lit-tests/xe_kernels_spec.ispc
@@ -46,69 +46,69 @@
 // CHECK_DATALAYOUT: target datalayout = "e-p:64:64-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 // CHECK_DATALAYOUT: target triple = "spir64-unknown-unknown"
 
-// CHECK_EXPORT_F1_GPU: void @f1__{{.*}}(float* noalias nocapture %RET, <16 x {{.*}}> %__mask)
-// CHECK_EXPORT_F1_GPU: spir_func void @f1(float addrspace(4)* noalias nocapture %RET) {{.*}}
-// CHECK_EXPORT_F1_GPU-NOT: spir_kernel void @f1(i8 addrspace(1)* noalias nocapture "VCArgumentIOKind"="0" %RET)
-// CHECK_EXPORT_F1_CPU: void @f1__{{.*}}(float* noalias nocapture %RET, <16 x {{.*}}> %__mask)
-// CHECK_EXPORT_F1_CPU: void @f1(float* noalias nocapture %RET)
+// CHECK_EXPORT_F1_GPU: void @f1__{{.*}}({{(float\*)|ptr}} noalias nocapture %RET, <16 x {{.*}}> %__mask)
+// CHECK_EXPORT_F1_GPU: spir_func void @f1({{(float addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias nocapture %RET) {{.*}}
+// CHECK_EXPORT_F1_GPU-NOT: spir_kernel void @f1({{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} noalias nocapture "VCArgumentIOKind"="0" %RET)
+// CHECK_EXPORT_F1_CPU: void @f1__{{.*}}({{(float\*)|ptr}} noalias nocapture %RET, <16 x {{.*}}> %__mask)
+// CHECK_EXPORT_F1_CPU: void @f1({{(float\*)|ptr}} noalias nocapture %RET)
 export void f1(uniform float RET[]) {}
 
-// CHECK_TASK_F1_GPU: dllexport spir_kernel void @f1_task(i8 addrspace(1)* {{.*}} "VCArgumentIOKind"="0" %RET) {{.*}}
+// CHECK_TASK_F1_GPU: dllexport spir_kernel void @f1_task({{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} {{.*}} "VCArgumentIOKind"="0" %RET) {{.*}}
 // CHECK_TASK_F1_GPU-NOT: void @f1_task__
 // CHECK_TASK_F1_CPU: void @f1_task__{{.*}} noalias {{.*}} %0, i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 %6, i32 %7, i32 %8, i32 %9, i32 %10)
-// CHECK_TASK_F1_CPU-NOT: void @f1_task(float* noalias nocapture %RET)
+// CHECK_TASK_F1_CPU-NOT: void @f1_task({{(float\*)|ptr}} noalias nocapture %RET)
 task void f1_task(uniform float RET[]) {}
 
-// CHECK_EXPORT_F2_GPU: void @f2__{{.*}}(float* noalias nocapture %aF, double* noalias nocapture %aD, i32* noalias nocapture %aI, <16 x {{.*}}> %__mask)
-// CHECK_EXPORT_F2_GPU: spir_func void @f2(float addrspace(4)* noalias nocapture %aF, double addrspace(4)* noalias nocapture %aD, i32 addrspace(4)* noalias nocapture %aI) {{.*}}
-// CHECK_EXPORT_F2_GPU-NOT: spir_kernel void @f2(i8 addrspace(1)* noalias nocapture "VCArgumentIOKind"="0" %aF, i8 addrspace(1)* noalias nocapture "VCArgumentIOKind"="0" %aD, i8 addrspace(1)* noalias nocapture "VCArgumentIOKind"="0" %aI)
-// CHECK_EXPORT_F2_CPU: void @f2__{{.*}}(float* noalias nocapture %aF, double* noalias nocapture %aD, i32* noalias nocapture %aI, <16 x {{.*}}> %__mask)
-// CHECK_EXPORT_F2_CPU: void @f2(float* noalias nocapture %aF, double* noalias nocapture %aD, i32* noalias nocapture %aI)
+// CHECK_EXPORT_F2_GPU: void @f2__{{.*}}({{(float\*)|ptr}} noalias nocapture %aF, {{(double\*)|ptr}} noalias nocapture %aD, {{(i32\*)|ptr}} noalias nocapture %aI, <16 x {{.*}}> %__mask)
+// CHECK_EXPORT_F2_GPU: spir_func void @f2({{(float addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias nocapture %aF, {{(double addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias nocapture %aD, {{(i32 addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias nocapture %aI) {{.*}}
+// CHECK_EXPORT_F2_GPU-NOT: spir_kernel void @f2({{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} noalias nocapture "VCArgumentIOKind"="0" %aF, {{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} noalias nocapture "VCArgumentIOKind"="0" %aD, {{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} noalias nocapture "VCArgumentIOKind"="0" %aI)
+// CHECK_EXPORT_F2_CPU: void @f2__{{.*}}({{(float\*)|ptr}} noalias nocapture %aF, {{(double\*)|ptr}} noalias nocapture %aD, {{(i32\*)|ptr}} noalias nocapture %aI, <16 x {{.*}}> %__mask)
+// CHECK_EXPORT_F2_CPU: void @f2({{(float\*)|ptr}} noalias nocapture %aF, {{(double\*)|ptr}} noalias nocapture %aD, {{(i32\*)|ptr}} noalias nocapture %aI)
 export void f2(uniform float aF[], uniform double aD[], uniform int aI[]) {}
 
-// CHECK_TASK_F2_GPU: dllexport spir_kernel void @f2_task(i8 addrspace(1)* {{.*}} "VCArgumentIOKind"="0" %aF, i8 addrspace(1)* {{.*}} "VCArgumentIOKind"="0" %aD, i8 addrspace(1)* {{.*}} "VCArgumentIOKind"="0" %aI)  {{.*}}
+// CHECK_TASK_F2_GPU: dllexport spir_kernel void @f2_task({{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} {{.*}} "VCArgumentIOKind"="0" %aF, {{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} {{.*}} "VCArgumentIOKind"="0" %aD, {{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} {{.*}} "VCArgumentIOKind"="0" %aI)  {{.*}}
 // CHECK_TASK_F2_GPU-NOT: void @f2_task__
 // CHECK_TASK_F2_CPU: void @f2_task__{{.*}} noalias {{.*}} %0, i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 %6, i32 %7, i32 %8, i32 %9, i32 %10)
-// CHECK_TASK_F2_CPU-NOT: void @f2_task(float* noalias nocapture %aF, double* noalias nocapture %aD, i32* noalias nocapture %aI)
+// CHECK_TASK_F2_CPU-NOT: void @f2_task({{(float\*)|ptr}} noalias nocapture %aF, {{(double\*)|ptr}} noalias nocapture %aD, {{(i32\*)|ptr}} noalias nocapture %aI)
 task void f2_task(uniform float aF[], uniform double aD[], uniform int aI[]) {}
 
-// CHECK_EXPORT_F3_GPU: void @f3__{{.*}}(float* noalias nocapture %aF1, float* noalias nocapture %aF2, float %a, <16 x {{.*}}> %__mask)
-// CHECK_EXPORT_F3_GPU: spir_func void @f3(float addrspace(4)* noalias nocapture %aF1, float addrspace(4)* noalias nocapture %aF2, float %a) {{.*}}
-// CHECK_EXPORT_F3_GPU-NOT: spir_kernel void @f3(i8 addrspace(1)* noalias nocapture "VCArgumentIOKind"="0" %aF1, i8 addrspace(1)* noalias nocapture "VCArgumentIOKind"="0" %aF2, float "VCArgumentIOKind"="0" %a)
-// CHECK_EXPORT_F3_CPU: void @f3__{{.*}}(float* noalias nocapture %aF1, float* noalias nocapture %aF2, float %a, <16 x {{.*}}> %__mask)
-// CHECK_EXPORT_F3_CPU: void @f3(float* noalias nocapture %aF1, float* noalias nocapture %aF2, float %a)
+// CHECK_EXPORT_F3_GPU: void @f3__{{.*}}({{(float\*)|ptr}} noalias nocapture %aF1, {{(float\*)|ptr}} noalias nocapture %aF2, float %a, <16 x {{.*}}> %__mask)
+// CHECK_EXPORT_F3_GPU: spir_func void @f3({{(float addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias nocapture %aF1, {{(float addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias nocapture %aF2, float %a) {{.*}}
+// CHECK_EXPORT_F3_GPU-NOT: spir_kernel void @f3({{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} noalias nocapture "VCArgumentIOKind"="0" %aF1, {{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} noalias nocapture "VCArgumentIOKind"="0" %aF2, float "VCArgumentIOKind"="0" %a)
+// CHECK_EXPORT_F3_CPU: void @f3__{{.*}}({{(float\*)|ptr}} noalias nocapture %aF1, {{(float\*)|ptr}} noalias nocapture %aF2, float %a, <16 x {{.*}}> %__mask)
+// CHECK_EXPORT_F3_CPU: void @f3({{(float\*)|ptr}} noalias nocapture %aF1, {{(float\*)|ptr}} noalias nocapture %aF2, float %a)
 export void f3(uniform float aF1[], uniform float aF2[], uniform float a) {}
 
-// CHECK_TASK_F3_GPU: dllexport spir_kernel void @f3_task(i8 addrspace(1)* {{.*}} "VCArgumentIOKind"="0" %aF1, i8 addrspace(1)* {{.*}} "VCArgumentIOKind"="0" %aF2, float "VCArgumentIOKind"="0" %a)  {{.*}}
+// CHECK_TASK_F3_GPU: dllexport spir_kernel void @f3_task({{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} {{.*}} "VCArgumentIOKind"="0" %aF1, {{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} {{.*}} "VCArgumentIOKind"="0" %aF2, float "VCArgumentIOKind"="0" %a)  {{.*}}
 // CHECK_TASK_F3_GPU-NOT: void @f3_task__
 // CHECK_TASK_F3_CPU: void @f3_task__{{.*}} noalias {{.*}} %0, i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 %6, i32 %7, i32 %8, i32 %9, i32 %10)
-// CHECK_TASK_F3_CPU-NOT: void @f3_task(float* noalias nocapture %aF1, float* noalias nocapture %aF2, float %a)
+// CHECK_TASK_F3_CPU-NOT: void @f3_task({{(float\*)|ptr}} noalias nocapture %aF1, {{(float\*)|ptr}} noalias nocapture %aF2, float %a)
 task void f3_task(uniform float aF1[], uniform float aF2[], uniform float a) {}
 
-// CHECK_EXPORT_F4_GPU: void @f4__{{.*}}(float* noalias nocapture %aF1, double* noalias nocapture %aF2, float %a, <16 x {{.*}}> %__mask)
-// CHECK_EXPORT_F4_GPU: spir_func void @f4(float addrspace(4)* noalias nocapture %aF1, double addrspace(4)* noalias nocapture %aF2, float %a) {{.*}}
-// CHECK_EXPORT_F4_GPU-NOT: spir_kernel void @f4(i8 addrspace(1)* noalias nocapture "VCArgumentIOKind"="0" %aF1, i8 addrspace(1)* noalias nocapture "VCArgumentIOKind"="0" %aF2, float "VCArgumentIOKind"="0" %a)
-// CHECK_EXPORT_F4_CPU: void @f4__{{.*}}(float* noalias nocapture %aF1, double* noalias nocapture %aF2, float %a, <16 x {{.*}}> %__mask)
-// CHECK_EXPORT_F4_CPU: void @f4(float* noalias nocapture %aF1, double* noalias nocapture %aF2, float %a)
+// CHECK_EXPORT_F4_GPU: void @f4__{{.*}}({{(float\*)|ptr}} noalias nocapture %aF1, {{(double\*)|ptr}} noalias nocapture %aF2, float %a, <16 x {{.*}}> %__mask)
+// CHECK_EXPORT_F4_GPU: spir_func void @f4({{(float addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias nocapture %aF1, {{(double addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias nocapture %aF2, float %a) {{.*}}
+// CHECK_EXPORT_F4_GPU-NOT: spir_kernel void @f4({{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} noalias nocapture "VCArgumentIOKind"="0" %aF1, {{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} noalias nocapture "VCArgumentIOKind"="0" %aF2, float "VCArgumentIOKind"="0" %a)
+// CHECK_EXPORT_F4_CPU: void @f4__{{.*}}({{(float\*)|ptr}} noalias nocapture %aF1, {{(double\*)|ptr}} noalias nocapture %aF2, float %a, <16 x {{.*}}> %__mask)
+// CHECK_EXPORT_F4_CPU: void @f4({{(float\*)|ptr}} noalias nocapture %aF1, {{(double\*)|ptr}} noalias nocapture %aF2, float %a)
 export void f4(uniform float aF1[], double *uniform aF2, uniform float a) {}
 
-// CHECK_TASK_F4_GPU: dllexport spir_kernel void @f4_task(i8 addrspace(1)* {{.*}} "VCArgumentIOKind"="0" %aF1, i8 addrspace(1)* {{.*}} "VCArgumentIOKind"="0" %aF2, float "VCArgumentIOKind"="0" %a)  {{.*}}
+// CHECK_TASK_F4_GPU: dllexport spir_kernel void @f4_task({{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} {{.*}} "VCArgumentIOKind"="0" %aF1, {{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} {{.*}} "VCArgumentIOKind"="0" %aF2, float "VCArgumentIOKind"="0" %a)  {{.*}}
 // CHECK_TASK_F4_GPU-NOT: void @f4_task__
 // CHECK_TASK_F4_CPU: void @f4_task__{{.*}} noalias {{.*}} %0, i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 %6, i32 %7, i32 %8, i32 %9, i32 %10)
-// CHECK_TASK_F4_CPU-NOT: void @f4_task(float* noalias nocapture %aF1, float* noalias nocapture %aF2, float %a)
+// CHECK_TASK_F4_CPU-NOT: void @f4_task({{(float\*)|ptr}} noalias nocapture %aF1, {{(float\*)|ptr}} noalias nocapture %aF2, float %a)
 task void f4_task(uniform float aF1[], double *uniform aF2, uniform float a) {}
 
-// CHECK_EXPORT_F5_GPU: void @f5__{{.*}}(i8* noalias nocapture %_p, <16 x {{.*}}> %__mask)
-// CHECK_EXPORT_F5_GPU: spir_func void @f5(i8 addrspace(4)* noalias nocapture %_p) {{.*}}
-// CHECK_EXPORT_F5_GPU-NOT: spir_kernel void @f5(i8 addrspace(1)* noalias nocapture "VCArgumentIOKind"="0" %_p)
-// CHECK_EXPORT_F5_CPU: void @f5__{{.*}}(i8* noalias nocapture %_p, <16 x {{.*}}> %__mask)
-// CHECK_EXPORT_F5_CPU: void @f5(i8* noalias nocapture %_p)
+// CHECK_EXPORT_F5_GPU: void @f5__{{.*}}({{(i8\*)|ptr}} noalias nocapture %_p, <16 x {{.*}}> %__mask)
+// CHECK_EXPORT_F5_GPU: spir_func void @f5({{(i8 addrspace\(4\)\*|ptr addrspace\(4\))}} noalias nocapture %_p) {{.*}}
+// CHECK_EXPORT_F5_GPU-NOT: spir_kernel void @f5({{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} noalias nocapture "VCArgumentIOKind"="0" %_p)
+// CHECK_EXPORT_F5_CPU: void @f5__{{.*}}({{(i8\*)|ptr}} noalias nocapture %_p, <16 x {{.*}}> %__mask)
+// CHECK_EXPORT_F5_CPU: void @f5({{(i8\*)|ptr}} noalias nocapture %_p)
 export void f5(void *uniform _p) {}
 
-// CHECK_TASK_F5_GPU: dllexport spir_kernel void @f5_task(i8 addrspace(1)* {{.*}} "VCArgumentIOKind"="0" %_p)  {{.*}}
+// CHECK_TASK_F5_GPU: dllexport spir_kernel void @f5_task({{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}} {{.*}} "VCArgumentIOKind"="0" %_p)  {{.*}}
 // CHECK_TASK_F5_GPU-NOT: void @f5_task__
 // CHECK_TASK_F5_CPU: void @f5_task__{{.*}} noalias {{.*}} %0, i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 %6, i32 %7, i32 %8, i32 %9, i32 %10)
-// CHECK_TASK_F5_CPU-NOT: void @f5_task(i8* noalias nocapture %_p)
+// CHECK_TASK_F5_CPU-NOT: void @f5_task({{(i8\*)|ptr}} noalias nocapture %_p)
 task void f5_task(void *uniform _p) {}
 
 // CHECK_EXPORT_F6_GPU: void @f6__{{.*}}(float %a, <16 x {{.*}}> %__mask)
@@ -185,20 +185,20 @@ extern uniform int t4_call() {
 }
 
 // Check signature of extern "C" functions
-// CHECK_FUNC_GPU: declare spir_func void @t5(i32 addrspace(4)* noalias) {{.*}}
-// CHECK_FUNC_CPU: declare void @t5(i32* noalias)
+// CHECK_FUNC_GPU: declare spir_func void @t5({{(i32 addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias) {{.*}}
+// CHECK_FUNC_CPU: declare void @t5({{(i32\*)|ptr}} noalias)
 extern "C" void t5(uniform int p[]);
 // CHECK_FUNC_GPU: void @t5_call___{{.*}}
-// CHECK_FUNC_GPU: addrspacecast i32* %p to i32 addrspace(4)*
-// CHECK_FUNC_GPU: call spir_func void @t5(i32 addrspace(4)* %{{.*}})
+// CHECK_FUNC_GPU: addrspacecast {{(i32\*)|ptr}} %p to {{(i32 addrspace\(4\)\*)|(ptr addrspace\(4\))}}
+// CHECK_FUNC_GPU: call spir_func void @t5({{(i32 addrspace\(4\)\*)|(ptr addrspace\(4\))}} %{{.*}})
 
-// CHECK_FUNC_GPU: spir_func void @t5_call(i32 addrspace(4)* noalias %p) {{.*}}
-// CHECK_FUNC_GPU: call spir_func void @t5(i32 addrspace(4)* %p)
+// CHECK_FUNC_GPU: spir_func void @t5_call({{(i32 addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias %p) {{.*}}
+// CHECK_FUNC_GPU: call spir_func void @t5({{(i32 addrspace\(4\)\*)|(ptr addrspace\(4\))}} %p)
 
 // CHECK_FUNC_CPU: void @t5_call___{{.*}}
-// CHECK_FUNC_CPU: call void @t5(i32* %p)
-// CHECK_FUNC_CPU: void @t5_call(i32* noalias %p)
-// CHECK_FUNC_CPU: call void @t5(i32* %p)
+// CHECK_FUNC_CPU: call void @t5({{(i32\*)|ptr}} %p)
+// CHECK_FUNC_CPU: void @t5_call({{(i32\*)|ptr}} noalias %p)
+// CHECK_FUNC_CPU: call void @t5({{(i32\*)|ptr}} %p)
 
 export void t5_call(uniform int p[]) {
     t5(p);

--- a/tests/lit-tests/xe_kernels_spec_addrspace.ispc
+++ b/tests/lit-tests/xe_kernels_spec_addrspace.ispc
@@ -36,62 +36,62 @@ inline void contextInit(uniform Context *uniform context) {
 }
 
 // CHECK-XE: define spir_func void @swap___{{.*}}
-// CHECK-XE: define spir_func void @intersectISPC___{{.*}}(i1 %{{.*}}, %v8_uniform_Context* noalias %{{.*}}, %v8_uniform_RayHit* noalias %{{.*}}, float* noalias %{{.*}}, i8* noalias %{{.*}}, <8 x i1> %__mask)
-// CHECK-XE-NOT: addrspacecast %v8_uniform_Context addrspace(4)* %{{.*}} to %v8_uniform_Context*
-// CHECK-XE-NOT: addrspacecast %v8_uniform_RayHit addrspace(4)* %{{.*}} to %v8_uniform_RayHit*
-// CHECK-XE-NOT: addrspacecast i8 addrspace(4)* %{{.*}} to i8*
+// CHECK-XE: define spir_func void @intersectISPC___{{.*}}(i1 %{{.*}}, {{(%v8_uniform_Context\*)|ptr}} noalias %{{.*}}, {{(%v8_uniform_RayHit\*)|ptr}} noalias %{{.*}}, {{(float\*)|ptr}} noalias %{{.*}}, {{(i8\*)|ptr}} noalias %{{.*}}, <8 x i1> %__mask)
+// CHECK-XE-NOT: addrspacecast {{(%v8_uniform_Context addrspace\(4\)\*)|(ptr addrspace\(4\))}} %{{.*}} to {{(%v8_uniform_Context\*)|ptr}}
+// CHECK-XE-NOT: addrspacecast {{(%v8_uniform_RayHit addrspace\(4\)\*)|(ptr addrspace\(4\))}} %{{.*}} to {{(%v8_uniform_RayHit\*)|ptr}}
+// CHECK-XE-NOT: addrspacecast {{(i8 addrspace\(4\)\*|ptr addrspace\(4\))}} %{{.*}} to {{(i8\*)|ptr}}
 // CHECK-XE: call spir_func void @swap___{{.*}}
 
-// CHECK-XE: declare spir_func void @intersectExternal(%v8_uniform_Context addrspace(4)* noalias, %v8_uniform_RayHit addrspace(4)* noalias, float addrspace(4)* noalias, i8 addrspace(4)* noalias)
+// CHECK-XE: declare spir_func void @intersectExternal({{(%v8_uniform_Context addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias, {{(%v8_uniform_RayHit addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias, {{(float addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias, {{(i8 addrspace\(4\)\*|ptr addrspace\(4\))}} noalias)
 
-// CHECK-XE: define spir_func void @ispc_test___{{.*}}(<8 x float>* noalias %out, <8 x i1> %__mask)
+// CHECK-XE: define spir_func void @ispc_test___{{.*}}({{(<8 x float>\*)|ptr}} noalias %out, <8 x i1> %__mask)
 
-// CHECK-XE: define spir_func void @intersectISPC(i1 %{{.*}}, %v8_uniform_Context addrspace(4)* noalias %{{.*}}, %v8_uniform_RayHit addrspace(4)* noalias %{{.*}}, float addrspace(4)* noalias %{{.*}}, i8 addrspace(4)* noalias %{{.*}})
-// CHECK-XE: addrspacecast %v8_uniform_Context addrspace(4)* %{{.*}} to %v8_uniform_Context*
-// CHECK-XE: addrspacecast %v8_uniform_RayHit addrspace(4)* %{{.*}} to %v8_uniform_RayHit*
-// CHECK-XE: addrspacecast i8 addrspace(4)* %{{.*}} to i8*
+// CHECK-XE: define spir_func void @intersectISPC(i1 %{{.*}}, {{(%v8_uniform_Context addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias %{{.*}}, {{(%v8_uniform_RayHit addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias %{{.*}}, {{(float addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias %{{.*}}, {{(i8 addrspace\(4\)\*|ptr addrspace\(4\))}} noalias %{{.*}})
+// CHECK-XE: addrspacecast {{(%v8_uniform_Context addrspace\(4\)\*)|(ptr addrspace\(4\))}} %{{.*}} to {{(%v8_uniform_Context\*)|ptr}}
+// CHECK-XE: addrspacecast {{(%v8_uniform_RayHit addrspace\(4\)\*)|(ptr addrspace\(4\))}} %{{.*}} to {{(%v8_uniform_RayHit\*)|ptr}}
+// CHECK-XE: addrspacecast {{(i8 addrspace\(4\)\*|ptr addrspace\(4\))}} %{{.*}} to {{(i8\*)|ptr}}
 // CHECK-XE: call spir_func void @swap___{{.*}}
 
-// CHECK-XE: define dllexport spir_kernel void @kernel(i8 addrspace(1)*
-// CHECK-XE: addrspacecast %v8_uniform_Context* %{{.*}} to %v8_uniform_Context addrspace(4)*
-// CHECK-XE: addrspacecast %v8_uniform_RayHit* %{{.*}} to %v8_uniform_RayHit addrspace(4)*
-// CHECK-XE: addrspacecast float* %{{.*}} to float addrspace(4)*
-// CHECK-XE: addrspacecast i8* %{{.*}} to i8 addrspace(4)*
-// CHECK-XE: call spir_func void @intersectExternal(%v8_uniform_Context addrspace(4)* %{{.*}}, %v8_uniform_RayHit addrspace(4)* %{{.*}}, float addrspace(4)* %{{.*}}, i8 addrspace(4)* %{{.*}})
-// CHECK-XE: call spir_func void @intersectISPC___{{.*}}(i1 {{.*}}, %v8_uniform_Context* {{.*}}, %v8_uniform_RayHit* {{.*}}, float* {{.*}}, i8* {{.*}}, <8 x i1> {{.*}}
+// CHECK-XE: define dllexport spir_kernel void @kernel({{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}}
+// CHECK-XE: addrspacecast {{(%v8_uniform_Context\*)|ptr}} %{{.*}} to {{(%v8_uniform_Context addrspace\(4\)\*)|(ptr addrspace\(4\))}}
+// CHECK-XE: addrspacecast {{(%v8_uniform_RayHit\*)|ptr}} %{{.*}} to {{(%v8_uniform_RayHit addrspace\(4\)\*)|(ptr addrspace\(4\))}}
+// CHECK-XE: addrspacecast {{(float\*)|ptr}} %{{.*}} to {{(float addrspace\(4\)\*)|(ptr addrspace\(4\))}}
+// CHECK-XE: addrspacecast {{(i8\*)|ptr}} %{{.*}} to {{(i8 addrspace\(4\)\*|ptr addrspace\(4\))}}
+// CHECK-XE: call spir_func void @intersectExternal({{(%v8_uniform_Context addrspace\(4\)\*)|(ptr addrspace\(4\))}} %{{.*}}, {{(%v8_uniform_RayHit addrspace\(4\)\*)|(ptr addrspace\(4\))}} %{{.*}}, {{(float addrspace\(4\)\*)|(ptr addrspace\(4\))}} %{{.*}}, {{(i8 addrspace\(4\)\*|ptr addrspace\(4\))}} %{{.*}})
+// CHECK-XE: call spir_func void @intersectISPC___{{.*}}(i1 {{.*}}, {{(%v8_uniform_Context\*)|ptr}} {{.*}}, {{(%v8_uniform_RayHit\*)|ptr}} {{.*}}, {{(float\*)|ptr}} {{.*}}, {{(i8\*)|ptr}} {{.*}}, <8 x i1> {{.*}}
 
-// CHECK-XE: define spir_func void @ispc_test(<8 x float> addrspace(4)* noalias %out)
-// CHECK-XE: define dllexport spir_kernel void @ispc_kernel(i8 addrspace(1)*
-// CHECK-XE: call spir_func void @ispc_test___{{.*}}(<8 x float>* {{.*}})
+// CHECK-XE: define spir_func void @ispc_test({{(<8 x float> addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias %out)
+// CHECK-XE: define dllexport spir_kernel void @ispc_kernel({{(i8 addrspace\(1\)\*|ptr addrspace\(1\))}}
+// CHECK-XE: call spir_func void @ispc_test___{{.*}}({{(<8 x float>\*)|ptr}} {{.*}})
 
 // CHECK-CPU: define void @swap___{{.*}}
-// CHECK-CPU: define void @intersectISPC___{{.*}}(i1 %{{.*}}, %v8_uniform_Context* noalias %{{.*}}, %v8_uniform_RayHit* noalias %{{.*}}, float* noalias %{{.*}}, i8* noalias %{{.*}}, <8 x i32> %__mask)
-// CHECK-CPU-NOT: addrspacecast %v8_uniform_Context* %{{.*}} to %v8_uniform_Context addrspace(4)*
-// CHECK-CPU-NOT: addrspacecast %v8_uniform_RayHit* %{{.*}} to %v8_uniform_RayHit addrspace(4)*
-// CHECK-CPU-NOT: addrspacecast i8 addrspace(4)* %{{.*}} to i8*
+// CHECK-CPU: define void @intersectISPC___{{.*}}(i1 %{{.*}}, {{(%v8_uniform_Context\*)|ptr}} noalias %{{.*}}, {{(%v8_uniform_RayHit\*)|ptr}} noalias %{{.*}}, {{(float\*)|ptr}} noalias %{{.*}}, {{(i8\*)|ptr}} noalias %{{.*}}, <8 x i32> %__mask)
+// CHECK-CPU-NOT: addrspacecast {{(%v8_uniform_Context\*)|ptr}} %{{.*}} to {{(%v8_uniform_Context addrspace\(4\)\*)|(ptr addrspace\(4\))}}
+// CHECK-CPU-NOT: addrspacecast {{(%v8_uniform_RayHit\*)|ptr}} %{{.*}} to {{(%v8_uniform_RayHit addrspace\(4\)\*)|(ptr addrspace\(4\))}}
+// CHECK-CPU-NOT: addrspacecast {{(i8 addrspace\(4\)\*|ptr addrspace\(4\))}} %{{.*}} to {{(i8\*)|ptr}}
 // CHECK-CPU: call void @swap___{{.*}}
 
-// CHECK-CPU: declare void @intersectExternal(%v8_uniform_Context* noalias, %v8_uniform_RayHit* noalias, float* noalias, i8* noalias)
+// CHECK-CPU: declare void @intersectExternal({{(%v8_uniform_Context\*)|ptr}} noalias, {{(%v8_uniform_RayHit\*)|ptr}} noalias, {{(float\*)|ptr}} noalias, {{(i8\*)|ptr}} noalias)
 
 // CHECK-CPU: define void @kernel___{{.*}}
-// CHECK-CPU-NOT: addrspacecast %v8_uniform_Context* %{{.*}} to %v8_uniform_Context addrspace(4)*
-// CHECK-CPU-NOT: addrspacecast %v8_uniform_RayHit* %{{.*}} to %v8_uniform_RayHit addrspace(4)*
-// CHECK-CPU-NOT: addrspacecast i8* %{{.*}} to i8 addrspace(4)*
-// CHECK-CPU: call void @intersectExternal(%v8_uniform_Context* %{{.*}}, %v8_uniform_RayHit* %{{.*}}, float* %{{.*}}, i8* %{{.*}})
-// CHECK-CPU: call void @intersectISPC___{{.*}}(i1 {{.*}}, %v8_uniform_Context* {{.*}}, %v8_uniform_RayHit* {{.*}}, float* {{.*}}, i8* {{.*}}, <8 x i32> {{.*}}
+// CHECK-CPU-NOT: addrspacecast {{(%v8_uniform_Context\*)|ptr}} %{{.*}} to {{(%v8_uniform_Context addrspace\(4\)\*)|(ptr addrspace\(4\))}}
+// CHECK-CPU-NOT: addrspacecast {{(%v8_uniform_RayHit\*)|ptr}} %{{.*}} to {{(%v8_uniform_RayHit addrspace\(4\)\*)|(ptr addrspace\(4\))}}
+// CHECK-CPU-NOT: addrspacecast {{(i8\*)|ptr}} %{{.*}} to {{(i8 addrspace\(4\)\*|ptr addrspace\(4\))}}
+// CHECK-CPU: call void @intersectExternal({{(%v8_uniform_Context\*)|ptr}} %{{.*}}, {{(%v8_uniform_RayHit\*)|ptr}} %{{.*}}, {{(float\*)|ptr}} %{{.*}}, {{(i8\*)|ptr}} %{{.*}})
+// CHECK-CPU: call void @intersectISPC___{{.*}}(i1 {{.*}}, {{(%v8_uniform_Context\*)|ptr}} {{.*}}, {{(%v8_uniform_RayHit\*)|ptr}} {{.*}}, {{(float\*)|ptr}} {{.*}}, {{(i8\*)|ptr}} {{.*}}, <8 x i32> {{.*}}
 
-// CHECK-CPU: define void @ispc_test___{{.*}}(<8 x float>* noalias %out, <8 x i32> %__mask)
+// CHECK-CPU: define void @ispc_test___{{.*}}({{(<8 x float>\*)|ptr}} noalias %out, <8 x i32> %__mask)
 // CHECK-CPU: define void @ispc_kernel___{{.*}}
-// CHECK-CPU: call void @ispc_test___{{.*}}(<8 x float>* {{.*}})
+// CHECK-CPU: call void @ispc_test___{{.*}}({{(<8 x float>\*)|ptr}} {{.*}})
 
-// CHECK-CPU: define void @intersectISPC(i1 %{{.*}}, %v8_uniform_Context* noalias %{{.*}}, %v8_uniform_RayHit* noalias %{{.*}}, float* noalias %{{.*}}, i8* noalias %{{.*}})
-// CHECK-CPU-NOT: addrspacecast %v8_uniform_Context addrspace(4)* %{{.*}} to %v8_uniform_Context*
-// CHECK-CPU-NOT: addrspacecast %v8_uniform_RayHit addrspace(4)* %{{.*}} to %v8_uniform_RayHit*
-// CHECK-CPU-NOT: addrspacecast float addrspace(4)* %{{.*}} to float*
-// CHECK-CPU-NOT: addrspacecast i8 addrspace(4)* %{{.*}} to i8*
+// CHECK-CPU: define void @intersectISPC(i1 %{{.*}}, {{(%v8_uniform_Context\*)|ptr}} noalias %{{.*}}, {{(%v8_uniform_RayHit\*)|ptr}} noalias %{{.*}}, {{(float\*)|ptr}} noalias %{{.*}}, {{(i8\*)|ptr}} noalias %{{.*}})
+// CHECK-CPU-NOT: addrspacecast {{(%v8_uniform_Context addrspace\(4\)\*)|(ptr addrspace\(4\))}} %{{.*}} to {{(%v8_uniform_Context\*)|ptr}}
+// CHECK-CPU-NOT: addrspacecast {{(%v8_uniform_RayHit addrspace\(4\)\*)|(ptr addrspace\(4\))}} %{{.*}} to {{(%v8_uniform_RayHit\*)|ptr}}
+// CHECK-CPU-NOT: addrspacecast {{(float addrspace\(4\)\*)|(ptr addrspace\(4\))}} %{{.*}} to {{(float\*)|ptr}}
+// CHECK-CPU-NOT: addrspacecast {{(i8 addrspace\(4\)\*|ptr addrspace\(4\))}} %{{.*}} to {{(i8\*)|ptr}}
 // CHECK-CPU: call void @swap___{{.*}}
 
-// CHECK-CPU: define void @ispc_test(<8 x float>* noalias %out)
+// CHECK-CPU: define void @ispc_test({{(<8 x float>\*)|ptr}} noalias %out)
 // CHECK-CPU-NOT: define void @ispc_kernel(
 
 noinline void swap(uniform bool doSwap, float &a_foo, float &b_foo) { a_foo = doSwap ? b_foo : a_foo; }

--- a/tests/lit-tests/xe_regcall-1.ispc
+++ b/tests/lit-tests/xe_regcall-1.ispc
@@ -7,7 +7,7 @@
 
 // REQUIRES: XE_ENABLED
 
-//CHECK: %v16_uniform_C_Struct = type { %v16_uniform_C, i32*, <4 x float> }
+//CHECK: %v16_uniform_C_Struct = type { %v16_uniform_C, {{(i32\*)|ptr}}, <4 x float> }
 //CHECK: %v16_uniform_C = type { float, float }
 //CHECK: %v16_uniform_C1 = type { %v16_uniform_B1 }
 //CHECK: %v16_uniform_B1 = type { %v16_uniform_A1 }
@@ -15,7 +15,6 @@
 //CHECK: %v16_varying_Float = type { <16 x float> }
 //CHECK: %v16_uniform_StillPassThroughRegisters = type { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }
 //CHECK: %v16_uniform_EndsWithFlexArray = type { i32, [0 x i32] }
-//CHECK: %v16_uniform_Callback = type { <16 x float> (<16 x float>, <16 x float>, float, <16 x i1>)* }
 
 // CHECK: declare x86_regcallcc <16 x i32> @__regcall3__foo1(
 // CHECK: call x86_regcallcc <16 x i32> @__regcall3__foo1(
@@ -104,7 +103,7 @@ extern "C" __regcall uniform EndsWithFlexArray foo7(uniform int b) {
   return f;
 }
 
-// CHECK: define x86_regcallcc <16 x float> @__regcall3__foo8(float addrspace(4)* noalias nocapture {{(readonly)?}} %A, <16 x float> %b, i32 %I, <16 x i1> %mask)
+// CHECK: define x86_regcallcc <16 x float> @__regcall3__foo8({{(float addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias nocapture {{(readonly)?}} %A, <16 x float> %b, i32 %I, <16 x i1> %mask)
 extern "C" __regcall float foo8(uniform float A[], float b, uniform int I, bool mask) {
   return A[programIndex+I];
 }
@@ -113,11 +112,11 @@ struct Callback {
  float (*uniform callback)(float, float, uniform float);
 };
 
-// CHECK: define x86_regcallcc <16 x float> @__regcall3__foo9(%v16_uniform_Callback addrspace(4)* noalias nocapture readnone %callback)
+// CHECK: define x86_regcallcc <16 x float> @__regcall3__foo9({{(%v16_uniform_Callback addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias nocapture readnone %callback)
 extern "C" __regcall float foo9(Callback * uniform callback) {}
 
 // CHECK: define x86_regcallcc <16 x float> @__regcall3__foo10(<16 x i64> %ptr)
 extern "C" __regcall float foo10(uniform float* ptr) {}
 
-// CHECK: define x86_regcallcc <16 x float> @__regcall3__foo11(float addrspace(4)* noalias nocapture readnone %ptr)
+// CHECK: define x86_regcallcc <16 x float> @__regcall3__foo11({{(float addrspace\(4\)\*)|(ptr addrspace\(4\))}} noalias nocapture readnone %ptr)
 extern "C" __regcall float foo11(uniform float* uniform ptr) {}


### PR DESCRIPTION
This PR fixes ISPC build with LLVM 17.0 and lit-tests (https://github.com/ispc/ispc/issues/2633).
Support of LLVM 17.0 is not fully ready, some tests and workloads are failing currently.

