### PR TITLE
CI: set read-all permissions

### DIFF
--- a/.github/workflows/compiler-warnings.yml
+++ b/.github/workflows/compiler-warnings.yml
@@ -1,7 +1,9 @@
-# Copyright 2023, Intel Corporation
+# Copyright 2023-2024, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Compiler Warnings
+
+permissions: read-all
 
 on:
   pull_request:

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -1,7 +1,9 @@
-# Copyright 2022, Intel Corporation
+# Copyright 2022-2024, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Check copyright
+
+permissions: read-all
 
 on: [pull_request]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,9 @@
-# Copyright 2021-2023, Intel Corporation
+# Copyright 2021-2024, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Docs check
+
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,7 +1,9 @@
-# Copyright 2020-2023, Intel Corporation
+# Copyright 2020-2024, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Check code formatting
+
+permissions: read-all
 
 on: [push, pull_request]
 

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -20,8 +20,8 @@ on:
         - 'smoke'
 
 env:
-  SDE_MIRROR_ID: 751535
-  SDE_TAR_NAME: sde-external-9.14.0-2022-10-25
+  SDE_MIRROR_ID: 813591
+  SDE_TAR_NAME: sde-external-9.33.0-2024-01-07
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
   LLVM_REPO: https://github.com/ispc/ispc.dependencies
   TARGETS_SMOKE: '["avx2-i32x8"]'

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -1,7 +1,9 @@
-# Copyright 2020-2023, Intel Corporation
+# Copyright 2020-2024, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Tests
+
+permissions: read-all
 
 on:
   schedule:

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -11,8 +11,8 @@ on:
         required: true
         default: 'full'
 env:
-  SDE_MIRROR_ID: 751535
-  SDE_TAR_NAME: sde-external-9.14.0-2022-10-25
+  SDE_MIRROR_ID: 813591
+  SDE_TAR_NAME: sde-external-9.33.0-2024-01-07
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
   LLVM_REPO: https://github.com/ispc/ispc.dependencies
   TARGETS_SMOKE: '["avx2-i32x8"]'

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -1,7 +1,9 @@
-# Copyright 2021-2023, Intel Corporation
+# Copyright 2021-2024, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: SVML
+
+permissions: read-all
 
 on:
   workflow_dispatch:

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -1,7 +1,9 @@
-# Copyright 2020-2023, Intel Corporation
+# Copyright 2020-2024, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Linux benchmarks / LLVM 16.0
+
+permissions: read-all
 
 on:
   pull_request_target:

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -15,8 +15,8 @@ on:
   workflow_dispatch:
 
 env:
-  SDE_MIRROR_ID: 751535
-  SDE_TAR_NAME: sde-external-9.14.0-2022-10-25
+  SDE_MIRROR_ID: 813591
+  SDE_TAR_NAME: sde-external-9.33.0-2024-01-07
 
 jobs:
   # Building LLVM in docker, as using native Ubuntu 18.04 github-hosted image contains newer-than-expected libs and

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -1,9 +1,11 @@
-# Copyright 2020-2023, Intel Corporation
+# Copyright 2020-2024, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Nightly Linux run.
 
 name: Nightly Linux tests / LLVM trunk
+
+permissions: read-all
 
 # Run daily - test sse2-avx512 targets @ -O0/-O1/-O2
 on:

--- a/.github/workflows/nightly-16.yml
+++ b/.github/workflows/nightly-16.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2023, Intel Corporation
+# Copyright 2022-2024, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Nightly Linux run.
@@ -8,6 +8,8 @@
 ####################################################################
 
 name: Nightly tests / LLVM 16.0
+
+permissions: read-all
 
 # Run daily - test sse2-avx512 targets @ -O0/-O1/-O2
 on:

--- a/.github/workflows/nightly-16.yml
+++ b/.github/workflows/nightly-16.yml
@@ -16,8 +16,8 @@ on:
   workflow_dispatch:
 
 env:
-  SDE_MIRROR_ID: 751535
-  SDE_TAR_NAME: sde-external-9.14.0-2022-10-25
+  SDE_MIRROR_ID: 813591
+  SDE_TAR_NAME: sde-external-9.33.0-2024-01-07
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
 
 jobs:

--- a/.github/workflows/rebuild-llvm14.yml
+++ b/.github/workflows/rebuild-llvm14.yml
@@ -1,7 +1,9 @@
-# Copyright 2022 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Rebuild LLVM 14.0
+
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/rebuild-llvm15.yml
+++ b/.github/workflows/rebuild-llvm15.yml
@@ -1,7 +1,9 @@
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Rebuild LLVM 15.0
+
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/rebuild-llvm16.yml
+++ b/.github/workflows/rebuild-llvm16.yml
@@ -1,7 +1,9 @@
-# Copyright 2023 Intel Corporation
+# Copyright 2023-2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Rebuild LLVM 16.0
+
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/rebuild-llvm17.yml
+++ b/.github/workflows/rebuild-llvm17.yml
@@ -1,7 +1,9 @@
-# Copyright 2023 Intel Corporation
+# Copyright 2023-2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Rebuild LLVM 17.0
+
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -1,7 +1,9 @@
-# Copyright 2022 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Reusable LLVM rebuild
+
+permissions: read-all
 
 on:
   workflow_call:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,7 +1,9 @@
-# Copyright 2023, Intel Corporation
+# Copyright 2023-2024, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Sanitizers
+
+permissions: read-all
 
 on:
   pull_request:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,7 +1,9 @@
-# Copyright 2023, Intel Corporation
+# Copyright 2023-2024, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Snap
+
+permissions: read-all
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This PR restricts token permissions used by CI pipelines. It should fix #2732.

It also updates SDE version because the previous one is not accessible anymore.