### PR TITLE
Improve const int varying initialization

### DIFF
--- a/check_copyright.sh
+++ b/check_copyright.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, Intel Corporation
+# Copyright (c) 2022-2024, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 REF="$1"
 
 export YEAR=$(date +%Y)
 
+REPLARG="-S 1024"
+if !(xargs $REPLARG 2>/dev/null); then
+    # xargs doesn't support -S argument, so do not use it
+    REPLARG=""
+fi
+
 # List files with Copyright whether they have up-to-date date.
-git diff --name-only "$REF" | xargs -I {} -S 1024 bash -c 'test -f {} && (grep -q "Copyright.*$YEAR" {} || (grep -q Copyright {} && echo {}))' | ( ! grep ^ )
+git diff --name-only "$REF" | xargs -I {} $REPLARG bash -c 'test -f {} && (grep -q "Copyright.*$YEAR" {} || (grep -q Copyright {} && echo {}))' | ( ! grep ^ )

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -2662,6 +2662,19 @@ guarded with ``#if TARGET_WIDTH``:
         ...
     #endif
 
+However, there is a special case when the only one value is in braces. All
+vector elements are initialized with this value:
+
+::
+
+    varying int x = { 3, };
+
+It is effectively equivalent to:
+
+::
+
+    varying int x = 3;
+
 Arrays can be initialized with individual element values in braces:
 
 ::
@@ -2693,6 +2706,18 @@ the expected syntax:
     struct Foo { int x; float bar[3]; };
     Foo fa[2] = { { 1, { 2, 3, 4 } }, { 10, { 20, 30, 40 } } };
     // now, fa[1].bar[2] == 40, and so forth
+
+Variables with const qualifiers can be initialized using the values of
+previously initialized const variables including arithmetic operations above
+them:
+
+::
+
+    const uniform int x = 1;
+    const uniform int y = 1 + 2;
+    ...
+    const varying int x = { 1, 2, 3, 2 + 2 };
+    const varying int y = x * 2;
 
 Expressions
 -----------

--- a/tests/lit-tests/2738.ispc
+++ b/tests/lit-tests/2738.ispc
@@ -1,0 +1,130 @@
+// RUN: %{ispc} -DTYPE_BOOL --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=BOOL
+// RUN: %{ispc} -DTYPE_INT8 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT8
+// RUN: %{ispc} -DTYPE_UINT8 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT8
+// RUN: %{ispc} -DTYPE_INT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT16
+// RUN: %{ispc} -DTYPE_UINT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT16
+// RUN: %{ispc} -DTYPE_INT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT
+// RUN: %{ispc} -DTYPE_UINT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT
+// RUN: %{ispc} -DTYPE_INT64 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT64
+// RUN: %{ispc} -DTYPE_UINT64 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT64
+// RUN: %{ispc} -DTYPE_FLOAT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=FLOAT16
+// RUN: %{ispc} -DTYPE_FLOAT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=FLOAT
+// RUN: %{ispc} -DTYPE_DOUBLE --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=DOUBLE
+
+// REQUIRES: X86_ENABLED
+
+// BOOL-LABEL: @foo___
+// BOOL-NEXT: allocas:
+// BOOL-NEXT: ret <4 x i32> <i32 0, i32 -1, i32 0, i32 -1>
+
+// INT8-LABEL: @foo___
+// INT8-NEXT: allocas:
+// INT8-NEXT: ret <4 x i8> <i8 1, i8 2, i8 3, i8 4>
+
+// INT16-LABEL: @foo___
+// INT16-NEXT: allocas:
+// INT16-NEXT: ret <4 x i16> <i16 1, i16 2, i16 3, i16 4>
+
+// INT-LABEL: @foo___
+// INT-NEXT: allocas:
+// INT-NEXT: ret <4 x i32> <i32 1, i32 2, i32 3, i32 4>
+
+// INT64-LABEL: @foo___
+// INT64-NEXT: allocas:
+// INT64-NEXT: ret <4 x i64> <i64 1, i64 2, i64 3, i64 4>
+
+// FLOAT16-LABEL: @foo___
+// FLOAT16-NEXT: allocas:
+// FLOAT16-NEXT: ret <4 x half> <half 0xH3C00, half 0xH4000, half 0xH4200, half 0xH4400>
+
+// FLOAT-LABEL: @foo___
+// FLOAT-NEXT: allocas:
+// FLOAT-NEXT: ret <4 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00>
+
+// DOUBLE-LABEL: @foo___
+// DOUBLE-NEXT: allocas:
+// DOUBLE-NEXT: ret <4 x double> <double 1.000000e+00, double 2.000000e+00, double 3.000000e+00, double 4.000000e+00>
+
+// BOOL-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT8-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT16-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT64-NOT: Error: Initializer for global variable "y" must be a constant.
+// FLOAT16-NOT: Error: Initializer for global variable "y" must be a constant.
+// FLOAT-NOT: Error: Initializer for global variable "y" must be a constant.
+// DOUBLE-NOT: Error: Initializer for global variable "y" must be a constant.
+
+#define FP_INITIALIZER 0.0, 1.0, 2.0, 3.0
+#define INT_INITIALIZER 0, 1, 2, 3
+#define BOOL_INITIALIZER true, false, true, false
+
+#ifdef TYPE_BOOL
+#define TYPE bool
+#define INITIALIZER BOOL_INITIALIZER
+#endif
+
+#ifdef TYPE_INT8
+#define TYPE int8
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT8
+#define TYPE uint8
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT16
+#define TYPE int16
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT16
+#define TYPE uint16
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT
+#define TYPE int
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT
+#define TYPE uint
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT64
+#define TYPE int64
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT64
+#define TYPE uint64
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_FLOAT16
+#define TYPE float16
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+#ifdef TYPE_FLOAT
+#define TYPE float
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+#ifdef TYPE_DOUBLE
+#define TYPE double
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+static const TYPE x = { INITIALIZER };
+#ifdef TYPE_BOOL
+static const TYPE y = !x;
+#else
+static const TYPE y = x + 1;
+#endif
+
+TYPE foo() {
+    return y;
+}

--- a/tests/lit-tests/2738_arith_exprs.ispc
+++ b/tests/lit-tests/2738_arith_exprs.ispc
@@ -1,0 +1,130 @@
+// RUN: %{ispc} -DTYPE_BOOL --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=BOOL
+// RUN: %{ispc} -DTYPE_INT8 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT8
+// RUN: %{ispc} -DTYPE_UINT8 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT8
+// RUN: %{ispc} -DTYPE_INT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT16
+// RUN: %{ispc} -DTYPE_UINT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT16
+// RUN: %{ispc} -DTYPE_INT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT
+// RUN: %{ispc} -DTYPE_UINT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT
+// RUN: %{ispc} -DTYPE_INT64 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT64
+// RUN: %{ispc} -DTYPE_UINT64 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT64
+// RUN: %{ispc} -DTYPE_FLOAT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=FLOAT16
+// RUN: %{ispc} -DTYPE_FLOAT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=FLOAT
+// RUN: %{ispc} -DTYPE_DOUBLE --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=DOUBLE
+
+// REQUIRES: X86_ENABLED
+
+// BOOL-LABEL: @foo___
+// BOOL-NEXT: allocas:
+// BOOL-NEXT: ret <4 x i32> <i32 0, i32 -1, i32 0, i32 -1>
+
+// INT8-LABEL: @foo___
+// INT8-NEXT: allocas:
+// INT8-NEXT: ret <4 x i8> <i8 1, i8 2, i8 3, i8 4>
+
+// INT16-LABEL: @foo___
+// INT16-NEXT: allocas:
+// INT16-NEXT: ret <4 x i16> <i16 1, i16 2, i16 3, i16 4>
+
+// INT-LABEL: @foo___
+// INT-NEXT: allocas:
+// INT-NEXT: ret <4 x i32> <i32 1, i32 2, i32 3, i32 4>
+
+// INT64-LABEL: @foo___
+// INT64-NEXT: allocas:
+// INT64-NEXT: ret <4 x i64> <i64 1, i64 2, i64 3, i64 4>
+
+// FLOAT16-LABEL: @foo___
+// FLOAT16-NEXT: allocas:
+// FLOAT16-NEXT: ret <4 x half> <half 0xH3C00, half 0xH4000, half 0xH4200, half 0xH4400>
+
+// FLOAT-LABEL: @foo___
+// FLOAT-NEXT: allocas:
+// FLOAT-NEXT: ret <4 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00>
+
+// DOUBLE-LABEL: @foo___
+// DOUBLE-NEXT: allocas:
+// DOUBLE-NEXT: ret <4 x double> <double 1.000000e+00, double 2.000000e+00, double 3.000000e+00, double 4.000000e+00>
+
+// BOOL-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT8-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT16-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT64-NOT: Error: Initializer for global variable "y" must be a constant.
+// FLOAT16-NOT: Error: Initializer for global variable "y" must be a constant.
+// FLOAT-NOT: Error: Initializer for global variable "y" must be a constant.
+// DOUBLE-NOT: Error: Initializer for global variable "y" must be a constant.
+
+#define FP_INITIALIZER 0.0, 0.0 + 1, 1.0 + 1.0, 5.0 - 2.0
+#define INT_INITIALIZER 0, 1 * 1, 1ul << 1, 6 / 2
+#define BOOL_INITIALIZER true, !true, true || false, true && false
+
+#ifdef TYPE_BOOL
+#define TYPE bool
+#define INITIALIZER BOOL_INITIALIZER
+#endif
+
+#ifdef TYPE_INT8
+#define TYPE int8
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT8
+#define TYPE uint8
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT16
+#define TYPE int16
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT16
+#define TYPE uint16
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT
+#define TYPE int
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT
+#define TYPE uint
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT64
+#define TYPE int64
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT64
+#define TYPE uint64
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_FLOAT16
+#define TYPE float16
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+#ifdef TYPE_FLOAT
+#define TYPE float
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+#ifdef TYPE_DOUBLE
+#define TYPE double
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+static const TYPE x = { INITIALIZER };
+#ifdef TYPE_BOOL
+static const TYPE y = !x;
+#else
+static const TYPE y = x + 1;
+#endif
+
+TYPE foo() {
+    return y;
+}

--- a/tests/lit-tests/2738_cast_types.ispc
+++ b/tests/lit-tests/2738_cast_types.ispc
@@ -1,0 +1,130 @@
+// RUN: %{ispc} -DTYPE_BOOL --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=BOOL
+// RUN: %{ispc} -DTYPE_INT8 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT8
+// RUN: %{ispc} -DTYPE_UINT8 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT8
+// RUN: %{ispc} -DTYPE_INT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT16
+// RUN: %{ispc} -DTYPE_UINT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT16
+// RUN: %{ispc} -DTYPE_INT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT
+// RUN: %{ispc} -DTYPE_UINT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT
+// RUN: %{ispc} -DTYPE_INT64 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT64
+// RUN: %{ispc} -DTYPE_UINT64 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT64
+// RUN: %{ispc} -DTYPE_FLOAT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=FLOAT16
+// RUN: %{ispc} -DTYPE_FLOAT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=FLOAT
+// RUN: %{ispc} -DTYPE_DOUBLE --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=DOUBLE
+
+// REQUIRES: X86_ENABLED
+
+// BOOL-LABEL: @foo___
+// BOOL-NEXT: allocas:
+// BOOL-NEXT: ret <4 x i32> <i32 0, i32 -1, i32 0, i32 -1>
+
+// INT8-LABEL: @foo___
+// INT8-NEXT: allocas:
+// INT8-NEXT: ret <4 x i8> <i8 1, i8 2, i8 3, i8 4>
+
+// INT16-LABEL: @foo___
+// INT16-NEXT: allocas:
+// INT16-NEXT: ret <4 x i16> <i16 1, i16 2, i16 3, i16 4>
+
+// INT-LABEL: @foo___
+// INT-NEXT: allocas:
+// INT-NEXT: ret <4 x i32> <i32 1, i32 2, i32 3, i32 4>
+
+// INT64-LABEL: @foo___
+// INT64-NEXT: allocas:
+// INT64-NEXT: ret <4 x i64> <i64 1, i64 2, i64 3, i64 4>
+
+// FLOAT16-LABEL: @foo___
+// FLOAT16-NEXT: allocas:
+// FLOAT16-NEXT: ret <4 x half> <half 0xH3C00, half 0xH4000, half 0xH4200, half 0xH4400>
+
+// FLOAT-LABEL: @foo___
+// FLOAT-NEXT: allocas:
+// FLOAT-NEXT: ret <4 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00>
+
+// DOUBLE-LABEL: @foo___
+// DOUBLE-NEXT: allocas:
+// DOUBLE-NEXT: ret <4 x double> <double 1.000000e+00, double 2.000000e+00, double 3.000000e+00, double 4.000000e+00>
+
+// BOOL-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT8-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT16-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT64-NOT: Error: Initializer for global variable "y" must be a constant.
+// FLOAT16-NOT: Error: Initializer for global variable "y" must be a constant.
+// FLOAT-NOT: Error: Initializer for global variable "y" must be a constant.
+// DOUBLE-NOT: Error: Initializer for global variable "y" must be a constant.
+
+#define FP_INITIALIZER 0.0, (float16)1, (float)2.0, (double)3.0
+#define INT_INITIALIZER 0, (int16)1, (uint8)2, (int64)3ul
+#define BOOL_INITIALIZER true, (bool)0.0, (bool)1ull, (bool)0
+
+#ifdef TYPE_BOOL
+#define TYPE bool
+#define INITIALIZER BOOL_INITIALIZER
+#endif
+
+#ifdef TYPE_INT8
+#define TYPE int8
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT8
+#define TYPE uint8
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT16
+#define TYPE int16
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT16
+#define TYPE uint16
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT
+#define TYPE int
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT
+#define TYPE uint
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT64
+#define TYPE int64
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT64
+#define TYPE uint64
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_FLOAT16
+#define TYPE float16
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+#ifdef TYPE_FLOAT
+#define TYPE float
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+#ifdef TYPE_DOUBLE
+#define TYPE double
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+static const TYPE x = { INITIALIZER };
+#ifdef TYPE_BOOL
+static const TYPE y = !x;
+#else
+static const TYPE y = x + 1;
+#endif
+
+TYPE foo() {
+    return y;
+}

--- a/tests/lit-tests/2738_mixed_types.ispc
+++ b/tests/lit-tests/2738_mixed_types.ispc
@@ -1,0 +1,130 @@
+// RUN: %{ispc} -DTYPE_BOOL --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=BOOL
+// RUN: %{ispc} -DTYPE_INT8 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT8
+// RUN: %{ispc} -DTYPE_UINT8 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT8
+// RUN: %{ispc} -DTYPE_INT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT16
+// RUN: %{ispc} -DTYPE_UINT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT16
+// RUN: %{ispc} -DTYPE_INT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT
+// RUN: %{ispc} -DTYPE_UINT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT
+// RUN: %{ispc} -DTYPE_INT64 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT64
+// RUN: %{ispc} -DTYPE_UINT64 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT64
+// RUN: %{ispc} -DTYPE_FLOAT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=FLOAT16
+// RUN: %{ispc} -DTYPE_FLOAT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=FLOAT
+// RUN: %{ispc} -DTYPE_DOUBLE --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=DOUBLE
+
+// REQUIRES: X86_ENABLED
+
+// BOOL-LABEL: @foo___
+// BOOL-NEXT: allocas:
+// BOOL-NEXT: ret <4 x i32> <i32 0, i32 -1, i32 0, i32 -1>
+
+// INT8-LABEL: @foo___
+// INT8-NEXT: allocas:
+// INT8-NEXT: ret <4 x i8> <i8 1, i8 2, i8 3, i8 4>
+
+// INT16-LABEL: @foo___
+// INT16-NEXT: allocas:
+// INT16-NEXT: ret <4 x i16> <i16 1, i16 2, i16 3, i16 4>
+
+// INT-LABEL: @foo___
+// INT-NEXT: allocas:
+// INT-NEXT: ret <4 x i32> <i32 1, i32 2, i32 3, i32 4>
+
+// INT64-LABEL: @foo___
+// INT64-NEXT: allocas:
+// INT64-NEXT: ret <4 x i64> <i64 1, i64 2, i64 3, i64 4>
+
+// FLOAT16-LABEL: @foo___
+// FLOAT16-NEXT: allocas:
+// FLOAT16-NEXT: ret <4 x half> <half 0xH3C00, half 0xH4000, half 0xH4200, half 0xH4400>
+
+// FLOAT-LABEL: @foo___
+// FLOAT-NEXT: allocas:
+// FLOAT-NEXT: ret <4 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00>
+
+// DOUBLE-LABEL: @foo___
+// DOUBLE-NEXT: allocas:
+// DOUBLE-NEXT: ret <4 x double> <double 1.000000e+00, double 2.000000e+00, double 3.000000e+00, double 4.000000e+00>
+
+// BOOL-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT8-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT16-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT64-NOT: Error: Initializer for global variable "y" must be a constant.
+// FLOAT16-NOT: Error: Initializer for global variable "y" must be a constant.
+// FLOAT-NOT: Error: Initializer for global variable "y" must be a constant.
+// DOUBLE-NOT: Error: Initializer for global variable "y" must be a constant.
+
+#define FP_INITIALIZER 0.0f16, 1, 2.0f, 3.0d
+#define INT_INITIALIZER 0, 1ll, 2ul, 3.0
+#define BOOL_INITIALIZER true, 0.0, 1, 0
+
+#ifdef TYPE_BOOL
+#define TYPE bool
+#define INITIALIZER BOOL_INITIALIZER
+#endif
+
+#ifdef TYPE_INT8
+#define TYPE int8
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT8
+#define TYPE uint8
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT16
+#define TYPE int16
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT16
+#define TYPE uint16
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT
+#define TYPE int
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT
+#define TYPE uint
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT64
+#define TYPE int64
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT64
+#define TYPE uint64
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_FLOAT16
+#define TYPE float16
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+#ifdef TYPE_FLOAT
+#define TYPE float
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+#ifdef TYPE_DOUBLE
+#define TYPE double
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+static const TYPE x = { INITIALIZER };
+#ifdef TYPE_BOOL
+static const TYPE y = !x;
+#else
+static const TYPE y = x + 1;
+#endif
+
+TYPE foo() {
+    return y;
+}

--- a/tests/lit-tests/2738_one_init.ispc
+++ b/tests/lit-tests/2738_one_init.ispc
@@ -1,0 +1,114 @@
+// RUN: %{ispc} -DTYPE_BOOL --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=BOOL
+// RUN: %{ispc} -DTYPE_INT8 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT8
+// RUN: %{ispc} -DTYPE_UINT8 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT8
+// RUN: %{ispc} -DTYPE_INT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT16
+// RUN: %{ispc} -DTYPE_UINT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT16
+// RUN: %{ispc} -DTYPE_INT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT
+// RUN: %{ispc} -DTYPE_UINT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT
+// RUN: %{ispc} -DTYPE_INT64 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT64
+// RUN: %{ispc} -DTYPE_UINT64 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=INT64
+// RUN: %{ispc} -DTYPE_FLOAT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=FLOAT16
+// RUN: %{ispc} -DTYPE_FLOAT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=FLOAT
+// RUN: %{ispc} -DTYPE_DOUBLE --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=DOUBLE
+
+// REQUIRES: X86_ENABLED
+
+// BOOL-LABEL: @foo___
+// BOOL-NEXT: allocas:
+// BOOL-NEXT: ret <4 x i32> zeroinitializer
+
+// INT8-LABEL: @foo___
+// INT8-NEXT: allocas:
+// INT8-NEXT: ret <4 x i8> <i8 2, i8 2, i8 2, i8 2>
+
+// INT16-LABEL: @foo___
+// INT16-NEXT: allocas:
+// INT16-NEXT: ret <4 x i16> <i16 2, i16 2, i16 2, i16 2>
+
+// INT-LABEL: @foo___
+// INT-NEXT: allocas:
+// INT-NEXT: ret <4 x i32> <i32 2, i32 2, i32 2, i32 2>
+
+// INT64-LABEL: @foo___
+// INT64-NEXT: allocas:
+// INT64-NEXT: ret <4 x i64> <i64 2, i64 2, i64 2, i64 2>
+
+// FLOAT16-LABEL: @foo___
+// FLOAT16-NEXT: allocas:
+// FLOAT16-NEXT: ret <4 x half> <half 0xH4000, half 0xH4000, half 0xH4000, half 0xH4000>
+
+// FLOAT-LABEL: @foo___
+// FLOAT-NEXT: allocas:
+// FLOAT-NEXT: ret <4 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>
+
+// DOUBLE-LABEL: @foo___
+// DOUBLE-NEXT: allocas:
+// DOUBLE-NEXT: ret <4 x double> <double 2.000000e+00, double 2.000000e+00, double 2.000000e+00, double 2.000000e+00>
+
+// BOOL-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT8-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT16-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT-NOT: Error: Initializer for global variable "y" must be a constant.
+// INT64-NOT: Error: Initializer for global variable "y" must be a constant.
+// FLOAT16-NOT: Error: Initializer for global variable "y" must be a constant.
+// FLOAT-NOT: Error: Initializer for global variable "y" must be a constant.
+// DOUBLE-NOT: Error: Initializer for global variable "y" must be a constant.
+
+#ifdef TYPE_BOOL
+#define TYPE bool
+#endif
+
+#ifdef TYPE_INT8
+#define TYPE int8
+#endif
+
+#ifdef TYPE_UINT8
+#define TYPE uint8
+#endif
+
+#ifdef TYPE_INT16
+#define TYPE int16
+#endif
+
+#ifdef TYPE_UINT16
+#define TYPE uint16
+#endif
+
+#ifdef TYPE_INT
+#define TYPE int
+#endif
+
+#ifdef TYPE_UINT
+#define TYPE uint
+#endif
+
+#ifdef TYPE_INT64
+#define TYPE int64
+#endif
+
+#ifdef TYPE_UINT64
+#define TYPE uint64
+#endif
+
+#ifdef TYPE_FLOAT16
+#define TYPE float16
+#endif
+
+#ifdef TYPE_FLOAT
+#define TYPE float
+#endif
+
+#ifdef TYPE_DOUBLE
+#define TYPE double
+#endif
+
+static const TYPE x = { 1 };
+#ifdef TYPE_BOOL
+static const TYPE y = !x;
+#else
+static const TYPE y = x + 1;
+#endif
+
+TYPE foo() {
+    return y;
+}

--- a/tests/lit-tests/2738_partial_init.ispc
+++ b/tests/lit-tests/2738_partial_init.ispc
@@ -1,0 +1,91 @@
+// RUN: not %{ispc} -DTYPE_BOOL --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+// RUN: not %{ispc} -DTYPE_INT8 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+// RUN: not %{ispc} -DTYPE_UINT8 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+// RUN: not %{ispc} -DTYPE_INT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+// RUN: not %{ispc} -DTYPE_UINT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+// RUN: not %{ispc} -DTYPE_INT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+// RUN: not %{ispc} -DTYPE_UINT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+// RUN: not %{ispc} -DTYPE_INT64 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+// RUN: not %{ispc} -DTYPE_UINT64 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+// RUN: not %{ispc} -DTYPE_FLOAT16 --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+// RUN: not %{ispc} -DTYPE_FLOAT --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+// RUN: not %{ispc} -DTYPE_DOUBLE --target=avx2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK: Error: Initializer list for {{.*}} must have 4 elements
+
+#define FP_INITIALIZER 0.0, 1.0
+#define INT_INITIALIZER 0, 1
+#define BOOL_INITIALIZER true, false
+
+#ifdef TYPE_BOOL
+#define TYPE bool
+#define INITIALIZER BOOL_INITIALIZER
+#endif
+
+#ifdef TYPE_INT8
+#define TYPE int8
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT8
+#define TYPE uint8
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT16
+#define TYPE int16
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT16
+#define TYPE uint16
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT
+#define TYPE int
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT
+#define TYPE uint
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_INT64
+#define TYPE int64
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_UINT64
+#define TYPE uint64
+#define INITIALIZER INT_INITIALIZER
+#endif
+
+#ifdef TYPE_FLOAT16
+#define TYPE float16
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+#ifdef TYPE_FLOAT
+#define TYPE float
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+#ifdef TYPE_DOUBLE
+#define TYPE double
+#define INITIALIZER FP_INITIALIZER
+#endif
+
+static const TYPE x = { INITIALIZER };
+#ifdef TYPE_BOOL
+static const TYPE y = !x;
+#else
+static const TYPE y = x + 1;
+#endif
+
+TYPE foo() {
+    return y;
+}


### PR DESCRIPTION
Allow to use arithmetic expression with const int varying initialized by list initializer with constants.

This fixes #2738 