### PR TITLE
Use same image to build Clang/LLVM and ISPC

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -79,14 +79,14 @@ for:
 -
   matrix:
     only:
-      - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
+      - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
   init:
     - sh: |-
         export ISPC_HOME=$APPVEYOR_BUILD_FOLDER
         export LLVM_HOME=$APPVEYOR_BUILD_FOLDER/llvm
         export CROSS_TOOLS=/usr/local/src/cross
         export WASM=OFF
-        export LLVM_TAR=llvm-17.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+        export LLVM_TAR=llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
   install:
     - sh: |-
         sudo apt-get update

--- a/.github/workflows/compiler-warnings.yml
+++ b/.github/workflows/compiler-warnings.yml
@@ -17,10 +17,10 @@ env:
 
 jobs:
   clang-16:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -44,10 +44,10 @@ jobs:
           cmake --build build --target all -j4
 
   gcc-11:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -101,6 +101,10 @@ jobs:
       with:
         submodules: false
 
+    - name: Set git safe directory
+      run: |
+        git config --global --add safe.directory /__w/ispc/ispc
+
     - name: Install dependencies
       run: |
         .github/workflows/scripts/install-build-deps-aarch64.sh

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -43,7 +43,7 @@ env:
 
 jobs:
   define-flow:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       tests_matrix_targets: ${{ steps.set-flow.outputs.matrix }}
       tests_optsets: ${{ steps.set-flow.outputs.optsets }}
@@ -89,7 +89,7 @@ jobs:
             opaque_ptr_mode: "ON"
     env:
       LLVM_VERSION: ${{ matrix.llvm.version }}
-      LLVM_TAR: llvm-${{ matrix.llvm.full_version }}-ubuntu18.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-${{ matrix.llvm.full_version }}-ubuntu22.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: ${{ matrix.llvm.opaque_ptr_mode }}
 
     steps:
@@ -126,7 +126,7 @@ jobs:
 
   linux-build-ispc:
     needs: [define-flow]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -145,7 +145,7 @@ jobs:
             opaque_ptr_mode: "ON"
     env:
       LLVM_VERSION: ${{ matrix.llvm.version }}
-      LLVM_TAR: llvm-${{ matrix.llvm.full_version }}-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-${{ matrix.llvm.full_version }}-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: ${{ matrix.llvm.opaque_ptr_mode }}
 
     steps:
@@ -178,10 +178,10 @@ jobs:
 
   linux-build-ispc-llvm17-lto:
     needs: [define-flow]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu18.04-Release+Asserts-lto-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-lto-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -215,10 +215,10 @@ jobs:
 
   linux-build-ispc-llvm17-release:
     needs: [define-flow]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu18.04-Release-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -251,10 +251,10 @@ jobs:
 
   linux-build-ispc-xe-llvm17-release:
     needs: [define-flow]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu18.04-Release-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "OFF"
       INSTALL_COMPUTE_RUNTIME: 1
 
@@ -303,7 +303,7 @@ jobs:
 
   linux-test:
     needs: [define-flow, linux-build-ispc]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -353,7 +353,7 @@ jobs:
 
   linux-test-llvm17-lto:
     needs: [define-flow, linux-build-ispc-llvm17-lto]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -402,7 +402,7 @@ jobs:
   # Test release version
   linux-test-llvm17-release:
     needs: [define-flow, linux-build-ispc-llvm17-release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -454,7 +454,7 @@ jobs:
   linux-test-debug-llvm17:
     needs: [define-flow, linux-build-ispc]
     if: ${{ needs.define-flow.outputs.flow_type == 'full' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -504,7 +504,7 @@ jobs:
   linux-test-xe-llvm17-release:
     needs: [define-flow, linux-build-ispc-xe-llvm17-release]
     if: ${{ needs.define-flow.outputs.flow_type == 'smoke' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -1123,10 +1123,10 @@ jobs:
 
   linux-package-examples:
     needs: [define-flow]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       LLVM_VERSION: "16.0"
-      LLVM_TAR: llvm-16.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-16.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -21,10 +21,8 @@ env:
   SDE_TAR_NAME: sde-external-9.33.0-2024-01-07
 
 jobs:
-  # Building LLVM in docker, as using native Ubuntu 18.04 github-hosted image contains newer-than-expected libs and
-  # makes the resulting build not usable on other Ubuntu 18.04 images.
   linux-build-llvm-trunk:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
@@ -37,31 +35,31 @@ jobs:
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/18.04/cpu_ispc_build
+        cd docker/ubuntu/22.04/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu18.04 --target=llvm_build --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=trunk --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu22.04 --target=llvm_build --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=trunk --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
-        cd docker/ubuntu/18.04/cpu_ispc_build
+        cd docker/ubuntu/22.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-trunk .
         # Note using gzip here, instead of xz - trading of space for speed, as it's just for passing to another stage.
-        tar czvf llvm-trunk-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-trunk
+        tar czvf llvm-trunk-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.gz bin-trunk
 
     - name: Upload package
       uses: actions/upload-artifact@v4
       with:
         name: llvm_trunk_linux
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-trunk-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+        path: docker/ubuntu/22.04/cpu_ispc_build/llvm-trunk-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.gz
 
   linux-build-ispc-llvm-trunk:
     needs: [linux-build-llvm-trunk]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       LLVM_VERSION: "trunk"
-      LLVM_TAR: llvm-trunk-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+      LLVM_TAR: llvm-trunk-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.gz
 
     steps:
     - uses: actions/checkout@v4
@@ -98,7 +96,7 @@ jobs:
 
   linux-test-llvm-trunk:
     needs: [linux-build-ispc-llvm-trunk]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: false
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-17.yml
+++ b/.github/workflows/nightly-17.yml
@@ -23,10 +23,8 @@ env:
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
 
 jobs:
-  # Building LLVM in docker, as using native Ubuntu 18.04 github-hosted image contains newer-than-expected libs and
-  # makes the resulting build not usable on other Ubuntu 18.04 images.
   linux-build-llvm-17:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
@@ -39,31 +37,31 @@ jobs:
 
     - name: Build LLVM
       run: |
-        cd docker/ubuntu/18.04/cpu_ispc_build
+        cd docker/ubuntu/22.04/cpu_ispc_build
         ls -al
         docker buildx create --use
-        docker buildx build --tag ispc/ubuntu18.04:stage2 --target=llvm_build --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=17.0 --output=type=tar,dest=result.tar .
+        docker buildx build --tag ispc/ubuntu22.04:stage2 --target=llvm_build --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=17.0 --output=type=tar,dest=result.tar .
 
     - name: Pack LLVM
       run: |
-        cd docker/ubuntu/18.04/cpu_ispc_build
+        cd docker/ubuntu/22.04/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-17.0 .
         # Note using gzip here, instead of xz - trading of space for speed, as it's just for passing to another stage.
-        tar czvf llvm-17.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz bin-17.0
+        tar czvf llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.gz bin-17.0
 
     - name: Upload package
       uses: actions/upload-artifact@v4
       with:
         name: llvm_17_linux
-        path: docker/ubuntu/18.04/cpu_ispc_build/llvm-17.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+        path: docker/ubuntu/22.04/cpu_ispc_build/llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.gz
 
   linux-build-ispc-llvm-17:
     needs: [linux-build-llvm-17]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.gz
+      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.gz
 
     steps:
     - uses: actions/checkout@v4
@@ -100,7 +98,7 @@ jobs:
 
   linux-test-llvm-17:
     needs: [linux-build-ispc-llvm-17]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: false
     strategy:
       fail-fast: false

--- a/.github/workflows/rebuild-llvm15.yml
+++ b/.github/workflows/rebuild-llvm15.yml
@@ -25,7 +25,7 @@ jobs:
       version: '15.0'
       full_version: '15.0.7'
       lto: 'OFF'
-      ubuntu: '18.04'
+      ubuntu: '22.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'
       win_sdk: '10.0.17763.0'

--- a/.github/workflows/rebuild-llvm16.yml
+++ b/.github/workflows/rebuild-llvm16.yml
@@ -24,7 +24,7 @@ jobs:
     with:
       version: '16.0'
       full_version: '16.0.6'
-      lto: 'ON'
+      lto: 'OFF'
       ubuntu: '22.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'

--- a/.github/workflows/rebuild-llvm16.yml
+++ b/.github/workflows/rebuild-llvm16.yml
@@ -25,7 +25,7 @@ jobs:
       version: '16.0'
       full_version: '16.0.6'
       lto: 'ON'
-      ubuntu: '18.04'
+      ubuntu: '22.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'
       win_sdk: '10.0.17763.0'

--- a/.github/workflows/rebuild-llvm17.yml
+++ b/.github/workflows/rebuild-llvm17.yml
@@ -29,7 +29,7 @@ jobs:
       version: '17.0'
       full_version: '17.0.6'
       lto: ${{ matrix.lto }}
-      ubuntu: '18.04'
+      ubuntu: '22.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'
       win_sdk: '10.0.18362.0'

--- a/.github/workflows/rebuild-llvm18.yml
+++ b/.github/workflows/rebuild-llvm18.yml
@@ -29,7 +29,7 @@ jobs:
       version: '18.1'
       full_version: '18.1.2'
       lto: ${{ matrix.lto }}
-      ubuntu: '18.04'
+      ubuntu: '22.04'
       vs_generator: 'Visual Studio 16 2019'
       vs_version_str: 'vs2019'
       win_sdk: '10.0.18362.0'

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -22,7 +22,7 @@ on:
         type: string
         default: 'OFF'
       ubuntu:
-        description: Version of Ubuntu Dockerfile to use. For example '18.04'.
+        description: Version of Ubuntu Dockerfile to use. For example '22.04'.
         required: true
         type: string
       vs_generator:
@@ -55,10 +55,10 @@ on:
         type: string
         default: 'OFF'
       ubuntu:
-        description: Version of Ubuntu Dockerfile to use. For example '18.04'.
+        description: Version of Ubuntu Dockerfile to use. For example '22.04'.
         required: true
         type: string
-        default: '18.04'
+        default: '22.04'
       vs_generator:
         description: VS generator to use. For example 'Visual Studio 16 2019'.
         required: true
@@ -77,8 +77,6 @@ on:
 
 
 jobs:
-  # Building LLVM in docker, as using native Ubuntu 18.04 github-hosted image contains newer-than-expected libs and
-  # makes the resulting build not usable on other Ubuntu 18.04 images.
   linux-build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -17,10 +17,10 @@ env:
 
 jobs:
   linux-ispc-llvm17-asan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:

--- a/docker/ubuntu/22.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/22.04/cpu_ispc_build/Dockerfile
@@ -1,14 +1,20 @@
 #
-#  Copyright (c) 2017-2023, Intel Corporation
+#  Copyright (c) 2017-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
-FROM ubuntu:22.04 AS llvm_build_only
+ARG LLVM_VERSION=17.0
+
+FROM ubuntu:22.04 AS llvm_build
 LABEL maintainer="Dmitry Babokin <dmitry.y.babokin@intel.com>"
 SHELL ["/bin/bash", "-c"]
 
 ARG REPO=ispc/ispc
 ARG SHA=main
+ARG LTO=OFF
+ARG PGO=OFF
+ARG LLVM_VERSION
+ARG LLVM_DISABLE_ASSERTIONS
 
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
@@ -43,21 +49,29 @@ RUN if [[ $(uname -m) =~ "x86" ]]; then \
 # If you are behind a proxy, you need to configure git.
 RUN if [ -v http_proxy ]; then git config --global --add http.proxy "$http_proxy"; fi
 
-WORKDIR /home/src
-RUN git clone https://github.com/$REPO.git ispc
-
-WORKDIR /home/src/ispc
-RUN git checkout $SHA && \
-    cmake superbuild \
+ENV LLVM_HOME=/usr/local/src/llvm
+WORKDIR /usr/local/src
+RUN git clone https://github.com/$REPO.git ispc && \
+    git -C ispc checkout $SHA && \
+    cmake ispc/superbuild \
         -B build \
         --preset os \
+        -DLTO=$LTO \
         -DXE_DEPS=OFF \
         -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON \
-        -DCMAKE_INSTALL_PREFIX=/usr/local && \
+        -DLLVM_VERSION="$LLVM_VERSION" \
+        -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON \
+        -DCMAKE_INSTALL_PREFIX="$LLVM_HOME"/bin-"$LLVM_VERSION" \
+        -DLLVM_DISABLE_ASSERTIONS="$LLVM_DISABLE_ASSERTIONS" && \
     cmake --build build && \
     rm -rf build
 
-FROM llvm_build_only AS ispc_build
+FROM llvm_build AS ispc_build
+SHELL ["/bin/bash", "-c"]
+
+ARG LTO=OFF
+ARG PGO=OFF
+ARG LLVM_VERSION
 
 RUN apt-get -y update && \
     apt-get --no-install-recommends install -y \
@@ -65,13 +79,16 @@ RUN apt-get -y update && \
     rm -rf /var/lib/apt/lists/*
 
 # Build ISPC
-WORKDIR /home/src/ispc
-RUN cmake . \
+WORKDIR /usr/local/src
+RUN cmake ispc/superbuild \
         -B build \
-        -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DX86_ENABLED=ON \
         -DARM_ENABLED=ON \
-        -DCMAKE_CXX_FLAGS="-Werror" && \
+        -DLTO=$LTO \
+        -DXE_DEPS=OFF \
+        -DCMAKE_CXX_FLAGS=-Werror \
+        -DPREBUILT_STAGE2_PATH="$LLVM_HOME"/bin-"$LLVM_VERSION" \
+        -DCMAKE_INSTALL_PREFIX=/usr/local/src/ispc/bin-"$LLVM_VERSION" && \
     cmake --build build -j"$(nproc)" && \
     cmake --build build --target check-all && \
     cmake --install build && \


### PR DESCRIPTION
Build Clang/LLVM in same ubuntu as ISPC to avoid issues with linking to different `libstdc++` versions. See #2892 and #2877 for context. 