### PR TITLE
Migrate dockers to superbuild

### DIFF
--- a/docker/centos/7/cpu_ispc_build/Dockerfile
+++ b/docker/centos/7/cpu_ispc_build/Dockerfile
@@ -3,32 +3,33 @@
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
-ARG LLVM_VERSION=16.0
-
 FROM centos:7 AS llvm_only
 LABEL maintainer="Dmitry Babokin <dmitry.y.babokin@intel.com>"
 SHELL ["/bin/bash", "-c"]
 
 ARG REPO=ispc/ispc
 ARG SHA=main
-ARG LLVM_VERSION
 
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
 
 # Packages required to build ISPC and Clang.
-RUN yum -y update; yum -y install centos-release-scl epel-release; yum clean all
-RUN yum install -y vim wget yum-utils gcc gcc-c++ git python3 m4 bison && \
+# libstdc++-static is required if you need to link ISPC with -static.
+RUN yum -y update && \
+    yum install -y centos-release-scl epel-release && \
+    yum install -y vim wget yum-utils gcc gcc-c++ git python3 m4 bison && \
     yum install -y flex patch make glibc-devel.x86_64 glibc-devel.i686 xz devtoolset-8 && \
     yum install -y libtool autopoint gettext-devel texinfo tbb-devel help2man && \
+    yum install -y ninja-build && \
+    yum install -y libstdc++-static && \
     yum clean -y all
 
-# These packages are required if you need to link ISPC with -static.
-RUN yum install -y libstdc++-static && \
-    yum clean -y all
-
-# Download and install required version of CMake. CMake 3.20 is required starting from LLVM 16.0.
-RUN if [[ $(uname -m) =~ "x86" ]]; then export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.sh"; else export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-aarch64.sh"; fi && \
+# Download and install required version of cmake (3.23.5 for both x86 and aarch64) as required for superbuild preset jsons.
+RUN if [[ $(uname -m) =~ "x86" ]]; then \
+        export CMAKE_URL="https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.sh"; \
+    else \
+        export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.23.5/cmake-3.23.5-linux-aarch64.sh"; \
+    fi && \
     wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $CMAKE_URL && \
     sh cmake-*.sh --prefix=/usr/local --skip-license && rm -rf cmake-*.sh
 
@@ -38,12 +39,7 @@ RUN if [ -v http_proxy ]; then git config --global --add http.proxy "$http_proxy
 WORKDIR /usr/local/src
 
 # Fork ispc on github and clone *your* fork.
-RUN mkdir /usr/local/src/llvm && \
-    git clone https://github.com/$REPO.git ispc
-
-# This is home for Clang builds
-ENV LLVM_HOME=/usr/local/src/llvm
-ENV ISPC_HOME=/usr/local/src/ispc
+RUN git clone https://github.com/$REPO.git ispc
 
 # If you are going to run test for future platforms, go to
 # http://www.intel.com/software/sde and download the latest version,
@@ -52,20 +48,21 @@ ENV ISPC_HOME=/usr/local/src/ispc
 WORKDIR /usr/local/src/ispc
 
 # Build Clang with all required patches.
-# Pass required LLVM_VERSION with --build-arg LLVM_VERSION=<version>.
-# Note self-build options, it's required to build clang and ispc with the same compiler,
-# i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
-# or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
+# Superbuild fetches LLVM_VERSION from preset json file.
 # "rm" are just to keep docker image small.
 RUN git checkout $SHA && \
     source /opt/rh/devtoolset-8/enable && \
-    ./alloy.py -b --version="$LLVM_VERSION" --selfbuild --llvm-disable-assertions --full-checkout && \
-    rm -rf "$LLVM_HOME"/build-"$LLVM_VERSION" "$LLVM_HOME"/llvm-"$LLVM_VERSION" "$LLVM_HOME"/bin-"$LLVM_VERSION"_temp "$LLVM_HOME"/build-"$LLVM_VERSION"_temp
+    cmake superbuild \
+        -B build \
+        --preset os \
+        -DXE_DEPS=OFF \
+        -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DLLVM_DISABLE_ASSERTIONS=ON && \
+    cmake --build build && \
+    rm -rf build
 
 FROM llvm_only AS ispc_build
-
-ARG LLVM_VERSION
-ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
 
 # Build ncurses with -fPIC: https://github.com/ispc/ispc/pull/2502#issuecomment-1526931698
 WORKDIR /usr/local/src
@@ -84,13 +81,10 @@ RUN git checkout v2.6.4 && ./autogen.sh && ./configure && make -j"$(nproc)" && m
 WORKDIR /usr/local/src/ispc
 RUN cmake . \
         -B build \
-        -DCMAKE_INSTALL_PREFIX=/usr/local/src/ispc/bin-$LLVM_VERSION \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DISPC_PREPARE_PACKAGE=ON \
         -DISPC_CROSS=ON && \
     cmake --build build --target package -j"$(nproc)" && \
     cmake --build build --target check-all && \
     cmake --install build && \
     rm -rf build
-
-# Export path for ispc
-ENV PATH=/usr/local/src/ispc/bin-$LLVM_VERSION/bin:$PATH

--- a/docker/centos/7/cpu_ispc_build/Dockerfile
+++ b/docker/centos/7/cpu_ispc_build/Dockerfile
@@ -46,12 +46,14 @@ RUN git clone https://github.com/$REPO.git ispc
 # extract it, add to path and set SDE_HOME.
 
 WORKDIR /usr/local/src/ispc
+# Set PATH and LD_LIBRARY_PATH instead of `source /opt/rh/devtoolset-8/enable` due to hadolint warning.
+ENV PATH=/opt/rh/devtoolset-8/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst:/opt/rh/devtoolset-8/root/usr/lib/dyninst:/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:$LD_LIBRARY_PATH
 
 # Build Clang with all required patches.
 # Superbuild fetches LLVM_VERSION from preset json file.
 # "rm" are just to keep docker image small.
 RUN git checkout $SHA && \
-    source /opt/rh/devtoolset-8/enable && \
     cmake superbuild \
         -B build \
         --preset os \

--- a/docker/centos/7/xpu_ispc_build/Dockerfile
+++ b/docker/centos/7/xpu_ispc_build/Dockerfile
@@ -67,10 +67,12 @@ RUN git clone https://github.com/$REPO.git ispc
 # extract it, add to path and set SDE_HOME.
 
 WORKDIR /usr/local/src/ispc
+# Set PATH and LD_LIBRARY_PATH instead of `source /opt/rh/devtoolset-8/enable` due to hadolint warning.
+ENV PATH=/opt/rh/devtoolset-8/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst:/opt/rh/devtoolset-8/root/usr/lib/dyninst:/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:$LD_LIBRARY_PATH
 
 # Build Clang/LLVM, XE dependencies and then ISPC.
 RUN git checkout $SHA && \
-    source /opt/rh/devtoolset-8/enable && \
     cmake superbuild \
         -B build \
         --preset os \

--- a/docker/centos/7/xpu_ispc_build/Dockerfile
+++ b/docker/centos/7/xpu_ispc_build/Dockerfile
@@ -4,25 +4,27 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 
 FROM centos:7
-LABEL maintainer="Dmitry Babokin <dmitry.y.babokin@intel.com>"
+LABEL maintainer="Aleksei Nurmukhametov <aleksei.nurmukhametov@intel.com>"
 SHELL ["/bin/bash", "-c"]
 
 ARG REPO=ispc/ispc
 ARG SHA=main
-ARG LLVM_VERSION=16.0
-ARG L0L_VER=1.14.0
-ARG VC_INTRINSICS_COMMIT_SHA="77f069b71fa9042bc4b2f68d06942a43c8ecec73"
-ARG SPIRV_TRANSLATOR_COMMIT_SHA="8703d43bd14d000fc630c2d3918d918819d23741"
 ARG TBB=default
+ARG LTO=OFF
+ARG PGO=OFF
 
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
 
 # Packages required to build ISPC and Clang.
-RUN yum -y update; yum -y install centos-release-scl epel-release; yum clean all
-RUN yum install -y vim wget yum-utils gcc gcc-c++ git python3 m4 bison flex patch make && \
+# libstdc++-static is required if you need to link ISPC with -static.
+RUN yum -y update && \
+    yum install -y centos-release-scl epel-release && \
+    yum install -y vim wget yum-utils gcc gcc-c++ git python3 m4 bison flex patch make && \
     yum install -y glibc-devel.x86_64 glibc-devel.i686 xz devtoolset-8 && \
     yum install -y libtool autopoint gettext-devel texinfo help2man && \
+    yum install -y ninja-build && \
+    yum install -y libstdc++-static && \
     yum clean -y all
 
 # TBB is parameter to build both packge usual and oneapi-tbb.
@@ -30,46 +32,14 @@ RUN if [ "$TBB" == "default" ]; then  yum -y install tbb tbb-devel && yum clean 
 COPY oneAPI.repo /etc/yum.repos.d/oneAPI.repo
 RUN if [ "$TBB" == "oneapi" ]; then yum -y install intel-oneapi-tbb-devel intel-oneapi-tbb && yum clean -y all; fi
 
-# These packages are required if you need to link ISPC with -static.
-RUN yum install -y libstdc++-static && \
-    yum clean -y all
-
-# Download and install required version of CMake. CMake 3.20 is required starting from LLVM 16.0.
-RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.sh && \
-    sh cmake-3.20.5-linux-x86_64.sh --prefix=/usr/local --skip-license && rm cmake-3.20.5-linux-x86_64.sh
-
-# If you are behind a proxy, you need to configure git.
-RUN if [ -v http_proxy ]; then git config --global --add http.proxy "$http_proxy"; fi
-
-WORKDIR /usr/local/src
-
-# Fork ispc on github and clone *your* fork.
-RUN mkdir /usr/local/src/llvm && \
-    git clone https://github.com/$REPO.git ispc
-
-# This is home for Clang builds
-ENV LLVM_HOME=/usr/local/src/llvm
-ENV ISPC_HOME=/usr/local/src/ispc
-ENV XE_DEPS=/usr/local/deps
-
-# If you are going to run test for future platforms, go to
-# http://www.intel.com/software/sde and download the latest version,
-# extract it, add to path and set SDE_HOME.
-
-WORKDIR /usr/local/src/ispc
-
-# Build Clang with all required patches.
-# Pass required LLVM_VERSION with --build-arg LLVM_VERSION=<version>.
-# Note self-build options, it's required to build clang and ispc with the same compiler,
-# i.e. if clang was built by gcc, you may need to use gcc to build ispc (i.e. run "make gcc"),
-# or better do clang selfbuild and use it for ispc build as well (i.e. just "make").
-# "rm" are just to keep docker image small.
-RUN git checkout $SHA && \
-    source /opt/rh/devtoolset-8/enable && \
-    ./alloy.py -b --version="$LLVM_VERSION" --selfbuild --llvm-disable-assertions --full-checkout && \
-    rm -rf "$LLVM_HOME"/build-"$LLVM_VERSION" "$LLVM_HOME"/llvm-"$LLVM_VERSION" "$LLVM_HOME"/bin-"$LLVM_VERSION"_temp "$LLVM_HOME"/build-"$LLVM_VERSION"_temp
-
-ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+# Download and install required version of cmake (3.23.5 for both x86 and aarch64) as required for superbuild preset jsons.
+RUN if [[ $(uname -m) =~ "x86" ]]; then \
+        export CMAKE_URL="https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.sh"; \
+    else \
+        export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.23.5/cmake-3.23.5-linux-aarch64.sh"; \
+    fi && \
+    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $CMAKE_URL && \
+    sh cmake-*.sh --prefix=/usr/local --skip-license && rm -rf cmake-*.sh
 
 # Build ncurses with -fPIC: https://github.com/ispc/ispc/pull/2502#issuecomment-1526931698
 WORKDIR /usr/local/src
@@ -84,60 +54,31 @@ RUN git clone https://github.com/westes/flex.git
 WORKDIR /usr/local/src/flex
 RUN git checkout v2.6.4 && ./autogen.sh && ./configure && make -j"$(nproc)" && make install
 
-# vc-intrinsics
+# If you are behind a proxy, you need to configure git.
+RUN if [ -v http_proxy ]; then git config --global --add http.proxy "$http_proxy"; fi
+
 WORKDIR /usr/local/src
-RUN git clone https://github.com/intel/vc-intrinsics.git src && \
-    git --git-dir=src/.git --work-tree=src checkout $VC_INTRINSICS_COMMIT_SHA && \
-    cmake src \
-        -B build \
-        -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_C_COMPILER=clang \
-        -DLLVM_DIR=$LLVM_HOME/bin-$LLVM_VERSION/lib/cmake/llvm \
-        -DCMAKE_INSTALL_PREFIX=$XE_DEPS && \
-    cmake --build build -j"$(nproc)" && \
-    cmake --install build && \
-    rm -rf build src
 
-# SPIRV Translator
-RUN git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git src && \
-    git --git-dir=src/.git --work-tree=src checkout $SPIRV_TRANSLATOR_COMMIT_SHA && \
-    cmake src \
-        -B build \
-        -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_C_COMPILER=clang \
-        -DLLVM_DIR=$LLVM_HOME/bin-$LLVM_VERSION/lib/cmake/llvm/ \
-        -DCMAKE_INSTALL_PREFIX=$XE_DEPS && \
-    cmake --build build -j"$(nproc)" && \
-    cmake --install build && \
-    rm -rf build src
+# Fork ispc on github and clone *your* fork.
+RUN git clone https://github.com/$REPO.git ispc
 
-# L0
-RUN git clone https://github.com/oneapi-src/level-zero.git src && \
-    git --git-dir=src/.git --work-tree=src checkout v$L0L_VER && \
-    cmake src \
-        -B build \
-        -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_C_COMPILER=clang \
-        -DCMAKE_INSTALL_PREFIX=/usr/local && \
-    cmake --build build -j"$(nproc)" && \
-    cmake --install build && \
-    rm -rf build src
+# If you are going to run test for future platforms, go to
+# http://www.intel.com/software/sde and download the latest version,
+# extract it, add to path and set SDE_HOME.
 
-# Build ISPC
-ENV LD_LIBRARY_PATH=$LLVM_HOME/bin-$LLVM_VERSION/lib:$LD_LIBRARY_PATH
 WORKDIR /usr/local/src/ispc
-RUN cmake . \
-        -B build \
-        -DCMAKE_INSTALL_PREFIX=/usr/local/src/ispc/bin-$LLVM_VERSION \
-        -DISPC_PREPARE_PACKAGE=ON \
-        -DISPC_CROSS=ON \
-        -DXE_ENABLED=ON \
-        -DXE_DEPS_DIR=$XE_DEPS && \
-    cmake --build build --target package -j"$(nproc)" && \
-    (cmake --build build --target check-all || true) && \
-    cmake --install build && \
-    mv build/*.tar.gz ./ && \
-    rm -rf build
 
-# Export path for ispc
-ENV PATH=/usr/local/src/ispc/bin-$LLVM_VERSION/bin:$PATH
+# Build Clang/LLVM, XE dependencies and then ISPC.
+RUN git checkout $SHA && \
+    source /opt/rh/devtoolset-8/enable && \
+    cmake superbuild \
+        -B build \
+        --preset os \
+        -DLTO=$LTO \
+        -DINSTALL_ISPC=ON \
+        -DINSTALL_TOOLCHAIN=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr/local && \
+    cmake --build build && \
+    (cmake --build build --target ispc-stage2-check-all || true) && \
+    mv build/build-ispc-stage2/src/ispc-stage2-build/*.tar.gz ./ && \
+    rm -rf build

--- a/docker/centos/8/cpu_ispc_build/Dockerfile
+++ b/docker/centos/8/cpu_ispc_build/Dockerfile
@@ -3,38 +3,41 @@
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
-ARG LLVM_VERSION=16.0
-
 FROM rockylinux:8 AS llvm_only
 LABEL maintainer="Dmitry Babokin <dmitry.y.babokin@intel.com>"
 SHELL ["/bin/bash", "-c"]
 
 ARG REPO=ispc/ispc
 ARG SHA=main
-ARG LLVM_VERSION
 
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
 
 # Packages required to build ISPC and Clang. libtool is needed to build ncurses.
 RUN dnf -y update && dnf install -y wget yum-utils gcc gcc-c++ git python3 make ncurses-devel xz libtool tbb-devel && \
-#    yum install -y libtool autopoint gettext-devel texinfo help2man && \
     dnf clean -y all
 
 # These packages are required if you need to link ISPC with -static.
-RUN dnf -y --enablerepo=powertools install libstdc++-static && \
+# Ninja is required for superbuild
+RUN dnf -y --enablerepo=powertools install ninja-build libstdc++-static && \
     dnf clean -y all
+
+RUN if [[ $(uname -m) =~ "x86" ]]; then dnf -y update && dnf install -y glibc-devel.i686 && dnf clean -y all; fi
 
 WORKDIR /usr/local/src
 
 # Ncurses for g++ --static -lcurses -ltinfo. Despite setting --enable-overwrite it doesn't link(only static not linked?) libncurses as libcurses so symlinked manually
 RUN git clone https://github.com/ThomasDickey/ncurses-snapshots.git --depth=1 --branch=v6_3
 WORKDIR /usr/local/src/ncurses-snapshots
-RUN ./configure --with-termlib --with-libtool --with-libtool-opts=-static --enable-static --enable-overwrite && make -j"$(nproc)" && make install && \
+RUN CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-termlib --with-libtool --with-libtool-opts=-static --enable-static --enable-overwrite && make -j"$(nproc)" && make install && \
   ln -s /usr/lib/libncurses.a /usr/lib/libcurses.a && ln -s /usr/lib/libncurses++.a /usr/lib/libcurses++.a
 
-# Download and install required version of CMake. CMake 3.20 is required starting from LLVM 16.0.
-RUN if [[ $(uname -m) =~ "x86" ]]; then export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.sh"; else export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-aarch64.sh"; fi && \
+# Download and install required version of cmake (3.23.5 for both x86 and aarch64) as required for superbuild preset jsons.
+RUN if [[ $(uname -m) =~ "x86" ]]; then \
+        export CMAKE_URL="https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.sh"; \
+    else \
+        export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.23.5/cmake-3.23.5-linux-aarch64.sh"; \
+    fi && \
     wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $CMAKE_URL && \
     sh cmake-*.sh --prefix=/usr/local --skip-license && rm -rf cmake-*.sh
 
@@ -44,12 +47,7 @@ RUN if [ -v http_proxy ]; then git config --global --add http.proxy "$http_proxy
 WORKDIR /usr/local/src
 
 # Fork ispc on github and clone *your* fork.
-RUN mkdir /usr/local/src/llvm && \
-    git clone https://github.com/$REPO.git ispc
-
-# This is home for Clang builds
-ENV LLVM_HOME=/usr/local/src/llvm
-ENV ISPC_HOME=/usr/local/src/ispc
+RUN git clone https://github.com/$REPO.git ispc
 
 # If you are going to run test for future platforms, go to
 # http://www.intel.com/software/sde and download the latest version,
@@ -65,20 +63,28 @@ WORKDIR /usr/local/src/ispc
 # "rm" are just to keep docker image small.
 # Add --llvm-disable-assertions for building "release" version.
 RUN git checkout $SHA && \
-    ./alloy.py -b --version="$LLVM_VERSION" --selfbuild --verbose && \
-    rm -rf "$LLVM_HOME"/build-"$LLVM_VERSION" "$LLVM_HOME"/llvm-"$LLVM_VERSION" "$LLVM_HOME"/bin-"$LLVM_VERSION"_temp "$LLVM_HOME"/build-"$LLVM_VERSION"_temp
-
-ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+    cmake superbuild \
+        -B build \
+        --preset os \
+        -DXE_DEPS=OFF \
+        -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr/local && \
+    cmake --build build && \
+    rm -rf build
 
 FROM llvm_only AS ispc_build
 SHELL ["/bin/bash", "-c"]
 
-ARG LLVM_VERSION
-
 RUN dnf -y update && dnf install -y m4 bison flex && dnf clean -y all
-RUN if [[ $(uname -m) =~ "x86" ]]; then dnf -y update && dnf install -y glibc-devel.i686 && dnf clean -y all; fi
 
 # Build ISPC
-RUN mkdir build
-WORKDIR /usr/local/src/ispc/build
-RUN cmake .. -DISPC_CROSS=ON && make -j"$(nproc)" && make check-all
+WORKDIR /usr/local/src/ispc
+RUN cmake . \
+        -B build \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DISPC_PREPARE_PACKAGE=ON \
+        -DISPC_CROSS=ON && \
+    cmake --build build --target package -j"$(nproc)" && \
+    cmake --build build --target check-all && \
+    cmake --install build && \
+    rm -rf build

--- a/docker/ubuntu/20.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/20.04/cpu_ispc_build/Dockerfile
@@ -3,16 +3,12 @@
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
-ARG LLVM_VERSION=16.0
-
 FROM ubuntu:20.04 AS llvm_build_only
 LABEL maintainer="Dmitry Babokin <dmitry.y.babokin@intel.com>"
 SHELL ["/bin/bash", "-c"]
 
 ARG REPO=ispc/ispc
 ARG SHA=main
-ARG LLVM_VERSION
-ARG EXTRA_BUILD_ARG
 
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
@@ -20,12 +16,26 @@ ARG EXTRA_BUILD_ARG
 RUN uname -a
 
 # Packages
-RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y wget build-essential gcc g++ git python3-dev ncurses-dev libtinfo-dev ca-certificates libtbb-dev && \
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y wget build-essential gcc g++ git python3-dev ncurses-dev libtinfo-dev ca-certificates libtbb-dev ninja-build && \
     rm -rf /var/lib/apt/lists/*
 
-# Download and install required version of cmake (3.20) for ISPC build
-RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.sh && \
-    sh cmake-3.20.5-linux-x86_64.sh --prefix=/usr/local --skip-license && rm cmake-3.20.5-linux-x86_64.sh
+# Install multilib libc needed to build clang_rt
+RUN if [[ $(uname -m) =~ "x86" ]]; then \
+        export CROSS_LIBS="libc6-dev-i386"; \
+    else \
+        export CROSS_LIBS="libc6-dev-armhf-cross"; \
+    fi && \
+    apt-get -y update && apt-get --no-install-recommends install -y "$CROSS_LIBS" && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and install required version of cmake (3.23.5 for both x86 and aarch64) as required for superbuild preset jsons.
+RUN if [[ $(uname -m) =~ "x86" ]]; then \
+        export CMAKE_URL="https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.sh"; \
+    else \
+        export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.23.5/cmake-3.23.5-linux-aarch64.sh"; \
+    fi && \
+    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $CMAKE_URL && \
+    sh cmake-*.sh --prefix=/usr/local --skip-license && rm -rf cmake-*.sh
 
 # If you are behind a proxy, you need to configure git.
 RUN if [ -v http_proxy ]; then git config --global --add http.proxy "$http_proxy"; fi
@@ -35,26 +45,31 @@ WORKDIR /home/src
 RUN git clone https://github.com/$REPO.git ispc
 
 WORKDIR /home/src/ispc
-RUN git checkout $SHA
-ENV ISPC_HOME=/home/src/ispc
-
-# LLVM
-ENV LLVM_HOME=/home/tools/llvm
-RUN python3 ./alloy.py -b --version="$LLVM_VERSION" --selfbuild --verbose "$EXTRA_BUILD_ARG" && \
-    rm -rf "$LLVM_HOME"/build-"$LLVM_VERSION" "$LLVM_HOME"/llvm-"$LLVM_VERSION" "$LLVM_HOME"/bin-"$LLVM_VERSION"_temp "$LLVM_HOME"/build-"$LLVM_VERSION"_temp
-ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+RUN git checkout $SHA && \
+    cmake superbuild \
+        -B build \
+        --preset os \
+        -DXE_DEPS=OFF \
+        -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr/local && \
+    cmake --build build && \
+    rm -rf build
 
 FROM llvm_build_only AS ispc_build
-
-ARG LLVM_VERSION
 
 RUN apt-get -y update && apt-get --no-install-recommends install -y m4 bison flex \
     libc6-dev-i386-cross libc6-dev-arm64-cross libc6-dev-armhf-cross && \
     rm -rf /var/lib/apt/lists/*
 
+# Build ISPC
 WORKDIR /home/src/ispc
-RUN mkdir -p build
-WORKDIR /home/src/ispc/build
-RUN cmake .. -DX86_ENABLED=ON -DARM_ENABLED=ON -DCMAKE_CXX_FLAGS=-Werror && make -j"$(nproc)" && make check-all
-# Add ISPC to PATH
-ENV PATH=/home/ispc/bin:$PATH
+RUN cmake . \
+        -B build \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DX86_ENABLED=ON \
+        -DARM_ENABLED=ON \
+        -DCMAKE_CXX_FLAGS="-Werror" && \
+    cmake --build build -j"$(nproc)" && \
+    cmake --build build --target check-all && \
+    cmake --install build && \
+    rm -rf build

--- a/docker/ubuntu/20.04/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/20.04/xpu_ispc_build/Dockerfile
@@ -9,10 +9,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG REPO=ispc/ispc
 ARG SHA=main
-ARG LLVM_VERSION=16.0
-ARG L0L_VER=1.14.0
-ARG VC_INTRINSICS_COMMIT_SHA="77f069b71fa9042bc4b2f68d06942a43c8ecec73"
-ARG SPIRV_TRANSLATOR_COMMIT_SHA="8703d43bd14d000fc630c2d3918d918819d23741"
+ARG LTO=OFF
 
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
@@ -21,26 +18,17 @@ ARG SPIRV_TRANSLATOR_COMMIT_SHA="8703d43bd14d000fc630c2d3918d918819d23741"
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y clang-8 build-essential \
     libnuma1 opencl-headers ocl-icd-libopencl1 clinfo vim gcc g++ git python3-dev imagemagick m4 bison flex libncurses-dev \
     libtinfo-dev libc6-dev-i386 cpio lsb-core wget gnupg netcat-openbsd libtbb-dev libglfw3-dev pkgconf gdb gcc-multilib g++-multilib curl ca-certificates && \
+    apt-get --no-install-recommends install -y ninja-build && \
     rm -rf /var/lib/apt/lists/*
 
-# Download and install required version of cmake (3.20) for ISPC build
-RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.sh && \
-    sh cmake-3.20.5-linux-x86_64.sh --prefix=/usr/local --skip-license && rm cmake-3.20.5-linux-x86_64.sh
-
-WORKDIR /home/src
-
-RUN git clone https://github.com/$REPO.git ispc
-
-WORKDIR /home/src/ispc
-RUN git checkout $SHA
-ENV ISPC_HOME=/home/src/ispc
-
-# LLVM
-ENV LLVM_HOME=/home/tools/llvm
-RUN python3 ./alloy.py -b --version="$LLVM_VERSION" --selfbuild && \
-    rm -rf "$LLVM_HOME"/build-"$LLVM_VERSION" "$LLVM_HOME"/llvm-"$LLVM_VERSION" "$LLVM_HOME"/bin-"$LLVM_VERSION"_temp "$LLVM_HOME"/build-"$LLVM_VERSION"_temp
-
-WORKDIR /home/packages
+# Download and install required version of cmake (3.23.5 for both x86 and aarch64) as required for superbuild preset jsons.
+RUN if [[ $(uname -m) =~ "x86" ]]; then \
+        export CMAKE_URL="https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.sh"; \
+    else \
+        export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.23.5/cmake-3.23.5-linux-aarch64.sh"; \
+    fi && \
+    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $CMAKE_URL && \
+    sh cmake-*.sh --prefix=/usr/local --skip-license && rm -rf cmake-*.sh
 
 # Add package repository and install graphics packages
 RUN set -eux && wget -qO - https://repositories.intel.com/graphics/intel-graphics.key | gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg && \
@@ -53,35 +41,20 @@ RUN set -eux && wget -qO - https://repositories.intel.com/graphics/intel-graphic
     mesa-vdpau-drivers mesa-vulkan-drivers va-driver-all && \
     rm -rf /var/lib/apt/lists/*
 
-# L0 loader
 WORKDIR /home/src
-RUN git clone https://github.com/oneapi-src/level-zero.git
-WORKDIR /home/src/level-zero
-RUN git checkout v$L0L_VER && mkdir -p build
-WORKDIR /home/src/level-zero/build
-RUN cmake -DCMAKE_INSTALL_PREFIX=/home/deps ../ && make install -j"$(nproc)"
+RUN git clone https://github.com/$REPO.git ispc
 
-# vc-intrinsics
-WORKDIR /home/src
-RUN git clone https://github.com/intel/vc-intrinsics.git
-WORKDIR /home/src/vc-intrinsics
-RUN git checkout $VC_INTRINSICS_COMMIT_SHA && mkdir -p build
-WORKDIR /home/src/vc-intrinsics/build
-RUN cmake -DLLVM_DIR=$LLVM_HOME/bin-$LLVM_VERSION/lib/cmake/llvm -DCMAKE_INSTALL_PREFIX=/home/deps ../ && make install -j"$(nproc)"
-
-# SPIRV Translator
-WORKDIR /home/src
-RUN git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git
-WORKDIR /home/src/SPIRV-LLVM-Translator
-RUN git checkout $SPIRV_TRANSLATOR_COMMIT_SHA && mkdir -p build
-WORKDIR /home/src/SPIRV-LLVM-Translator/build
-RUN cmake -DLLVM_DIR=$LLVM_HOME/bin-$LLVM_VERSION/lib/cmake/llvm/ -DCMAKE_INSTALL_PREFIX=/home/deps ../ && make install -j"$(nproc)"
-
-# ISPC build
-ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
 WORKDIR /home/src/ispc
-RUN mkdir -p build
-WORKDIR /home/src/ispc/build
-RUN cmake -DXE_ENABLED=ON -DCMAKE_INSTALL_PREFIX=/home/ispc/ -DXE_DEPS_DIR=/home/deps -DLEVEL_ZERO_ROOT=/home/deps ../ && make install -j"$(nproc)" && (make check-all -j"$(nproc)" || true)
-# Add ISPC to PATH
-ENV PATH=/home/ispc/bin:$PATH
+# Build Clang/LLVM, XE dependencies and then ISPC.
+RUN git checkout $SHA && \
+    cmake superbuild \
+        -B build \
+        --preset os \
+        -DLTO=$LTO \
+        -DINSTALL_ISPC=ON \
+        -DINSTALL_TOOLCHAIN=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr/local && \
+    cmake --build build && \
+    (cmake --build build --target ispc-stage2-check-all || true) && \
+    mv build/build-ispc-stage2/src/ispc-stage2-build/*.tar.gz ./ && \
+    rm -rf build

--- a/docker/ubuntu/22.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/22.04/cpu_ispc_build/Dockerfile
@@ -3,16 +3,12 @@
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
-ARG LLVM_VERSION=16.0
-
 FROM ubuntu:22.04 AS llvm_build_only
 LABEL maintainer="Dmitry Babokin <dmitry.y.babokin@intel.com>"
 SHELL ["/bin/bash", "-c"]
 
 ARG REPO=ispc/ispc
 ARG SHA=main
-ARG LLVM_VERSION
-ARG EXTRA_BUILD_ARG
 
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
@@ -20,37 +16,63 @@ ARG EXTRA_BUILD_ARG
 RUN uname -a
 
 # Packages
-RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y wget cmake build-essential gcc g++ git python3-dev ncurses-dev libtinfo-dev ca-certificates libtbb2-dev && \
+RUN apt-get -y update && \
+    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
+        wget ninja-build build-essential gcc g++ git python3-dev \
+        ncurses-dev libtinfo-dev ca-certificates libtbb2-dev && \
     rm -rf /var/lib/apt/lists/*
+
+# Install multilib libc needed to build clang_rt
+RUN if [[ $(uname -m) =~ "x86" ]]; then \
+        export CROSS_LIBS="libc6-dev-i386"; \
+    else \
+        export CROSS_LIBS="libc6-dev-armhf-cross"; \
+    fi && \
+    apt-get -y update && apt-get --no-install-recommends install -y "$CROSS_LIBS" && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and install required version of cmake (3.23.5 for both x86 and aarch64) as required for superbuild preset jsons.
+RUN if [[ $(uname -m) =~ "x86" ]]; then \
+        export CMAKE_URL="https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.sh"; \
+    else \
+        export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.23.5/cmake-3.23.5-linux-aarch64.sh"; \
+    fi && \
+    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $CMAKE_URL && \
+    sh cmake-*.sh --prefix=/usr/local --skip-license && rm -rf cmake-*.sh
 
 # If you are behind a proxy, you need to configure git.
 RUN if [ -v http_proxy ]; then git config --global --add http.proxy "$http_proxy"; fi
 
 WORKDIR /home/src
-
 RUN git clone https://github.com/$REPO.git ispc
 
 WORKDIR /home/src/ispc
-RUN git checkout $SHA
-ENV ISPC_HOME=/home/src/ispc
-
-# LLVM
-ENV LLVM_HOME=/home/tools/llvm
-RUN python3 ./alloy.py -b --version="$LLVM_VERSION" --selfbuild --verbose "$EXTRA_BUILD_ARG" && \
-    rm -rf "$LLVM_HOME"/build-"$LLVM_VERSION" "$LLVM_HOME"/llvm-"$LLVM_VERSION" "$LLVM_HOME"/bin-"$LLVM_VERSION"_temp "$LLVM_HOME"/build-"$LLVM_VERSION"_temp
-ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+RUN git checkout $SHA && \
+    cmake superbuild \
+        -B build \
+        --preset os \
+        -DXE_DEPS=OFF \
+        -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr/local && \
+    cmake --build build && \
+    rm -rf build
 
 FROM llvm_build_only AS ispc_build
 
-ARG LLVM_VERSION
-
-RUN apt-get -y update && apt-get --no-install-recommends install -y m4 bison flex \
-    libc6-dev-i386-cross libc6-dev-arm64-cross libc6-dev-armhf-cross && \
+RUN apt-get -y update && \
+    apt-get --no-install-recommends install -y \
+        m4 bison flex libc6-dev-i386-cross libc6-dev-arm64-cross libc6-dev-armhf-cross && \
     rm -rf /var/lib/apt/lists/*
 
+# Build ISPC
 WORKDIR /home/src/ispc
-RUN mkdir -p build
-WORKDIR /home/src/ispc/build
-RUN cmake .. -DX86_ENABLED=ON -DARM_ENABLED=ON -DCMAKE_CXX_FLAGS=-Werror && make -j"$(nproc)" && make check-all
-# Add ISPC to PATH
-ENV PATH=/home/ispc/bin:$PATH
+RUN cmake . \
+        -B build \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DX86_ENABLED=ON \
+        -DARM_ENABLED=ON \
+        -DCMAKE_CXX_FLAGS="-Werror" && \
+    cmake --build build -j"$(nproc)" && \
+    cmake --build build --target check-all && \
+    cmake --install build && \
+    rm -rf build

--- a/docker/ubuntu/22.04/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/22.04/xpu_ispc_build/Dockerfile
@@ -9,77 +9,54 @@ SHELL ["/bin/bash", "-c"]
 
 ARG REPO=ispc/ispc
 ARG SHA=main
-ARG LLVM_VERSION=16.0
 ARG IGC_VER=14062.11
-ARG L0L_VER=1.14.0
 ARG CR_VER=23.22.26516.18
 ARG CR_VER_SUFFIX=26516.18
-ARG VC_INTRINSICS_COMMIT_SHA="77f069b71fa9042bc4b2f68d06942a43c8ecec73"
-ARG SPIRV_TRANSLATOR_COMMIT_SHA="8703d43bd14d000fc630c2d3918d918819d23741"
+ARG LTO
 
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
 
 # Packages
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y clang-12 build-essential libnuma1 opencl-headers ocl-icd-libopencl1 clinfo vim gcc g++ git python3-dev imagemagick \
-    m4 bison flex libncurses-dev libtinfo-dev libc6-dev-i386 cpio lsb-core wget netcat-openbsd libtbb2-dev libglfw3-dev pkgconf gdb gcc-multilib g++-multilib curl ca-certificates cmake && \
+    m4 bison flex libncurses-dev libtinfo-dev libc6-dev-i386 cpio lsb-core wget netcat-openbsd libtbb2-dev libglfw3-dev pkgconf gdb gcc-multilib g++-multilib curl ca-certificates ninja-build && \
     rm -rf /var/lib/apt/lists/*
 
-WORKDIR /home/src
-
-RUN git clone https://github.com/$REPO.git ispc
-
-WORKDIR /home/src/ispc
-RUN git checkout $SHA
-ENV ISPC_HOME=/home/src/ispc
-
-# LLVM
-ENV LLVM_HOME=/home/tools/llvm
-RUN python3 ./alloy.py -b --version="$LLVM_VERSION" --selfbuild && \
-    rm -rf "$LLVM_HOME"/build-"$LLVM_VERSION" "$LLVM_HOME"/llvm-"$LLVM_VERSION" "$LLVM_HOME"/bin-"$LLVM_VERSION"_temp "$LLVM_HOME"/build-"$LLVM_VERSION"_temp
-
-WORKDIR /home/packages
+# Download and install required version of cmake (3.23.5 for both x86 and aarch64) as required for superbuild preset jsons.
+RUN if [[ $(uname -m) =~ "x86" ]]; then \
+        export CMAKE_URL="https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.sh"; \
+    else \
+        export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.23.5/cmake-3.23.5-linux-aarch64.sh"; \
+    fi && \
+    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $CMAKE_URL && \
+    sh cmake-*.sh --prefix=/usr/local --skip-license && rm -rf cmake-*.sh
 
 # Compute runtime
+# Install packages and clean up
 RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5  https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.${IGC_VER}/intel-igc-core_1.0.${IGC_VER}_amd64.deb && \
     wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5  https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.${IGC_VER}/intel-igc-opencl_1.0.${IGC_VER}_amd64.deb && \
     wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5  https://github.com/intel/compute-runtime/releases/download/${CR_VER}/intel-level-zero-gpu-dbgsym_1.3.${CR_VER_SUFFIX}_amd64.ddeb && \
     wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5  https://github.com/intel/compute-runtime/releases/download/${CR_VER}/intel-level-zero-gpu_1.3.${CR_VER_SUFFIX}_amd64.deb && \
     wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5  https://github.com/intel/compute-runtime/releases/download/${CR_VER}/intel-opencl-icd-dbgsym_${CR_VER}_amd64.ddeb && \
     wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5  https://github.com/intel/compute-runtime/releases/download/${CR_VER}/intel-opencl-icd_${CR_VER}_amd64.deb && \
-    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5  https://github.com/intel/compute-runtime/releases/download/${CR_VER}/libigdgmm12_22.3.0_amd64.deb
+    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5  https://github.com/intel/compute-runtime/releases/download/${CR_VER}/libigdgmm12_22.3.0_amd64.deb && \
+    dpkg -i ./*.deb && \
+    rm ./*.deb
 
-# L0 loaader
-RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/oneapi-src/level-zero/releases/download/v${L0L_VER}/level-zero-devel_${L0L_VER}+u22.04_amd64.deb && \
-    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://github.com/oneapi-src/level-zero/releases/download/v${L0L_VER}/level-zero_${L0L_VER}+u22.04_amd64.deb
-
-# Install packages and clean up
-RUN dpkg -i ./*.deb
-WORKDIR /home
-RUN rm -rf packages
-
-# vc-intrinsics
 WORKDIR /home/src
-RUN git clone https://github.com/intel/vc-intrinsics.git
-WORKDIR /home/src/vc-intrinsics
-RUN git checkout $VC_INTRINSICS_COMMIT_SHA && mkdir -p build
-WORKDIR /home/src/vc-intrinsics/build
-RUN cmake -DLLVM_DIR=$LLVM_HOME/bin-$LLVM_VERSION/lib/cmake/llvm -DCMAKE_INSTALL_PREFIX=/home/deps -DPYTHON_EXECUTABLE=/usr/bin/python3 ../ && make install -j"$(nproc)"
+RUN git clone https://github.com/$REPO.git ispc
 
-# SPIRV Translator
-WORKDIR /home/src
-RUN git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git
-WORKDIR /home/src/SPIRV-LLVM-Translator
-RUN git checkout $SPIRV_TRANSLATOR_COMMIT_SHA && mkdir -p build
-WORKDIR /home/src/SPIRV-LLVM-Translator/build
-RUN cmake -DLLVM_DIR=$LLVM_HOME/bin-$LLVM_VERSION/lib/cmake/llvm/ -DCMAKE_INSTALL_PREFIX=/home/deps -DPYTHON_EXECUTABLE=/usr/bin/python3 ../ && make install -j"$(nproc)"
-
-# ISPC build
-ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
 WORKDIR /home/src/ispc
-RUN mkdir -p build
-WORKDIR /home/src/ispc/build
-RUN cmake -DXE_ENABLED=ON -DCMAKE_INSTALL_PREFIX=/home/ispc/ -DXE_DEPS_DIR=/home/deps ../ && make install -j"$(nproc)"
-RUN make check-all -j"$(nproc)"
-# Add ISPC to PATH
-ENV PATH=/home/ispc/bin:$PATH
+# Build Clang/LLVM, XE dependencies and then ISPC.
+RUN git checkout $SHA && \
+    cmake superbuild \
+        -B build \
+        --preset os \
+        -DLTO=$LTO \
+        -DINSTALL_ISPC=ON \
+        -DINSTALL_TOOLCHAIN=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr/local && \
+    cmake --build build && \
+    (cmake --build build --target ispc-stage2-check-all || true) && \
+    mv build/build-ispc-stage2/src/ispc-stage2-build/*.tar.gz ./ && \
+    rm -rf build


### PR DESCRIPTION
This PR changes dockers to use superbuild to build ISPC and all dependencies. It also fixes minor hadolint warnings.