### PR TITLE
check_isa.cpp, ispc.cpp: do not assume "not arm" means "x86_64"

### DIFF
--- a/check_isa.cpp
+++ b/check_isa.cpp
@@ -19,7 +19,7 @@
 #define HOST_IS_APPLE
 #endif
 
-#if !defined(__arm__) && !defined(__aarch64__) && !defined(_M_ARM64)
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
 #if !defined(HOST_IS_WINDOWS)
 static void __cpuid(int info[4], int infoType) {
     __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(infoType));
@@ -85,12 +85,12 @@ static bool __os_enabled_amx_support() {
     return (rEAX & 0x60000) == 0x60000;
 #endif // !defined(HOST_IS_WINDOWS)
 }
-#endif // !__arm__
+#endif // !__x86_64__
 
 static const char *lGetSystemISA() {
 #if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64)
     return "ARM NEON";
-#else
+#elif defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
     int info[4];
     __cpuid(info, 1);
 
@@ -199,6 +199,8 @@ static const char *lGetSystemISA() {
     } else {
         return "Error";
     }
+#else
+#error "Unsupported host CPU architecture."
 #endif
 }
 

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -60,10 +60,10 @@ Module *ispc::m;
 // Target
 
 #if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64)
-#define ARM_HOST
+#define ISPC_HOST_IS_ARM 
 #endif
 
-#if !defined(ISPC_HOST_IS_WINDOWS) && !defined(ARM_HOST)
+#if !defined(ISPC_HOST_IS_WINDOWS) && !defined(ISPC_HOST_IS_ARM)
 // __cpuid() and __cpuidex() are defined on Windows in <intrin.h> for x86/x64.
 // On *nix they need to be defined manually through inline assembler.
 static void __cpuid(int info[4], int infoType) {
@@ -75,7 +75,7 @@ static void __cpuidex(int info[4], int level, int count) {
 }
 #endif // !ISPC_HOST_IS_WINDOWS && !__ARM__ && !__AARCH64__
 
-#ifndef ARM_HOST
+#ifndef ISPC_HOST_IS_ARM 
 static bool __os_has_avx_support() {
 #if defined(ISPC_HOST_IS_WINDOWS)
     // Check if the OS will save the YMM registers
@@ -116,10 +116,10 @@ static bool __os_has_avx512_support() {
     return (rEAX & 0xE6) == 0xE6;
 #endif // !defined(ISPC_HOST_IS_WINDOWS)
 }
-#endif // !ARM_HOST
+#endif // !ISPC_HOST_IS_ARM
 
 static ISPCTarget lGetSystemISA() {
-#ifdef ARM_HOST
+#ifdef ISPC_HOST_IS_ARM
     return ISPCTarget::neon_i32x4;
 #else
     int info[4];


### PR DESCRIPTION
currently, if you attempt to compile ispc on a host which is not x86_64 or arm, the build fails on inline assembly directives, with the reason why being potentially non-obvious. for example:

```
linear@mihari:~/code/ispc/build $ uname -m
ppc64le
linear@mihari:~/code/ispc/build $ make
[  1%] Building CXX object CMakeFiles/check_isa.dir/check_isa.cpp.o
/usr/people/linear/code/ispc/check_isa.cpp:25:36: error: invalid output constraint '=a' in asm
    __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(infoType));
                                   ^
/usr/people/linear/code/ispc/check_isa.cpp:29:36: error: invalid output constraint '=a' in asm
    __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(level), "2"(count));
                                   ^
/usr/people/linear/code/ispc/check_isa.cpp:43:53: error: invalid output constraint '=a' in asm
    __asm__ __volatile__(".byte 0x0f, 0x01, 0xd0" : "=a"(rEAX), "=d"(rEDX) : "c"(0));
                                                    ^
/usr/people/linear/code/ispc/check_isa.cpp:69:53: error: invalid output constraint '=a' in asm
    __asm__ __volatile__(".byte 0x0f, 0x01, 0xd0" : "=a"(rEAX), "=d"(rEDX) : "c"(0));
                                                    ^
/usr/people/linear/code/ispc/check_isa.cpp:84:53: error: invalid output constraint '=a' in asm
    __asm__ __volatile__(".byte 0x0f, 0x01, 0xd0" : "=a"(rEAX), "=d"(rEDX) : "c"(0));
                                                    ^
5 errors generated.
make[2]: *** [CMakeFiles/check_isa.dir/build.make:76: CMakeFiles/check_isa.dir/check_isa.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:174: CMakeFiles/check_isa.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
linear@mihari:~/code/ispc/build $
```

this is because the code currently assumes that an architecture which is not arm, must be x86_64.

this pull request makes changes to check_isa.cpp and src/ispc.cpp to explicitly check for supported architectures instead. and adding a more informative error if an unsupported host architecture is in use. it also renames the definition used in ispc.cpp to align with those used for operating system detection. after this change, attempting to build on an unsupported platform looks like this instead:
```
linear@mihari:~/code/ispc/build $ uname -m
ppc64le
linear@mihari:~/code/ispc/build $ make
[  1%] Building CXX object CMakeFiles/check_isa.dir/check_isa.cpp.o
/usr/people/linear/code/ispc/check_isa.cpp:203:2: error: "Unsupported host CPU architecture."
#error "Unsupported host CPU architecture."
 ^
1 error generated.
make[2]: *** [CMakeFiles/check_isa.dir/build.make:76: CMakeFiles/check_isa.dir/check_isa.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:174: CMakeFiles/check_isa.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
linear@mihari:~/code/ispc/build $
```