### PR TITLE
Use UTC with timestamp to help reproducible build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,7 @@ if (WIN32)
 endif()
 
 # Build definitions
-string(TIMESTAMP BUILD_DATE "%Y%m%d")
+string(TIMESTAMP BUILD_DATE "%Y%m%d" UTC)
 target_compile_definitions(${PROJECT_NAME} PRIVATE BUILD_DATE=\"${BUILD_DATE}\"
                                                    BUILD_VERSION=\"${GIT_COMMIT_HASH}\")
 if (UNIX)


### PR DESCRIPTION
The version 1.22.0 is not [reproducible](https://reproducible-builds.org/) because the binary prints the build time which depends on time zone (see [here](https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/diffoscope-results/ispc.html) for Debian package version 1.22.0-3 for example).

Adding the `UTC` keyword in the CMake command seems to fix the issue. Let me know if this is an acceptable solution.

Thanks!
François

