### PR TITLE
Deprecate avx512knl-x16 target

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -72,6 +72,7 @@ Contents:
   + `Updating ISPC Programs For Changes In ISPC 1.22.0`_
   + `Updating ISPC Programs For Changes In ISPC 1.23.0`_
   + `Updating ISPC Programs For Changes In ISPC 1.24.0`_
+  + `Updating ISPC Programs For Changes In ISPC 1.25.0`_
 
 * `Getting Started with ISPC`_
 
@@ -625,6 +626,11 @@ older versions:
   all targets. It may potentially affect the results of the code that uses this
   function for the following targets: ``avx2-i16x16``, ``avx2-i8x32`` and all
   ``avx512`` targets. Please, refer to `Basic Math Functions`_ for more details.
+
+Updating ISPC Programs For Changes In ISPC 1.25.0
+-------------------------------------------------
+
+``avx512knl-x16`` target is deprecated and will be removed in future releases.
 
 Getting Started with ISPC
 =========================

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1273,6 +1273,12 @@ int main(int Argc, char *Argv[]) {
     }
 #endif
 
+    for (auto target : targets) {
+        if (target == ISPCTarget::avx512knl_x16) {
+            Warning(SourcePos(), "The target avx512knl_x16 is deprecated and will be removed in the future.");
+        }
+    }
+
     // If [no]wrap-signed-int is explicitly specified, then use this value.
     // Disable NSW bit optimization by default due to performance regressions
     // on some GPU workloads.  Otherwise enable it by default only for CPU targets.

--- a/tests/lit-tests/knl-deprecation.ispc
+++ b/tests/lit-tests/knl-deprecation.ispc
@@ -1,0 +1,9 @@
+// RUN: %{ispc} --nowrap --target=avx512knl-x16 --emit-asm -o %t.s %s 2>&1 | FileCheck %s
+// RUN: %{ispc} --nowrap --target=avx512knl-i32x16 --emit-asm -o %t.s %s 2>&1 | FileCheck %s
+// RUN: %{ispc} --nowrap --target=avx512knl-x16,avx2-i32x4 --emit-asm -o %t.s %s 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK: Warning: The target avx512knl_x16 is deprecated and will be removed in the future.
+
+void foo() {}


### PR DESCRIPTION
This is to address #2867. It just adds a warning when avx512knl-x16 target is used.