### PR TITLE
Fix path to clang_rt.profile library

### DIFF
--- a/.github/workflows/rebuild-llvm17.yml
+++ b/.github/workflows/rebuild-llvm17.yml
@@ -20,11 +20,15 @@ on:
 
 jobs:
   llvm17:
+    strategy:
+      fail-fast: false
+      matrix:
+        lto: ['ON', 'OFF']
     uses: ./.github/workflows/reusable.rebuild.yml
     with:
       version: '17.0'
       full_version: '17.0.6'
-      lto: 'OFF'
+      lto: ${{ matrix.lto }}
       ubuntu: '18.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -131,13 +131,13 @@ jobs:
         rm -rf cache.local
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-${{ inputs.version }} .
-        tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release+Asserts-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
+        tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
         name: llvm_linux_x86
-        path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release+Asserts-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz
 
   linux-build-release-1:
     runs-on: ubuntu-latest
@@ -195,13 +195,13 @@ jobs:
         rm -rf cache.local
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-${{ inputs.version }} .
-        tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
+        tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
         name: llvmrel_linux_x86
-        path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz
 
   linux-arm-build-1:
     runs-on: [self-hosted, linux, ARM64]
@@ -263,14 +263,14 @@ jobs:
         rm -rf cache.local
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-${{ inputs.version }} .
-        tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release+Asserts-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
+        tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
         rm -rf result.tar usr bin-${{ inputs.version }}
 
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
         name: llvm_linux_aarch64
-        path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz
 
   linux-arm-build-release-1:
     runs-on: [self-hosted, linux, ARM64]
@@ -331,14 +331,14 @@ jobs:
         cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-${{ inputs.version }} .
-        tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
+        tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release-x86${{ inputs.lto == 'ON' && '-lto' || '' }}.arm.wasm.tar.xz bin-${{ inputs.version }}
         rm -rf result.tar usr bin-${{ inputs.version }}
 
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
         name: llvmrel_linux_aarch64
-        path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release-x86.arm.wasm.tar.xz
+        path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz
 
   win-build:
     runs-on: windows-2019
@@ -374,7 +374,7 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release+Asserts-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-${{ inputs.version }}
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -382,7 +382,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: llvm_win_x86
-        path: llvm/llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release+Asserts-x86.arm.wasm.tar.7z
+        path: llvm/llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.7z
 
   win-build-release:
     runs-on: windows-2019
@@ -418,7 +418,7 @@ jobs:
       shell: cmd
       run: |
         cd llvm
-        set TAR_BASE_NAME=llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release-x86.arm.wasm
+        set TAR_BASE_NAME=llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm
         7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-${{ inputs.version }}
         7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
 
@@ -426,7 +426,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: llvmrel_win_x86
-        path: llvm/llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release-x86.arm.wasm.tar.7z
+        path: llvm/llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.7z
 
   mac-build:
     # This job is not capable to build on a shared runner, so need to use self-hosted.
@@ -456,13 +456,13 @@ jobs:
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-${{ inputs.full_version }}-macos-Release+Asserts-universal-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
+        tar cJvf llvm-${{ inputs.full_version }}-macos-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-universal-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
         name: llvm_macos_universal
-        path: llvm/llvm-${{ inputs.full_version }}-macos-Release+Asserts-universal-x86.arm.wasm.tar.xz
+        path: llvm/llvm-${{ inputs.full_version }}-macos-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-universal-x86.arm.wasm.tar.xz
 
   mac-build-release:
     # This job is not capable to build on a shared runner, so need to use self-hosted.
@@ -492,10 +492,10 @@ jobs:
     - name: Pack LLVM
       run: |
         cd llvm
-        tar cJvf llvm-${{ inputs.full_version }}-macos-Release-universal-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
+        tar cJvf llvm-${{ inputs.full_version }}-macos-Release${{ inputs.lto == 'ON' && '-lto' || '' }}-universal-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
         name: llvmrel_macos_universal
-        path: llvm/llvm-${{ inputs.full_version }}-macos-Release-universal-x86.arm.wasm.tar.xz
+        path: llvm/llvm-${{ inputs.full_version }}-macos-Release${{ inputs.lto == 'ON' && '-lto' || '' }}-universal-x86.arm.wasm.tar.xz

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -43,10 +43,12 @@ on:
         description: Version to build in major.minor format For example '14.0'.
         required: true
         type: string
+        default: '17.0'
       full_version:
         description: Version to build in major.minor.patch format. For example '14.0.6'.
         required: true
         type: string
+        default: '17.0.6'
       lto:
         description: Build LTO-enabled LLVM toolchain.
         required: true
@@ -56,18 +58,22 @@ on:
         description: Version of Ubuntu Dockerfile to use. For example '18.04'.
         required: true
         type: string
+        default: '18.04'
       vs_generator:
         description: VS generator to use. For example 'Visual Studio 16 2019'.
         required: true
         type: string
+        default: 'Visual Studio 16 2019'
       vs_version_str:
         description: VS version string to use in artifact naming. For example, 'vs2019'.
         required: true
         type: string
+        default: 'vs2019'
       win_sdk:
         description: Win SDK version string. For example, '10.0.18362.0'.
         required: true
         type: string
+        default: '10.0.18362.0'
 
 
 jobs:

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -102,7 +102,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvm_linux_x86_stage1_cache
+        name: llvm_linux_x86_lto_${{ inputs.lto }}_stage1_cache
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
 
   linux-build-2:
@@ -121,7 +121,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v3
       with:
-        name: llvm_linux_x86_stage1_cache
+        name: llvm_linux_x86_lto_${{ inputs.lto }}_stage1_cache
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
 
     - name: Build LLVM
@@ -142,7 +142,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvm_linux_x86
+        name: llvm_linux_x86_lto_${{ inputs.lto }}
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz
 
   linux-build-release-1:
@@ -166,7 +166,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvmrel_linux_x86_stage1_cache
+        name: llvmrel_linux_x86_lto_${{ inputs.lto }}_stage1_cache
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
 
   linux-build-release-2:
@@ -185,7 +185,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v3
       with:
-        name: llvmrel_linux_x86_stage1_cache
+        name: llvmrel_linux_x86_lto_${{ inputs.lto }}_stage1_cache
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
 
     - name: Build LLVM
@@ -206,7 +206,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvmrel_linux_x86
+        name: llvmrel_linux_x86_lto_${{ inputs.lto }}
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz
 
   linux-arm-build-1:
@@ -232,7 +232,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvm_linux_aarch64_stage1_cache
+        name: llvm_linux_aarch64_lto_${{ inputs.lto }}_stage1_cache
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
 
   linux-arm-build-2:
@@ -253,7 +253,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v3
       with:
-        name: llvm_linux_aarch64_stage1_cache
+        name: llvm_linux_aarch64_lto_${{ inputs.lto }}_stage1_cache
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
 
     - name: Build LLVM
@@ -275,7 +275,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvm_linux_aarch64
+        name: llvm_linux_aarch64_lto_${{ inputs.lto }}
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz
 
   linux-arm-build-release-1:
@@ -301,7 +301,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvmrel_linux_aarch64_stage1_cache
+        name: llvmrel_linux_aarch64_lto_${{ inputs.lto }}_stage1_cache
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
 
   linux-arm-build-release-2:
@@ -322,7 +322,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v3
       with:
-        name: llvmrel_linux_aarch64_stage1_cache
+        name: llvmrel_linux_aarch64_lto_${{ inputs.lto }}_stage1_cache
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/cache.local
 
     - name: Build LLVM
@@ -343,7 +343,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvmrel_linux_aarch64
+        name: llvmrel_linux_aarch64_lto_${{ inputs.lto }}
         path: docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build/llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz
 
   win-build:
@@ -387,7 +387,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvm_win_x86
+        name: llvm_win_x86_lto_${{ inputs.lto }}
         path: llvm/llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.7z
 
   win-build-release:
@@ -431,7 +431,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvmrel_win_x86
+        name: llvmrel_win_x86_lto_${{ inputs.lto }}
         path: llvm/llvm-${{ inputs.full_version }}-win.${{ inputs.vs_version_str }}-Release${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.7z
 
   mac-build:
@@ -467,7 +467,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvm_macos_universal
+        name: llvm_macos_universal_lto_${{ inputs.lto }}
         path: llvm/llvm-${{ inputs.full_version }}-macos-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-universal-x86.arm.wasm.tar.xz
 
   mac-build-release:
@@ -503,5 +503,5 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: llvmrel_macos_universal
+        name: llvmrel_macos_universal_lto_${{ inputs.lto }}
         path: llvm/llvm-${{ inputs.full_version }}-macos-Release${{ inputs.lto == 'ON' && '-lto' || '' }}-universal-x86.arm.wasm.tar.xz

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -857,10 +857,18 @@ set(CLANG_RT_VERSION ${LLVM_VERSION_DOTTED})
 if (${LLVM_VERSION_MAJOR} VERSION_GREATER_EQUAL 16)
     set(CLANG_RT_VERSION ${LLVM_VERSION_MAJOR})
 endif()
+set(CLANG_RT_TARGET x86_64-pc-windows-msvc)
+if (${LLVM_VERSION_MAJOR} VERSION_GREATER_EQUAL 17)
+    set(CLANG_RT_TARGET windows)
+endif()
+set(CLANG_RT_LIB clang_rt.profile.lib)
+if (${LLVM_VERSION_MAJOR} VERSION_GREATER_EQUAL 17)
+    set(CLANG_RT_LIB clang_rt.profile-x86_64.lib)
+endif()
 # MSVC has an outdated clang_rt.profile lib in its SDK.
 # We need to enforce explicitly our freshly built library to avoid profile mismatch errors.
 cmake_path(CONVERT
-           ${STAGE2_PATH}/lib/clang/${CLANG_RT_VERSION}/lib/x86_64-pc-windows-msvc/clang_rt.profile.lib
+           ${STAGE2_PATH}/lib/clang/${CLANG_RT_VERSION}/lib/${CLANG_RT_TARGET}/${CLANG_RT_LIB}
            TO_CMAKE_PATH_LIST
            CLANG_RT_PROFLIB
            NORMALIZE)


### PR DESCRIPTION
This PR fixes path to `clang_rt.profile.lib` in superbuild.

It also updates name of LLVM artifacts with `-lto` for reusable build triggered with `LTO=ON`. The minor thing is to provide defaults for reusable builds.