### PR TITLE
Refactor TemplateArgs to support non-type parameters

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -8289,7 +8289,7 @@ FunctionSymbolExpr *FunctionSymbolExpr::Instantiate(TemplateInstantiation &templ
     }
     TemplateArgs instTemplateArgs;
     for (auto &arg : templateArgs) {
-        instTemplateArgs.AddArg(
+        instTemplateArgs.push_back(
             arg.IsType() ? TemplateArg(arg.GetAsType()->ResolveDependenceForTopType(templInst), arg.GetPos()) : arg);
     }
     return new FunctionSymbolExpr(name.c_str(), candidateTemplateFunctions, instTemplateArgs, pos);
@@ -8544,7 +8544,7 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
         }
 
         // This looks like a candidate, so now we need get to instantiation and add it to candidate list.
-        if (templateArgs.Size() == templateParms->GetCount()) {
+        if (templateArgs.size() == templateParms->GetCount()) {
             // Easy, we have all template arguments specified explicitly, no deduction is needed.
             Symbol *funcSym = templSym->functionTemplate->LookupInstantiation(templateArgs);
             if (funcSym == nullptr) {
@@ -8555,7 +8555,7 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
             // Success
             ret.push_back(funcSym);
             continue;
-        } else if (templateArgs.Size() > templateParms->GetCount()) {
+        } else if (templateArgs.size() > templateParms->GetCount()) {
             // Too many template arguments specified
             continue;
         }
@@ -8653,8 +8653,8 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
         // Build a complete vector of deduced template arguments.
         TemplateArgs deducedArgs;
         for (int i = 0; i < templateParms->GetCount(); ++i) {
-            if (i < templateArgs.Size()) {
-                deducedArgs.AddArg(templateArgs[i]);
+            if (i < templateArgs.size()) {
+                deducedArgs.push_back(templateArgs[i]);
             } else {
                 const Type *deducedArg = inst.InstantiateType((*templateParms)[i]->GetName());
                 if (!deducedArg || deducedArg->IsDependentType()) {
@@ -8663,7 +8663,7 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
                     deductionFailed = true;
                     break;
                 }
-                deducedArgs.AddArg(TemplateArg(deducedArg, pos));
+                deducedArgs.push_back(TemplateArg(deducedArg, pos));
             }
         }
         if (deductionFailed) {

--- a/src/expr.h
+++ b/src/expr.h
@@ -12,6 +12,7 @@
 
 #include "ast.h"
 #include "ctx.h"
+#include "func.h"
 #include "ispc.h"
 #include "type.h"
 
@@ -737,8 +738,8 @@ class SymbolExpr : public Expr {
 class FunctionSymbolExpr : public Expr {
   public:
     FunctionSymbolExpr(const char *name, const std::vector<Symbol *> &candFuncs, SourcePos pos);
-    FunctionSymbolExpr(const char *name, const std::vector<TemplateSymbol *> &candFuncs,
-                       const std::vector<std::pair<const Type *, SourcePos>> &types, SourcePos pos);
+    FunctionSymbolExpr(const char *name, const std::vector<TemplateSymbol *> &candFuncs, const TemplateArgs &templArgs,
+                       SourcePos pos);
 
     static inline bool classof(FunctionSymbolExpr const *) { return true; }
     static inline bool classof(ASTNode const *N) { return N->getValueID() == FunctionSymbolExprID; }
@@ -784,7 +785,7 @@ class FunctionSymbolExpr : public Expr {
         overload is the best match. */
     std::vector<Symbol *> candidateFunctions;
     std::vector<TemplateSymbol *> candidateTemplateFunctions;
-    std::vector<std::pair<const Type *, SourcePos>> templateArgs;
+    TemplateArgs templateArgs;
 
     /** The actual matching function found after overload resolution. */
     Symbol *matchingFunc;

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -835,7 +835,7 @@ std::string TemplateArg::GetString() const {
 
 bool TemplateArg::IsType() const { return argType == ArgType::Type; }
 
-bool TemplateArg::IsEqual(const TemplateArg &other) const {
+bool TemplateArg::operator==(const TemplateArg &other) const {
     if (argType != other.argType)
         return false;
     switch (argType) {
@@ -861,37 +861,6 @@ void TemplateArg::SetAsVaryingType() {
         type = type->GetAsVaryingType();
     }
 }
-///////////////////////////////////////////////////////////////////////////
-// TemplateArgs
-TemplateArgs::TemplateArgs(const std::vector<TemplateArg> &args) : args(args) {}
-
-void TemplateArgs::AddArg(const TemplateArg &arg) { args.push_back(arg); }
-
-const std::vector<TemplateArg> &TemplateArgs::GetArgs() const { return args; }
-
-bool TemplateArgs::IsEqual(const TemplateArgs &other) const {
-    if (args.size() != other.args.size())
-        return false;
-    for (size_t i = 0; i < args.size(); ++i) {
-        if (!args[i].IsEqual(other.args[i]))
-            return false;
-    }
-    return true;
-}
-
-size_t TemplateArgs::Size() const { return args.size(); }
-
-std::vector<TemplateArg>::iterator TemplateArgs::begin() { return args.begin(); }
-
-std::vector<TemplateArg>::iterator TemplateArgs::end() { return args.end(); }
-
-std::vector<TemplateArg>::const_iterator TemplateArgs::begin() const { return args.begin(); }
-
-std::vector<TemplateArg>::const_iterator TemplateArgs::end() const { return args.end(); }
-
-const TemplateArg &TemplateArgs::operator[](std::size_t index) { return args[index]; }
-
-const TemplateArg &TemplateArgs::operator[](std::size_t index) const { return args[index]; }
 
 ///////////////////////////////////////////////////////////////////////////
 // FunctionTemplate
@@ -1005,10 +974,10 @@ void FunctionTemplate::Print(Indent &indent) const {
 
     for (const auto &inst : instantiations) {
         std::string args;
-        for (size_t i = 0; i < inst.first->Size(); i++) {
+        for (size_t i = 0; i < inst.first->size(); i++) {
             const TemplateArg &arg = (*inst.first)[i];
             args += arg.GetString();
-            if (i + 1 < inst.first->Size()) {
+            if (i + 1 < inst.first->size()) {
                 args += ", ";
             }
         }
@@ -1033,7 +1002,7 @@ bool FunctionTemplate::IsStdlibSymbol() const {
 Symbol *FunctionTemplate::LookupInstantiation(const TemplateArgs &tArgs) {
     TemplateArgs argsToMatch(tArgs);
     for (const auto &inst : instantiations) {
-        if (inst.first->IsEqual(argsToMatch)) {
+        if (*(inst.first) == argsToMatch) {
             return inst.second;
         }
     }
@@ -1098,16 +1067,16 @@ Symbol *FunctionTemplate::AddSpecialization(const FunctionType *ftype, const Tem
 TemplateInstantiation::TemplateInstantiation(const TemplateParms &typeParms, const TemplateArgs &tArgs,
                                              TemplateInstantiationKind k, bool ii, bool ini)
     : functionSym(nullptr), kind(k), isInline(ii), isNoInline(ini) {
-    Assert(tArgs.Size() <= typeParms.GetCount());
+    Assert(tArgs.size() <= typeParms.GetCount());
     // Create a mapping from the template parameters to the arguments.
     // Note we do that for all specified templates arguments, which number may be less than a number of template
     // parameters. In this case the rest of template parameters will be deduced later during template argumnet
     // deduction.
-    for (int i = 0; i < tArgs.Size(); i++) {
+    for (int i = 0; i < tArgs.size(); i++) {
         std::string name = typeParms[i]->GetName();
         const Type *type = tArgs[i].GetAsType();
         argsTypeMap[name] = type;
-        templateArgs.AddArg(tArgs[i]);
+        templateArgs.push_back(tArgs[i]);
     }
 }
 

--- a/src/func.h
+++ b/src/func.h
@@ -89,41 +89,12 @@ class TemplateArg {
     std::string GetString() const;
     // Returns `true` if this argument is a Type.
     bool IsType() const;
-    // Compares two `TemplateArg` instances for equality.
-    bool IsEqual(const TemplateArg &other) const;
     // Mangles the stored type to a string representation.
     std::string Mangle() const;
     // Transforms the stored type to its varying equivalent.
     void SetAsVaryingType();
-};
-
-// Represents a list of template arguments. This is used
-// to store all arguments provided to a template, preserving their order and types.
-class TemplateArgs {
-  public:
-    TemplateArgs() = default;
-    TemplateArgs(const std::vector<TemplateArg> &args);
-
-    // Adds a new TemplateArg to the list of arguments.
-    void AddArg(const TemplateArg &arg);
-    // Returns a constant reference to the internal vector of template arguments.
-    const std::vector<TemplateArg> &GetArgs() const;
-    // Compares this TemplateArgs instance with another for equality. Two TemplateArgs instances are considered equal if
-    // they contain the same number of arguments and each corresponding pair of arguments is equal.
-    bool IsEqual(const TemplateArgs &other) const;
-    // Returns the number of template arguments
-    size_t Size() const;
-    // Iterators support, both in const and non-const contexts.
-    std::vector<TemplateArg>::iterator begin();
-    std::vector<TemplateArg>::iterator end();
-    std::vector<TemplateArg>::const_iterator begin() const;
-    std::vector<TemplateArg>::const_iterator end() const;
-    // Access to individual arguments by index, both in const and non-const contexts.
-    const TemplateArg &operator[](std::size_t index);
-    const TemplateArg &operator[](std::size_t index) const;
-
-  private:
-    std::vector<TemplateArg> args;
+    // Operator support
+    bool operator==(const TemplateArg &other) const;
 };
 
 enum class TemplateInstantiationKind { Implicit, Explicit, Specialization };

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -87,12 +87,12 @@ class Stmt;
 class Symbol;
 class SymbolTable;
 class TemplateArg;
-class TemplateArgs;
 class TemplateInstantiation;
 class TemplateParms;
 class TemplateSymbol;
 class Type;
 struct VariableDeclaration;
+typedef std::vector<TemplateArg> TemplateArgs;
 
 enum StorageClass { SC_NONE, SC_EXTERN, SC_STATIC, SC_TYPEDEF, SC_EXTERN_C, SC_EXTERN_SYCL };
 

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2023, Intel Corporation
+  Copyright (c) 2010-2024, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -86,6 +86,8 @@ class PointerType;
 class Stmt;
 class Symbol;
 class SymbolTable;
+class TemplateArg;
+class TemplateArgs;
 class TemplateInstantiation;
 class TemplateParms;
 class TemplateSymbol;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1291,7 +1291,7 @@ FunctionTemplate *Module::MatchFunctionTemplate(const std::string &name, const F
     FunctionTemplate *templ = nullptr;
     for (auto &templateSymbol : matches) {
         // Number of template parameters must match.
-        if (normTypes.Size() != templateSymbol->templateParms->GetCount()) {
+        if (normTypes.size() != templateSymbol->templateParms->GetCount()) {
             // We don't have default parameters yet, so just matching the size exactly.
             continue;
         }

--- a/src/module.h
+++ b/src/module.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2023, Intel Corporation
+  Copyright (c) 2010-2024, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -86,18 +86,15 @@ class Module {
     void AddFunctionTemplateDefinition(const TemplateParms *templateParmList, const std::string &name,
                                        const FunctionType *ftype, Stmt *code);
 
-    void AddFunctionTemplateInstantiation(const std::string &name,
-                                          const std::vector<std::pair<const Type *, SourcePos>> &types,
-                                          const FunctionType *ftype, StorageClass sc, bool isInline, bool isNoInline,
-                                          SourcePos pos);
+    void AddFunctionTemplateInstantiation(const std::string &name, const TemplateArgs &tArgs, const FunctionType *ftype,
+                                          StorageClass sc, bool isInline, bool isNoInline, SourcePos pos);
 
     void AddFunctionTemplateSpecializationDeclaration(const std::string &name, const FunctionType *ftype,
-                                                      const std::vector<std::pair<const Type *, SourcePos>> &types,
-                                                      StorageClass sc, bool isInline, bool isNoInline, SourcePos pos);
+                                                      const TemplateArgs &tArgs, StorageClass sc, bool isInline,
+                                                      bool isNoInline, SourcePos pos);
 
     void AddFunctionTemplateSpecializationDefinition(const std::string &name, const FunctionType *ftype,
-                                                     const std::vector<std::pair<const Type *, SourcePos>> &types,
-                                                     SourcePos pos, Stmt *code);
+                                                     const TemplateArgs &tArgs, SourcePos pos, Stmt *code);
 
     /** Adds the given type to the set of types that have their definitions
         included in automatically generated header files. */
@@ -112,8 +109,8 @@ class Module {
        template <typename T> void foo(T t);
        foo<int>(1); // T is assumed to be "varying int" here.
     */
-    FunctionTemplate *MatchFunctionTemplate(const std::string &name, const FunctionType *ftype,
-                                            std::vector<std::pair<const Type *, SourcePos>> &normTypes, SourcePos pos);
+    FunctionTemplate *MatchFunctionTemplate(const std::string &name, const FunctionType *ftype, TemplateArgs &normTypes,
+                                            SourcePos pos);
 
     /** After a source file has been compiled, output can be generated in a
         number of different formats. */

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -2508,13 +2508,13 @@ template_argument_list
     : rate_qualified_type_specifier
       {
           TemplateArgs *templArgs = new TemplateArgs();
-          templArgs->AddArg(TemplateArg($1, @1));
+          templArgs->push_back(TemplateArg($1, @1));
           $$ = templArgs;
       }
     | template_argument_list ',' rate_qualified_type_specifier
       {
           TemplateArgs *templArgs = (TemplateArgs *) $1;
-          templArgs->AddArg(TemplateArg($3, @3));
+          templArgs->push_back(TemplateArg($3, @3));
           $$ = templArgs;
       }
     ;
@@ -2575,7 +2575,7 @@ template_function_instantiation
           const FunctionType *ftype = CastType<FunctionType>(d->type);
           bool isInline = ($2->typeQualifiers & TYPEQUAL_INLINE);
           bool isNoInline = ($2->typeQualifiers & TYPEQUAL_NOINLINE);
-          if ($3->second->Size() == 0) {
+          if ($3->second->size() == 0) {
               Error(d->pos, "Template arguments deduction is not yet supported in explicit template instantiation.");
           }
           m->AddFunctionTemplateInstantiation($3->first->name, *$3->second, ftype, $2->storageClass, isInline, isNoInline, Union(@1, @6));
@@ -2596,7 +2596,7 @@ template_function_instantiation
           const FunctionType *ftype = CastType<FunctionType>(d->type);
           bool isInline = ($2->typeQualifiers & TYPEQUAL_INLINE);
           bool isNoInline = ($2->typeQualifiers & TYPEQUAL_NOINLINE);
-          if ($3->second->Size() == 0) {
+          if ($3->second->size() == 0) {
               Error(d->pos, "Template arguments deduction is not yet supported in explicit template instantiation.");
           }
           m->AddFunctionTemplateInstantiation($3->first->name, *$3->second, ftype, $2->storageClass, isInline, isNoInline, Union(@1, @5));
@@ -2914,7 +2914,7 @@ lAddTemplateSpecialization(const TemplateArgs &templArgs, DeclSpecs *ds, Declara
         return;
     }
 
-    if (templArgs.Size() == 0) {
+    if (templArgs.size() == 0) {
         Error(decl->pos, "Template arguments deduction is not yet supported in template function specialization.");
         return;
     }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2023, Intel Corporation
+  Copyright (c) 2010-2024, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -2924,23 +2924,19 @@ const std::string FunctionType::GetReturnTypeString() const {
     return ret + returnType->GetString();
 }
 
-std::string FunctionType::mangleTemplateArgs(std::vector<const Type *> *templateArgs) const {
+std::string FunctionType::mangleTemplateArgs(TemplateArgs *templateArgs) const {
     if (templateArgs == nullptr) {
         return "";
     }
     std::string ret = "___";
-    for (const Type *arg : *templateArgs) {
-        if (arg) {
-            ret += arg->Mangle();
-        } else {
-            Assert(m->errorCount > 0);
-        }
+    for (const auto &arg : *templateArgs) {
+        ret += arg.Mangle();
     }
     return ret;
 }
 
 FunctionType::FunctionMangledName FunctionType::GetFunctionMangledName(bool appFunction,
-                                                                       std::vector<const Type *> *templateArgs) const {
+                                                                       TemplateArgs *templateArgs) const {
     FunctionMangledName mangle = {};
     // Mangle internal functions name.
     if (!(isExternC || isExternSYCL || appFunction)) {

--- a/src/type.h
+++ b/src/type.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2023, Intel Corporation
+  Copyright (c) 2010-2024, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -975,8 +975,7 @@ class FunctionType : public Type {
     /** This method returns the FunctionMangledName depending on Function type.
         The \c appFunction parameter indicates whether the function is generated for
         internal ISPC call or for external call from application.*/
-    FunctionMangledName GetFunctionMangledName(bool appFunction,
-                                               std::vector<const Type *> *templateArgs = nullptr) const;
+    FunctionMangledName GetFunctionMangledName(bool appFunction, TemplateArgs *templateArgs = nullptr) const;
 
     /** This method returns std::vector of LLVM types of function arguments.
         The \c disableMask parameter indicates whether the mask parameter should be
@@ -1037,7 +1036,7 @@ class FunctionType : public Type {
     int costOverride;
 
   private:
-    std::string mangleTemplateArgs(std::vector<const Type *> *templateArgs) const;
+    std::string mangleTemplateArgs(TemplateArgs *templateArgs) const;
 
     const Type *const returnType;
 


### PR DESCRIPTION
Refactor TemplateArgs to support non-type parameters:
1. Wrap `std::pair<const Type *, SourcePos>` to `TemplateArg`
2. Wrap `std::vector<std::pair<const Type *, SourcePos>>` to `TemplateArgs`

`TemplateArg` will be extended with NonType arguments in a separate PR.