### PR TITLE
Fix stability runs

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -333,8 +333,7 @@ jobs:
     - name: Running tests
       run: |
         echo PATH=$PATH
-        # Just sanity check for 14.0
-        ./alloy.py -r --only="stability current -O2" --only-targets="avx2-i32x8" --time --update-errors=FP
+        ./alloy.py -r --only="stability current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
 
     - name: Check
       run: |
@@ -1104,8 +1103,7 @@ jobs:
       run: |
         $env:ISPC_HOME = "$pwd"
         .github/workflows/scripts/load-vs-env.ps1 "${{ matrix.arch }}"
-        # Just sanity check for 14.0
-        python .\alloy.py -r --only="stability ${{ matrix.arch }} current -O2" --only-targets="avx2-i32x8" --time --update-errors=FP
+        python .\alloy.py -r --only="stability ${{ matrix.arch }} current ${{ needs.define-flow.outputs.tests_optsets }}" --only-targets="${{ matrix.target }}" --time --update-errors=FP
 
     - name: Check
       run: |


### PR DESCRIPTION
This PR fixes two issues with the full Tests pipeline:
1. Full Test pipeline has strange failures and hangs for win-tests on x86 avx1 targets. It is caused by misconfiguration in alloy.py code that resulted in same tests had been run twice: the first time natively on hardware, the second time in SDE. Targets after AVX1.1 have to include both AVX and AVX1.1 otherwise one of them will run under SDE.
2. LLVM14 tests jobs are matrix and have to be run with matrix arguments.