### PR TITLE
Finalize removing of ncurses/terminfo dependency

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "name": "ISPC developers environment (CPU only)",
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu22.04",
   "features": {
-    "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": { "packages" : "libc6-dev,libc6-dev-i386,cmake,make,flex,bison,m4,wget,libtbb-dev,libtinfo5,libncurses5-dev" },
+    "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": { "packages" : "libc6-dev,libc6-dev-i386,cmake,make,flex,bison,m4,wget,libtbb-dev" },
     "ghcr.io/wxw-matt/devcontainer-features/command_runner:latest": {
       "command1" : "mkdir /llvm && cd /llvm && wget -q https://github.com/ispc/ispc.dependencies/releases/download/llvm-17.0-ispc-dev/llvm-17.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz",
       "command2" : "cd /llvm && tar xvf llvm-17.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz && rm -rf llvm-*" }

--- a/.github/workflows/scripts/install-build-deps-aarch64.sh
+++ b/.github/workflows/scripts/install-build-deps-aarch64.sh
@@ -5,7 +5,7 @@
 
 add-apt-repository ppa:ubuntu-toolchain-r/test -y && apt-get -y update
 
-apt-get --no-install-recommends install -y wget build-essential gcc g++ git python3-dev ncurses-dev libtinfo-dev ca-certificates libtbb-dev ninja-build
+apt-get --no-install-recommends install -y wget build-essential gcc g++ git python3-dev ca-certificates libtbb-dev ninja-build
 
 # ISPC and LLVM starting 16.0 build in C++17 mode and will fail without modern libstdc++
 apt-get --no-install-recommends install -y software-properties-common libstdc++-9-dev

--- a/.github/workflows/scripts/install-build-deps.sh
+++ b/.github/workflows/scripts/install-build-deps.sh
@@ -5,7 +5,7 @@ echo "APT::Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-retries
 for i in {1..5}
 do
   sudo apt-get update | tee log${i}.txt
-  sudo apt-get install ninja-build bison flex libc6-dev-i386 g++-multilib lib32stdc++6 ncurses-dev libtinfo5 libtbb-dev libstdc++6 | tee -a log${i}.txt
+  sudo apt-get install ninja-build bison flex libc6-dev-i386 g++-multilib lib32stdc++6 libtbb-dev libstdc++6 | tee -a log${i}.txt
   if [[ ! `grep "^Err: " log${i}.txt` && ! `grep "^E: " log${i}.txt` ]]; then
     echo "APT packages installation was successful"
     break

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -736,21 +736,6 @@ endif()
 if (WIN32)
     list(APPEND LINK_LIBRARIES version.lib shlwapi.lib odbc32.lib odbccp32.lib)
 else()
-    if (ISPC_STATIC_LINK)
-        list(APPEND LINK_LIBRARIES tinfo.a curses.a)
-    else()
-        find_package(Curses REQUIRED)
-        if (CURSES_EXTRA_LIBRARY)
-            # this contains the tinfo library, if found
-            list(APPEND LINK_LIBRARIES ${CURSES_EXTRA_LIBRARY})
-        endif()
-        # Recommended way to get Curses library is to use CURSES_LIBRARIES variable
-        # https://cmake.org/cmake/help/v3.27/module/FindCurses.html
-        # but it contains both libform.so and libcurses.so.
-        # We need libcurses.so only, so exclude libform.so from the list.
-        list(FILTER CURSES_LIBRARIES EXCLUDE REGEX ".*libform.*")
-        list(APPEND LINK_LIBRARIES ${CURSES_LIBRARIES})
-    endif()
     # ISPC doesn't use pthreads directly, but LLVM does. Although, it looks
     # like we do not use LLVM code that depend on pthreads, don't we?
     find_library(PTHREAD_LIB REQUIRED NAMES pthread)

--- a/docker/centos/7/cpu_ispc_build/Dockerfile
+++ b/docker/centos/7/cpu_ispc_build/Dockerfile
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2017-2023, Intel Corporation
+#  Copyright (c) 2017-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -19,7 +19,7 @@ RUN yum -y update && \
     yum install -y centos-release-scl epel-release && \
     yum install -y vim wget yum-utils gcc gcc-c++ git python3 m4 bison && \
     yum install -y flex patch make glibc-devel.x86_64 glibc-devel.i686 xz devtoolset-8 && \
-    yum install -y libtool autopoint gettext-devel texinfo tbb-devel help2man && \
+    yum install -y autopoint gettext-devel texinfo tbb-devel help2man && \
     yum install -y ninja-build && \
     yum install -y libstdc++-static && \
     yum clean -y all
@@ -65,13 +65,6 @@ RUN git checkout $SHA && \
     rm -rf build
 
 FROM llvm_only AS ispc_build
-
-# Build ncurses with -fPIC: https://github.com/ispc/ispc/pull/2502#issuecomment-1526931698
-WORKDIR /usr/local/src
-RUN git clone https://github.com/mirror/ncurses.git
-WORKDIR /usr/local/src/ncurses
-# Checkout version with fix for CVE-2023-29491
-RUN git checkout 87c2c84 && CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-termlib && make -j"$(nproc)" && make install -j"$(nproc)"
 
 # Install new flex (2.6.4)
 WORKDIR /usr/local/src

--- a/docker/centos/7/xpu_ispc_build/Dockerfile
+++ b/docker/centos/7/xpu_ispc_build/Dockerfile
@@ -22,7 +22,7 @@ RUN yum -y update && \
     yum install -y centos-release-scl epel-release && \
     yum install -y vim wget yum-utils gcc gcc-c++ git python3 m4 bison flex patch make && \
     yum install -y glibc-devel.x86_64 glibc-devel.i686 xz devtoolset-8 && \
-    yum install -y libtool autopoint gettext-devel texinfo help2man && \
+    yum install -y autopoint gettext-devel texinfo help2man && \
     yum install -y ninja-build && \
     yum install -y libstdc++-static && \
     yum clean -y all
@@ -40,13 +40,6 @@ RUN if [[ $(uname -m) =~ "x86" ]]; then \
     fi && \
     wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $CMAKE_URL && \
     sh cmake-*.sh --prefix=/usr/local --skip-license && rm -rf cmake-*.sh
-
-# Build ncurses with -fPIC: https://github.com/ispc/ispc/pull/2502#issuecomment-1526931698
-WORKDIR /usr/local/src
-RUN git clone https://github.com/mirror/ncurses.git
-WORKDIR /usr/local/src/ncurses
-# Checkout version with fix for CVE-2023-29491
-RUN git checkout 87c2c84 && CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-termlib && make -j"$(nproc)" && make install -j"$(nproc)"
 
 # Install new flex (2.6.4)
 WORKDIR /usr/local/src

--- a/docker/centos/8/cpu_ispc_build/Dockerfile
+++ b/docker/centos/8/cpu_ispc_build/Dockerfile
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2017-2023, Intel Corporation
+#  Copyright (c) 2017-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -13,8 +13,8 @@ ARG SHA=main
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
 
-# Packages required to build ISPC and Clang. libtool is needed to build ncurses.
-RUN dnf -y update && dnf install -y wget yum-utils gcc gcc-c++ git python3 make ncurses-devel xz libtool tbb-devel && \
+# Packages required to build ISPC and Clang.
+RUN dnf -y update && dnf install -y wget yum-utils gcc gcc-c++ git python3 make xz tbb-devel && \
     dnf clean -y all
 
 # These packages are required if you need to link ISPC with -static.
@@ -25,12 +25,6 @@ RUN dnf -y --enablerepo=powertools install ninja-build libstdc++-static && \
 RUN if [[ $(uname -m) =~ "x86" ]]; then dnf -y update && dnf install -y glibc-devel.i686 && dnf clean -y all; fi
 
 WORKDIR /usr/local/src
-
-# Ncurses for g++ --static -lcurses -ltinfo. Despite setting --enable-overwrite it doesn't link(only static not linked?) libncurses as libcurses so symlinked manually
-RUN git clone https://github.com/ThomasDickey/ncurses-snapshots.git --depth=1 --branch=v6_3
-WORKDIR /usr/local/src/ncurses-snapshots
-RUN CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-termlib --with-libtool --with-libtool-opts=-static --enable-static --enable-overwrite && make -j"$(nproc)" && make install && \
-  ln -s /usr/lib/libncurses.a /usr/lib/libcurses.a && ln -s /usr/lib/libncurses++.a /usr/lib/libcurses++.a
 
 # Download and install required version of cmake (3.23.5 for both x86 and aarch64) as required for superbuild preset jsons.
 RUN if [[ $(uname -m) =~ "x86" ]]; then \

--- a/docker/ubuntu/16.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/16.04/cpu_ispc_build/Dockerfile
@@ -21,7 +21,7 @@ RUN uname -a
 
 # Packages required to build ISPC and Clang.
 RUN apt-get -y update && apt-get --no-install-recommends install -y software-properties-common && \
-    apt-get --no-install-recommends install -y wget build-essential git ncurses-dev libtinfo-dev libtbb-dev && \
+    apt-get --no-install-recommends install -y wget build-essential git libtbb-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # ISPC and LLVM starting 16.0 build in C++17 mode and will fail without modern compiler (gcc>=7).

--- a/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
@@ -22,7 +22,7 @@ ARG LLVM_DISABLE_ASSERTIONS
 RUN uname -a
 
 # Packages required to build ISPC and Clang.
-RUN apt-get -y update && apt-get --no-install-recommends install -y wget build-essential gcc g++ git ncurses-dev libtinfo-dev ca-certificates libtbb-dev ninja-build && \
+RUN apt-get -y update && apt-get --no-install-recommends install -y wget build-essential gcc g++ git ca-certificates libtbb-dev ninja-build && \
     rm -rf /var/lib/apt/lists/*
 
 # Install multilib libc needed to build clang_rt

--- a/docker/ubuntu/20.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/20.04/cpu_ispc_build/Dockerfile
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2017-2023, Intel Corporation
+#  Copyright (c) 2017-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -16,7 +16,7 @@ ARG SHA=main
 RUN uname -a
 
 # Packages
-RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y wget build-essential gcc g++ git python3-dev ncurses-dev libtinfo-dev ca-certificates libtbb-dev ninja-build && \
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y wget build-essential gcc g++ git python3-dev ca-certificates libtbb-dev ninja-build && \
     rm -rf /var/lib/apt/lists/*
 
 # Install multilib libc needed to build clang_rt

--- a/docker/ubuntu/20.04/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/20.04/xpu_ispc_build/Dockerfile
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2017-2023, Intel Corporation
+#  Copyright (c) 2017-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -16,8 +16,8 @@ ARG LTO=OFF
 
 # Packages
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y clang-8 build-essential \
-    libnuma1 opencl-headers ocl-icd-libopencl1 clinfo vim gcc g++ git python3-dev imagemagick m4 bison flex libncurses-dev \
-    libtinfo-dev libc6-dev-i386 cpio lsb-core wget gnupg netcat-openbsd libtbb-dev libglfw3-dev pkgconf gdb gcc-multilib g++-multilib curl ca-certificates && \
+    libnuma1 opencl-headers ocl-icd-libopencl1 clinfo vim gcc g++ git python3-dev imagemagick m4 bison flex \
+    libc6-dev-i386 cpio lsb-core wget gnupg netcat-openbsd libtbb-dev libglfw3-dev pkgconf gdb gcc-multilib g++-multilib curl ca-certificates && \
     apt-get --no-install-recommends install -y ninja-build && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/ubuntu/22.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/22.04/cpu_ispc_build/Dockerfile
@@ -25,7 +25,7 @@ RUN uname -a
 RUN apt-get -y update && \
     DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
         wget ninja-build build-essential gcc g++ git python3-dev \
-        ncurses-dev libtinfo-dev ca-certificates libtbb2-dev && \
+        ca-certificates libtbb2-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Install multilib libc needed to build clang_rt

--- a/docker/ubuntu/22.04/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/22.04/xpu_ispc_build/Dockerfile
@@ -19,7 +19,7 @@ ARG LTO
 
 # Packages
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y clang-12 build-essential libnuma1 opencl-headers ocl-icd-libopencl1 clinfo vim gcc g++ git python3-dev imagemagick \
-    m4 bison flex libncurses-dev libtinfo-dev libc6-dev-i386 cpio lsb-core wget netcat-openbsd libtbb2-dev libglfw3-dev pkgconf gdb gcc-multilib g++-multilib curl ca-certificates ninja-build && \
+    m4 bison flex libc6-dev-i386 cpio lsb-core wget netcat-openbsd libtbb2-dev libglfw3-dev pkgconf gdb gcc-multilib g++-multilib curl ca-certificates ninja-build && \
     rm -rf /var/lib/apt/lists/*
 
 # Download and install required version of cmake (3.23.5 for both x86 and aarch64) as required for superbuild preset jsons.

--- a/third-party-programs.txt
+++ b/third-party-programs.txt
@@ -346,40 +346,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-4. libncurses
-
-   libtinfo
-
-
-Copyright 2018-2021,2022 Thomas E. Dickey
-Copyright 1998-2017,2018 Free Software Foundation, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, distribute with modifications, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE ABOVE COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
-THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-Except as contained in this notice, the name(s) of the above copyright
-holders shall not be used in advertising or otherwise to promote the
-sale, use or other dealings in this Software without prior written
-authorization.
-
---------------------------------------------------------------------------------
-
 5. GNU libstdc++
 
    libgcc


### PR DESCRIPTION
This fixes #2855.

This PR:
1. Remove installation of libncurses and libtinfo in docker/CI/devcontainers.
2. Remove CMake logic to find them.
3. Remove the license entry from `third-party-programs.txt`