### PR TITLE
ci: add coverity scans

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,62 @@
+# Copyright 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Coverity
+# It runs static analysis build - Coverity. It requires special token (set in CI's secret).
+
+permissions: read-all
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every day at 22:00 UTC
+    - cron: '0 22 * * *'
+
+env:
+  SDE_MIRROR_ID: 813591
+  SDE_TAR_NAME: sde-external-9.33.0-2024-01-07
+  USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
+  LLVM_REPO: https://github.com/ispc/ispc.dependencies
+
+jobs:
+  linux:
+    name: Coverity
+    runs-on: ubuntu-22.04
+    env:
+      COVERITY_SCAN_BUILD_COMMAND: "cmake --build ${{github.workspace}}/build"
+      COVERITY_SCAN_BRANCH_PATTERN: "main"
+      COVERITY_SCAN_NOTIFICATION_EMAIL: ${{ secrets.COVERITY_SCAN_NOTIFICATION_EMAIL }}
+      COVERITY_SCAN_PROJECT_NAME: ${{ secrets.COVERITY_SCAN_PROJECT_NAME }}
+      COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+      LLVM_VERSION: "17.0"
+      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+
+    # Disabling this workflow for non ispc/ispc repo, since number of build submissions is limited.
+    if: github.repository == 'ispc/ispc'
+
+    steps:
+      - name: Clone the git repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Install dependencies
+        run: |
+         .github/workflows/scripts/install-build-deps.sh
+
+      - name: Check environment
+        run: |
+          which -a clang
+          cat /proc/cpuinfo
+
+      - name: Build package
+        run: |
+          .github/workflows/scripts/build-ispc.sh
+
+      - name: Run Coverity
+        run: |
+          .github/workflows/scripts/run-coverity.sh
+
+      - name: Upload Coverity artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scm_log.txt
+          path: cov-int/scm_log.txt

--- a/.github/workflows/scripts/run-coverity.sh
+++ b/.github/workflows/scripts/run-coverity.sh
@@ -1,0 +1,97 @@
+#!/bin/bash -e
+
+# Environment check
+required_vars=(
+  "COVERITY_SCAN_PROJECT_NAME"
+  "COVERITY_SCAN_NOTIFICATION_EMAIL"
+  "COVERITY_SCAN_BUILD_COMMAND"
+  "COVERITY_SCAN_TOKEN"
+  "COVERITY_SCAN_BRANCH_PATTERN"
+)
+
+for var in "${required_vars[@]}"; do
+  if [ -z "${!var}" ]; then
+    echo "ERROR: $var must be set"
+    exit 1
+  fi
+done
+
+PLATFORM="linux64"
+TOOL_ARCHIVE=/tmp/cov-analysis-${PLATFORM}.tgz
+TOOL_URL=https://scan.coverity.com/download/cxx/${PLATFORM}
+TOOL_BASE=/tmp/coverity-scan-analysis
+COVERITY_UPLOAD_URL="https://scan.coverity.com/builds"
+COVERITY_SCAN_URL="https://scan.coverity.com"
+COVERITY_RESULTS_DIR="cov-int"
+COVERITY_RESULTS_ARCHIVE="analysis-results.tgz"
+
+# Check if the current branch matches the Coverity scan branch pattern
+if [[ "$GITHUB_REF_NAME" =~ ^$COVERITY_SCAN_BRANCH_PATTERN$ ]]; then
+  echo -e "Coverity Scan configured to run on branch ${GITHUB_REF_NAME}"
+else
+  echo -e "Coverity Scan is NOT configured to run on branch ${GITHUB_REF_NAME}"
+  exit 1
+fi
+
+# Verify upload is permitted. See https://scan.coverity.com/faq#frequency
+AUTH_RES=$(curl -s --form project="$COVERITY_SCAN_PROJECT_NAME" --form token="$COVERITY_SCAN_TOKEN" "$COVERITY_SCAN_URL/api/upload_permitted")
+if [ "$AUTH_RES" = "Access denied" ]; then
+  echo "Coverity Scan API access denied. Check COVERITY_SCAN_PROJECT_NAME and COVERITY_SCAN_TOKEN."
+  exit 1
+fi
+
+AUTH=$(echo "$AUTH_RES" | jq -r '.upload_permitted')
+if [ "$AUTH" = "true" ]; then
+  echo "Coverity Scan analysis authorized per quota."
+else
+  WHEN=$(echo "$AUTH_RES" | jq -r '.next_upload_permitted_at')
+  echo "Coverity Scan analysis NOT authorized until $WHEN."
+  exit 0
+fi
+
+# Download and set up Coverity tool if not already done
+if [ ! -d "$TOOL_BASE" ]; then
+  echo "Downloading Coverity Scan Analysis Tool..."
+  wget -nv -O "$TOOL_ARCHIVE" "$TOOL_URL" --post-data "project=$COVERITY_SCAN_PROJECT_NAME&token=$COVERITY_SCAN_TOKEN"
+  
+  echo "Extracting Coverity Scan Analysis Tool..."
+  mkdir -p "$TOOL_BASE"
+  tar xzf "$TOOL_ARCHIVE" -C "$TOOL_BASE"
+fi
+
+echo "Adding Coverity to PATH..."
+TOOL_DIR=$(find "$TOOL_BASE" -type d -name 'cov-analysis*')
+export PATH="$TOOL_DIR/bin:$PATH"
+
+# Clean up the build directory
+cd "$GITHUB_WORKSPACE"
+cmake --build build --target clean
+
+# Build
+echo "Capturing ISPC build by Coverity Scan and importing source code information..."
+cov-build --dir $COVERITY_RESULTS_DIR $COVERITY_SCAN_BUILD_COMMAND
+cov-import-scm --dir $COVERITY_RESULTS_DIR --scm git --log $COVERITY_RESULTS_DIR/scm_log.txt 2>&1
+
+# Upload results
+echo "Tarring Coverity Scan results..."
+tar czf "$COVERITY_RESULTS_ARCHIVE" "$COVERITY_RESULTS_DIR"
+SHA=$(git rev-parse --short HEAD)
+
+echo "Uploading Coverity Scan results..."
+response=$(curl \
+  --silent --write-out "\n%{http_code}\n" \
+  --form project="$COVERITY_SCAN_PROJECT_NAME" \
+  --form token="$COVERITY_SCAN_TOKEN" \
+  --form email="$COVERITY_SCAN_NOTIFICATION_EMAIL" \
+  --form file=@"$COVERITY_RESULTS_ARCHIVE" \
+  --form version="$SHA" \
+  --form description="Github Action build" \
+  "$COVERITY_UPLOAD_URL")
+
+status_code=$(echo "$response" | tail -n 1)
+if [ "$status_code" != "200" ]; then
+  echo "Coverity Scan upload failed: $response."
+  exit 1
+fi
+
+echo "Coverity Scan completed successfully."


### PR DESCRIPTION
Our Coverity open source project is set up here: https://scan.coverity.com/projects/intel-ispc?tab=overview.
Open source Coverity has limitations on number of runs: https://scan.coverity.com/faq#frequency so I'm setting it to run by schedule or on workflow_dispatch.
Here is example run: https://github.com/aneshlya/ispc/actions/runs/9998651864

Feel free to contribute to this PR if you think something is missing.
