### PR TITLE
macos/llvm 17 compile fix: std::va_list undefined

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -47,7 +47,7 @@
 // See https://libcxx.llvm.org/UsingLibcxx.html#overriding-the-default-termination-handler
 // It is not quite clear why and where this symbol is used.
 void std::__libcpp_verbose_abort(char const *format, ...) {
-    std::va_list list;
+    va_list list;
     va_start(list, format);
     std::vfprintf(stderr, format, list);
     va_end(list);


### PR DESCRIPTION
Use va_list from global namespace, as <stdarg.h> does not seem to put va_list also into std namespace.
This fixes compilation on macOS 14 against LLVM 17.0.6 as reported in #2784.