### PR TITLE
builtins: align all implementations of __round_varying

### DIFF
--- a/builtins/target-avx2-i16x16.ll
+++ b/builtins/target-avx2-i16x16.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2023, Intel Corporation
+;;  Copyright (c) 2020-2024, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -199,14 +199,14 @@ define double @__ceil_uniform_double(double) nounwind readonly alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; round/floor/ceil varying float/doubles
 
-declare <8 x float> @llvm.nearbyint.v8f32(<8 x float> %p)
+declare <8 x float> @llvm.roundeven.v8f32(<8 x float> %p)
 declare <8 x float> @llvm.floor.v8f32(<8 x float> %p)
 declare <8 x float> @llvm.ceil.v8f32(<8 x float> %p)
 
 define <16 x float> @__round_varying_float(<16 x float> %v) nounwind readonly alwaysinline {
   v16tov8(float, %v, %v0, %v1)
-  %r0 = call <8 x float> @llvm.nearbyint.v8f32(<8 x float> %v0)
-  %r1 = call <8 x float> @llvm.nearbyint.v8f32(<8 x float> %v1)
+  %r0 = call <8 x float> @llvm.roundeven.v8f32(<8 x float> %v0)
+  %r1 = call <8 x float> @llvm.roundeven.v8f32(<8 x float> %v1)
   v8tov16(float, %r0, %r1, %r)
   ret <16 x float> %r
 }
@@ -227,16 +227,16 @@ define <16 x float> @__ceil_varying_float(<16 x float> %v) nounwind readonly alw
   ret <16 x float> %r
 }
 
-declare <4 x double> @llvm.nearbyint.v4f64(<4 x double> %p)
+declare <4 x double> @llvm.roundeven.v4f64(<4 x double> %p)
 declare <4 x double> @llvm.floor.v4f64(<4 x double> %p)
 declare <4 x double> @llvm.ceil.v4f64(<4 x double> %p)
 
 define <16 x double> @__round_varying_double(<16 x double> %v) nounwind readonly alwaysinline {
   v16tov4(double, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v0)
-  %r1 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v1)
-  %r2 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v2)
-  %r3 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v3)
+  %r0 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v0)
+  %r1 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v1)
+  %r2 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v2)
+  %r3 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v3)
   v4tov16(double, %r0, %r1, %r2, %r3, %r)
   ret <16 x double> %r
 }

--- a/builtins/target-avx2-i8x32.ll
+++ b/builtins/target-avx2-i8x32.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2023, Intel Corporation
+;;  Copyright (c) 2020-2024, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -201,16 +201,16 @@ define double @__ceil_uniform_double(double) nounwind readonly alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; round/floor/ceil varying float/doubles
 
-declare <8 x float> @llvm.nearbyint.v8f32(<8 x float> %p)
+declare <8 x float> @llvm.roundeven.v8f32(<8 x float> %p)
 declare <8 x float> @llvm.floor.v8f32(<8 x float> %p)
 declare <8 x float> @llvm.ceil.v8f32(<8 x float> %p)
 
 define <32 x float> @__round_varying_float(<32 x float> %v) nounwind readonly alwaysinline {
   v32tov8(float, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <8 x float> @llvm.nearbyint.v8f32(<8 x float> %v0)
-  %r1 = call <8 x float> @llvm.nearbyint.v8f32(<8 x float> %v1)
-  %r2 = call <8 x float> @llvm.nearbyint.v8f32(<8 x float> %v2)
-  %r3 = call <8 x float> @llvm.nearbyint.v8f32(<8 x float> %v3)
+  %r0 = call <8 x float> @llvm.roundeven.v8f32(<8 x float> %v0)
+  %r1 = call <8 x float> @llvm.roundeven.v8f32(<8 x float> %v1)
+  %r2 = call <8 x float> @llvm.roundeven.v8f32(<8 x float> %v2)
+  %r3 = call <8 x float> @llvm.roundeven.v8f32(<8 x float> %v3)
   v8tov32(float, %r0, %r1, %r2, %r3, %r)
   ret <32 x float> %r
 }
@@ -235,20 +235,20 @@ define <32 x float> @__ceil_varying_float(<32 x float> %v) nounwind readonly alw
   ret <32 x float> %r
 }
 
-declare <4 x double> @llvm.nearbyint.v4f64(<4 x double> %p)
+declare <4 x double> @llvm.roundeven.v4f64(<4 x double> %p)
 declare <4 x double> @llvm.floor.v4f64(<4 x double> %p)
 declare <4 x double> @llvm.ceil.v4f64(<4 x double> %p)
 
 define <32 x double> @__round_varying_double(<32 x double> %v) nounwind readonly alwaysinline {
   v32tov4(double, %v, %v0, %v1, %v2, %v3, %v4, %v5, %v6, %v7)
-  %r0 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v0)
-  %r1 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v1)
-  %r2 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v2)
-  %r3 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v3)
-  %r4 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v4)
-  %r5 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v5)
-  %r6 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v6)
-  %r7 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v7)
+  %r0 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v0)
+  %r1 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v1)
+  %r2 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v2)
+  %r3 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v3)
+  %r4 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v4)
+  %r5 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v5)
+  %r6 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v6)
+  %r7 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v7)
   v4tov32(double, %r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7, %r)
   ret <32 x double> %r
 }

--- a/builtins/target-avx512-common-16.ll
+++ b/builtins/target-avx512-common-16.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2015-2023, Intel Corporation
+;;  Copyright (c) 2015-2024, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -65,12 +65,12 @@ define <16 x i16> @__float_to_half_varying(<16 x float> %v) nounwind readnone {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rounding floats
 
-declare <16 x float> @llvm.nearbyint.v16f32(<16 x float> %p)
+declare <16 x float> @llvm.roundeven.v16f32(<16 x float> %p)
 declare <16 x float> @llvm.floor.v16f32(<16 x float> %p)
 declare <16 x float> @llvm.ceil.v16f32(<16 x float> %p)
 
 define <16 x float> @__round_varying_float(<16 x float>) nounwind readonly alwaysinline {
-  %res = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %0)
+  %res = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %0)
   ret <16 x float> %res
 }
 
@@ -87,15 +87,15 @@ define <16 x float> @__ceil_varying_float(<16 x float>) nounwind readonly always
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rounding doubles
 
-declare <8 x double> @llvm.nearbyint.v8f64(<8 x double> %p)
+declare <8 x double> @llvm.roundeven.v8f64(<8 x double> %p)
 declare <8 x double> @llvm.floor.v8f64(<8 x double> %p)
 declare <8 x double> @llvm.ceil.v8f64(<8 x double> %p)
 
 define <16 x double> @__round_varying_double(<16 x double>) nounwind readonly alwaysinline {
   %v0 = shufflevector <16 x double> %0, <16 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %v1 = shufflevector <16 x double> %0, <16 x double> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %r0 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v1)
+  %r0 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v0)
+  %r1 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v1)
   %res = shufflevector <8 x double> %r0, <8 x double> %r1, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                                                                        i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   ret <16 x double> %res

--- a/builtins/target-avx512-common-4.ll
+++ b/builtins/target-avx512-common-4.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2023, Intel Corporation
+;;  Copyright (c) 2020-2024, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -41,12 +41,12 @@ define <4 x i16> @__float_to_half_varying(<4 x float> %v) nounwind readnone {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rounding floats
 
-declare <4 x float> @llvm.nearbyint.v4f32(<4 x float> %p)
+declare <4 x float> @llvm.roundeven.v4f32(<4 x float> %p)
 declare <4 x float> @llvm.floor.v4f32(<4 x float> %p)
 declare <4 x float> @llvm.ceil.v4f32(<4 x float> %p)
 
 define <4 x float> @__round_varying_float(<4 x float>) nounwind readonly alwaysinline {
-  %res = call <4 x float> @llvm.nearbyint.v4f32(<4 x float> %0)
+  %res = call <4 x float> @llvm.roundeven.v4f32(<4 x float> %0)
   ret <4 x float> %res
 }
 
@@ -63,12 +63,12 @@ define <4 x float> @__ceil_varying_float(<4 x float>) nounwind readonly alwaysin
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rounding doubles
 
-declare <4 x double> @llvm.nearbyint.v4f64(<4 x double> %p)
+declare <4 x double> @llvm.roundeven.v4f64(<4 x double> %p)
 declare <4 x double> @llvm.floor.v4f64(<4 x double> %p)
 declare <4 x double> @llvm.ceil.v4f64(<4 x double> %p)
 
 define <4 x double> @__round_varying_double(<4 x double>) nounwind readonly alwaysinline {
-  %res = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %0)
+  %res = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %0)
   ret <4 x double> %res
 }
 

--- a/builtins/target-avx512-common-8.ll
+++ b/builtins/target-avx512-common-8.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2023, Intel Corporation
+;;  Copyright (c) 2020-2024, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -37,12 +37,12 @@ define <8 x i16> @__float_to_half_varying(<8 x float> %v) nounwind readnone {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rounding floats
 
-declare <8 x float> @llvm.nearbyint.v8f32(<8 x float> %p)
+declare <8 x float> @llvm.roundeven.v8f32(<8 x float> %p)
 declare <8 x float> @llvm.floor.v8f32(<8 x float> %p)
 declare <8 x float> @llvm.ceil.v8f32(<8 x float> %p)
 
 define <8 x float> @__round_varying_float(<8 x float>) nounwind readonly alwaysinline {
-  %res = call <8 x float> @llvm.nearbyint.v8f32(<8 x float> %0)
+  %res = call <8 x float> @llvm.roundeven.v8f32(<8 x float> %0)
   ret <8 x float> %res
 }
 
@@ -59,15 +59,15 @@ define <8 x float> @__ceil_varying_float(<8 x float>) nounwind readonly alwaysin
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rounding doubles
 
-declare <4 x double> @llvm.nearbyint.v4f64(<4 x double> %p)
+declare <4 x double> @llvm.roundeven.v4f64(<4 x double> %p)
 declare <4 x double> @llvm.floor.v4f64(<4 x double> %p)
 declare <4 x double> @llvm.ceil.v4f64(<4 x double> %p)
 
 define <8 x double> @__round_varying_double(<8 x double>) nounwind readonly alwaysinline {
   %v0 = shufflevector <8 x double> %0, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v1 = shufflevector <8 x double> %0, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %r0 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v0)
-  %r1 = call <4 x double> @llvm.nearbyint.v4f64(<4 x double> %v1)
+  %r0 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v0)
+  %r1 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v1)
   %res = shufflevector <4 x double> %r0, <4 x double> %r1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x double> %res
 }

--- a/builtins/target-avx512skx-x32.ll
+++ b/builtins/target-avx512skx-x32.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2023, Intel Corporation
+;;  Copyright (c) 2020-2024, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -202,14 +202,14 @@ define double @__ceil_uniform_double(double) nounwind readonly alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; round/floor/ceil varying float/doubles
 
-declare <16 x float> @llvm.nearbyint.v16f32(<16 x float> %p)
+declare <16 x float> @llvm.roundeven.v16f32(<16 x float> %p)
 declare <16 x float> @llvm.floor.v16f32(<16 x float> %p)
 declare <16 x float> @llvm.ceil.v16f32(<16 x float> %p)
 
 define <32 x float> @__round_varying_float(<32 x float> %v) nounwind readonly alwaysinline {
   v32tov16(float, %v, %v0, %v1)
-  %r0 = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %v0)
-  %r1 = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %v1)
+  %r0 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v0)
+  %r1 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v1)
   v16tov32(float, %r0, %r1, %r)
   ret <32 x float> %r
 }
@@ -230,16 +230,16 @@ define <32 x float> @__ceil_varying_float(<32 x float> %v) nounwind readonly alw
   ret <32 x float> %r
 }
 
-declare <8 x double> @llvm.nearbyint.v8f64(<8 x double> %p)
+declare <8 x double> @llvm.roundeven.v8f64(<8 x double> %p)
 declare <8 x double> @llvm.floor.v8f64(<8 x double> %p)
 declare <8 x double> @llvm.ceil.v8f64(<8 x double> %p)
 
 define <32 x double> @__round_varying_double(<32 x double> %v) nounwind readonly alwaysinline {
   v32tov8(double, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v1)
-  %r2 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v2)
-  %r3 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v3)
+  %r0 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v0)
+  %r1 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v1)
+  %r2 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v2)
+  %r3 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v3)
   v8tov32(double, %r0, %r1, %r2, %r3, %r)
   ret <32 x double> %r
 }

--- a/builtins/target-avx512skx-x64.ll
+++ b/builtins/target-avx512skx-x64.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2023, Intel Corporation
+;;  Copyright (c) 2020-2024, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -205,16 +205,16 @@ define double @__ceil_uniform_double(double) nounwind readonly alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; round/floor/ceil varying float/doubles
 
-declare <16 x float> @llvm.nearbyint.v16f32(<16 x float> %p)
+declare <16 x float> @llvm.roundeven.v16f32(<16 x float> %p)
 declare <16 x float> @llvm.floor.v16f32(<16 x float> %p)
 declare <16 x float> @llvm.ceil.v16f32(<16 x float> %p)
 
 define <64 x float> @__round_varying_float(<64 x float> %v) nounwind readonly alwaysinline {
   v64tov16(float, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %v0)
-  %r1 = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %v1)
-  %r2 = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %v2)
-  %r3 = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %v3)
+  %r0 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v0)
+  %r1 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v1)
+  %r2 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v2)
+  %r3 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v3)
   v16tov64(float, %r0, %r1, %r2, %r3, %r)
   ret <64 x float> %r
 }
@@ -239,20 +239,20 @@ define <64 x float> @__ceil_varying_float(<64 x float> %v) nounwind readonly alw
   ret <64 x float> %r
 }
 
-declare <8 x double> @llvm.nearbyint.v8f64(<8 x double> %p)
+declare <8 x double> @llvm.roundeven.v8f64(<8 x double> %p)
 declare <8 x double> @llvm.floor.v8f64(<8 x double> %p)
 declare <8 x double> @llvm.ceil.v8f64(<8 x double> %p)
 
 define <64 x double> @__round_varying_double(<64 x double> %v) nounwind readonly alwaysinline {
   v64tov8(double, %v, %v0, %v1, %v2, %v3, %v4, %v5, %v6, %v7)
-  %r0 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v1)
-  %r2 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v2)
-  %r3 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v3)
-  %r4 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v4)
-  %r5 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v5)
-  %r6 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v6)
-  %r7 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v7)
+  %r0 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v0)
+  %r1 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v1)
+  %r2 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v2)
+  %r3 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v3)
+  %r4 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v4)
+  %r5 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v5)
+  %r6 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v6)
+  %r7 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v7)
   v8tov64(double, %r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7, %r)
   ret <64 x double> %r
 }

--- a/builtins/target-avx512spr-x32.ll
+++ b/builtins/target-avx512spr-x32.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2023, Intel Corporation
+;;  Copyright (c) 2020-2024, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -230,14 +230,14 @@ define double @__ceil_uniform_double(double) nounwind readonly alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; round/floor/ceil varying float/doubles
 
-declare <16 x float> @llvm.nearbyint.v16f32(<16 x float> %p)
+declare <16 x float> @llvm.roundeven.v16f32(<16 x float> %p)
 declare <16 x float> @llvm.floor.v16f32(<16 x float> %p)
 declare <16 x float> @llvm.ceil.v16f32(<16 x float> %p)
 
 define <32 x float> @__round_varying_float(<32 x float> %v) nounwind readonly alwaysinline {
   v32tov16(float, %v, %v0, %v1)
-  %r0 = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %v0)
-  %r1 = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %v1)
+  %r0 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v0)
+  %r1 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v1)
   v16tov32(float, %r0, %r1, %r)
   ret <32 x float> %r
 }
@@ -258,16 +258,16 @@ define <32 x float> @__ceil_varying_float(<32 x float> %v) nounwind readonly alw
   ret <32 x float> %r
 }
 
-declare <8 x double> @llvm.nearbyint.v8f64(<8 x double> %p)
+declare <8 x double> @llvm.roundeven.v8f64(<8 x double> %p)
 declare <8 x double> @llvm.floor.v8f64(<8 x double> %p)
 declare <8 x double> @llvm.ceil.v8f64(<8 x double> %p)
 
 define <32 x double> @__round_varying_double(<32 x double> %v) nounwind readonly alwaysinline {
   v32tov8(double, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v1)
-  %r2 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v2)
-  %r3 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v3)
+  %r0 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v0)
+  %r1 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v1)
+  %r2 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v2)
+  %r3 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v3)
   v8tov32(double, %r0, %r1, %r2, %r3, %r)
   ret <32 x double> %r
 }

--- a/builtins/target-avx512spr-x64.ll
+++ b/builtins/target-avx512spr-x64.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2023, Intel Corporation
+;;  Copyright (c) 2020-2024, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -273,16 +273,16 @@ define double @__ceil_uniform_double(double) nounwind readonly alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; round/floor/ceil varying float/doubles
 
-declare <16 x float> @llvm.nearbyint.v16f32(<16 x float> %p)
+declare <16 x float> @llvm.roundeven.v16f32(<16 x float> %p)
 declare <16 x float> @llvm.floor.v16f32(<16 x float> %p)
 declare <16 x float> @llvm.ceil.v16f32(<16 x float> %p)
 
 define <64 x float> @__round_varying_float(<64 x float> %v) nounwind readonly alwaysinline {
   v64tov16(float, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %v0)
-  %r1 = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %v1)
-  %r2 = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %v2)
-  %r3 = call <16 x float> @llvm.nearbyint.v16f32(<16 x float> %v3)
+  %r0 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v0)
+  %r1 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v1)
+  %r2 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v2)
+  %r3 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v3)
   v16tov64(float, %r0, %r1, %r2, %r3, %r)
   ret <64 x float> %r
 }
@@ -307,20 +307,20 @@ define <64 x float> @__ceil_varying_float(<64 x float> %v) nounwind readonly alw
   ret <64 x float> %r
 }
 
-declare <8 x double> @llvm.nearbyint.v8f64(<8 x double> %p)
+declare <8 x double> @llvm.roundeven.v8f64(<8 x double> %p)
 declare <8 x double> @llvm.floor.v8f64(<8 x double> %p)
 declare <8 x double> @llvm.ceil.v8f64(<8 x double> %p)
 
 define <64 x double> @__round_varying_double(<64 x double> %v) nounwind readonly alwaysinline {
   v64tov8(double, %v, %v0, %v1, %v2, %v3, %v4, %v5, %v6, %v7)
-  %r0 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v1)
-  %r2 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v2)
-  %r3 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v3)
-  %r4 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v4)
-  %r5 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v5)
-  %r6 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v6)
-  %r7 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %v7)
+  %r0 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v0)
+  %r1 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v1)
+  %r2 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v2)
+  %r3 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v3)
+  %r4 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v4)
+  %r5 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v5)
+  %r6 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v6)
+  %r7 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v7)
   v8tov64(double, %r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7, %r)
   ret <64 x double> %r
 }

--- a/builtins/util.m4
+++ b/builtins/util.m4
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2023, Intel Corporation
+;;  Copyright (c) 2010-2024, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -7093,15 +7093,15 @@ define void @__restore_ftz_daz_flags(i32 %oldVal) nounwind alwaysinline {
 ;; $1: target vector width
 
 define(`halfMath', `
-declare half @llvm.nearbyint.f16(half)
+declare half @llvm.roundeven.f16(half)
 define half @__round_uniform_half(half %Val) nounwind readnone alwaysinline {
-  %retVal = call half @llvm.nearbyint.f16(half %Val)
+  %retVal = call half @llvm.roundeven.f16(half %Val)
   ret half %retVal
 }
 
-declare <$1 x half> @llvm.nearbyint.v$1f16(<$1 x half>)
+declare <$1 x half> @llvm.roundeven.v$1f16(<$1 x half>)
 define <$1 x half> @__round_varying_half(<$1 x half> %Val) nounwind readnone alwaysinline {
-  %retVal = call <$1 x half> @llvm.nearbyint.v$1f16(<$1 x half> %Val)
+  %retVal = call <$1 x half> @llvm.roundeven.v$1f16(<$1 x half> %Val)
   ret <$1 x half> %retVal
 }
 

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -4124,9 +4124,16 @@ is on (i.e. the value is negative) and zero if it is off.
     unsigned int64 signbits(double x)
     uniform unsigned int64 signbits(uniform double x)
 
-Standard rounding functions are provided for ``float16``, ``float`` and ``double``
-types.  (On machines that support Intel®SSE or Intel® AVX, these functions all
-map to variants of the ``roundss`` and ``roundps`` instructions, respectively.)
+The standard library provides four rounding functions: ``round``, ``floor``,
+``ceil`` and ``trunc`` for ``float16``, ``float`` and ``double`` data types. On
+machines that support Intel®SSE or Intel® AVX, these functions all map to a
+single instruction, specifically a variant of the ``roundss`` and ``roundps``
+instructions. This offers enhanced performance, despite a minor semantic
+difference in the ``round`` function when compared to the ``C`` math library
+``round`` function. It computes the nearest integer value, rounding halfway
+cases to nearest even integer, i.e., corresponds to the ``C`` math library
+``roundeven`` function. These function operate regardless of the current
+rounding mode and do not signal precision exceptions.
 
 ::
 

--- a/tests/lit-tests/2780-1.ispc
+++ b/tests/lit-tests/2780-1.ispc
@@ -1,0 +1,43 @@
+// RUN: %{ispc} --pic --target=avx512skx-x8 -h %t.h %s -o %t.o
+// RUN: %{cc} -x c -c %s -o %t.c.o --include %t.h
+// RUN: %{cc} %t.o %t.c.o -o %t.c.bin
+// RUN: %t.c.bin | FileCheck %s
+
+// REQUIRES: !MACOS_HOST && X86_ENABLED
+
+// The result of round stdlib function should not depend on MXCSR
+// CHECK: rounded 0: [2.000000,
+// CHECK: rounded 1: [2.000000,
+
+#ifdef ISPC
+extern "C" void RoundToInt(uniform int i, uniform float input[])
+{
+    float r = round(input[programIndex]);
+    print("rounded %: %\n", i, r);
+}
+#else
+#include <xmmintrin.h>
+
+extern void RoundToInt(int, float*);
+
+int main() {
+    float input[64] = { 2.5, 0.0 };
+    unsigned int currentMXCSR, newMXCSR;
+    currentMXCSR = _mm_getcsr();
+
+    // Set rounding mode to round toward zero (01)
+    newMXCSR = (currentMXCSR & ~0x6000) | (0x1 << 13);
+    _mm_setcsr(newMXCSR);
+
+    RoundToInt(0, input);
+
+    // Set rounding mode to round to nearest (00), which is the default
+    newMXCSR = (currentMXCSR & ~0x6000);
+    _mm_setcsr(newMXCSR);
+
+    RoundToInt(1, input);
+
+    _mm_setcsr(currentMXCSR);
+    return 0;
+}
+#endif // ISPC

--- a/tests/lit-tests/2780.ispc
+++ b/tests/lit-tests/2780.ispc
@@ -1,0 +1,12 @@
+// RUN: %{ispc} --pic --target=avx512skx-x8 %s --x86-asm-syntax=intel --emit-asm -o - | FileCheck %s
+
+// REQUIRES: !MACOS_HOST && X86_ENABLED
+
+// CHECK-LABEL: RoundToInt___vyf:
+// CHECK-NEXT: # %bb.0:
+// CHECK-NEXT: vroundps        ymm0, {{.*}}, 8
+// CHECK-NEXT: ret
+float RoundToInt(float x)
+{
+    return round(x);
+}

--- a/tests/lit-tests/fp16_code_gen.ispc
+++ b/tests/lit-tests/fp16_code_gen.ispc
@@ -95,7 +95,7 @@ unmasked float16 fp16_fnms(float16 a, float16 b, float16 c) {
 }
 
 // CHECK_SPR-LABEL: fp16_round
-// CHECK_SPR: vrndscaleph $12
+// CHECK_SPR: vrndscalesh $8
 unmasked float16 fp16_round(float16 a) {
   return round(a);
 }


### PR DESCRIPTION
Make all implementations of __round_varying across different targets and types to actually do roundeven.

This PR fixes #2780 