### PR TITLE
opt: add ReplaceMaskedMemOps pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,6 +503,8 @@ list(APPEND OPT_SOURCES
     src/opt/MakeInternalFuncsStatic.h
     src/opt/PeepholePass.cpp
     src/opt/PeepholePass.h
+    src/opt/ReplaceMaskedMemOps.cpp
+    src/opt/ReplaceMaskedMemOps.h
     src/opt/ReplacePseudoMemoryOps.cpp
     src/opt/ReplacePseudoMemoryOps.h
     src/opt/ReplaceStdlibShiftPass.cpp

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -606,6 +606,7 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
 #else
         optPM.addFunctionPass(llvm::GVN(), 301);
 #endif
+        optPM.addFunctionPass(ReplaceMaskedMemOpsPass());
         optPM.addFunctionPass(IsCompileTimeConstantPass(true));
         optPM.addFunctionPass(IntrinsicsOpt());
         optPM.addFunctionPass(InstructionSimplifyPass());

--- a/src/opt/ISPCPassRegistry.def
+++ b/src/opt/ISPCPassRegistry.def
@@ -13,6 +13,7 @@ FUNCTION_PASS("instruction-simplify", InstructionSimplifyPass())
 FUNCTION_PASS("intrinsics-opt", IntrinsicsOpt())
 FUNCTION_PASS("is-compile-time-constant", IsCompileTimeConstantPass())
 FUNCTION_PASS("peephole", PeepholePass())
+FUNCTION_PASS("replace-masked-memory-ops", ReplaceMaskedMemOpsPass())
 FUNCTION_PASS("replace-pseudo-memory-ops", ReplacePseudoMemoryOpsPass())
 FUNCTION_PASS("replace-stdlib-shift", ReplaceStdlibShiftPass())
 #ifdef ISPC_XE_ENABLED

--- a/src/opt/ISPCPasses.h
+++ b/src/opt/ISPCPasses.h
@@ -19,6 +19,7 @@
 #include "MakeInternalFuncsStatic.h"
 #include "MangleOpenCLBuiltins.h"
 #include "PeepholePass.h"
+#include "ReplaceMaskedMemOps.h"
 #include "ReplacePseudoMemoryOps.h"
 #include "ReplaceStdlibShiftPass.h"
 #include "XeGatherCoalescePass.h"

--- a/src/opt/ReplaceMaskedMemOps.cpp
+++ b/src/opt/ReplaceMaskedMemOps.cpp
@@ -1,0 +1,253 @@
+/*
+  Copyright (c) 2024, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include "ReplaceMaskedMemOps.h"
+
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/Transforms/Utils/Local.h>
+
+#include <numeric>
+
+namespace ispc {
+
+bool lIsPowerOf2(unsigned n) { return (n > 0) && !(n & (n - 1)); }
+
+// Check if the mask is a constant vector with the first part being all ones
+// and the second part being all zeros. The length of the first part is
+// returned in TrueSubmaskLength argument. We are looking for the mask with the
+// true prefix of length 2^k only. This is a limitation of the current
+// implementation of lMaskedMergeVectors.
+bool lCheckMask(llvm::Value *mask, unsigned &TrueSubmaskLength) {
+    if (auto *CV = llvm::dyn_cast<llvm::ConstantVector>(mask)) {
+        auto N = CV->getType()->getNumElements();
+        if (!lIsPowerOf2(N)) {
+            return false;
+        }
+
+        unsigned TruePrefixLength = 0;
+        for (auto i = 0; i < N; i++) {
+            llvm::Constant *E = CV->getAggregateElement(i);
+            if (auto *C = llvm::dyn_cast<llvm::ConstantInt>(E)) {
+                if (C->isOne()) {
+                    TruePrefixLength++;
+                    continue;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        for (auto i = TruePrefixLength + 1; i < N; i++) {
+            llvm::Constant *E = CV->getAggregateElement(i);
+            if (auto *C = llvm::dyn_cast<llvm::ConstantInt>(E)) {
+                if (C->isZero()) {
+                    continue;
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        if (!lIsPowerOf2(TruePrefixLength)) {
+            return false;
+        }
+
+        TrueSubmaskLength = TruePrefixLength;
+        return true;
+    }
+    return false;
+}
+
+// Extract the first part of the vector with the shufflevector instruction. The
+// length of the part is passed in SubVectorLength.
+llvm::Value *lShrinkVector(llvm::IRBuilder<> &B, llvm::Value *originalVector, unsigned SubVectorLength) {
+    // Create a vector of indices with [0, 1, 2, ..., SubVectorLength).
+    std::vector<unsigned> indices(SubVectorLength);
+    std::iota(indices.begin(), indices.end(), 0);
+    llvm::Constant *mask = llvm::ConstantDataVector::get(B.getContext(), indices);
+
+    // Use shufflevector instruction to create the new vector
+    llvm::Twine name = originalVector->getName() + ".part";
+    return B.CreateShuffleVector(originalVector, llvm::UndefValue::get(originalVector->getType()), mask, name);
+}
+
+// Create a new vector containing the second part of the const vector.
+// The length of the first part is passed in SubVectorLength. The new vector
+// has the length of N - SubVectorLength, where N is the length of the original
+// vectors we are working with.
+llvm::Constant *lExtractSecondPartOfConstVec(llvm::LLVMContext &context, llvm::Constant *originalMask,
+                                             unsigned SubVectorLength) {
+    auto *vecType = llvm::dyn_cast<llvm::VectorType>(originalMask->getType());
+    Assert(vecType);
+    unsigned N = vecType->getElementCount().getKnownMinValue();
+
+    // Iterate over the second part of the elements and add them to the new vector.
+    std::vector<llvm::Constant *> newValues;
+    for (unsigned i = SubVectorLength; i < N; ++i) {
+        auto *element = originalMask->getAggregateElement(i);
+        if (!element) {
+            return nullptr;
+        }
+        newValues.push_back(element);
+    }
+
+    llvm::ArrayRef<llvm::Constant *> newValuesRef(newValues);
+    return llvm::ConstantVector::get(newValuesRef);
+}
+
+// Merge two vectors into a single vector with the sequence of shufflevector
+// instructions. The first vector length is the power of 2 (M). The overall
+// length is the power of 2 either (N). This means that we can do the merge in
+// the log2(N) - log2(M) steps. The second vector has the length of N. In
+// resulting vector, we want to have the first part and the rest elements from
+// the second vector. In other words, change in the second vector the first M
+// elements with the elemenst from the first vector.
+// Ideally, we would like to merge vector of different lengths. This would
+// simplify the current implemenation, but shuffle instruction requires the
+// vector to have same length.
+llvm::Value *lMaskedMergeVectors(llvm::IRBuilder<> &B, llvm::Value *firstVector, llvm::Constant *secondVector,
+                                 const llvm::Twine &name) {
+    auto *firstVecType = llvm::dyn_cast<llvm::VectorType>(firstVector->getType());
+    auto *secondVecType = llvm::dyn_cast<llvm::VectorType>(secondVector->getType());
+    Assert(firstVecType && secondVecType);
+    unsigned M = firstVecType->getElementCount().getKnownMinValue();
+    unsigned N = secondVecType->getElementCount().getKnownMinValue();
+
+    for (unsigned length = M; length < N; length *= 2) {
+        // Create a vector of indices [0, 1, 2, ..., length*2).
+        std::vector<unsigned> indices(length * 2);
+        std::iota(indices.begin(), indices.end(), 0);
+        llvm::Constant *mask = llvm::ConstantDataVector::get(B.getContext(), indices);
+
+        // We don't change the second vector here, i.e., it always has the length of N.
+        // Slice from the second vector corresponding to [length:N).
+        llvm::Value *secondSubVector = lExtractSecondPartOfConstVec(B.getContext(), secondVector, length);
+        // Slice from the second vector corresponding to [length:length*2).
+        secondSubVector = lShrinkVector(B, secondSubVector, length);
+
+        // Update the first vector, so it has the length of length*2.
+        firstVector = B.CreateShuffleVector(firstVector, secondSubVector, mask, name + ".p." + llvm::Twine(length));
+    }
+
+    return firstVector;
+}
+
+llvm::Value *lBitcastPointerType(llvm::IRBuilder<> &B, llvm::Value *ptr, llvm::Value *value) {
+    auto *vecType = llvm::dyn_cast<llvm::VectorType>(value->getType());
+    llvm::PointerType *ptrType = llvm::dyn_cast<llvm::PointerType>(ptr->getType());
+    Assert(vecType && ptrType);
+    auto *newPtrType = llvm::PointerType::get(vecType, ptrType->getAddressSpace());
+    // If ptr is opaque pointer then no-op is generated here.
+    return B.CreateBitCast(ptr, newPtrType);
+}
+
+// This function replaces masked store intrinsic with an unmasked store instruction.
+// Unmasked store instruction stores only the first part of the initial vector
+// with the length of SubVectorLength.
+void lReplaceMaskedStore(llvm::IRBuilder<> &B, llvm::CallInst *CI, unsigned SubVectorLength) {
+    llvm::Value *origVec = CI->getOperand(0);
+    llvm::Value *ptr = CI->getOperand(1);
+    llvm::ConstantInt *alignmentCI = llvm::dyn_cast<llvm::ConstantInt>(CI->getOperand(2));
+    Assert(alignmentCI);
+    int alignment = alignmentCI->getZExtValue();
+
+    B.SetInsertPoint(CI);
+
+    llvm::Value *subVec = lShrinkVector(B, origVec, SubVectorLength);
+    ptr = lBitcastPointerType(B, ptr, subVec);
+    llvm::Value *store = B.CreateAlignedStore(subVec, ptr, llvm::Align(alignment));
+
+    LLVMCopyMetadata(store, CI);
+    CI->eraseFromParent();
+}
+
+// This function replaces half-masked load intrinsic with an unmasked load
+// instruction that loads the first part [0:SubVectorLength) of the vector.
+// Masked load intrinsic has the passthrough value that is needed to be
+// preserved in the new vector in case it is used later. It is done by merging
+// the result of the unmasked load with the rest part of the passthrough value.
+void lReplaceMaskedLoad(llvm::IRBuilder<> &B, llvm::CallInst *CI, unsigned SubVectorLength) {
+    llvm::Value *ptr = CI->getOperand(0);
+    llvm::ConstantInt *alignmentCI = llvm::dyn_cast<llvm::ConstantInt>(CI->getOperand(1));
+    llvm::Constant *passthrough = llvm::dyn_cast<llvm::Constant>(CI->getOperand(3));
+    Assert(alignmentCI && passthrough);
+    int alignment = alignmentCI->getZExtValue();
+
+    B.SetInsertPoint(CI);
+
+    auto origName = CI->getName();
+    auto *vecType = llvm::dyn_cast<llvm::VectorType>(CI->getType());
+    Assert(vecType);
+    auto *subVecType = llvm::VectorType::get(vecType->getElementType(), SubVectorLength, false);
+    ptr = B.CreateBitCast(ptr, subVecType->getPointerTo());
+
+    llvm::LoadInst *subVec = B.CreateLoad(subVecType, ptr, llvm::Twine(origName) + ".part");
+    // It is important to preserve the alignment of the original masked load.
+    subVec->setAlignment(llvm::Align(alignment));
+
+    llvm::Value *replacement = lMaskedMergeVectors(B, subVec, passthrough, llvm::Twine(origName));
+
+    LLVMCopyMetadata(replacement, CI);
+    CI->replaceAllUsesWith(replacement);
+    llvm::RecursivelyDeleteTriviallyDeadInstructions(CI);
+}
+
+llvm::PreservedAnalyses ReplaceMaskedMemOpsPass::run(llvm::Function &F, llvm::FunctionAnalysisManager &FAM) {
+    if (F.empty()) {
+        return llvm::PreservedAnalyses::all();
+    }
+
+    llvm::IRBuilder<> builder(F.getParent()->getContext());
+    std::unordered_map<llvm::CallInst *, unsigned> storesToReplace;
+    std::unordered_map<llvm::CallInst *, unsigned> loadsToReplace;
+    for (auto &BB : F) {
+        for (auto &I : BB) {
+            auto *CI = llvm::dyn_cast<llvm::CallInst>(&I);
+            if (!CI) {
+                continue;
+            }
+
+            llvm::Function *CF = CI->getCalledFunction();
+            if (!(CF && CF->isIntrinsic())) {
+                continue;
+            }
+
+            unsigned SubVectorLength = 0;
+            if (CF->getIntrinsicID() == llvm::Intrinsic::masked_store) {
+                llvm::Value *mask = CI->getOperand(3);
+                if (lCheckMask(mask, SubVectorLength)) {
+                    storesToReplace[CI] = SubVectorLength;
+                }
+            }
+
+            if (CF->getIntrinsicID() == llvm::Intrinsic::masked_load) {
+                llvm::Value *mask = CI->getOperand(2);
+                llvm::Value *passthrough = CI->getOperand(3);
+                if (llvm::isa<llvm::Constant>(passthrough) && lCheckMask(mask, SubVectorLength)) {
+                    loadsToReplace[CI] = SubVectorLength;
+                }
+            }
+        }
+    }
+
+    if (storesToReplace.empty() && loadsToReplace.empty()) {
+        return llvm::PreservedAnalyses::all();
+    }
+
+    for (auto const &[CI, SubVectorLength] : storesToReplace) {
+        lReplaceMaskedStore(builder, CI, SubVectorLength);
+    }
+
+    for (auto const &[CI, SubVectorLength] : loadsToReplace) {
+        lReplaceMaskedLoad(builder, CI, SubVectorLength);
+    }
+
+    llvm::PreservedAnalyses PA;
+    PA.preserveSet<llvm::CFGAnalyses>();
+    return PA;
+}
+
+} // namespace ispc

--- a/src/opt/ReplaceMaskedMemOps.h
+++ b/src/opt/ReplaceMaskedMemOps.h
@@ -1,0 +1,26 @@
+/*
+  Copyright (c) 2024, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#pragma once
+
+#include "ISPCPass.h"
+
+namespace ispc {
+
+// This pass transforms some masked loads and stores into their unmasked
+// counterparts. This is done to improve the performance of the generated code
+// in cases when only the part of the vector is actually used. The masked.load
+// and masked.store intrinsics are directly mapped to machine instructions with
+// the specified full width of vector values being loaded or stored. This
+// transformation allows the backend to generate shorter vector memory
+// operations and corresponding math operations avoiding extra spills of
+// temporal values to memory.
+
+struct ReplaceMaskedMemOpsPass : public llvm::PassInfoMixin<ReplaceMaskedMemOpsPass> {
+    llvm::PreservedAnalyses run(llvm::Function &F, llvm::FunctionAnalysisManager &FAM);
+};
+
+} // namespace ispc

--- a/tests/lit-tests/2611-2.ispc
+++ b/tests/lit-tests/2611-2.ispc
@@ -1,0 +1,33 @@
+// RUN: %{ispc} --target=avx2-i32x4 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+struct vec2 {
+    float V[2];
+};
+
+uniform vec2 vmax(const uniform vec2 &V1, const uniform vec2 &V2) {
+    uniform vec2 Result;
+
+    foreach (i = 0 ... 2) {
+        Result.V[i] = max(V1.V[i], V2.V[i]);
+    }
+
+    return Result;
+}
+
+// CHECK-LABEL: foo:
+// CHECK-NEXT: # %bb.0:
+// CHECK-NEXT: vmovsd  xmm0, qword ptr [r{{.*}}]
+// CHECK-NEXT: vmovsd  xmm1, qword ptr [r{{.*}}]
+// CHECK-NEXT: vmaxps  xmm0, xmm0, xmm1
+// CHECK-NEXT: vmovss  dword ptr [r{{.*}}], xmm0
+// CHECK-NEXT: vextractps      dword ptr [r{{.*}} + 4], xmm0, 1
+// CHECK-NEXT: ret
+export void foo(uniform float A[], uniform float B[]) {
+
+    uniform vec2 *uniform pA = (uniform vec2 * uniform) A;
+    uniform vec2 *uniform pB = (uniform vec2 * uniform) B;
+
+    *pA = vmax(*pA, *pB);
+}

--- a/tests/lit-tests/2611-3.ispc
+++ b/tests/lit-tests/2611-3.ispc
@@ -1,0 +1,31 @@
+// RUN: %{ispc} --target=avx512skx-x32 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+// RUN: %{ispc} --target=avx512skx-x64 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+// XFAIL: *
+
+struct vec4 {
+    float V[4];
+};
+
+uniform vec4 vmax(const uniform vec4 &V1, const uniform vec4 &V2) {
+    uniform vec4 Result;
+
+    foreach (i = 0 ... 4) {
+        Result.V[i] = max(V1.V[i], V2.V[i]);
+    }
+
+    return Result;
+}
+
+// CHECK-LABEL: foo:
+// CHECK: vmov{{.}}ps xmm0, xmmword ptr [r{{.*}}]
+// CHECK-NEXT: vmaxps  xmm0, xmm0, xmmword ptr [r{{.*}}]
+// CHECK-NEXT: vmov{{.}}ps xmmword ptr [r{{.*}}], xmm0
+export void foo(uniform float A[], uniform float B[]) {
+
+    uniform vec4 *uniform pA = (uniform vec4 * uniform) A;
+    uniform vec4 *uniform pB = (uniform vec4 * uniform) B;
+
+    *pA = vmax(*pA, *pB);
+}

--- a/tests/lit-tests/2611-4.ispc
+++ b/tests/lit-tests/2611-4.ispc
@@ -1,0 +1,33 @@
+// RUN: %{ispc} --target=avx2-i32x8 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+// RUN: %{ispc} --target=avx512skx-x8 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+// RUN: %{ispc} --target=avx2-i32x16 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+// RUN: %{ispc} --target=avx512skx-x16 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+// REQUIRES: LLVM_17_0+
+
+struct vec4 {
+    double V[4];
+};
+
+uniform vec4 vmax(const uniform vec4 &V1, const uniform vec4 &V2) {
+    uniform vec4 Result;
+
+    foreach (i = 0 ... 4) {
+        Result.V[i] = max(V1.V[i], V2.V[i]);
+    }
+
+    return Result;
+}
+
+// CHECK-LABEL: foo:
+// CHECK: vmovupd ymm{{.*}}, ymmword ptr [r{{.*}}]
+// CHECK-NEXT: vmaxpd  ymm{{.*}}, ymm{{.*}}, ymmword ptr [r{{.*}}]
+// CHECK-NEXT: vmovupd ymmword ptr [r{{.*}}], ymm{{.*}}
+export void foo(uniform double A[], uniform double B[]) {
+
+    uniform vec4 *uniform pA = (uniform vec4 * uniform) A;
+    uniform vec4 *uniform pB = (uniform vec4 * uniform) B;
+
+    *pA = vmax(*pA, *pB);
+}

--- a/tests/lit-tests/2611-align.ispc
+++ b/tests/lit-tests/2611-align.ispc
@@ -1,0 +1,33 @@
+// RUN: %{ispc} --target=avx512skx-x16 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK-NOT: vmovapd ymm{{.*}}
+// CHECK: vmovupd ymm{{.*}}
+
+typedef double FReal;
+
+#define REAL_BITS doublebits
+#define DOUBLE_NAN 0xFFFFFFFFFFFFFFFF
+#define NAN DOUBLE_NAN
+
+struct FVector4 {
+    double V[4];
+};
+
+static inline uniform FVector4 VectorCompareGE1(const uniform FVector4 &A, const uniform FVector4 &B) {
+    varying FReal Result;
+
+    foreach (i = 0 ... 4) {
+        Result = A.V[i] >= B.V[i] ? REAL_BITS(NAN) : REAL_BITS(0);
+    }
+
+    return *((uniform FVector4 * uniform) & Result);
+}
+
+export void CompareGE1(uniform FVector4 Result[], const uniform FVector4 Src0[], const uniform FVector4 Src1[],
+                       const uniform int NumCompares) {
+    for (uniform int i = 0; i < NumCompares; i++) {
+        Result[i] = VectorCompareGE1(Src0[i], Src1[i]);
+    }
+}

--- a/tests/lit-tests/2611.ispc
+++ b/tests/lit-tests/2611.ispc
@@ -1,0 +1,36 @@
+// RUN: %{ispc} --target=avx2-i32x8 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+// RUN: %{ispc} --target=avx512skx-x8 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+// RUN: %{ispc} --target=avx2-i32x16 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+// RUN: %{ispc} --target=avx512skx-x16 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+struct vec4
+{
+	float V[4];
+};
+
+uniform vec4 vmax(const uniform vec4& V1, const uniform vec4& V2)
+{
+	uniform vec4 Result;
+
+	foreach(i = 0 ... 4)
+	{
+		Result.V[i] = max(V1.V[i], V2.V[i]);
+	}
+
+	return Result;
+}
+
+// CHECK-LABEL: foo:
+// CHECK: vmov{{.}}ps xmm0, xmmword ptr [r{{.*}}]
+// CHECK-NEXT: vmaxps  xmm0, xmm0, xmmword ptr [r{{.*}}]
+// CHECK-NEXT: vmov{{.}}ps xmmword ptr [r{{.*}}], xmm0
+export void foo(uniform float A[], uniform float B[])
+{
+
+	uniform vec4 *uniform pA = (uniform vec4 *uniform)A;
+	uniform vec4 *uniform pB = (uniform vec4 *uniform)B;
+
+	*pA = vmax(*pA, *pB);
+}

--- a/tests/lit-tests/2611.ll
+++ b/tests/lit-tests/2611.ll
@@ -1,0 +1,102 @@
+; RUN: %{ispc-opt} --passes=replace-masked-memory-ops %s -o - | FileCheck %s
+
+; REQUIRES: LLVM_17_0+
+
+declare <4 x i32> @llvm.masked.load.v4i32.p0v4i32(<4 x i32>*, i32, <4 x i1>, <4 x i32>)
+declare void @llvm.masked.store.v4i32.p0v4i32(<4 x i32>, <4 x i32>*, i32, <4 x i1>)
+
+; CHECK-LABEL: @foo
+; CHECK-NEXT: [[HL:%.*]] = load <2 x i32>, ptr %a, align 16
+; CHECK-NEXT: [[VEC:%.*]] = shufflevector <2 x i32> [[HL]], <2 x i32> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT: [[HS:%.*]] = shufflevector <4 x i32> [[VEC]], <4 x i32> undef, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT: store <2 x i32> [[HS]], ptr %b, align 16
+; CHECK-NEXT: ret void
+define void @foo(<4 x i32>* %a, <4 x i32>* %b) {
+  %vec = call <4 x i32> @llvm.masked.load.v4i32.p0v4i32(<4 x i32>* %a, i32 16,
+                                                        <4 x i1> <i1 true, i1 true, i1 false, i1 false>,
+                                                        <4 x i32> <i32 poison, i32 poison, i32 0, i32 0>)
+  call void @llvm.masked.store.v4i32.p0v4i32(<4 x i32> %vec, <4 x i32>* %b, i32 16,
+                                             <4 x i1> <i1 true, i1 true, i1 false, i1 false>)
+  ret void
+}
+
+; CHECK-LABEL: @bad_mask
+; CHECK-NEXT: call <4 x i32> @llvm.masked.load
+; CHECK-NEXT: ret void
+define void @bad_mask(<4 x i32>* %a) {
+  %vec1 = call <4 x i32> @llvm.masked.load.v4i32.p0v4i32(<4 x i32>* %a, i32 1,
+                                                        <4 x i1> <i1 true, i1 true, i1 true, i1 false>,
+                                                        <4 x i32> <i32 poison, i32 poison, i32 0, i32 0>)
+
+  ret void
+}
+
+; CHECK-LABEL: @oneelemmask
+; CHECK-NEXT: [[V1:%.*]] = load <1 x i32>, ptr %a, align 1
+; CHECK-NEXT: [[V2:%.*]] = shufflevector <1 x i32> [[V1]], <1 x i32> zeroinitializer, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT: {{%.*}} = shufflevector <2 x i32> [[V2]], <2 x i32> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT: ret void
+define void@oneelemmask(<4 x i32>* %a) {
+  %vec2 = call <4 x i32> @llvm.masked.load.v4i32.p0v4i32(<4 x i32>* %a, i32 1,
+                                                        <4 x i1> <i1 true, i1 false, i1 false, i1 false>,
+                                                        <4 x i32> <i32 poison, i32 0, i32 0, i32 0>)
+  ret void
+}
+
+; CHECK-LABEL: @passthrough
+; CHECK-NEXT: [[V1:%.*]] = load <2 x i32>, ptr %a, align 8
+; CHECK-NEXT: {{.*}} = shufflevector <2 x i32> [[V1]], <2 x i32> <i32 42, i32 43>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT: ret void
+define void @passthrough(<4 x i32>* %a, <4 x i32>* %b) {
+  %vec = call <4 x i32> @llvm.masked.load.v4i32.p0v4i32(<4 x i32>* %a, i32 8,
+                                                        <4 x i1> <i1 true, i1 true, i1 false, i1 false>,
+                                                        <4 x i32> <i32 poison, i32 poison, i32 42, i32 43>)
+  ret void
+}
+
+; non-const mask values are not supported.
+; CHECK-LABEL: @notconstmaskargs
+; CHECK-NEXT: @llvm.masked.load
+; CHECK-NEXT: @llvm.masked.store
+; CHECK-NEXT: ret void
+define void @notconstmaskargs(ptr %a, <4 x i1> %m) {
+  %vec = call <4 x i32> @llvm.masked.load.v4i32.p0v4i32(ptr %a, i32 8, <4 x i1> %m,
+                                                        <4 x i32> <i32 poison, i32 poison, i32 42, i32 43>)
+  call void @llvm.masked.store.v4i32.p0v4i32(<4 x i32> %vec, ptr %a, i32 16, <4 x i1> %m)
+  ret void
+}
+
+; non-const passthrough values are not supported.
+; CHECK-LABEL: @notconstpassthrough
+; CHECK-NEXT: @llvm.masked.load
+; CHECK-NEXT: ret void
+define void @notconstpassthrough(ptr %a, <4 x i32> %b) {
+  %vec = call <4 x i32> @llvm.masked.load.v4i32.p0v4i32(ptr %a, i32 8,
+                                                        <4 x i1> <i1 true, i1 true, i1 false, i1 false>, <4 x i32> %b)
+  ret void
+}
+
+declare <8 x float> @llvm.masked.load.v8f32.p0v8f32(ptr, i32, <8 x i1>, <8 x float>)
+; Reducing to quarters is not supported at the moment or lesser parts are
+; useful for x16 and wider targets.
+; CHECK-LABEL: @quarter
+; CHECK-NEXT: [[V1:%.*]] = load <2 x float>, ptr %a, align 1
+; CHECK-NEXT: [[V2:%.*]] = shufflevector <2 x float> [[V1]], <2 x float> <float 1.000000e+00, float 0.000000e+00>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT: [[V:%.*]] = shufflevector <4 x float> [[V2]], <4 x float> zeroinitializer, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+define void @quarter(ptr %a) {
+  %vec1 = call <8 x float> @llvm.masked.load.v8f32.p0v8f32(ptr %a, i32 1,
+                    <8 x i1> <i1 true, i1 true, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false>,
+                    <8 x float> <float poison, float poison, float 1.0, float 0.0, float 0.0, float 0.0, float 0.0, float 0.0>)
+  ret void
+}
+
+; do not optimize if the mask is all false because such loads are removed by other passes.
+; CHECK-LABEL: @allzeromask
+; CHECK-NEXT: @llvm.masked.load
+; CHECK-NEXT: ret <4 x i32> %vec
+define <4 x i32> @allzeromask(<4 x i32>* %a, <4 x i32>* %b) {
+  %vec = call <4 x i32> @llvm.masked.load.v4i32.p0v4i32(<4 x i32>* %a, i32 8,
+                                                        <4 x i1> <i1 false, i1 false, i1 false, i1 false>,
+                                                        <4 x i32> <i32 poison, i32 poison, i32 42, i32 43>)
+  ret <4 x i32> %vec
+}

--- a/tests/lit-tests/2719.ispc
+++ b/tests/lit-tests/2719.ispc
@@ -1,0 +1,14 @@
+// RUN: %{ispc} --target=avx2-i32x8 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK-LABEL: foo
+// CHECK-NOT: vbroadcastss    ymm0, xmm0
+// CHECK-NOT: vmovaps    ymm1, dword ptr [{{.*}}]
+// CHECK-NOT: vmaskmovps      ymmword ptr [{{.*}}], ymm1, ymm0
+uniform int foo(uniform float v1[], uniform float v2[], uniform float v3[], uniform float result[]) {
+    float invArea = 1.f / ((v3[0] - v1[0]) * (v2[1] - v1[1]) - ((v3[1] - v1[1]) * (v2[0] - v1[0])));
+    foreach (i = 0 ... 4) {
+        result[i] = invArea;
+    }
+}

--- a/tests/lit-tests/ispc-opt.ll
+++ b/tests/lit-tests/ispc-opt.ll
@@ -9,6 +9,7 @@
 ; CHECK-PRINT-NEXT:   intrinsics-opt
 ; CHECK-PRINT-NEXT:   is-compile-time-constant
 ; CHECK-PRINT-NEXT:   peephole
+; CHECK-PRINT-NEXT:   replace-masked-memory-ops
 ; CHECK-PRINT-NEXT:   replace-pseudo-memory-ops
 ; CHECK-PRINT-NEXT:   replace-stdlib-shift
 


### PR DESCRIPTION
It traverses bitcode for masked stores that have the turned-off second part and the turned-on first part. We can safely replace them with narrow unmasked stores and loads with the following shuffle with the passthrough value. This can help the back-end to generate better code (no extra spills, assigning narrow registers).

This fixes that last part of issue https://github.com/ispc/ispc/issues/2611