### PR TITLE
Rename Print() method for debuggers

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2023, Intel Corporation
+  Copyright (c) 2011-2024, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -101,7 +101,7 @@ void Indent::Done() {
 
 ASTNode::~ASTNode() {}
 
-void ASTNode::Print() const {
+void ASTNode::Dump() const {
     Indent indent;
     indent.pushSingle();
     Print(indent);

--- a/src/ast.h
+++ b/src/ast.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2023, Intel Corporation
+  Copyright (c) 2011-2024, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -173,7 +173,7 @@ class ASTNode : public Traceable {
     unsigned getValueID() const { return SubclassID; }
 
     /** A function for interactive debugging */
-    void Print() const;
+    void Dump() const;
 
     /** A function that should be used for hierarchical AST dump. */
     virtual void Print(Indent &indent) const = 0;


### PR DESCRIPTION
It is needed to avoid name conflict that happens with overloaded virtual method Print(Indent). Debuggers struggle (at least gdb) to resolve it.

This fixes #2805 