### PR TITLE
Fix bool swizzles

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -5299,9 +5299,8 @@ llvm::Value *VectorMemberExpr::GetValue(FunctionEmitContext *ctx) const {
 
             llvm::Value *ptmp =
                 ctx->AddElementOffset(resultPtrInfo, i, llvm::Twine(resultPtrInfo->getPointer()->getName()) + idStr);
-            // TODO: when we have swizzle on bool type, it breaks here on StoreInst.
-            // The condition in StoreInst checking that SwitchBoolSize is needed doesn't detect it.
-            ctx->StoreInst(elementValue, new AddressInfo(ptmp, exprVectorType->GetElementType()), elementPtrType);
+            ctx->StoreInst(elementValue, new AddressInfo(ptmp, exprVectorType->GetElementType()),
+                           elementPtrType->GetBaseType());
         }
 
         return ctx->LoadInst(resultPtrInfo, memberType, llvm::Twine(basePtr->getName()) + "_swizzle");

--- a/tests/lit-tests/bool_swizzle.ispc
+++ b/tests/lit-tests/bool_swizzle.ispc
@@ -1,8 +1,5 @@
-// This test checks that compiler is not crashing on bool swizzle.
-// Currently fails (https://github.com/ispc/ispc/issues/2367).
-
 // RUN: %{ispc} %s --target=host --nostdlib
-// XFAIL: !OPAQUE_PTRS_ENABLED
+
 export void test(uniform float out[]) {
     uniform bool<3> a = {1,0,1};
     uniform bool<3> b = a.zxy;


### PR DESCRIPTION
This PR fixes #2367 

StoreInst expects value type as third argument not type of pointer to value. Otherwise, the code inside casting bool is meaningless because PointerType can't be bool. Moreover, other use cases shows that the third argument is just type of the value passed as the first argument. I don't know why argument name is so confusing here.