### PR TITLE
Replace alloca with heap allocation

### DIFF
--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -88,15 +88,6 @@
 #include <llvm/Transforms/Utils/Mem2Reg.h>
 #include <llvm/Transforms/Vectorize/LoadStoreVectorizer.h>
 
-#ifdef ISPC_HOST_IS_LINUX
-#include <alloca.h>
-#elif defined(ISPC_HOST_IS_WINDOWS)
-#include <malloc.h>
-#ifndef __MINGW32__
-#define alloca _alloca
-#endif
-#endif // ISPC_HOST_IS_WINDOWS
-
 #ifdef ISPC_XE_ENABLED
 #include <llvm/GenXIntrinsics/GenXSPIRVWriterAdaptor.h>
 #endif


### PR DESCRIPTION
This PR removes `alloca` usage as requested here https://github.com/ispc/ispc/pull/2788#discussion_r1521970362

It also removes unused its declaration in `src/opt.cpp`. There is one more left in `src/util.cpp` - I'm not sure if it is worth changing it.