### PR TITLE
Zero extend bool values for storage representation

### DIFF
--- a/tests/lit-tests/2752-1.ispc
+++ b/tests/lit-tests/2752-1.ispc
@@ -1,0 +1,37 @@
+// RUN: %{ispc} -DISPC --pic --target=host -h %t.h %s -o %t.o
+// RUN: %{cc} -x c -c %s -o %t.c.o --include %t.h
+// RUN: %{cc} %t.o %t.c.o -o %t.c.bin
+// RUN: %t.c.bin | FileCheck %s
+// RUN: %{cc} -x c++ -c %s -o %t.cpp.o --include %t.h
+// RUN: %{cxx} %t.o %t.cpp.o -o %t.cpp.bin
+// RUN: %t.cpp.bin | FileCheck %s
+
+// REQUIRES: !MACOS_HOST
+
+// CHECK: b=1, b==true is 1
+
+#ifdef ISPC
+export void set(uniform bool &result) {
+    result = true;
+}
+#else
+#if defined(__cplusplus)
+#include <iostream>
+using namespace ispc;
+int main(int argc, char **argv) {
+    bool b = false;
+    set(b);
+    std::cout << "b=" << b << ", b==true is " <<  (b == true) << "\n";
+    return 0;
+}
+#else
+#include <stdio.h>
+int main(int argc, char **argv) {
+    bool b = 0;
+    set(&b);
+    printf("b=%i, b==true is %i\n", b, b == !0);
+    return 0;
+}
+#endif
+#endif
+

--- a/tests/lit-tests/2752.ispc
+++ b/tests/lit-tests/2752.ispc
@@ -1,0 +1,30 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s --check-prefix=LLVM
+// RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-asm --x86-asm-syntax=intel %s -o - | FileCheck %s --check-prefix=ASM
+
+// LLVM-LABEL: @set_ref(
+// LLVM-NEXT: allocas:
+// LLVM-NEXT: store i8 1, {{.*}} %result
+// LLVM-NEXT: ret void
+
+// ASM-LABEL: set_ref:
+// ASM-NEXT: # %bb.0:
+// ASM-NEXT:        mov     byte ptr [r{{.*}}], 1
+// ASM-NEXT:        ret
+
+export void set_ref(uniform bool &result) {
+    result = true;
+}
+
+// LLVM-LABEL: @set_ptr(
+// LLVM-NEXT: allocas:
+// LLVM-NEXT: store i8 1, {{.*}} %result
+// LLVM-NEXT: ret void
+
+// ASM-LABEL: set_ptr:
+// ASM-NEXT: # %bb.0:
+// ASM-NEXT:        mov     byte ptr [r{{.*}}], 1
+// ASM-NEXT:        ret
+
+export void set_ptr(uniform bool * uniform result) {
+    *result = true;
+}

--- a/tests/lit-tests/2753.ispc
+++ b/tests/lit-tests/2753.ispc
@@ -1,0 +1,15 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-asm --x86-asm-syntax=intel %s -o - | FileCheck %s --check-prefix=O2
+// RUN: %{ispc} --target=host --nowrap --nostdlib -O0 --emit-asm --x86-asm-syntax=intel %s -o - | FileCheck %s --check-prefix=O0
+
+// O2-LABEL: set:
+// O2-NEXT:# %bb.0:
+// O2-NEXT:        mov     al, 1
+// O2-NEXT:        ret
+
+// O0-LABEL: set:
+// O0:        mov     byte ptr [rsp {{[-+]}} {{[0-9]+}}], 1
+// O0:        mov     al, byte ptr [rsp {{[-+]}}  {{[0-9]+}}]
+// O0:        ret
+export uniform bool set() {
+    return true;
+}

--- a/tests/lit-tests/bool-store-varying.ispc
+++ b/tests/lit-tests/bool-store-varying.ispc
@@ -18,7 +18,7 @@ uniform bool x;
 // COMMON-LABEL: @foo___vyTvyT(
 // COMMON-NEXT: allocas:
 // COMMON-NEXT: [[CMP:%.*]] = icmp ult <[[WIDTH]] x i8> %a, %b
-// COMMON-NEXT: [[CAST:%.*]] = sext <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x i8>
+// COMMON-NEXT: [[CAST:%.*]] = zext <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x i8>
 // COMMON-NEXT: store <[[WIDTH]] x i8> [[CAST]], {{.*}} @y
 // COMMON-NEXT: ret void
 
@@ -37,13 +37,14 @@ void foo(uint8 a, uint8 b)
 
 // AVX2: define void @boo___vyb(<[[WIDTH]] x [[RTYPE:i[0-9]+]]> %a, <[[WIDTH]] x [[RTYPE]]> %__mask)
 // AVX2-NEXT: allocas:
-// AVX2-NEXT: [[CAST:%.*]] = trunc <[[WIDTH]] x [[RTYPE]]> %a to <[[WIDTH]] x i8>
+// AVX2-NEXT: [[TRUNC:%.*]] = trunc <[[WIDTH]] x [[RTYPE]]> %a to <[[WIDTH]] x i8>
+// AVX2-NEXT: [[CAST:%.*]] = and <[[WIDTH]] x i8> [[TRUNC]], <i8 1, i8 1, i8 1, i8 1>
 // AVX2-NEXT: store <[[WIDTH]] x i8> [[CAST]], {{.*}} @y
 // AVX2-NEXT: ret void
 
 // AVX512: define void @boo___vyb(<[[WIDTH]] x [[RTYPE:i[0-9]+]]> %a, <[[WIDTH]] x [[RTYPE]]> %__mask)
 // AVX512-NEXT: allocas:
-// AVX512-NEXT: [[CAST:%.*]] = sext <[[WIDTH]] x [[RTYPE]]> %a to <[[WIDTH]] x i8>
+// AVX512-NEXT: [[CAST:%.*]] = zext <[[WIDTH]] x [[RTYPE]]> %a to <[[WIDTH]] x i8>
 // AVX512-NEXT: store <[[WIDTH]] x i8> [[CAST]], {{.*}} @y
 // AVX512-NEXT: ret void
 
@@ -53,7 +54,7 @@ void boo(bool a) {
 
 // COMMON: define void @coo___unb(i1 %a
 // COMMON-NEXT: allocas:
-// COMMON-NEXT: [[CAST:%.*]] = sext i1 %a to i8
+// COMMON-NEXT: [[CAST:%.*]] = zext i1 %a to i8
 // COMMON-NEXT: store i8 [[CAST]], {{.*}} @x
 // COMMON-NEXT: ret void
 

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -25,6 +25,7 @@ if ispc_test_exec_root != '':
 config.substitutions.append(('%{ispc}', 'ispc'))
 config.substitutions.append(('FileCheck', 'FileCheck'))
 config.substitutions.append(('%{cc}', 'clang'))
+config.substitutions.append(('%{cxx}', 'clang++'))
 
 print("Config:")
 


### PR DESCRIPTION
This PR fixes ABI incompatibility of `bool` type covered by issues #2752, #2753 that were introduced in 1.13 release by commit #https://github.com/ispc/ispc/commit/c889cdee2b5c7ebecb2f159b3173ea22f4318474. That commit split `bool` type to two different representations (internal corresponding to mask and in-memory/storage corresponding to C/C++). Storage representation of `bool` has to comply with ABI not only about their size but about their values either. We need to zero extend values when converting boolean values for storage representation.


Copied from comments:
Internal representation of bool matches mask behavior that requires `true` value to be `-1`. It is an implication of some instruction requirements, e.g., `blendvps` (the most significant bit should be 1). Whereas, storage representation matches SystemV ABI (or windows one). It requires `bool` to be presented as one `byte` with the least significant bit equal `0` or `1` and others `7` bits equal to `0`, i.e., `true` is `1` when we read or write values to/from `C/C++`. Both `fromType` and `toType` can be vector or scalar and storage or internal `bool` representation. We need to support here conversion from internal vector type to storage vector type, it may be conversions: 1) `<4 x i32>` to `<4 x i8>` or 2) `<4 x i8>` to `<4 x i32>`, e.g., 1) `<-1, 0,...>` to `<1, 0,...>` 2) `<1, 0,...>` to `<-1, 0,...>`. To support all cases with less code do bool casting in two stages:
1) truncate to LLVM IR native bool types `i1` or `<N x i1>`
2) zero or sign extend from native bool types to storage or internal correspondingly.