### PR TITLE
Allow select expr to be a lvalue

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -3648,6 +3648,15 @@ const Type *SelectExpr::GetType() const {
                                  becomesVarying, vectorSize);
 }
 
+const Type *SelectExpr::GetLValueType() const {
+    const Type *t = GetType();
+    if (CastType<PointerType>(t) != nullptr) {
+        return t;
+    } else {
+        return nullptr;
+    }
+}
+
 template <typename T>
 Expr *lConstFoldSelect(const bool bv[], ConstExpr *constExpr1, ConstExpr *constExpr2, const Type *exprType,
                        SourcePos pos) {
@@ -4619,8 +4628,9 @@ llvm::Value *IndexExpr::GetValue(FunctionEmitContext *ctx) const {
         mask = LLVMMaskAllOn;
     } else {
         Symbol *baseSym = GetBaseSymbol();
-        if (llvm::dyn_cast<FunctionCallExpr>(baseExpr) == nullptr && llvm::dyn_cast<BinaryExpr>(baseExpr) == nullptr) {
-            // Don't check if we're doing a function call or pointer arith
+        if (llvm::dyn_cast<FunctionCallExpr>(baseExpr) == nullptr && llvm::dyn_cast<BinaryExpr>(baseExpr) == nullptr &&
+            llvm::dyn_cast<SelectExpr>(baseExpr) == nullptr) {
+            // Don't check if we're doing a function call or pointer arith or select
             AssertPos(pos, baseSym != nullptr);
         }
         mask = lMaskForSymbol(baseSym, ctx);

--- a/src/expr.h
+++ b/src/expr.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2023, Intel Corporation
+  Copyright (c) 2010-2024, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -212,6 +212,7 @@ class SelectExpr : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
+    const Type *GetLValueType() const;
     void Print(Indent &indent) const;
 
     Expr *Optimize();

--- a/tests/lit-tests/2754-1.ispc
+++ b/tests/lit-tests/2754-1.ispc
@@ -1,0 +1,24 @@
+// RUN: %{ispc} -DISPC --pic --target=host -h %t.h %s -o %t.o
+// RUN: %{cc} -x c -c %s -o %t.c.o --include %t.h
+// RUN: %{cc} %t.o %t.c.o -o %t.c.bin
+// RUN: %t.c.bin | FileCheck %s
+
+// REQUIRES: !MACOS_HOST
+
+// CHECK: a[2]=-3 b[2]=3
+
+#ifdef ISPC
+export uniform int func(uniform bool cond, uniform int a[], uniform int b[]) {
+    return (cond ? a : b)[2];
+}
+#else
+#include <stdio.h>
+int main(int argc, char **argv) {
+    int a[] = { -1, -2, -3, -4 };
+    int b[] = { 1, 2, 3, 4 };
+    int a2 = func(true, a, b);
+    int b2 = func(false, a, b);
+    printf("a[2]=%i b[2]=%i\n", a2, b2);
+    return 0;
+}
+#endif

--- a/tests/lit-tests/2754.ispc
+++ b/tests/lit-tests/2754.ispc
@@ -1,0 +1,20 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib --emit-llvm-text %s -o - | FileCheck %s
+
+// CHECK-NOT: FATAL ERROR: Unhandled signal sent to process
+
+varying float test_orig(uniform bool bCond, uniform float* uniform * uniform ptrA, uniform float* uniform* uniform ptrB)
+{
+    return (bCond ? *ptrA : *ptrB)[programIndex];
+}
+
+// CHECK-LABEL: @test(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT:   [[SELECT:%.*]] = select i1 %bCond, {{.*}} %a, {{.*}} %b
+// CHECK-NEXT:   [[PTR:%.*]] = getelementptr i32, {{.*}} [[SELECT]], i64 4
+// CHECK-NEXT:   [[LOAD:%.*]] = load i32, {{.*}} [[PTR]]
+// CHECK-NEXT:   ret i32 [[LOAD]]
+// CHECK-NEXT: }
+export uniform int test(uniform bool bCond, uniform int* uniform a, uniform int* uniform b)
+{
+    return (bCond ? a : b)[4];
+}


### PR DESCRIPTION
This PR allows to use select expr (ternary operator) as lvalue, e.g., dereference it. This fixes #2754 