### PR TITLE
Report error when var declarations have incompatible type specifiers

### DIFF
--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -36,6 +36,14 @@ void lCheckVariableTypeQualifiers(int typeQualifiers, SourcePos pos) {
         Error(pos, "\"export\" qualifier illegal in variable declaration.");
         return;
     }
+    if (typeQualifiers & TYPEQUAL_INLINE) {
+        Error(pos, "\"inline\" qualifier illegal in variable declaration.");
+        return;
+    }
+    if (typeQualifiers & TYPEQUAL_NOINLINE) {
+        Error(pos, "\"noinline\" qualifier illegal in variable declaration.");
+        return;
+    }
 }
 
 void lCheckTypeQualifiers(int typeQualifiers, DeclaratorKind kind, SourcePos pos) {

--- a/tests/lit-tests/err-export-1.ispc
+++ b/tests/lit-tests/err-export-1.ispc
@@ -1,0 +1,18 @@
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error: "export" qualifier is illegal outside of function declarations.
+struct Example {
+    export int x;
+};
+// CHECK-COUNT-8: Error: "export" qualifier illegal in variable declaration.
+export int x;
+export uniform int w = 0;
+void foo(export int y) {
+  export float a, c;
+  export varying float b = 0;
+}
+export uniform int boo(), f, *p;
+export void func() {
+  return;
+}
+export uniform int64 * uniform p64();

--- a/tests/lit-tests/err-inline.ispc
+++ b/tests/lit-tests/err-inline.ispc
@@ -1,0 +1,18 @@
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error: "inline" qualifier is illegal outside of function declarations.
+struct Example {
+    inline int x;
+};
+// CHECK-COUNT-8: Error: "inline" qualifier illegal in variable declaration.
+inline int x;
+inline uniform int w = 0;
+void foo(inline int y) {
+  inline float a, c;
+  inline varying float b = 0;
+}
+inline int boo(), f, *p;
+inline void func() {
+  return;
+}
+inline uniform int64 * uniform p64();

--- a/tests/lit-tests/err-noinline.ispc
+++ b/tests/lit-tests/err-noinline.ispc
@@ -1,0 +1,18 @@
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error: "noinline" qualifier is illegal outside of function declarations.
+struct Example {
+    noinline int x;
+};
+// CHECK-COUNT-8: Error: "noinline" qualifier illegal in variable declaration.
+noinline int x;
+noinline uniform int w = 0;
+void foo(noinline int y) {
+  noinline float a, c;
+  noinline varying float b = 0;
+}
+noinline int boo(), f, *p;
+noinline void func() {
+  return;
+}
+noinline uniform int64 * uniform p64();

--- a/tests/lit-tests/err-task.ispc
+++ b/tests/lit-tests/err-task.ispc
@@ -1,0 +1,17 @@
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error: "task" qualifier is illegal outside of function declarations.
+struct Example {
+    task int x;
+};
+// CHECK-COUNT-8: Error: "task" qualifier illegal in variable declaration.
+task int x;
+task uniform int w = 0;
+void foo(task int y) {
+  task float a, c;
+  task varying float b = 0;
+}
+task int f, *p;
+task void func() {
+  return;
+}

--- a/tests/lit-tests/err-unmasked.ispc
+++ b/tests/lit-tests/err-unmasked.ispc
@@ -1,0 +1,19 @@
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error: "unmasked" qualifier is illegal outside of function declarations.
+struct Example {
+    unmasked int x;
+};
+// CHECK-COUNT-8: Error: "unmasked" qualifier illegal in variable declaration.
+unmasked int x;
+unmasked uniform int w = 0;
+void foo(unmasked int y) {
+  unmasked float a, c;
+  unmasked varying float b = 0;
+}
+unmasked int boo(), f, *p;
+unmasked void func() {
+  unmasked { func(); }
+  return;
+}
+unmasked uniform int64 * uniform p64();


### PR DESCRIPTION
This PR fixes #2835.

It fixes the reporting logic for cases when unsuited qualifiers provided for variable declarations.