### PR TITLE
Add uwtable attr to all created functions

### DIFF
--- a/src/func.cpp
+++ b/src/func.cpp
@@ -705,6 +705,8 @@ void Function::GenerateIR() {
             appFunction->setDoesNotThrow();
             appFunction->setCallingConv(type->GetCallingConv());
 
+            AddUWTableFuncAttr(appFunction);
+
             // Xe kernel should have "dllexport" and "CMGenxMain" attribute,
             // otherss have "CMStackCall" attribute
             if (g->target->isXeTarget()) {
@@ -1311,6 +1313,8 @@ llvm::Function *TemplateInstantiation::createLLVMFunction(Symbol *functionSym) {
     if (isNoInline) {
         function->addFnAttr(llvm::Attribute::NoInline);
     }
+
+    AddUWTableFuncAttr(function);
 
     // Add NoAlias attribute to function arguments if needed.
     int nArgs = functionType->GetNumParameters();

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2023, Intel Corporation
+  Copyright (c) 2010-2024, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -1812,6 +1812,18 @@ MaskStatus GetMaskStatusFromValue(llvm::Value *mask, int vecWidth) {
             return MaskStatus::mixed;
     }
     return MaskStatus::all_on;
+}
+
+void AddUWTableFuncAttr(llvm::Function *fn) {
+    if (g->target_os == TargetOS::windows) {
+        // Enable generation an unwind table during codegen.
+        // It is needed to generate backtraces during debugging and to unwind callstack.
+#if ISPC_LLVM_VERSION <= ISPC_LLVM_14_0
+        fn->setHasUWTable();
+#else
+        fn->setUWTableKind(llvm::UWTableKind::Default);
+#endif
+    }
 }
 
 #ifdef ISPC_XE_ENABLED

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2023, Intel Corporation
+  Copyright (c) 2010-2024, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -407,6 +407,10 @@ extern bool GetMaskFromValue(llvm::Value *factor, uint64_t *mask);
     unknown at compile time.
 */
 extern MaskStatus GetMaskStatusFromValue(llvm::Value *mask, int vecWidth = -1);
+
+/** Add uwtable attribute for function, windows specific.
+ */
+extern void AddUWTableFuncAttr(llvm::Function *fn);
 
 #ifdef ISPC_XE_ENABLED
 /** This is utility function to determine memory in which pointer was created.

--- a/tests/lit-tests/2839-1.ispc
+++ b/tests/lit-tests/2839-1.ispc
@@ -1,0 +1,12 @@
+//; RUN: %{ispc} %s --nostdlib --target=sse4-i32x4,avx2-i32x4 --target-os=windows --emit-llvm-text -o %t.ll
+//; RUN FileCheck %s %t.ll --check-prefix=DISPATCHER
+//; RUN FileCheck %s %t_sse4.ll --check-prefix=TARGET
+//; RUN FileCheck %s %t_avx2.ll --check-prefix=TARGET
+
+// REQUIRES: X86_ENABLED && WINDOWS_ENABLED
+
+// CHECK-DISPATCHER-COUNT-3: ; Function Attrs: uwtable
+// CHECK-TARGET-COUNT-2: ; Function Attrs: {{.*}} uwtable
+export uniform int foo() {
+    return 2;
+}

--- a/tests/lit-tests/2839-2.ispc
+++ b/tests/lit-tests/2839-2.ispc
@@ -1,0 +1,13 @@
+//; RUN: %{ispc} %s --nostdlib --target=avx2-i32x4 --target-os=windows --emit-llvm-text -o - | FileCheck %s
+
+// REQUIRES: X86_ENABLED && WINDOWS_ENABLED
+
+template<typename TYPE>
+TYPE bar() {
+    return 42;
+}
+
+// CHECK-COUNT-2: ; Function Attrs: {{.*}} uwtable
+export uniform int foo() {
+    return bar<uniform int>();
+}

--- a/tests/lit-tests/2839.ispc
+++ b/tests/lit-tests/2839.ispc
@@ -1,0 +1,8 @@
+//; RUN: %{ispc} %s --nostdlib --target=avx2-i32x4 --target-os=windows --emit-llvm-text -o - | FileCheck %s
+
+// REQUIRES: X86_ENABLED && WINDOWS_ENABLED
+
+// CHECK-COUNT-2: ; Function Attrs: {{.*}} uwtable
+export uniform int foo() {
+    return 42;
+}


### PR DESCRIPTION
ISPC has several places where LLVM functions created. We need to add the uwtable attribute in all of them to genereate unwind info under Windows.

Initial PR https://github.com/ispc/ispc/pull/2630 with uwtable attr did that only for internal copy of exported functions, and completely missed this attribute for template instantiations and dispatch functions.

This PR fixes #2839 