### PR TITLE
Add LTO swtich to rebuild LLVM job

### DIFF
--- a/.github/workflows/rebuild-llvm14.yml
+++ b/.github/workflows/rebuild-llvm14.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       version: '14.0'
       full_version: '14.0.6'
+      lto: 'OFF'
       ubuntu: '18.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'

--- a/.github/workflows/rebuild-llvm15.yml
+++ b/.github/workflows/rebuild-llvm15.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       version: '15.0'
       full_version: '15.0.7'
+      lto: 'OFF'
       ubuntu: '18.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'

--- a/.github/workflows/rebuild-llvm16.yml
+++ b/.github/workflows/rebuild-llvm16.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       version: '16.0'
       full_version: '16.0.6'
+      lto: 'OFF'
       ubuntu: '18.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'

--- a/.github/workflows/rebuild-llvm17.yml
+++ b/.github/workflows/rebuild-llvm17.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       version: '17.0'
       full_version: '17.0.6'
+      lto: 'OFF'
       ubuntu: '18.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -201,7 +201,7 @@ jobs:
         name: llvmrel_linux_x86
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release-x86.arm.wasm.tar.xz
 
-  linux-arm-build:
+  linux-arm-build-1:
     runs-on: [self-hosted, linux, ARM64]
     # Disabling this rebuild for non ispc/ispc repo, as it requires self-hosted runner
     if: github.repository == 'ispc/ispc'
@@ -218,12 +218,47 @@ jobs:
       run: |
         cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }} --no-cache --target=llvm_build_step2 --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LTO=${{ inputs.lto }} --build-arg LLVM_VERSION=${{ inputs.version }} --output=type=tar,dest=result.tar --build-arg LLVM_DISABLE_ASSERTIONS=OFF .
+        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LTO=${{ inputs.lto }} --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=OFF .
+        docker buildx rm
+
+    - name: Upload package
+      uses: actions/upload-artifact@v3
+      with:
+        name: llvm_linux_aarch64_stage1_cache
+        path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
+
+  linux-arm-build-2:
+    needs: [linux-arm-build-1]
+    runs-on: [self-hosted, linux, ARM64]
+    # Disabling this rebuild for non ispc/ispc repo, as it requires self-hosted runner
+    if: github.repository == 'ispc/ispc'
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Check environment
+      run: |
+        cat /proc/cpuinfo
+
+    - name: Download package
+      uses: actions/download-artifact@v3
+      with:
+        name: llvm_linux_aarch64_stage1_cache
+        path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
+
+    - name: Build LLVM
+      run: |
+        cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
+        docker buildx create --use
+        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LTO=${{ inputs.lto }} --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=OFF --output=type=tar,dest=result.tar .
         docker buildx rm
 
     - name: Pack LLVM
       run: |
         cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
+        rm -rf cache.local
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-${{ inputs.version }} .
         tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release+Asserts-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
@@ -235,7 +270,7 @@ jobs:
         name: llvm_linux_aarch64
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release+Asserts-x86.arm.wasm.tar.xz
 
-  linux-arm-build-release:
+  linux-arm-build-release-1:
     runs-on: [self-hosted, linux, ARM64]
     # Disabling this rebuild for non ispc/ispc repo, as it requires self-hosted runner
     if: github.repository == 'ispc/ispc'
@@ -252,7 +287,41 @@ jobs:
       run: |
         cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }} --no-cache --target=llvm_build_step2 --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LTO=${{ inputs.lto }} --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=ON --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LTO=${{ inputs.lto }} --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=ON .
+        docker buildx rm
+
+    - name: Upload package
+      uses: actions/upload-artifact@v3
+      with:
+        name: llvmrel_linux_aarch64_stage1_cache
+        path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
+
+  linux-arm-build-release-2:
+    needs: [linux-arm-build-release-1]
+    runs-on: [self-hosted, linux, ARM64]
+    # Disabling this rebuild for non ispc/ispc repo, as it requires self-hosted runner
+    if: github.repository == 'ispc/ispc'
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Check environment
+      run: |
+        cat /proc/cpuinfo
+
+    - name: Download package
+      uses: actions/download-artifact@v3
+      with:
+        name: llvmrel_linux_aarch64_stage1_cache
+        path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
+
+    - name: Build LLVM
+      run: |
+        cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
+        docker buildx create --use
+        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LTO=${{ inputs.lto }} --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=ON --output=type=tar,dest=result.tar .
         docker buildx rm
 
     - name: Pack LLVM

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -14,6 +14,11 @@ on:
         description: Version to build in major.minor.patch format. For example '14.0.6'.
         required: true
         type: string
+      lto:
+        description: Build LTO-enabled LLVM toolchain ('ON' or 'OFF').
+        required: true
+        type: string
+        default: 'OFF'
       ubuntu:
         description: Version of Ubuntu Dockerfile to use. For example '18.04'.
         required: true
@@ -30,6 +35,38 @@ on:
         description: Win SDK version string. For example, '10.0.18362.0'.
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to build in major.minor format For example '14.0'.
+        required: true
+        type: string
+      full_version:
+        description: Version to build in major.minor.patch format. For example '14.0.6'.
+        required: true
+        type: string
+      lto:
+        description: Build LTO-enabled LLVM toolchain.
+        required: true
+        type: string
+        default: 'OFF'
+      ubuntu:
+        description: Version of Ubuntu Dockerfile to use. For example '18.04'.
+        required: true
+        type: string
+      vs_generator:
+        description: VS generator to use. For example 'Visual Studio 16 2019'.
+        required: true
+        type: string
+      vs_version_str:
+        description: VS version string to use in artifact naming. For example, 'vs2019'.
+        required: true
+        type: string
+      win_sdk:
+        description: Win SDK version string. For example, '10.0.18362.0'.
+        required: true
+        type: string
+
 
 jobs:
   # Building LLVM in docker, as using native Ubuntu 18.04 github-hosted image contains newer-than-expected libs and
@@ -52,7 +89,7 @@ jobs:
       run: |
         cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=OFF .
+        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LTO=${{ inputs.lto }} --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=OFF .
 
     - name: Upload package
       uses: actions/upload-artifact@v3
@@ -84,7 +121,7 @@ jobs:
         cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=OFF --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LTO=${{ inputs.lto }} --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=OFF --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
@@ -116,7 +153,7 @@ jobs:
       run: |
         cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=ON .
+        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage1 --target=llvm_build_step1 --cache-to=type=local,dest=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LTO=${{ inputs.lto }} --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=ON .
 
     - name: Upload package
       uses: actions/upload-artifact@v3
@@ -148,7 +185,7 @@ jobs:
         cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=ON --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }}:stage2 --target=llvm_build_step2 --cache-from=type=local,src=cache.local --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LTO=${{ inputs.lto }} --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=ON --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
@@ -181,7 +218,7 @@ jobs:
       run: |
         cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }} --no-cache --target=llvm_build_step2 --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=${{ inputs.version }} --output=type=tar,dest=result.tar --build-arg LLVM_DISABLE_ASSERTIONS=OFF .
+        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }} --no-cache --target=llvm_build_step2 --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LTO=${{ inputs.lto }} --build-arg LLVM_VERSION=${{ inputs.version }} --output=type=tar,dest=result.tar --build-arg LLVM_DISABLE_ASSERTIONS=OFF .
         docker buildx rm
 
     - name: Pack LLVM
@@ -215,7 +252,7 @@ jobs:
       run: |
         cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }} --no-cache --target=llvm_build_step2 --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=ON --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu${{ inputs.ubuntu }} --no-cache --target=llvm_build_step2 --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LTO=${{ inputs.lto }} --build-arg LLVM_VERSION=${{ inputs.version }} --build-arg LLVM_DISABLE_ASSERTIONS=ON --output=type=tar,dest=result.tar .
         docker buildx rm
 
     - name: Pack LLVM
@@ -258,7 +295,7 @@ jobs:
       run: |
         set VSVARS="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         call %VSVARS%
-        cmake %ISPC_HOME%\superbuild -B build-${{ inputs.version }} --preset os -DLLVM_VERSION=${{ inputs.version }} -DCMAKE_SYSTEM_VERSION=${{ inputs.win_sdk }} -DCMAKE_INSTALL_PREFIX=%LLVM_HOME%\bin-${{ inputs.version }} -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON -DXE_DEPS=OFF -DLLVM_DISABLE_ASSERTIONS=OFF
+        cmake %ISPC_HOME%\superbuild -B build-${{ inputs.version }} --preset os -DLTO=${{ inputs.lto }} -DLLVM_VERSION=${{ inputs.version }} -DCMAKE_SYSTEM_VERSION=${{ inputs.win_sdk }} -DCMAKE_INSTALL_PREFIX=%LLVM_HOME%\bin-${{ inputs.version }} -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON -DXE_DEPS=OFF -DLLVM_DISABLE_ASSERTIONS=OFF
         cmake --build build-${{ inputs.version }}
         rmdir /s /q build-${{ inputs.version }}
 
@@ -302,7 +339,7 @@ jobs:
       run: |
         set VSVARS="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         call %VSVARS%
-        cmake %ISPC_HOME%\superbuild -B build-${{ inputs.version }} --preset os -DLLVM_VERSION=${{ inputs.version }} -DCMAKE_SYSTEM_VERSION=${{ inputs.win_sdk }} -DCMAKE_INSTALL_PREFIX=%LLVM_HOME%\bin-${{ inputs.version }} -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON -DXE_DEPS=OFF -DLLVM_DISABLE_ASSERTIONS=ON
+        cmake %ISPC_HOME%\superbuild -B build-${{ inputs.version }} --preset os -DLTO=${{ inputs.lto }} -DLLVM_VERSION=${{ inputs.version }} -DCMAKE_SYSTEM_VERSION=${{ inputs.win_sdk }} -DCMAKE_INSTALL_PREFIX=%LLVM_HOME%\bin-${{ inputs.version }} -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON -DXE_DEPS=OFF -DLLVM_DISABLE_ASSERTIONS=ON
         cmake --build build-${{ inputs.version }}
         rmdir /s /q build-${{ inputs.version }}
 
@@ -341,7 +378,7 @@ jobs:
 
     - name: Build LLVM
       run: |
-        cmake $ISPC_HOME/superbuild -B build-${{ inputs.version }} --preset os -DLLVM_VERSION=${{ inputs.version }} -DCMAKE_INSTALL_PREFIX=$LLVM_HOME/bin-${{ inputs.version }} -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON -DXE_DEPS=OFF -DMACOS_UNIVERSAL_BIN=ON -DLLVM_DISABLE_ASSERTIONS=OFF -DISPC_ANDROID_NDK_PATH=/Users/Shared/android-ndk-r20b
+        cmake $ISPC_HOME/superbuild -B build-${{ inputs.version }} --preset os -DLTO=${{ inputs.lto }} -DLLVM_VERSION=${{ inputs.version }} -DCMAKE_INSTALL_PREFIX=$LLVM_HOME/bin-${{ inputs.version }} -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON -DXE_DEPS=OFF -DMACOS_UNIVERSAL_BIN=ON -DLLVM_DISABLE_ASSERTIONS=OFF -DISPC_ANDROID_NDK_PATH=/Users/Shared/android-ndk-r20b
         cmake --build build-${{ inputs.version }}
         rm -rf build-${{ inputs.version }}
 
@@ -377,7 +414,7 @@ jobs:
 
     - name: Build LLVM
       run: |
-        cmake $ISPC_HOME/superbuild -B build-${{ inputs.version }} --preset os -DLLVM_VERSION=${{ inputs.version }} -DCMAKE_INSTALL_PREFIX=$LLVM_HOME/bin-${{ inputs.version }} -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON -DXE_DEPS=OFF -DMACOS_UNIVERSAL_BIN=ON -DLLVM_DISABLE_ASSERTIONS=ON -DISPC_ANDROID_NDK_PATH=/Users/Shared/android-ndk-r20b
+        cmake $ISPC_HOME/superbuild -B build-${{ inputs.version }} --preset os -DLTO=${{ inputs.lto }} -DLLVM_VERSION=${{ inputs.version }} -DCMAKE_INSTALL_PREFIX=$LLVM_HOME/bin-${{ inputs.version }} -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON -DXE_DEPS=OFF -DMACOS_UNIVERSAL_BIN=ON -DLLVM_DISABLE_ASSERTIONS=ON -DISPC_ANDROID_NDK_PATH=/Users/Shared/android-ndk-r20b
         cmake --build build-${{ inputs.version }}
         rm -rf build-${{ inputs.version }}
 

--- a/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
@@ -11,6 +11,8 @@ SHELL ["/bin/bash", "-c"]
 
 ARG REPO=ispc/ispc
 ARG SHA=main
+ARG LTO=OFF
+ARG PGO=OFF
 ARG LLVM_VERSION
 ARG LLVM_DISABLE_ASSERTIONS
 
@@ -69,6 +71,7 @@ RUN git clone https://github.com/$REPO.git ispc && \
     cmake ispc/superbuild \
         -B build \
         --preset os \
+        -DLTO=$LTO \
         -DXE_DEPS=OFF \
         -DLLVM_VERSION="$LLVM_VERSION" \
         -DBUILD_STAGE1_TOOLCHAIN_ONLY=ON \
@@ -86,6 +89,7 @@ WORKDIR /usr/local/src
 RUN cmake ispc/superbuild \
         -B build \
         --preset os \
+        -DLTO=$LTO \
         -DXE_DEPS=OFF \
         -DLLVM_VERSION="$LLVM_VERSION" \
         -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON \
@@ -110,6 +114,7 @@ WORKDIR /usr/local/src
 RUN cmake ispc/superbuild \
         -B build \
         --preset os \
+        -DLTO=$LTO \
         -DXE_DEPS=OFF \
         -DCMAKE_CXX_FLAGS=-Werror \
         -DPREBUILT_STAGE2_PATH="$LLVM_HOME"/bin-"$LLVM_VERSION" \


### PR DESCRIPTION
This PR allows to build LTO-enabled LLVM. Although, linux arm64 and x86_64 Release+Asserts builds hit time limit in CI ([job](https://github.com/ispc/ispc/actions/runs/7114600586)).