### PR TITLE
Fix return type of lParseOperator

### DIFF
--- a/src/lex.ll
+++ b/src/lex.ll
@@ -20,6 +20,7 @@ using namespace ispc;
 static uint64_t lParseBinary(const char *ptr, SourcePos pos, char **endPtr);
 static int lParseInteger(bool dotdotdot);
 static int lParseFP();
+static int lParseOperator(const char *ptr);
 static void lCComment(SourcePos *);
 static void lCppComment(SourcePos *);
 static void lNextValidChar(SourcePos *, char const*&);
@@ -29,7 +30,6 @@ static bool lConsumePragma(YYSTYPE *, SourcePos *);
 static void lHandleCppHash(SourcePos *);
 static void lStringConst(YYSTYPE *, SourcePos *);
 static double lParseHexFloat(const char *ptr);
-static yytokentype lParseOperator(const char *ptr);
 extern const char *RegisterDependency(const std::string &fileName);
 
 #define YY_USER_ACTION \
@@ -1162,7 +1162,7 @@ lParseHexFloat(const char *ptr) {
 
 /** Parse an operator.
 */
-static yytokentype
+static int
 lParseOperator(const char *ptr) {
     yylval.stringVal = new std::string(ptr);
     if (m->symbolTable->LookupFunctionTemplate(yytext))


### PR DESCRIPTION
This fixes #2706.

When bison is used in `-y` mode that emulates POSIX Yacc, tokens are defined as enums (under `YYTOKENTYPE` ifdef) or as `int` via macro definitions. Defining return type as `yytokentype` causes compile error: invalid conversion from 'int' to 'yytokentype'. To avoid it, return `int` as we do with `lParseInteger` and `lParseFP`.