### PR TITLE
Fix casting of bool short vectors to numeric ones

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -6301,7 +6301,7 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_FLOAT16: {
         switch (basicFromType) {
         case AtomicType::TYPE_BOOL:
-            if (fromType->IsVaryingAtomicOrUniformVectorType())
+            if (fromType->IsVaryingAtomic())
                 // If we have a bool vector of non-i1 elements, first
                 // truncate down to a single bit.
                 exprVal = ctx->SwitchBoolSize(exprVal, LLVMTypes::Int1VectorType, cOpName);
@@ -6355,7 +6355,7 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_FLOAT: {
         switch (basicFromType) {
         case AtomicType::TYPE_BOOL:
-            if (fromType->IsVaryingAtomicOrUniformVectorType())
+            if (fromType->IsVaryingAtomic())
                 // If we have a bool vector of non-i1 elements, first
                 // truncate down to a single bit.
                 exprVal = ctx->SwitchBoolSize(exprVal, LLVMTypes::Int1VectorType, cOpName);
@@ -6409,7 +6409,7 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_DOUBLE: {
         switch (basicFromType) {
         case AtomicType::TYPE_BOOL:
-            if (fromType->IsVaryingAtomicOrUniformVectorType())
+            if (fromType->IsVaryingAtomic())
                 // truncate bool vector values to i1s if necessary.
                 exprVal = ctx->SwitchBoolSize(exprVal, LLVMTypes::Int1VectorType, cOpName);
             cast = ctx->CastInst(llvm::Instruction::UIToFP, // unsigned int to double
@@ -6460,7 +6460,7 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_INT8: {
         switch (basicFromType) {
         case AtomicType::TYPE_BOOL:
-            if (fromType->IsVaryingAtomicOrUniformVectorType())
+            if (fromType->IsVaryingAtomic())
                 exprVal = ctx->SwitchBoolSize(exprVal, LLVMTypes::Int1VectorType, cOpName);
             cast = ctx->ZExtInst(exprVal, targetType, cOpName);
             break;
@@ -6490,8 +6490,9 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_UINT8: {
         switch (basicFromType) {
         case AtomicType::TYPE_BOOL:
-            if (fromType->IsVaryingAtomicOrUniformVectorType())
+            if (fromType->IsVaryingAtomic()) {
                 exprVal = ctx->SwitchBoolSize(exprVal, LLVMTypes::Int1VectorType, cOpName);
+            }
             cast = ctx->ZExtInst(exprVal, targetType, cOpName);
             break;
         case AtomicType::TYPE_INT8:
@@ -6526,7 +6527,7 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_INT16: {
         switch (basicFromType) {
         case AtomicType::TYPE_BOOL:
-            if (fromType->IsVaryingAtomicOrUniformVectorType())
+            if (fromType->IsVaryingAtomic())
                 exprVal = ctx->SwitchBoolSize(exprVal, LLVMTypes::Int1VectorType, cOpName);
             cast = ctx->ZExtInst(exprVal, targetType, cOpName);
             break;
@@ -6560,7 +6561,7 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_UINT16: {
         switch (basicFromType) {
         case AtomicType::TYPE_BOOL:
-            if (fromType->IsVaryingAtomicOrUniformVectorType())
+            if (fromType->IsVaryingAtomic())
                 exprVal = ctx->SwitchBoolSize(exprVal, LLVMTypes::Int1VectorType, cOpName);
             cast = ctx->ZExtInst(exprVal, targetType, cOpName);
             break;
@@ -6600,7 +6601,7 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_INT32: {
         switch (basicFromType) {
         case AtomicType::TYPE_BOOL:
-            if (fromType->IsVaryingAtomicOrUniformVectorType())
+            if (fromType->IsVaryingAtomic())
                 exprVal = ctx->SwitchBoolSize(exprVal, LLVMTypes::Int1VectorType, cOpName);
             cast = ctx->ZExtInst(exprVal, targetType, cOpName);
             break;
@@ -6634,7 +6635,7 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_UINT32: {
         switch (basicFromType) {
         case AtomicType::TYPE_BOOL:
-            if (fromType->IsVaryingAtomicOrUniformVectorType())
+            if (fromType->IsVaryingAtomic())
                 exprVal = ctx->SwitchBoolSize(exprVal, LLVMTypes::Int1VectorType, cOpName);
             cast = ctx->ZExtInst(exprVal, targetType, cOpName);
             break;
@@ -6686,7 +6687,7 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_INT64: {
         switch (basicFromType) {
         case AtomicType::TYPE_BOOL:
-            if (fromType->IsVaryingAtomicOrUniformVectorType())
+            if (fromType->IsVaryingAtomic())
                 exprVal = ctx->SwitchBoolSize(exprVal, LLVMTypes::Int1VectorType, cOpName);
             cast = ctx->ZExtInst(exprVal, targetType, cOpName);
             break;
@@ -6718,7 +6719,7 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_UINT64: {
         switch (basicFromType) {
         case AtomicType::TYPE_BOOL:
-            if (fromType->IsVaryingAtomicOrUniformVectorType())
+            if (fromType->IsVaryingAtomic())
                 exprVal = ctx->SwitchBoolSize(exprVal, LLVMTypes::Int1VectorType, cOpName);
             cast = ctx->ZExtInst(exprVal, targetType, cOpName);
             break;
@@ -6768,7 +6769,7 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_BOOL: {
         switch (basicFromType) {
         case AtomicType::TYPE_BOOL:
-            if (fromType->IsVaryingAtomicOrUniformVectorType()) {
+            if (fromType->IsVaryingAtomic()) {
                 // truncate bool vector values to i1s if necessary.
                 exprVal = ctx->SwitchBoolSize(exprVal, LLVMTypes::Int1VectorType, cOpName);
             }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -157,6 +157,10 @@ bool Type::IsVaryingAtomicOrUniformVectorType() const {
             (CastType<VectorType>(this) != nullptr && IsUniformType()));
 }
 
+bool Type::IsVaryingAtomic() const { return IsAtomicType() && IsVaryingType(); }
+
+bool Type::IsUniformVector() const { return IsVectorType() && IsUniformType(); }
+
 bool Type::IsReferenceType() const { return (CastType<ReferenceType>(this) != nullptr); }
 
 bool Type::IsVectorType() const { return (CastType<VectorType>(this) != nullptr); }

--- a/src/type.h
+++ b/src/type.h
@@ -105,6 +105,12 @@ class Type : public Traceable {
     /** Returns true if the underlying type is an varying atomic or uniform vector type */
     bool IsVaryingAtomicOrUniformVectorType() const;
 
+    /** Returns true if the underlying type is a varying atomic type */
+    bool IsVaryingAtomic() const;
+
+    /** Returns true if the underlying type is an uniform vector type */
+    bool IsUniformVector() const;
+
     /** Returns true if the underlying type is a reference type */
     bool IsReferenceType() const;
 

--- a/tests/lit-tests/2689-2.ispc
+++ b/tests/lit-tests/2689-2.ispc
@@ -1,0 +1,18 @@
+// RUN: %{ispc} --pic -O2 --target=host %s -o %t.o
+// RUN: %{cc} %t.o -o %t.bin
+// RUN: %t.bin | FileCheck %s
+
+// REQUIRES: !MACOS_HOST
+
+uniform uint8<3> foo(uniform uint8<3> a, uniform uint8<3> b) { return a < b; }
+
+// CHECK: 0 1 0
+
+extern "C" uniform int main() {
+    uniform uint8<3> a = { 5, 3, 9 };
+    uniform uint8<3> b = { 1, 8, 2 };
+
+    uniform uint8<3> r = foo(a, b);
+    print("% % %\n", r[0], r[1], r[2]);
+    return 0;
+}

--- a/tests/lit-tests/2689-3.ispc
+++ b/tests/lit-tests/2689-3.ispc
@@ -1,0 +1,18 @@
+// RUN: %{ispc} --pic -O2 --target=host %s -o %t.o
+// RUN: %{cc} %t.o -o %t.bin
+// RUN: %t.bin | FileCheck %s
+
+// REQUIRES: !MACOS_HOST
+
+uniform float<3> foo(uniform float<3> a, uniform float<3> b) { return a < b; }
+
+// CHECK: 0.000000 1.000000 0.000000
+
+extern "C" uniform int main() {
+    uniform float<3> a = { 5., 3., 9. };
+    uniform float<3> b = { 1., 8., 2. };
+
+    uniform float<3> r = foo(a, b);
+    print("% % %\n", r[0], r[1], r[2]);
+    return 0;
+}

--- a/tests/lit-tests/2689.ispc
+++ b/tests/lit-tests/2689.ispc
@@ -1,0 +1,24 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s --check-prefix=COMMON
+// RUN: %{ispc} --target=avx512skx-x32 --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s --check-prefix=AVX512_X32
+// RUN: %{ispc} --target=avx512skx-x16 --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s --check-prefix=COMMON
+// RUN: %{ispc} --target=avx2-i32x4 --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s --check-prefix=COMMON
+
+// COMMON-LABEL: @foo___unT_3C_4_3E_unT_3C_4_3E_(
+// COMMON-NEXT: allocas:
+// COMMON-NEXT: [[CMP:%.*]] = icmp ult <4 x i8> %a, %b
+// COMMON-NEXT: [[CAST:%.*]] = zext <4 x i1> [[CMP]] to <4 x i8>
+// COMMON-NEXT: ret <4 x i8> [[CAST]]
+
+// By some reason, avx512-x32 has 8 wide vector for uint8<4>, x64 has 16
+// AVX512_X32-LABEL: @foo___unT_3C_4_3E_unT_3C_4_3E_(
+// AVX512_X32-NEXT: allocas:
+// AVX512_X32-NEXT: [[CMP:%.*]] = icmp ult <8 x i8> %a, %b
+// AVX512_X32-NEXT: [[CAST:%.*]] = zext <8 x i1> [[CMP]] to <8 x i8>
+// AVX512_X32-NEXT: ret <8 x i8> [[CAST]]
+
+// REQUIRES: X86_ENABLED
+
+uniform uint8<4> foo(uniform uint8<4> a, uniform uint8<4> b)
+{
+	return a < b;
+}

--- a/tests/lit-tests/bool-casts-varying.ispc
+++ b/tests/lit-tests/bool-casts-varying.ispc
@@ -1,0 +1,91 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s
+
+// CHECK-LABEL: @to_float16___vyhvyh(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = fcmp olt <[[WIDTH:.*]] x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = uitofp <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x [[TYPE]]>
+// CHECK-NEXT: ret <[[WIDTH]] x [[TYPE]]> [[CAST]]
+
+float16 to_float16(float16 a, float16 b) { return a < b; }
+
+// CHECK-LABEL: @to_float___vyfvyf(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = fcmp olt <[[WIDTH:.*]] x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = uitofp <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x [[TYPE]]>
+// CHECK-NEXT: ret <[[WIDTH]] x [[TYPE]]> [[CAST]]
+
+float to_float(float a, float b) { return a < b; }
+
+// CHECK-LABEL: @to_double___vydvyd(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = fcmp olt <[[WIDTH:.*]] x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = uitofp <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x [[TYPE]]>
+// CHECK-NEXT: ret <[[WIDTH]] x [[TYPE]]> [[CAST]]
+
+double to_double(double a, double b) { return a < b; }
+
+// CHECK-LABEL: @to_int8___vytvyt(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp slt <[[WIDTH:.*]] x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x [[TYPE]]>
+// CHECK-NEXT: ret <[[WIDTH]] x [[TYPE]]> [[CAST]]
+
+int8 to_int8(int8 a, int8 b) { return a < b; }
+
+// CHECK-LABEL: @to_uint8___vyTvyT(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp ugt <[[WIDTH:.*]] x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x [[TYPE]]>
+// CHECK-NEXT: ret <[[WIDTH]] x [[TYPE]]> [[CAST]]
+
+uint8 to_uint8(uint8 a, uint8 b) { return a > b; }
+
+// CHECK-LABEL: @to_int16___vysvys(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp slt <[[WIDTH:.*]] x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x [[TYPE]]>
+// CHECK-NEXT: ret <[[WIDTH]] x [[TYPE]]> [[CAST]]
+
+int16 to_int16(int16 a, int16 b) { return a < b; }
+
+// CHECK-LABEL: @to_uint16___vySvyS(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp ugt <[[WIDTH:.*]] x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x [[TYPE]]>
+// CHECK-NEXT: ret <[[WIDTH]] x [[TYPE]]> [[CAST]]
+
+uint16 to_uint16(uint16 a, uint16 b) { return a > b; }
+
+// CHECK-LABEL: @to_int32___vyivyi(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp slt <[[WIDTH:.*]] x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x [[TYPE]]>
+// CHECK-NEXT: ret <[[WIDTH]] x [[TYPE]]> [[CAST]]
+
+int32 to_int32(int32 a, int32 b) { return a < b; }
+
+// CHECK-LABEL: @to_uint32___vyuvyu(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp ugt <[[WIDTH:.*]] x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x [[TYPE]]>
+// CHECK-NEXT: ret <[[WIDTH]] x [[TYPE]]> [[CAST]]
+
+uint32 to_uint32(uint32 a, uint32 b) { return a > b; }
+
+// CHECK-LABEL: @to_int64___vyIvyI(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp slt <[[WIDTH:.*]] x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x [[TYPE]]>
+// CHECK-NEXT: ret <[[WIDTH]] x [[TYPE]]> [[CAST]]
+
+int64 to_int64(int64 a, int64 b) { return a < b; }
+
+// CHECK-LABEL: @to_uint64___vyUvyU(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp ugt <[[WIDTH:.*]] x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x [[TYPE]]>
+// CHECK-NEXT: ret <[[WIDTH]] x [[TYPE]]> [[CAST]]
+
+uint64 to_uint64(uint64 a, uint64 b) { return a > b; }
+
+bool to_bool(bool a, bool b) { return a == b; }

--- a/tests/lit-tests/bool-casts-vectors.ispc
+++ b/tests/lit-tests/bool-casts-vectors.ispc
@@ -1,0 +1,97 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s
+
+// CHECK-LABEL: @to_float16___unh_3C_4_3E_unh_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = fcmp olt <4 x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = uitofp <4 x i1> [[CMP]] to <4 x [[TYPE]]>
+// CHECK-NEXT: ret <4 x [[TYPE]]> [[CAST]]
+
+uniform float16<4> to_float16(uniform float16<4> a, uniform float16<4> b) { return a < b; }
+
+// CHECK-LABEL: @to_float___unf_3C_4_3E_unf_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = fcmp olt <4 x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = uitofp <4 x i1> [[CMP]] to <4 x [[TYPE]]>
+// CHECK-NEXT: ret <4 x [[TYPE]]> [[CAST]]
+
+uniform float<4> to_float(uniform float<4> a, uniform float<4> b) { return a < b; }
+
+// CHECK-LABEL: @to_double___und_3C_4_3E_und_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = fcmp olt <4 x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = uitofp <4 x i1> [[CMP]] to <4 x [[TYPE]]>
+// CHECK-NEXT: ret <4 x [[TYPE]]> [[CAST]]
+
+uniform double<4> to_double(uniform double<4> a, uniform double<4> b) { return a < b; }
+
+// CHECK-LABEL: @to_int8___unt_3C_4_3E_unt_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp slt <4 x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <4 x i1> [[CMP]] to <4 x [[TYPE]]>
+// CHECK-NEXT: ret <4 x [[TYPE]]> [[CAST]]
+
+uniform int8<4> to_int8(uniform int8<4> a, uniform int8<4> b) { return a < b; }
+
+// CHECK-LABEL: @to_uint8___unT_3C_4_3E_unT_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp ugt <4 x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <4 x i1> [[CMP]] to <4 x [[TYPE]]>
+// CHECK-NEXT: ret <4 x [[TYPE]]> [[CAST]]
+
+uniform uint8<4> to_uint8(uniform uint8<4> a, uniform uint8<4> b) { return a > b; }
+
+// CHECK-LABEL: @to_int16___uns_3C_4_3E_uns_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp slt <4 x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <4 x i1> [[CMP]] to <4 x [[TYPE]]>
+// CHECK-NEXT: ret <4 x [[TYPE]]> [[CAST]]
+
+uniform int16<4> to_int16(uniform int16<4> a, uniform int16<4> b) { return a < b; }
+
+// CHECK-LABEL: @to_uint16___unS_3C_4_3E_unS_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp ugt <4 x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <4 x i1> [[CMP]] to <4 x [[TYPE]]>
+// CHECK-NEXT: ret <4 x [[TYPE]]> [[CAST]]
+
+uniform uint16<4> to_uint16(uniform uint16<4> a, uniform uint16<4> b) { return a > b; }
+
+// CHECK-LABEL: @to_int32___uni_3C_4_3E_uni_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp slt <4 x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <4 x i1> [[CMP]] to <4 x [[TYPE]]>
+// CHECK-NEXT: ret <4 x [[TYPE]]> [[CAST]]
+
+uniform int32<4> to_int32(uniform int32<4> a, uniform int32<4> b) { return a < b; }
+
+// CHECK-LABEL: @to_uint32___unu_3C_4_3E_unu_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp ugt <4 x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <4 x i1> [[CMP]] to <4 x [[TYPE]]>
+// CHECK-NEXT: ret <4 x [[TYPE]]> [[CAST]]
+
+uniform uint32<4> to_uint32(uniform uint32<4> a, uniform uint32<4> b) { return a > b; }
+
+// CHECK-LABEL: @to_int64___unI_3C_4_3E_unI_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp slt <4 x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <4 x i1> [[CMP]] to <4 x [[TYPE]]>
+// CHECK-NEXT: ret <4 x [[TYPE]]> [[CAST]]
+
+uniform int64<4> to_int64(uniform int64<4> a, uniform int64<4> b) { return a < b; }
+
+// CHECK-LABEL: @to_uint64___unU_3C_4_3E_unU_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp ugt <4 x [[TYPE:.*]]> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = zext <4 x i1> [[CMP]] to <4 x [[TYPE]]>
+// CHECK-NEXT: ret <4 x [[TYPE]]> [[CAST]]
+
+uniform uint64<4> to_uint64(uniform uint64<4> a, uniform uint64<4> b) { return a > b; }
+
+// CHECK-LABEL: @to_bool___unb_3C_4_3E_unb_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[XOR:%.*]] = xor <4 x i1> %a, %b
+// CHECK-NEXT: [[NE:%.*]] = xor <4 x i1> [[XOR]], <i1 true, i1 true, i1 true, i1 true>
+// CHECK-NEXT: ret <4 x i1> [[NE]]
+
+uniform bool<4> to_bool(uniform bool<4> a, uniform bool<4> b) { return a == b; }

--- a/tests/lit-tests/bool-store-varying.ispc
+++ b/tests/lit-tests/bool-store-varying.ispc
@@ -1,0 +1,62 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s --check-prefix=COMMON
+// RUN: %{ispc} --target=avx512skx-x64 --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s --check-prefixes=COMMON,AVX512
+// RUN: %{ispc} --target=avx512skx-x32 --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s --check-prefixes=COMMON,AVX512
+// RUN: %{ispc} --target=avx512skx-x16 --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s --check-prefixes=COMMON,AVX512
+// RUN: %{ispc} --target=avx2-i32x4 --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s --check-prefixes=COMMON,AVX2
+
+// REQUIRES: X86_ENABLED
+
+// COMMON-LABEL: @y
+// COMMON: local_unnamed_addr global <[[WIDTH:.*]] x i8> zeroinitializer
+
+// COMMON-LABEL: @x
+// COMMON: local_unnamed_addr global i8 0
+bool y;
+
+uniform bool x;
+
+// COMMON-LABEL: @foo___vyTvyT(
+// COMMON-NEXT: allocas:
+// COMMON-NEXT: [[CMP:%.*]] = icmp ult <[[WIDTH]] x i8> %a, %b
+// COMMON-NEXT: [[CAST:%.*]] = sext <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x i8>
+// COMMON-NEXT: store <[[WIDTH]] x i8> [[CAST]], {{.*}} @y
+// COMMON-NEXT: ret void
+
+void foo(uint8 a, uint8 b)
+{
+    y = a < b;
+}
+
+// Note:
+// bool type has two different representations in ISPC: storage and register.
+// Storage representation is governed by C++ compatiblity (i8), whereas
+// register representation matches ABI (arguments passing) (i1). Moreover,
+// varying vectors of bool matches masks bit count, so they have different
+// element type (i1, i8, i16, i32, i64) for different archs (see
+// src/llvmutil.cpp BoolVectoType).
+
+// AVX2: define void @boo___vyb(<[[WIDTH]] x [[RTYPE:i[0-9]+]]> %a, <[[WIDTH]] x [[RTYPE]]> %__mask)
+// AVX2-NEXT: allocas:
+// AVX2-NEXT: [[CAST:%.*]] = trunc <[[WIDTH]] x [[RTYPE]]> %a to <[[WIDTH]] x i8>
+// AVX2-NEXT: store <[[WIDTH]] x i8> [[CAST]], {{.*}} @y
+// AVX2-NEXT: ret void
+
+// AVX512: define void @boo___vyb(<[[WIDTH]] x [[RTYPE:i[0-9]+]]> %a, <[[WIDTH]] x [[RTYPE]]> %__mask)
+// AVX512-NEXT: allocas:
+// AVX512-NEXT: [[CAST:%.*]] = sext <[[WIDTH]] x [[RTYPE]]> %a to <[[WIDTH]] x i8>
+// AVX512-NEXT: store <[[WIDTH]] x i8> [[CAST]], {{.*}} @y
+// AVX512-NEXT: ret void
+
+void boo(bool a) {
+    y = a;
+}
+
+// COMMON: define void @coo___unb(i1 %a
+// COMMON-NEXT: allocas:
+// COMMON-NEXT: [[CAST:%.*]] = sext i1 %a to i8
+// COMMON-NEXT: store i8 [[CAST]], {{.*}} @x
+// COMMON-NEXT: ret void
+
+void coo(uniform bool a) {
+    x = a;
+}

--- a/tests/lit-tests/bool-store-vector.ispc
+++ b/tests/lit-tests/bool-store-vector.ispc
@@ -1,0 +1,25 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s
+
+uniform bool<4> x;
+
+// CHECK-LABEL: @foo___unT_3C_4_3E_unT_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CMP:%.*]] = icmp ult <4 x i8> %a, %b
+// CHECK-NEXT: [[CAST:%.*]] = sext <4 x i1> [[CMP]] to <4 x i8>
+// CHECK-NEXT: store <4 x i8> [[CAST]], {{.*}} @x
+// CHECK-NEXT: ret void
+
+void foo(uniform uint8<4> a, uniform uint8<4> b)
+{
+    x = a < b;
+}
+
+// CHECK-LABEL: @boo___unb_3C_4_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT: [[CAST:%.*]] = sext <4 x i1> %a to <4 x i8>
+// CHECK-NEXT: store <4 x i8> [[CAST]], {{.*}} @x
+// CHECK-NEXT: ret void
+
+void boo(uniform bool<4> a) {
+    x = a;
+}


### PR DESCRIPTION
This PR fixes #2689.

ISPC generated a cast like this:
```c
%19 = sext <4 x i1> %18 to <8 x i1>, !dbg !24061
```
by this https://github.com/ispc/ispc/blob/5725fb8d495980af52b417ae0c7a89e2a258d2bd/src/expr.cpp#L6494

`LLVMTypes::Int1VectorType` always has target width whereas short vector length can be different.