### PR TITLE
lit-tests: adjust tests for arm

### DIFF
--- a/tests/lit-tests/2752.ispc
+++ b/tests/lit-tests/2752.ispc
@@ -1,6 +1,8 @@
 // RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s --check-prefix=LLVM
 // RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-asm --x86-asm-syntax=intel %s -o - | FileCheck %s --check-prefix=ASM
 
+// REQUIRES: X86_ENABLED && !ARM_ENABLED
+
 // LLVM-LABEL: @set_ref(
 // LLVM-NEXT: allocas:
 // LLVM-NEXT: store i8 1, {{.*}} %result

--- a/tests/lit-tests/2753.ispc
+++ b/tests/lit-tests/2753.ispc
@@ -1,6 +1,8 @@
 // RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-asm --x86-asm-syntax=intel %s -o - | FileCheck %s --check-prefix=O2
 // RUN: %{ispc} --target=host --nowrap --nostdlib -O0 --emit-asm --x86-asm-syntax=intel %s -o - | FileCheck %s --check-prefix=O0
 
+// REQUIRES: X86_ENABLED && !ARM_ENABLED
+
 // O2-LABEL: set:
 // O2-NEXT:# %bb.0:
 // O2-NEXT:        mov     al, 1

--- a/tests/lit-tests/bool-store-vector.ispc
+++ b/tests/lit-tests/bool-store-vector.ispc
@@ -1,5 +1,7 @@
 // RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s
 
+// REQUIRES: X86_ENABLED && !ARM_ENABLED
+
 uniform bool<4> x;
 
 // CHECK-LABEL: @foo___unT_3C_4_3E_unT_3C_4_3E_(


### PR DESCRIPTION
Do not try to match x86 asm when arm asm generated. I think we need to create CI jobs that will run tests on `aarch64` worker that we have in our CI to avoid this in future.

When `host` can generate both `x86` and `asm` it is not clear how to distinguish when host is arm target when it is not (especially minding that universal binary contains both), so `X86_ENABLED && !ARM_ENABLED` is used. We need to figure out that properly later.

`bool-store-vector.ispc` checks that ISPC sign extends `i1` for internal `bool` representation. I am not sure whether there is a requirement of internal `true` to be `-1` for `arm`, but it looks like ISPC matched their behavior before. We need to figure out that later.

