### PR TITLE
CI: rename Choco-Install to Install-ChocoPackage

### DIFF
--- a/.github/workflows/scripts/install-build-deps.ps1
+++ b/.github/workflows/scripts/install-build-deps.ps1
@@ -1,9 +1,9 @@
-# Choco-Install is GH Actions wrappers around choco, which does retries
-Choco-Install -PackageName winflexbison3
-Choco-Install -PackageName wget
-Choco-Install -PackageName 7zip
-Choco-Install -PackageName cygwin
-Choco-Install -PackageName cyg-get
+# Install-ChocoPackage is GH Actions wrappers around choco, which does retries
+Install-ChocoPackage winflexbison3
+Install-ChocoPackage wget
+Install-ChocoPackage 7zip
+Install-ChocoPackage cygwin
+Install-ChocoPackage cyg-get
 
 # Install M4 exec and put it into PATH
 cyg-get m4

--- a/.github/workflows/scripts/install-test-deps.ps1
+++ b/.github/workflows/scripts/install-test-deps.ps1
@@ -1,5 +1,5 @@
-# Choco-Install is GH Actions wrappers around choco, which does retries
-Choco-Install -PackageName wget
+# Install-ChocoPackage is GH Actions wrappers around choco, which does retries
+Install-ChocoPackage wget
 
 # Install ISPC package
 Expand-Archive $pwd\ispc-trunk-windows.zip -DestinationPath $pwd


### PR DESCRIPTION
This PR fixes CI errors on windows caused by renaming the `Choco-Install` command to `Install-ChocoPackage`  https://github.com/actions/runner-images/pull/8865