### PR TITLE
CI: run check_env.py with python 3.11 in appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,10 +58,11 @@ for:
         7z.exe x -ttar llvm*tar
         set PATH=%LLVM_HOME%\bin-%LLVM_VERSION%\bin;%PATH%
   before_build:
+      # check_env.py script relies on pkg_resources that removed from python 3.12
     - cmd: |-
         call %vspath%\Community\VC\Auxiliary\Build\vcvars64.bat
         cd %ISPC_HOME%
-        check_env.py
+        C:\Python311\python.exe check_env.py
         mkdir build && cd build
         cmake .. -Thost=x64 -G %generator% -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=%ISPC_HOME%\install -DISPC_PREPARE_PACKAGE=ON -DM4_EXECUTABLE=C:\cygwin64\bin\m4.exe -DISPC_CROSS=ON -DISPC_GNUWIN32_PATH=%CROSS_TOOLS%\gnuwin32 -DWASM_ENABLED=%WASM% -DISPC_INCLUDE_BENCHMARKS=ON
   build_script:


### PR DESCRIPTION
This PR fixes appveyor jobs that have recently updated python up to 3.12.
It is similar to problem fixed in https://github.com/ispc/ispc/pull/2685/commits/1f7ac4752ff4700f80961ee5b30714fb7b60906d