### PR TITLE
Fix CI and skip xe builds for full tests

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -552,6 +552,7 @@ jobs:
   # Test xe release version
   linux-test-xe-llvm16-release:
     needs: [define-flow, linux-build-ispc-xe-llvm16-release]
+    if: ${{ needs.define-flow.outputs.flow_type == 'smoke' }}
     runs-on: ubuntu-latest
     continue-on-error: false
     strategy:
@@ -1258,6 +1259,7 @@ jobs:
 
   win-test-xe-llvm16-release:
     needs: [define-flow, win-build-ispc-xe-llvm16-release]
+    if: ${{ needs.define-flow.outputs.flow_type == 'smoke' }}
     env:
       LLVM_HOME: "C:\\projects\\llvm"
     runs-on: windows-2022

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 # ispc CMakeLists.txt
 #
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -276,7 +276,10 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Version.cmake)
 # Get ispc version
 get_ispc_version("${CMAKE_CURRENT_SOURCE_DIR}/common/version.h")
 
-find_package(Python3 REQUIRED)
+# tests/lit-tests/lit.cfg uses distutils that removed since python3.12
+# GitHub Windows images has recently installed this although they have older versions alongside.
+# Unfortunately, range syntax requires cmake 3.19 at least.
+find_package(Python3 3.6...<3.12 REQUIRED)
     if (NOT Python3_Interpreter_FOUND)
         message(FATAL_ERROR "Python interpreter is not found")
     endif()

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -2,6 +2,10 @@ import os
 import platform
 import shutil
 import subprocess
+
+# distutils deprecated and removed since python 3.12
+# consider to use instead
+# from packaging.version import Version as LooseVersion
 from distutils.version import LooseVersion
 
 import lit.formats


### PR DESCRIPTION
This PR fixes the failing jobs in Test pipeline on windows (like [here]( https://github.com/ispc/ispc/actions/runs/6563815552/job/17828914206)) and skips xe-tests jobs in `full` run of this pipeline.

Jobs started  to fail because GitHub Windows runners updated python version up to 3.12.

test/lit-tests/lit.cfg [imports](https://github.com/ispc/ispc/blob/163b9904ed893d279908c8123e52597fd1b627c8/tests/lit-tests/lit.cfg#L5) distutils package that is deprecated and removed since python 3.12. GitHub Windows runners updated their environment to include 3.12 version.

We may use different package, e.g., packaging, but we need to install it. Windows GitHub runner images have quite strange environment where there are several python installations. I didn't manage to force pip to install packaging into python 3.12 (it considers only 3.7). By default, cmake finds the latest python version (3.12).

The most reasonable fix is explicitly require a specific range of supported Python versions (3.6 ... <3.12) in find_package invocation. Unfortunately, this syntax is supported since cmake 3.19.