### PR TITLE
tests: do not run some tests on macOS

### DIFF
--- a/tests/lit-tests/2652_3.ispc
+++ b/tests/lit-tests/2652_3.ispc
@@ -6,6 +6,8 @@
 // RUN: %{cc} %t.o %t.cpp.o -o %t.cpp.bin
 // RUN: %t.cpp.bin | FileCheck %s
 
+// REQUIRES: !MACOS_HOST
+
 // CHECK: my_data = 10
 
 #ifdef ISPC

--- a/tests/lit-tests/header-bool-1.ispc
+++ b/tests/lit-tests/header-bool-1.ispc
@@ -9,9 +9,12 @@
 // RUN: %{cc} %t.o %t.cpp.o -o %t.cpp.bin
 // RUN: %t.cpp.bin | FileCheck %s
 
+// REQUIRES: !MACOS_HOST
+
 // CHECK-LABEL: bool x=false
 // CHECK-COUNT-2: bool x=true
 // CHECK: bool x=false
+
 
 #ifdef ISPC
 export void use(uniform bool x) {

--- a/tests/lit-tests/header-ref-1.ispc
+++ b/tests/lit-tests/header-ref-1.ispc
@@ -9,6 +9,8 @@
 // RUN: %{cc} %t.o %t.cpp.o -o %t.cpp.bin
 // RUN: %t.cpp.bin | FileCheck %s
 
+// REQUIRES: !MACOS_HOST
+
 // CHECK-LABEL: uint x=10
 // CHECK: uint x=4294967295
 

--- a/tests/lit-tests/header-ref-2.ispc
+++ b/tests/lit-tests/header-ref-2.ispc
@@ -9,6 +9,8 @@
 // RUN: %{cc} %t.o %t.cpp.o -o %t.cpp.bin
 // RUN: %t.cpp.bin | FileCheck %s
 
+// REQUIRES: !MACOS_HOST
+
 // CHECK: uint x=99
 
 #ifdef ISPC


### PR DESCRIPTION
It may have universal binaries that may cause failing due to arm64/x86_64 mess.