### PR TITLE
Fix static const declaration of bool types

### DIFF
--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -160,7 +160,7 @@ void DeclStmt::EmitCode(FunctionEmitContext *ctx) const {
             }
         }
 
-        llvm::Type *llvmType = sym->type->LLVMType(g->ctx);
+        llvm::Type *llvmType = sym->type->LLVMStorageType(g->ctx);
         if (llvmType == nullptr) {
             AssertPos(pos, m->errorCount > 0);
             return;
@@ -185,7 +185,7 @@ void DeclStmt::EmitCode(FunctionEmitContext *ctx) const {
                     initExpr = ::Optimize(initExpr);
                 }
 
-                std::pair<llvm::Constant *, bool> cinitPair = initExpr->GetConstant(sym->type);
+                std::pair<llvm::Constant *, bool> cinitPair = initExpr->GetStorageConstant(sym->type);
                 cinit = cinitPair.first;
                 if (cinit == nullptr)
                     Error(initExpr->pos,

--- a/tests/lit-tests/2333.ispc
+++ b/tests/lit-tests/2333.ispc
@@ -1,0 +1,24 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib -O2 %s -o %t.o
+
+#if   TARGET_WIDTH == 2
+#define INITIALIZER 1,0,
+#elif TARGET_WIDTH == 4
+#define INITIALIZER 1,0,1,0,
+#elif TARGET_WIDTH == 8
+#define INITIALIZER 1,0,1,0,1,0,1,0,
+#elif TARGET_WIDTH == 16
+#define INITIALIZER 1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,
+#elif TARGET_WIDTH == 32
+#define INITIALIZER 1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,
+#elif TARGET_WIDTH == 64
+#define INITIALIZER 1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,
+#endif
+
+void foo( uniform float dst[], const uniform uint32 baseIndex, const varying float src )
+{
+    static const varying bool mask = { INITIALIZER };  // crashes
+    if ( mask != 0 )
+    {
+        dst[baseIndex+programIndex] = src;
+    }
+}

--- a/tests/lit-tests/init-const-arrays.ispc
+++ b/tests/lit-tests/init-const-arrays.ispc
@@ -1,0 +1,96 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib --debug-phase=first:first --emit-llvm-text %s -o - | FileCheck %s
+
+// CHECK: @glb_goo_bool = global [4 x i8] c"\FF\00\FF\00"
+// CHECK: @glb_goo_int8 = global [4 x i8] c"\01\00\01\00"
+// CHECK: @glb_goo_uint8 = global [4 x i8] c"\01\00\01\00"
+// CHECK: @glb_goo_int16 = global [4 x i16] [i16 1, i16 0, i16 1, i16 0]
+// CHECK: @glb_goo_uint16 = global [4 x i16] [i16 1, i16 0, i16 1, i16 0]
+// CHECK: @glb_goo_int32 = global [4 x i32] [i32 1, i32 0, i32 1, i32 0]
+// CHECK: @glb_goo_uint32 = global [4 x i32] [i32 1, i32 0, i32 1, i32 0]
+// CHECK: @glb_goo_int64 = global [4 x i64] [i64 1, i64 0, i64 1, i64 0]
+// CHECK: @glb_goo_uint64 = global [4 x i64] [i64 1, i64 0, i64 1, i64 0]
+// CHECK: @glb_goo_float = global [4 x float] [float 1.000000e+00, float 0.000000e+00, float 1.000000e+00, float 0.000000e+00]
+// CHECK: @glb_goo_double = global [4 x double] [double 1.000000e+00, double 0.000000e+00, double 1.000000e+00, double 0.000000e+00]
+
+// CHECK: @static.{{[0-9]+}}.v_foo_bool = internal constant [4 x i8] c"\FF\00\FF\00"
+// CHECK: @static.{{[0-9]+}}.v_foo_int8 = internal constant [4 x i8] c"\01\00\01\00"
+// CHECK: @static.{{[0-9]+}}.v_foo_uint8 = internal constant [4 x i8] c"\01\00\01\00"
+// CHECK: @static.{{[0-9]+}}.v_foo_int16 = internal constant [4 x i16] [i16 1, i16 0, i16 1, i16 0]
+// CHECK: @static.{{[0-9]+}}.v_foo_uint16 = internal constant [4 x i16] [i16 1, i16 0, i16 1, i16 0]
+// CHECK: @static.{{[0-9]+}}.v_foo_int32 = internal constant [4 x i32] [i32 1, i32 0, i32 1, i32 0]
+// CHECK: @static.{{[0-9]+}}.v_foo_uint32 = internal constant [4 x i32] [i32 1, i32 0, i32 1, i32 0]
+// CHECK: @static.{{[0-9]+}}.v_foo_int64 = internal constant [4 x i64] [i64 1, i64 0, i64 1, i64 0]
+// CHECK: @static.{{[0-9]+}}.v_foo_uint64 = internal constant [4 x i64] [i64 1, i64 0, i64 1, i64 0]
+// CHECK: @static.{{[0-9]+}}.v_foo_float = internal constant [4 x float] [float 1.000000e+00, float 0.000000e+00, float 1.000000e+00, float 0.000000e+00]
+// CHECK: @static.{{[0-9]+}}.v_foo_double = internal constant [4 x double] [double 1.000000e+00, double 0.000000e+00, double 1.000000e+00, double 0.000000e+00]
+
+// CHECK: @const_initializer{{.*}} = internal constant [4 x i8] c"\FF\00\FF\00"
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant [4 x i8] c"\01\00\01\00"
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant [4 x i8] c"\01\00\01\00"
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant [4 x i16] [i16 1, i16 0, i16 1, i16 0]
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant [4 x i16] [i16 1, i16 0, i16 1, i16 0]
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant [4 x i32] [i32 1, i32 0, i32 1, i32 0]
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant [4 x i32] [i32 1, i32 0, i32 1, i32 0]
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant [4 x i64] [i64 1, i64 0, i64 1, i64 0]
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant [4 x i64] [i64 1, i64 0, i64 1, i64 0]
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant [4 x float] [float 1.000000e+00, float 0.000000e+00, float 1.000000e+00, float 0.000000e+00]
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant [4 x double] [double 1.000000e+00, double 0.000000e+00, double 1.000000e+00, double 0.000000e+00]
+
+#define FOO(TYPE)                                                                     \
+void foo_##TYPE(uniform float dst[], const uniform uint32 b, const varying float src) \
+{                                                                                     \
+    static const uniform TYPE v_foo_##TYPE[4] = { 1,0,1,0 };                          \
+    if (v_foo_##TYPE[0] != 0) { dst[b+programIndex] = src; }                          \
+}
+
+FOO(bool)
+FOO(int8)
+FOO(uint8)
+FOO(int16)
+FOO(uint16)
+FOO(int32)
+FOO(uint32)
+FOO(int64)
+FOO(uint64)
+FOO(float)
+FOO(double)
+
+
+#define BOO(TYPE)                                                                     \
+void boo_##TYPE(uniform float dst[], const uniform uint32 b, const varying float src) \
+{                                                                                     \
+    const uniform TYPE cst_boo_##TYPE[4] = { 1,0,1,0 };                               \
+    if (cst_boo_##TYPE[0] != 0) { dst[b+programIndex] = src; }                        \
+}
+
+BOO(bool)
+BOO(int8)
+BOO(uint8)
+BOO(int16)
+BOO(uint16)
+BOO(int32)
+BOO(uint32)
+BOO(int64)
+BOO(uint64)
+BOO(float)
+BOO(double)
+
+
+#define GOO(TYPE)                                                                     \
+uniform TYPE glb_goo_##TYPE[4] = { 1,0,1,0 };                                         \
+void goo_##TYPE(uniform float dst[], const uniform uint32 b, const varying float src) \
+{                                                                                     \
+    if (glb_goo_##TYPE[0] != 0) { dst[b+programIndex] = src; }                        \
+}
+
+GOO(bool)
+GOO(int8)
+GOO(uint8)
+GOO(int16)
+GOO(uint16)
+GOO(int32)
+GOO(uint32)
+GOO(int64)
+GOO(uint64)
+GOO(float)
+GOO(double)

--- a/tests/lit-tests/init-const-varying.ispc
+++ b/tests/lit-tests/init-const-varying.ispc
@@ -1,0 +1,110 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib --debug-phase=first:first %s --emit-llvm-text -o - | FileCheck %s
+
+// CHECK: @programCount = internal constant i32 [[WIDTH:[0-9]+]]
+
+// CHECK: @glb_goo_bool = global <[[WIDTH]] x i8> <i8 -1, i8 0
+// CHECK: @glb_goo_int8 = global <[[WIDTH]] x i8> <i8 1, i8 0
+// CHECK: @glb_goo_uint8 = global <[[WIDTH]] x i8> <i8 1, i8 0
+// CHECK: @glb_goo_int16 = global <[[WIDTH]] x i16> <i16 1, i16 0
+// CHECK: @glb_goo_uint16 = global <[[WIDTH]] x i16> <i16 1, i16 0
+// CHECK: @glb_goo_int32 = global <[[WIDTH]] x i32> <i32 1, i32 0
+// CHECK: @glb_goo_uint32 = global <[[WIDTH]] x i32> <i32 1, i32 0
+// CHECK: @glb_goo_int64 = global <[[WIDTH]] x i64> <i64 1, i64 0
+// CHECK: @glb_goo_uint64 = global <[[WIDTH]] x i64> <i64 1, i64 0
+// CHECK: @glb_goo_float = global <[[WIDTH]] x float> <float 1.000000e+00, float 0.000000e+00
+// CHECK: @glb_goo_double = global <[[WIDTH]] x double> <double 1.000000e+00, double 0.000000e+00
+
+// CHECK: @static.{{[0-9]+}}.v_foo_bool = internal constant <[[WIDTH]] x i8> <i8 -1, i8 0
+// CHECK: @static.{{[0-9]+}}.v_foo_int8 = internal constant <[[WIDTH]] x i8> <i8 1, i8 0
+// CHECK: @static.{{[0-9]+}}.v_foo_uint8 = internal constant <[[WIDTH]] x i8> <i8 1, i8 0
+// CHECK: @static.{{[0-9]+}}.v_foo_int16 = internal constant <[[WIDTH]] x i16> <i16 1, i16 0
+// CHECK: @static.{{[0-9]+}}.v_foo_uint16 = internal constant <[[WIDTH]] x i16> <i16 1, i16 0
+// CHECK: @static.{{[0-9]+}}.v_foo_int32 = internal constant <[[WIDTH]] x i32> <i32 1, i32 0
+// CHECK: @static.{{[0-9]+}}.v_foo_uint32 = internal constant <[[WIDTH]] x i32> <i32 1, i32 0
+// CHECK: @static.{{[0-9]+}}.v_foo_int64 = internal constant <[[WIDTH]] x i64> <i64 1, i64 0
+// CHECK: @static.{{[0-9]+}}.v_foo_uint64 = internal constant <[[WIDTH]] x i64> <i64 1, i64 0
+// CHECK: @static.{{[0-9]+}}.v_foo_float = internal constant <[[WIDTH]] x float> <float 1.000000e+00, float 0.000000e+00
+// CHECK: @static.{{[0-9]+}}.v_foo_double = internal constant <[[WIDTH]] x double> <double 1.000000e+00, double 0.000000e+00
+
+// CHECK: %cst_boo_bool = alloca <[[WIDTH]] x i8>
+// CHECK: %cst_boo_int8 = alloca <[[WIDTH]] x i8>
+// CHECK: %cst_boo_uint8 = alloca <[[WIDTH]] x i8>
+// CHECK: %cst_boo_int16 = alloca <[[WIDTH]] x i16>
+// CHECK: %cst_boo_uint16 = alloca <[[WIDTH]] x i16>
+// CHECK: %cst_boo_int32 = alloca <[[WIDTH]] x i32>
+// CHECK: %cst_boo_uint32 = alloca <[[WIDTH]] x i32>
+// CHECK: %cst_boo_int64 = alloca <[[WIDTH]] x i64>
+// CHECK: %cst_boo_uint64 = alloca <[[WIDTH]] x i64>
+// CHECK: %cst_boo_float = alloca <[[WIDTH]] x float>
+// CHECK: %cst_boo_double = alloca <[[WIDTH]] x double>
+
+#if   TARGET_WIDTH == 2
+#define INITIALIZER 1,0,
+#elif TARGET_WIDTH == 4
+#define INITIALIZER 1,0,1,0,
+#elif TARGET_WIDTH == 8
+#define INITIALIZER 1,0,1,0,1,0,1,0,
+#elif TARGET_WIDTH == 16
+#define INITIALIZER 1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,
+#elif TARGET_WIDTH == 32
+#define INITIALIZER 1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,
+#elif TARGET_WIDTH == 64
+#define INITIALIZER 1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,
+#endif
+
+#define FOO(TYPE)                                                                     \
+void foo_##TYPE(uniform float dst[], const uniform uint32 b, const varying float src) \
+{                                                                                     \
+    static const varying TYPE v_foo_##TYPE = { INITIALIZER };                         \
+    if (v_foo_##TYPE != 0) { dst[b+programIndex] = src; }                             \
+}
+
+FOO(bool)
+FOO(int8)
+FOO(uint8)
+FOO(int16)
+FOO(uint16)
+FOO(int32)
+FOO(uint32)
+FOO(int64)
+FOO(uint64)
+FOO(float)
+FOO(double)
+
+#define BOO(TYPE)                                                                     \
+void boo_##TYPE(uniform float dst[], const uniform uint32 b, const varying float src) \
+{                                                                                     \
+    const varying TYPE cst_boo_##TYPE = { INITIALIZER };                              \
+    if (cst_boo_##TYPE != 0) { dst[b+programIndex] = src; }                           \
+}
+
+BOO(bool)
+BOO(int8)
+BOO(uint8)
+BOO(int16)
+BOO(uint16)
+BOO(int32)
+BOO(uint32)
+BOO(int64)
+BOO(uint64)
+BOO(float)
+BOO(double)
+
+#define GOO(TYPE)                                                                     \
+varying TYPE glb_goo_##TYPE = { INITIALIZER };                                        \
+void goo_##TYPE(uniform float dst[], const uniform uint32 b, const varying float src) \
+{                                                                                     \
+    if (glb_goo_##TYPE != 0) { dst[b+programIndex] = src; }                           \
+}
+
+GOO(bool)
+GOO(int8)
+GOO(uint8)
+GOO(int16)
+GOO(uint16)
+GOO(int32)
+GOO(uint32)
+GOO(int64)
+GOO(uint64)
+GOO(float)
+GOO(double)

--- a/tests/lit-tests/init-const-vectors.ispc
+++ b/tests/lit-tests/init-const-vectors.ispc
@@ -1,0 +1,96 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib --debug-phase=first:first --emit-llvm-text %s -o - | FileCheck %s
+
+// CHECK: @glb_goo_bool = global <4 x i8> <i8 -1, i8 0, i8 -1, i8 0>
+// CHECK: @glb_goo_int8 = global <4 x i8> <i8 1, i8 0
+// CHECK: @glb_goo_uint8 = global <4 x i8> <i8 1, i8 0
+// CHECK: @glb_goo_int16 = global <4 x i16> <i16 1, i16 0
+// CHECK: @glb_goo_uint16 = global <4 x i16> <i16 1, i16 0
+// CHECK: @glb_goo_int32 = global <4 x i32> <i32 1, i32 0
+// CHECK: @glb_goo_uint32 = global <4 x i32> <i32 1, i32 0
+// CHECK: @glb_goo_int64 = global <4 x i64> <i64 1, i64 0
+// CHECK: @glb_goo_uint64 = global <4 x i64> <i64 1, i64 0
+// CHECK: @glb_goo_float = global <4 x float> <float 1.000000e+00, float 0.000000e+00
+// CHECK: @glb_goo_double = global <4 x double> <double 1.000000e+00, double 0.000000e+00
+
+// CHECK: @static.{{[0-9]+}}.v_foo_bool = internal constant <4 x i8> <i8 -1, i8 0, i8 -1, i8 0>
+// CHECK: @static.{{[0-9]+}}.v_foo_int8 = internal constant <4 x i8> <i8 1, i8 0
+// CHECK: @static.{{[0-9]+}}.v_foo_uint8 = internal constant <4 x i8> <i8 1, i8 0
+// CHECK: @static.{{[0-9]+}}.v_foo_int16 = internal constant <4 x i16> <i16 1, i16 0
+// CHECK: @static.{{[0-9]+}}.v_foo_uint16 = internal constant <4 x i16> <i16 1, i16 0
+// CHECK: @static.{{[0-9]+}}.v_foo_int32 = internal constant <4 x i32> <i32 1, i32 0
+// CHECK: @static.{{[0-9]+}}.v_foo_uint32 = internal constant <4 x i32> <i32 1, i32 0
+// CHECK: @static.{{[0-9]+}}.v_foo_int64 = internal constant <4 x i64> <i64 1, i64 0
+// CHECK: @static.{{[0-9]+}}.v_foo_uint64 = internal constant <4 x i64> <i64 1, i64 0
+// CHECK: @static.{{[0-9]+}}.v_foo_float = internal constant <4 x float> <float 1.000000e+00, float 0.000000e+00
+// CHECK: @static.{{[0-9]+}}.v_foo_double = internal constant <4 x double> <double 1.000000e+00, double 0.000000e+00
+
+// CHECK: @const_initializer{{.*}} = internal constant <4 x i8> <i8 -1, i8 0, i8 -1, i8 0>
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant <4 x i8> <i8 1, i8 0
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant <4 x i8> <i8 1, i8 0
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant <4 x i16> <i16 1, i16 0
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant <4 x i16> <i16 1, i16 0
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant <4 x i32> <i32 1, i32 0
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant <4 x i32> <i32 1, i32 0
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant <4 x i64> <i64 1, i64 0
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant <4 x i64> <i64 1, i64 0
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant <4 x float> <float 1.000000e+00, float 0.000000e+00
+// CHECK: @const_initializer.{{[0-9]+}} = internal constant <4 x double> <double 1.000000e+00, double 0.000000e+00
+
+#define FOO(TYPE)                                                                     \
+void foo_##TYPE(uniform float dst[], const uniform uint32 b, const varying float src) \
+{                                                                                     \
+    static const uniform TYPE<4> v_foo_##TYPE = { 1,0,1,0 };                          \
+    if (v_foo_##TYPE[0] != 0) { dst[b+programIndex] = src; }                          \
+}
+
+FOO(bool)
+FOO(int8)
+FOO(uint8)
+FOO(int16)
+FOO(uint16)
+FOO(int32)
+FOO(uint32)
+FOO(int64)
+FOO(uint64)
+FOO(float)
+FOO(double)
+
+
+#define BOO(TYPE)                                                                     \
+void boo_##TYPE(uniform float dst[], const uniform uint32 b, const varying float src) \
+{                                                                                     \
+    const uniform TYPE<4> cst_boo_##TYPE = { 1,0,1,0 };                               \
+    if (cst_boo_##TYPE[0] != 0) { dst[b+programIndex] = src; }                        \
+}
+
+BOO(bool)
+BOO(int8)
+BOO(uint8)
+BOO(int16)
+BOO(uint16)
+BOO(int32)
+BOO(uint32)
+BOO(int64)
+BOO(uint64)
+BOO(float)
+BOO(double)
+
+
+#define GOO(TYPE)                                                                     \
+uniform TYPE<4> glb_goo_##TYPE = { 1,0,1,0 };                                         \
+void goo_##TYPE(uniform float dst[], const uniform uint32 b, const varying float src) \
+{                                                                                     \
+    if (glb_goo_##TYPE[0] != 0) { dst[b+programIndex] = src; }                        \
+}
+
+GOO(bool)
+GOO(int8)
+GOO(uint8)
+GOO(int16)
+GOO(uint16)
+GOO(int32)
+GOO(uint32)
+GOO(int64)
+GOO(uint64)
+GOO(float)
+GOO(double)


### PR DESCRIPTION
This PR fixes #2333 and similar crashes with initalization of bool vectors and arrays. 

Code generating static const declaration should match an InitSymbol behaviour that was changed in the commit https://github.com/ispc/ispc/commit/c889cdee2b5c7ebe. The generated constants stored in memory so we should generate storage type bools and bool vectors.

Add also tests for different initialization cases (varying, vector, arrays).