### PR TITLE
KNL targets partial removal

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -33,7 +33,6 @@ env:
                    "avx1-i32x4", "avx1-i32x8", "avx1-i32x16", "avx1-i64x4",
                    "avx2-i8x32", "avx2-i16x16", "avx2-i32x4", "avx2-i32x8", "avx2-i32x16", "avx2-i64x4",
                    "avx2vnni-i32x4", "avx2vnni-i32x8", "avx2vnni-i32x16",
-                   "avx512knl-x16",
                    "avx512skx-x4", "avx512skx-x8", "avx512skx-x16", "avx512skx-x64", "avx512skx-x32",
                    "avx512icl-x4", "avx512icl-x8", "avx512icl-x16", "avx512icl-x64", "avx512icl-x32",
                    "avx512spr-x4", "avx512spr-x8", "avx512spr-x16", "avx512spr-x64", "avx512spr-x32"]'

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -23,7 +23,6 @@ env:
                    "sse4-i8x16", "sse4-i16x8", "sse4-i32x4", "sse4-i32x8",
                    "avx1-i32x4", "avx1-i32x8", "avx1-i32x16", "avx1-i64x4",
                    "avx2-i8x32", "avx2-i16x16", "avx2-i32x4", "avx2-i32x8", "avx2-i32x16", "avx2-i64x4",
-                   "avx512knl-x16",
                    "avx512skx-x4", "avx512skx-x8", "avx512skx-x16", "avx512skx-x64", "avx512skx-x32"]'
   OPTSETS_FULL: "-O0 -O1 -O2"
 

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -105,7 +105,6 @@ jobs:
                  sse4-i8x16, sse4-i16x8, sse4-i32x4, sse4-i32x8,
                  avx1-i32x4, avx1-i32x8, avx1-i32x16, avx1-i64x4,
                  avx2-i8x32, avx2-i16x16, avx2-i32x4, avx2-i32x8, avx2-i32x16, avx2-i64x4,
-                 avx512knl-x16,
                  avx512skx-x4, avx512skx-x8, avx512skx-x16, avx512skx-x64, avx512skx-x32]
     steps:
     - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,12 +336,17 @@ list(APPEND X86_TARGETS
     avx2-i8x32 avx2-i16x16
     avx2-i32x4 avx2-i32x8 avx2-i32x16 avx2-i64x4
     avx2vnni-i32x4 avx2vnni-i32x8 avx2vnni-i32x16
-    avx512knl-x16
     avx512skx-x4 avx512skx-x8 avx512skx-x16
     avx512skx-x32 avx512skx-x64
     avx512icl-x4 avx512icl-x8 avx512icl-x16
     avx512icl-x32 avx512icl-x64
     avx512spr-x4 avx512spr-x8 avx512spr-x16 avx512spr-x32 avx512spr-x64)
+
+# LLVM is removing support for Xeon Phi in 19.0
+if (${LLVM_VERSION_NUMBER} VERSION_LESS "19.0.0")
+    list(APPEND X86_TARGETS avx512knl-x16)
+endif()
+
 list(APPEND ARM_TARGETS neon-i8x16 neon-i16x8 neon-i32x4 neon-i32x8)
 list(APPEND WASM_TARGETS wasm-i32x4)
 list(APPEND XE_TARGETS gen9-x16 gen9-x8 xelp-x16 xelp-x8 xehpg-x16 xehpg-x8 xehpc-x16 xehpc-x32 xelpg-x16 xelpg-x8)

--- a/tests/lit-tests/1323_1.ispc
+++ b/tests/lit-tests/1323_1.ispc
@@ -1,4 +1,4 @@
-// RUN: %{ispc} %s --target=sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16 -h %t.h --emit-llvm -o %t.bc
+// RUN: %{ispc} %s --target=sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512skx-x16 -h %t.h --emit-llvm -o %t.bc
 // -opaque-pointers option was introduced in LLVM 14.0 and it's became necessary to pass it explicitely to llvm-dis starting LLVM 16.0
 // RUN: llvm-dis -opaque-pointers=0 %t.bc -o - | FileCheck %s -check-prefix=CHECK_TYPES
 // REQUIRES: X86_ENABLED && LLVM_14_0+

--- a/tests/lit-tests/1323_2.ispc
+++ b/tests/lit-tests/1323_2.ispc
@@ -1,4 +1,4 @@
-// RUN: %{ispc} %s --target=sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16 -h %t.h --emit-llvm -o %t.bc
+// RUN: %{ispc} %s --target=sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512skx-x16 -h %t.h --emit-llvm -o %t.bc
 // RUN: FileCheck --input-file=%t.h %s -check-prefix=CHECK_ALIGN
 // REQUIRES: X86_ENABLED
 

--- a/tests/lit-tests/1408.ispc
+++ b/tests/lit-tests/1408.ispc
@@ -1,5 +1,4 @@
 // RUN: %{ispc} %s -g -O2 -o %t.o --target=avx512skx-x16
-// RUN: %{ispc} %s -g -O2 -o %t.o --target=avx512knl-x16
 
 // REQUIRES: X86_ENABLED
 

--- a/tests/lit-tests/1469.ispc
+++ b/tests/lit-tests/1469.ispc
@@ -2,7 +2,6 @@
 // RUN: %{ispc} --target=sse4 -h %t.h %s
 // RUN: %{ispc} --target=avx1 -h %t.h %s
 // RUN: %{ispc} --target=avx2 -h %t.h %s
-// RUN: %{ispc} --target=avx512knl-x16 -h %t.h %s
 // RUN: %{ispc} --target=avx512skx-x16 -h %t.h %s
 
 // REQUIRES: X86_ENABLED

--- a/tests/lit-tests/1470.ispc
+++ b/tests/lit-tests/1470.ispc
@@ -30,7 +30,6 @@
 // RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx2-i32x16   -o - | FileCheck %s
 // RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx2-i64x4    -o - | FileCheck %s
 
-// RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx512knl-x16 -o - | FileCheck %s
 // RUN: %{ispc}  %s --emit-llvm-text -h %t.h --nostdlib --target=avx512skx-x16 -o - | FileCheck %s
 
 // REQUIRES: X86_ENABLED

--- a/tests/lit-tests/1608.ispc
+++ b/tests/lit-tests/1608.ispc
@@ -1,4 +1,3 @@
-//; RUN: %{ispc} %s --target=avx512knl-x16 --emit-asm -o - | FileCheck %s --implicit-check-not "vpcmpeqb"
 //; RUN: %{ispc} %s --target=avx512skx-x16 --emit-asm -o - | FileCheck %s --implicit-check-not "vpcmpeqb"
 //; RUN: %{ispc} %s --target=avx512skx-x8 --emit-asm -o - | FileCheck %s --implicit-check-not "vpcmpeqw" --implicit-check-not "vpcmpneqw"
 //; RUN: %{ispc} %s --target=avx512skx-x4 --emit-asm -o - | FileCheck %s --implicit-check-not "vpcmpeqw" --implicit-check-not "vpcmpneqw"

--- a/tests/lit-tests/1609.ispc
+++ b/tests/lit-tests/1609.ispc
@@ -1,4 +1,3 @@
-//; RUN: %{ispc} %s --target=avx512knl-x16 --emit-asm -o - | FileCheck %s --implicit-check-not "vpcmpeqb" -check-prefix=CHECK_AVX512knl16
 //; RUN: %{ispc} %s --target=avx512skx-x16 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_AVX512skx16
 //; RUN: %{ispc} %s --target=avx512skx-x8 --emit-asm -o - | FileCheck %s --implicit-check-not "vptestnmw" -check-prefix=CHECK_AVX512skx8
 // REQUIRES: X86_ENABLED
@@ -6,15 +5,6 @@ void while_loop_test(uniform float cmp[], uniform float vout[], uniform int coun
     foreach (index = 0 ... count) {
         varying float c = cmp[index];
 // Might have to revisit instructions being checked for.
-
-// CHECK_AVX512knl16: vcmp
-// CHECK_AVX512knl16-NEXT: kortestw
-// CHECK_AVX512knl16: vcmp
-// CHECK_AVX512knl16-NEXT: kortestw
-// CHECK_AVX512knl16:vcmp
-// CHECK_AVX512knl16-NEXT: kortestw
-// CHECK_AVX512knl16: vcmp
-// CHECK_AVX512knl16-NEXT: kortestw
 
 // CHECK_AVX512skx16: vcmp
 // CHECK_AVX512skx16-NEXT: kortestw

--- a/tests/lit-tests/1963.ispc
+++ b/tests/lit-tests/1963.ispc
@@ -7,8 +7,6 @@
 //; RUN: FileCheck --input-file=%t.avx2.s -check-prefix=CHECK_AVX2_ASM %s
 //; RUN: %{ispc} %s --emit-asm -o %t.avx512skx.s --nowrap --target=avx512skx-x16 2>&1 | FileCheck %s --allow-empty -check-prefix=CHECK_AVX512SKX_WARNING
 //; RUN: FileCheck --input-file=%t.avx512skx.s -check-prefix=CHECK_AVX512SKX_ASM %s
-//; RUN: %{ispc} %s --emit-asm -o %t.avx512knl.s --nowrap --target=avx512knl-x16 2>&1 | FileCheck %s --allow-empty -check-prefix=CHECK_AVX512KNL_WARNING
-//; RUN: FileCheck --input-file=%t.avx512knl.s -check-prefix=CHECK_AVX512KNL_ASM %s
 
 //; REQUIRES: X86_ENABLED
 
@@ -20,10 +18,6 @@
 
 //; CHECK_AVX512SKX_WARNING-NOT: Performance Warning: Conversion from uint32 to float is slow. Use "int32" if possible
 //; CHECK_AVX512SKX_ASM: vcvt
-
-//; CHECK_AVX512KNL_WARNING-NOT: Performance Warning: Conversion from uint32 to float is slow. Use "int32" if possible
-//; CHECK_AVX512KNL_ASM: vcvt
-
 
 unmasked varying float test_uint_f(varying uint arg1)
 {

--- a/tests/lit-tests/2134.ispc
+++ b/tests/lit-tests/2134.ispc
@@ -1,4 +1,4 @@
-// RUN: %{ispc} %s --target=sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16 -h %t.h --emit-llvm -o %t.bc
+// RUN: %{ispc} %s --target=sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512skx-x16 -h %t.h --emit-llvm -o %t.bc
 // RUN: FileCheck --input-file=%t.h %s -check-prefix=CHECK_ALIGN
 
 // REQUIRES: X86_ENABLED

--- a/tests/lit-tests/check_dispatch.ispc
+++ b/tests/lit-tests/check_dispatch.ispc
@@ -1,6 +1,6 @@
 // Compile the test for different x86 targets with auto-dispatch enabled and run the test under SDE to verify that correct platform was picked in runtime.
 
-// RUN: %{ispc} %s --target=sse2-i32x4,sse4-i32x4,avx1-i32x8,avx2-i32x8,avx2vnni-i32x8,avx512knl-x16,avx512skx-x16,avx512icl-x16,avx512spr-x16 -o %t_ispc0.o --nostdlib
+// RUN: %{ispc} %s --target=sse2-i32x4,sse4-i32x4,avx1-i32x8,avx2-i32x8,avx2vnni-i32x8,avx512skx-x16,avx512icl-x16,avx512spr-x16 -o %t_ispc0.o --nostdlib
 // RUN: %{cc} -O2 %S/check_dispatch.c %t_ispc0*.o -o %t.exe
 // RUN: sde -mrm -- %t.exe | FileCheck %s -check-prefix=CHECK_SSE2
 // Note sse4-i32x4 implies SSE4.2 ISA, while Penryn is SSE4.1, so should fall back to SSE2.
@@ -10,18 +10,17 @@
 // RUN: sde -hsw -- %t.exe | FileCheck %s -check-prefix=CHECK_AVX2
 // RUN: sde -adl -- %t.exe | FileCheck %s -check-prefix=CHECK_AVX2VNNI
 // RUN: sde -skx -- %t.exe | FileCheck %s -check-prefix=CHECK_SKX
-// RUN: sde -knl -- %t.exe | FileCheck %s -check-prefix=CHECK_KNL
 // RUN: sde -icl -- %t.exe | FileCheck %s -check-prefix=CHECK_ICL
 // RUN: sde -spr -- %t.exe | FileCheck %s -check-prefix=CHECK_SPR
 
-// RUN: %{ispc} %s --target=sse2-i32x4,sse4.1-i32x4,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16,avx512spr-x16 -o %t_ispc2.o --nostdlib
+// RUN: %{ispc} %s --target=sse2-i32x4,sse4.1-i32x4,avx1-i32x8,avx2-i32x8,avx512skx-x16,avx512spr-x16 -o %t_ispc2.o --nostdlib
 // RUN: %{cc} -O2 %S/check_dispatch.c %t_ispc2*.o -o %t2.exe
 // RUN: sde -mrm -- %t2.exe | FileCheck %s -check-prefix=CHECK_SSE2
 // sse4.1-i32x4 is specified, so both Penryn and Nehalem should use it.
 // RUN: sde -pnr -- %t2.exe | FileCheck %s -check-prefix=CHECK_SSE4
 // RUN: sde -nhm -- %t2.exe | FileCheck %s -check-prefix=CHECK_SSE4
 
-// RUN: %{ispc} %s --target=sse2-i32x4,sse4.2-i32x4,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16,avx512spr-x16 -o %t_ispc3.o --nostdlib
+// RUN: %{ispc} %s --target=sse2-i32x4,sse4.2-i32x4,avx1-i32x8,avx2-i32x8,avx512skx-x16,avx512spr-x16 -o %t_ispc3.o --nostdlib
 // RUN: %{cc} -O2 %S/check_dispatch.c %t_ispc3*.o -o %t3.exe
 // RUN: sde -mrm -- %t3.exe | FileCheck %s -check-prefix=CHECK_SSE2
 // sse4.2-i32x4 is specified, so Penryn should fall back to SSE2.
@@ -36,7 +35,6 @@
 // CHECK_AVX2: AVX2
 // CHECK_AVX2VNNI: AVX2VNNI
 // CHECK_SKX: AVX512SKX
-// CHECK_KNL: AVX512KNL
 // CHECK_ICL: AVX512ICL
 // CHECK_SPR: AVX512SPR
 

--- a/tests/lit-tests/cpus_x86.ispc
+++ b/tests/lit-tests/cpus_x86.ispc
@@ -23,7 +23,6 @@
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=znver2
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=znver3
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=ps5
-//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=knl
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=skx
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=icelake-client
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=icl

--- a/tests/lit-tests/deps.ispc
+++ b/tests/lit-tests/deps.ispc
@@ -12,7 +12,6 @@
 //; RUN: %{ispc} %s --nowrap -o deps.o --target=avx2-i32x8,avx512skx-x16 -M -MT new_file.ispc 2>&1 | FileCheck %s -check-prefix=CHECK2
 //; RUN: %{ispc} %s --nowrap -o deps.o --target=sse4-i32x4,avx2-i32x8       -M -MF %t.d && FileCheck %s --input-file=%t.d -check-prefix=CHECK1
 //; RUN: %{ispc} %s --nowrap -o deps.o --target=sse4-i32x4,avx2-i32x8       -M -MF %t.d -MT new_file.ispc && FileCheck %s --input-file=%t.d -check-prefix=CHECK2
-//; RUN: %{ispc} %s --nowrap -o deps.o --target=sse2-i32x8,avx512knl-x16 -MMM %t.d && FileCheck %s --input-file=%t.d -check-prefix=CHECK3
 
 //; REQUIRES: X86_ENABLED
 

--- a/tests/lit-tests/disable_gather_scatter.ispc
+++ b/tests/lit-tests/disable_gather_scatter.ispc
@@ -35,8 +35,6 @@
 // RUN: %{ispc} %s -O2 --woff --target=avx2-i32x16 --addressing=64 --nostdlib --emit-llvm-text --opt=disable-gathers --opt=disable-scatters -o - | FileCheck %s
 // RUN: %{ispc} %s -O2 --woff --target=avx2-i64x4 --addressing=32 --nostdlib --emit-llvm-text --opt=disable-gathers --opt=disable-scatters -o - | FileCheck %s
 // RUN: %{ispc} %s -O2 --woff --target=avx2-i64x4 --addressing=64 --nostdlib --emit-llvm-text --opt=disable-gathers --opt=disable-scatters -o - | FileCheck %s
-// RUN: %{ispc} %s -O2 --woff --target=avx512knl-x16 --addressing=32 --nostdlib --emit-llvm-text --opt=disable-gathers --opt=disable-scatters -o - | FileCheck %s
-// RUN: %{ispc} %s -O2 --woff --target=avx512knl-x16 --addressing=64 --nostdlib --emit-llvm-text --opt=disable-gathers --opt=disable-scatters -o - | FileCheck %s
 // RUN: %{ispc} %s -O2 --woff --target=avx512skx-x4 --addressing=32 --nostdlib --emit-llvm-text --opt=disable-gathers --opt=disable-scatters -o - | FileCheck %s
 // RUN: %{ispc} %s -O2 --woff --target=avx512skx-x4 --addressing=64 --nostdlib --emit-llvm-text --opt=disable-gathers --opt=disable-scatters -o - | FileCheck %s
 // RUN: %{ispc} %s -O2 --woff --target=avx512skx-x8 --addressing=32 --nostdlib --emit-llvm-text --opt=disable-gathers --opt=disable-scatters -o - | FileCheck %s

--- a/tests/lit-tests/dispatch.ispc
+++ b/tests/lit-tests/dispatch.ispc
@@ -1,6 +1,6 @@
-// RUN: %{ispc} -DISPC --pic --target=sse2-i32x4,sse4.1-i32x4,avx1-i32x4,avx2-i32x4,avx2vnni-i32x4,avx512knl-x16,avx512icl-x4,avx512skx-x4,avx512spr-x4 -h %t.h %s -o %t.o -g
+// RUN: %{ispc} -DISPC --pic --target=sse2-i32x4,sse4.1-i32x4,avx1-i32x4,avx2-i32x4,avx2vnni-i32x4,avx512icl-x4,avx512skx-x4,avx512spr-x4 -h %t.h %s -o %t.o -g
 // RUN: %{cc} -x c -c %s -o %t.c.o --include %t.h -g
-// RUN: %{cc} %t.c.o -o %t.c.bin -g -rdynamic %t.o %t_sse2.o %t_sse4.o %t_avx.o %t_avx2.o %t_avx2vnni.o %t_avx512knl.o %t_avx512icl.o %t_avx512skx.o %t_avx512spr.o
+// RUN: %{cc} %t.c.o -o %t.c.bin -g -rdynamic %t.o %t_sse2.o %t_sse4.o %t_avx.o %t_avx2.o %t_avx2vnni.o %t_avx512icl.o %t_avx512skx.o %t_avx512spr.o
 
 // RUN: sde -mrm -- %t.c.bin | FileCheck %s --check-prefix=CHECK-SSE2
 // RUN: sde -pnr -- %t.c.bin | FileCheck %s --check-prefix=CHECK-SSE4
@@ -8,7 +8,6 @@
 // RUN: sde -hsw -- %t.c.bin | FileCheck %s --check-prefix=CHECK-AVX2
 // RUN: sde -adl -- %t.c.bin | FileCheck %s --check-prefix=CHECK-AVX2VNNI
 // RUN: sde -skx -- %t.c.bin | FileCheck %s --check-prefix=CHECK-SKX
-// RUN: sde -knl -- %t.c.bin | FileCheck %s --check-prefix=CHECK-KNL
 // RUN: sde -icl -- %t.c.bin | FileCheck %s --check-prefix=CHECK-ICL
 // RUN: sde -spr -- %t.c.bin | FileCheck %s --check-prefix=CHECK-SPR
 
@@ -20,7 +19,6 @@
 // CHECK-AVX2: ispc_foo_avx2
 // CHECK-AVX2VNNI: ispc_foo_avx2vnni
 // CHECK-SKX: ispc_foo_avx512skx
-// CHECK-KNL: ispc_foo_avx512knl
 // CHECK-ICL: ispc_foo_avx512icl
 // CHECK-SPR: ispc_foo_avx512spr
 

--- a/tests/lit-tests/gatherScaleConst.ispc
+++ b/tests/lit-tests/gatherScaleConst.ispc
@@ -7,8 +7,6 @@
 // RUN: llvm-dis %t.bc -o - | FileCheck %s -check-prefix=CHECK_AVX2_I32X8 --implicit-check-not "switch"
 // RUN: %{ispc} %s --target=avx2-i32x16 -h %t.h --emit-llvm -o %t.bc
 // RUN: llvm-dis %t.bc -o - | FileCheck %s -check-prefix=CHECK_AVX2_I32X16 --implicit-check-not "switch"
-// RUN: %{ispc} %s --target=avx512knl-x16 -h %t.h --emit-llvm -o %t.bc
-// RUN: llvm-dis %t.bc -o - | FileCheck %s -check-prefix=CHECK_AVX512KNL_X16 --implicit-check-not "switch"
 // RUN: %{ispc} %s --target=avx512skx-x16 -h %t.h --emit-llvm -o %t.bc
 // RUN: llvm-dis %t.bc -o - | FileCheck %s -check-prefix=CHECK_AVX512SKX_X16 --implicit-check-not "switch"
 
@@ -19,8 +17,6 @@
 //; CHECK_AVX2_I32X8: llvm.x86.avx2.gather.d.ps.256
 
 //; CHECK_AVX2_I32X16: llvm.x86.avx2.gather.d.ps.256
-
-//; CHECK_AVX512KNL_X16: llvm.x86.avx512.mask.gather.dps.512
 
 //; CHECK_AVX512SKX_X16: llvm.x86.avx512.mask.gather.dps.512
 struct Foo {
@@ -46,9 +42,6 @@ void f_fu(uniform float RET[], uniform float aFOO[]) {
 //; CHECK_AVX2_I32X16: llvm.x86.avx2.gather.d.ps.256
 //; CHECK_AVX2_I32X16: llvm.x86.avx2.gather.d.ps.256
 //; CHECK_AVX2_I32X16-NOT: llvm.x86.avx2.gather.d.ps.256
-
-//; CHECK_AVX512KNL_X16: llvm.x86.avx512.mask.gather.dps.512
-//; CHECK_AVX512KNL_X16-NOT: llvm.x86.avx512.mask.gather.dps.512
 
 //; CHECK_AVX512SKX_X16: llvm.x86.avx512.mask.gather.dps.512
 //; CHECK_AVX512SKX_X16-NOT: llvm.x86.avx512.mask.gather.dps.512

--- a/tests/lit-tests/gather_scatter.ispc
+++ b/tests/lit-tests/gather_scatter.ispc
@@ -11,8 +11,6 @@
 // RUN: %{ispc} %s -O2 --woff --target=avx2-i32x16 --addressing=64 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_AVX2_X16_64
 // avx2-i16x16 is missing gathers.
 // avx2-i8x32 is missing gathers.
-// RUN: %{ispc} %s -O2 --woff --target=avx512knl-x16 --addressing=32 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_AVX512_X16_32
-// RUN: %{ispc} %s -O2 --woff --target=avx512knl-x16 --addressing=64 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_AVX512_X16_64
 // RUN: %{ispc} %s -O2 --woff --target=avx512skx-x4 --addressing=32 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_AVX512_X4_32
 // RUN: %{ispc} %s -O2 --woff --target=avx512skx-x4 --addressing=64 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_AVX512_X4_64
 // RUN: %{ispc} %s -O2 --woff --target=avx512skx-x8 --addressing=32 --emit-asm -o - | FileCheck %s -check-prefix=CHECK_AVX512_X8_32

--- a/tests/lit-tests/knl-deprecation.ispc
+++ b/tests/lit-tests/knl-deprecation.ispc
@@ -2,7 +2,7 @@
 // RUN: %{ispc} --nowrap --target=avx512knl-i32x16 --emit-asm -o %t.s %s 2>&1 | FileCheck %s
 // RUN: %{ispc} --nowrap --target=avx512knl-x16,avx2-i32x4 --emit-asm -o %t.s %s 2>&1 | FileCheck %s
 
-// REQUIRES: X86_ENABLED
+// REQUIRES: X86_ENABLED && !LLVM_19_0+
 
 // CHECK: Warning: The target avx512knl_x16 is deprecated and will be removed in the future.
 

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -51,6 +51,12 @@ if llvm_version_major >= 17:
 else:
     print("LLVM_17_0+: NO")
 
+if llvm_version_major >= 19:
+    print("LLVM_19_0+: YES")
+    config.available_features.add("LLVM_19_0+")
+else:
+    print("LLVM_19_0+: NO")
+
 # Windows target OS is enabled
 windows_enabled = lit_config.params.get('windows_enabled')
 if windows_enabled == "ON":

--- a/tests/lit-tests/nested_response_files.args
+++ b/tests/lit-tests/nested_response_files.args
@@ -1,1 +1,1 @@
---target=sse2-i32x8,avx2,avx512knl-x16 @missing_response_file.args
+--target=sse2-i32x8,avx2 @missing_response_file.args

--- a/tests/lit-tests/perf-warnings.ispc
+++ b/tests/lit-tests/perf-warnings.ispc
@@ -22,7 +22,6 @@
 // RUN: %{ispc} %s --nostdlib --nowrap --target=avx2-i32x16 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX2
 // RUN: %{ispc} %s --nostdlib --nowrap --target=avx2-i64x4 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX2
 
-// RUN: %{ispc} %s --nostdlib --nowrap --target=avx512knl-x16 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX512
 // RUN: %{ispc} %s --nostdlib --nowrap --target=avx512skx-x4 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX512
 // RUN: %{ispc} %s --nostdlib --nowrap --target=avx512skx-x8 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX512
 // RUN: %{ispc} %s --nostdlib --nowrap --target=avx512skx-x16 -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_AVX512

--- a/tests/lit-tests/targets_x86.ispc
+++ b/tests/lit-tests/targets_x86.ispc
@@ -20,8 +20,6 @@
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=avx2-i32x8
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=avx2-i32x16
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=avx2-i64x4
-//; RUN: %{ispc} %s -o %t.o --nostdlib --target=avx512knl-x16
-//; RUN: %{ispc} %s -o %t.o --nostdlib --target=avx512knl-i32x16
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=avx512skx-x4
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=avx512skx-i32x4
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=avx512skx-x8


### PR DESCRIPTION
Remove KNL targets from lit-tests, full testing and trunk testing.
Addresses https://github.com/ispc/ispc/issues/2867#issuecomment-2228893891

I don't want to remove the target completely right now, it should go through deprecation. It's the right approach to communicate about changed targets to users. However (since it's deprecated) we can stop testing it.