### PR TITLE
Fix devcontainer build deps

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,9 @@
   "__comment1__": "Copyright (c) 2023-2024, Intel Corporation",
   "__comment2__": "SPDX-License-Identifier: BSD-3-Clause",
   "name": "ISPC developers environment (CPU only)",
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu22.04",
   "features": {
-    "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": { "packages" : "libc6-dev,libc6-dev-i386,flex,wget,libtbb-dev" },
+    "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": { "packages" : "libc6-dev,libc6-dev-i386,cmake,make,flex,bison,m4,wget,libtbb-dev,libtinfo5,libncurses5-dev" },
     "ghcr.io/wxw-matt/devcontainer-features/command_runner:latest": {
       "command1" : "mkdir /llvm && cd /llvm && wget -q https://github.com/ispc/ispc.dependencies/releases/download/llvm-17.0-ispc-dev/llvm-17.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz",
       "command2" : "cd /llvm && tar xvf llvm-17.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz && rm -rf llvm-*" }
@@ -15,7 +15,7 @@
   },
   "remoteEnv": { "PATH": "/llvm/bin-17.0/bin:${containerEnv:PATH}" },
   "onCreateCommand": {
-    "command1": "cd ${containerWorkspaceFolder} && mkdir build && cd build && cmake .."
+    "command1": "cmake -B ${containerWorkspaceFolder}/build ${containerWorkspaceFolder}"
   },
   "customizations": {
     "codespaces": {


### PR DESCRIPTION
It also updates the base image up to `ubuntu22.04` to be able to run clang from ispc.dependencies.