### PR TITLE
ImproveMemOps: consider zext in lOffsets32BitSafe

### DIFF
--- a/src/opt/ImproveMemoryOps.cpp
+++ b/src/opt/ImproveMemoryOps.cpp
@@ -569,9 +569,13 @@ static bool lOffsets32BitSafe(llvm::Value **variableOffsetPtr, llvm::Value **con
 
     if (variableOffset->getType() != LLVMTypes::Int32VectorType) {
         llvm::SExtInst *sext = llvm::dyn_cast<llvm::SExtInst>(variableOffset);
+        llvm::ZExtInst *zext = llvm::dyn_cast<llvm::ZExtInst>(variableOffset);
         if (sext != nullptr && sext->getOperand(0)->getType() == LLVMTypes::Int32VectorType)
             // sext of a 32-bit vector -> the 32-bit vector is good
             variableOffset = sext->getOperand(0);
+        else if (zext != nullptr && zext->getOperand(0)->getType() == LLVMTypes::Int32VectorType)
+            // zext of a 32-bit vector -> the 32-bit vector is good
+            variableOffset = zext->getOperand(0);
         else if (lVectorIs32BitInts(variableOffset))
             // The only constant vector we should have here is a vector of
             // all zeros (i.e. a ConstantAggregateZero, but just in case,


### PR DESCRIPTION
After LLVM change [d77067d08](https://github.com/llvm/llvm-project/commit/d77067d08), InstCombine substitutes 
```llvm-ir
%v2 = sext <4 x i32> %v1 to <4 x i64>
```
with
```llvm-ir
%v2 = zext nneg <4 x i32> %v1 to <4 x i64>
```

`lOffsets32BitSafe` should consider `zext` too to be able to replace `__pseudo_scatter64_i32` with `__pseudo_scatter_factored_base_offsets32_i32`. Otherwise, it replaces it with `__pseudo_scatter_factored_base_offsets32_i32` that somehow results in generation of `vunpckhps`.

This fixes https://github.com/ispc/ispc/blob/main/tests/lit-tests/interleaved.ispc (issue #2813) with LLVM 18.1.