### PR TITLE
Prerequisite changes for templates with non-type parameters support

### DIFF
--- a/src/expr.h
+++ b/src/expr.h
@@ -515,10 +515,16 @@ class ConstExpr : public Expr {
     int GetValues(uint64_t *, bool forceVarying = false) const;
     int GetValues(std::vector<llvm::APFloat> &) const;
 
+    /** Return the ConstExpr's values as a string. */
+    std::string GetValuesAsStr(const std::string &separator) const;
+
     /** Return the number of values in the ConstExpr; should be either 1,
         if it has uniform type, or the target's vector width if it's
         varying. */
     int Count() const;
+
+    /** Return true if the type and values of two ConstExpr are the same. */
+    bool IsEqual(const ConstExpr *ce) const;
 
   private:
     AtomicType::BasicType getBasicType() const;

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -780,15 +780,58 @@ void Function::GenerateIR() {
 }
 
 ///////////////////////////////////////////////////////////////////////////
+// TemplateParam
+
+TemplateParam::TemplateParam(const TemplateTypeParmType *p) : paramType(ParamType::Type), typeParam(p) {
+    name = p->GetName();
+    pos = p->GetSourcePos();
+}
+
+TemplateParam::TemplateParam(Symbol *s) : paramType(ParamType::NonType), nonTypeParam(s) {
+    name = s->name;
+    pos = s->pos;
+}
+
+bool TemplateParam::IsTypeParam() const { return paramType == ParamType::Type; }
+
+bool TemplateParam::IsNonTypeParam() const { return paramType == ParamType::NonType; }
+
+bool TemplateParam::IsEqual(const TemplateParam &other) const {
+    if (IsTypeParam()) {
+        return Type::Equal(typeParam, other.typeParam);
+    } else if (IsNonTypeParam()) {
+        return nonTypeParam->name == other.nonTypeParam->name &&
+               Type::Equal(nonTypeParam->type, other.nonTypeParam->type);
+    }
+    return false;
+}
+
+std::string TemplateParam::GetName() const { return name; }
+
+const TemplateTypeParmType *TemplateParam::GetTypeParam() const {
+    Assert(IsTypeParam());
+    return typeParam;
+}
+
+Symbol *TemplateParam::GetNonTypeParam() const {
+    Assert(IsNonTypeParam());
+    return nonTypeParam;
+}
+
+SourcePos TemplateParam::GetSourcePos() const { return pos; }
+
+///////////////////////////////////////////////////////////////////////////
 // TemplateParms
 
 TemplateParms::TemplateParms() {}
 
-void TemplateParms::Add(const TemplateTypeParmType *p) { parms.push_back(p); }
+void TemplateParms::Add(const TemplateParam *p) { parms.push_back(p); }
 
 size_t TemplateParms::GetCount() const { return parms.size(); }
 
-const TemplateTypeParmType *TemplateParms::operator[](size_t i) const { return parms[i]; }
+const TemplateParam *TemplateParms::operator[](size_t i) const { return parms[i]; }
+
+const TemplateParam *TemplateParms::operator[](size_t i) { return parms[i]; }
 
 bool TemplateParms::IsEqual(const TemplateParms *p) const {
     if (p == nullptr) {
@@ -800,7 +843,8 @@ bool TemplateParms::IsEqual(const TemplateParms *p) const {
     }
 
     for (size_t i = 0; i < GetCount(); i++) {
-        if (!Type::Equal((*this)[i], (*p)[i])) {
+        const TemplateParam *other = (*p)[i];
+        if (!(parms[i]->IsEqual(*other))) {
             return false;
         }
     }
@@ -957,7 +1001,10 @@ void FunctionTemplate::Print(Indent &indent) const {
             snprintf(buffer, BUFSIZE, "template param %d", i);
             indent.setNextLabel(buffer);
             if ((*typenames)[i]) {
-                indent.Print("TemplateTypeParmType", (*typenames)[i]->GetSourcePos());
+                indent.Print((*typenames)[i]->IsTypeParam()
+                                 ? "TemplateTypeParmType"
+                                 : (*typenames)[i]->GetNonTypeParam()->type->GetString().c_str(),
+                             (*typenames)[i]->GetSourcePos());
                 printf("\"%s\"\n", (*typenames)[i]->GetName().c_str());
                 indent.Done();
             } else {

--- a/src/func.h
+++ b/src/func.h
@@ -103,27 +103,37 @@ class TemplateParms : public Traceable {
 };
 
 // Represents a single argument in a template instantiation. This can either be a type
-// or a non-type (constant expression).
-class TemplateArg {
+// or a non-type (constant or symbol expression).
+class TemplateArg : public Traceable {
   public:
-    enum class ArgType { Type, /*To be extended with NoneType*/ };
+    enum class ArgType { Type, NonType };
 
   private:
     ArgType argType;
     union {
         const Type *type;
+        const Expr *expr;
     };
     SourcePos pos;
 
   public:
     TemplateArg(const Type *t, SourcePos pos);
+    TemplateArg(const Expr *c, SourcePos pos);
 
     // Returns ISPC type of the argument.
     const Type *GetAsType() const;
+    // Returns const expression if this argument is a ConstExpr or SymbolExpr with constValue.
+    // Note that SymbolExpr may not have constValue until it has been instantiated during template function call.
+    // See: FunctionSymbolExpr::Instantiate()
+    const ConstExpr *GetAsConstExpr() const;
+    // Returns expression if this argument is a non-type, nullptr otherwise.
+    const Expr *GetAsExpr() const;
     // Returns the source position associated with this template argument.
     SourcePos GetPos() const;
     // Produces a string representation of the argument.
     std::string GetString() const;
+    // Returns `true` if this argument is a non-type.
+    bool IsNonType() const;
     // Returns `true` if this argument is a Type.
     bool IsType() const;
     // Mangles the stored type to a string representation.

--- a/src/func.h
+++ b/src/func.h
@@ -52,17 +52,54 @@ class Function {
     Symbol *taskIndexSym2, *taskCountSym2;
 };
 
-// A helper class to manage template parameters list.
+// Represents a single template parameter, which can either be a type (TemplateTypeParmType) or a non-type
+// (Symbol).
+class TemplateParam : public Traceable {
+  public:
+    enum class ParamType { Type, NonType };
+
+  private:
+    ParamType paramType;
+    union {
+        const TemplateTypeParmType *typeParam;
+        Symbol *nonTypeParam;
+    };
+
+    std::string name;
+    SourcePos pos;
+
+  public:
+    TemplateParam(const TemplateTypeParmType *tp);
+    TemplateParam(Symbol *ntp);
+
+    // Checks if the parameter is a type parameter.
+    bool IsTypeParam() const;
+    // Checks if the parameter is a non-type parameter.
+    bool IsNonTypeParam() const;
+    // Compares two `TemplateParam` instances for equality.
+    bool IsEqual(const TemplateParam &other) const;
+    // Gets the name of the parameter.
+    std::string GetName() const;
+    // Returns type parameter.
+    const TemplateTypeParmType *GetTypeParam() const;
+    // Returns type parameter.
+    Symbol *GetNonTypeParam() const;
+    // Returns the source position associated with this template parameter.
+    SourcePos GetSourcePos() const;
+};
+
+// A helper class to manage template parameters list and clean up allocated memory.
 class TemplateParms : public Traceable {
   public:
     TemplateParms();
-    void Add(const TemplateTypeParmType *);
+    void Add(const TemplateParam *);
     size_t GetCount() const;
-    const TemplateTypeParmType *operator[](size_t i) const;
+    const TemplateParam *operator[](size_t i) const;
+    const TemplateParam *operator[](size_t i);
     bool IsEqual(const TemplateParms *p) const;
 
   private:
-    std::vector<const TemplateTypeParmType *> parms;
+    std::vector<const TemplateParam *> parms;
 };
 
 // Represents a single argument in a template instantiation. This can either be a type

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -88,6 +88,7 @@ class Symbol;
 class SymbolTable;
 class TemplateArg;
 class TemplateInstantiation;
+class TemplateParam;
 class TemplateParms;
 class TemplateSymbol;
 class Type;

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -172,6 +172,7 @@ struct ForeachDimension {
     std::pair<std::string, SourcePos> *declspecPair;
     std::vector<std::pair<std::string, SourcePos> > *declspecList;
     PragmaAttributes *pragmaAttributes;
+    const TemplateArg *templateArg;
     const TemplateArgs *templateArgs;
     const TemplateParam *templateParm;
     TemplateParms *templateParmList;
@@ -271,6 +272,7 @@ struct ForeachDimension {
 %type <declspecList> declspec_specifier declspec_list
 
 %type <constCharPtr> template_identifier
+%type <templateArg> template_argument
 %type <templateArgs> template_argument_list
 %type <simpleTemplateID> simple_template_id template_function_specialization_declaration
 %type <templateTypeParm> template_type_parameter
@@ -2518,17 +2520,29 @@ template_function_declaration_or_definition
       }
     ;
 
-template_argument_list
+template_argument
     : rate_qualified_type_specifier
+    {
+        $$ = new TemplateArg($1, @1);
+    }
+    ;
+
+template_argument_list
+    : template_argument
       {
           TemplateArgs *templArgs = new TemplateArgs();
-          templArgs->push_back(TemplateArg($1, @1));
+          if ($1 != nullptr) {
+            templArgs->push_back(*$1);
+          }
           $$ = templArgs;
+
       }
-    | template_argument_list ',' rate_qualified_type_specifier
+    | template_argument_list ',' template_argument
       {
           TemplateArgs *templArgs = (TemplateArgs *) $1;
-          templArgs->push_back(TemplateArg($3, @3));
+          if ($3 != nullptr) {
+            templArgs->push_back(*$3);
+          }
           $$ = templArgs;
       }
     ;


### PR DESCRIPTION
This PR includes 3 changes:
1. Adding `Mangle()` method to `Expr` which is needed to produce mangled names of template functions with non-type parameters.
2. Encapsulation of template parameters logic in `TemplateParam` class
3. Support of non-type template arguments.