### PR TITLE
Enable nontrivial unswitch in Simple Loop Unswitch

### DIFF
--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -641,7 +641,8 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
             // not efficient for Xe targets. Moreover when this pass is used
             // some integer division tests are failing on TGLLP Windows.
             // Disable this pass on Xe until the problem is fixed on BE side.
-            optPM.addLoopPass(llvm::SimpleLoopUnswitchPass(false), 293);
+            // Note: enable both trivial and non-trivial loop unswitching.
+            optPM.addLoopPass(llvm::SimpleLoopUnswitchPass(true /* NonTrivial */, true /* Trivial */), 293);
         }
         optPM.commitLoopToFunctionPassManager(true, true);
 

--- a/tests/lit-tests/blend-curves-loop.ispc
+++ b/tests/lit-tests/blend-curves-loop.ispc
@@ -1,0 +1,19 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s
+
+// CHECK-LABEL: @foo(
+// CHECK: foreach_full_body.lr.ph:
+// CHECK: br i1 [[TMP:%.*]], label %[[FOREACH_SPLIT_US:.*]], label %[[FOREACH_SPLIT:.*]]
+// CHECK: [[FOREACH_SPLIT_US]]:
+// CHECK: [[FOREACH_SPLIT]]:
+// CHECK: foreach_reset:
+export void foo(const uniform uint32 input[], uniform uint32 output[],
+                const uniform int index, const uniform int n)
+{
+    foreach (i = 0 ... n) {
+        if (index == 0) {
+                output[i] = input[i];
+        } else {
+                output[i] |= input[i];
+        }
+    }
+}


### PR DESCRIPTION
Before v1.20.0, ISPC used LoopUnswitch that was removed and changed by SimpleLoopUnswitch in LLVM 15. However, it stops to optimize by default loops like this:
```
export void foo(const uniform uint32 input[], uniform uint32 output[],
                const uniform int index)
{
    foreach (i = 0 ... 32) {
        if (index == 0) {
                output[i] = input[i];
        } else {
                output[i] |= input[i];
        }
    }
}
```
To turn on unswithcing for this loop with SimpleLoopUnswitch, we need to enable unswitching of untrivial loops with --enable-nontrivial-unswitch.