### PR TITLE
Support __attribute__ syntax.

### DIFF
--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -23,6 +23,34 @@
 
 using namespace ispc;
 
+void lCheckAddressSpace(int64_t &addrSpace, const std::string &name, SourcePos pos) {
+    if (addrSpace < 0) {
+        Error(pos, "\"address_space\" attribute must be non-negative, \"%s\".", name.c_str());
+        addrSpace = 0;
+    }
+    if (addrSpace > (int64_t)AddressSpace::ispc_generic) {
+        Error(pos, "\"address_space\" attribute %" PRId64 " is out of scope of supported [%d, %d], \"%s\".", addrSpace,
+              (int)AddressSpace::ispc_default, (int)AddressSpace::ispc_generic, name.c_str());
+        addrSpace = 0;
+    }
+}
+
+const Type *lGetTypeWithAddressSpace(const Type *type, int addrSpace, const std::string &name, SourcePos pos) {
+    if (auto *pt = CastType<PointerType>(type)) {
+        type = pt->GetWithAddrSpace((AddressSpace)addrSpace);
+    } else if (auto *rt = CastType<ReferenceType>(type)) {
+        type = rt->GetWithAddrSpace((AddressSpace)addrSpace);
+    } else {
+        // ISPC type system seems to support only pointer and reference
+        // types with address space, that doesn't look correct in general.
+        // Although, it's not a big deal to support it in the future.
+        // For now, just issue a warning.
+        Warning(pos, "\"address_space\" attribute is only allowed for pointer or reference types, \"%s\".",
+                name.c_str());
+    }
+    return type;
+}
+
 void lCheckVariableTypeQualifiers(int typeQualifiers, SourcePos pos) {
     if (typeQualifiers & TYPEQUAL_TASK) {
         Error(pos, "\"task\" qualifier illegal in variable declaration.");
@@ -142,6 +170,111 @@ static const Type *lApplyTypeQualifiers(int typeQualifiers, const Type *type, So
 }
 
 ///////////////////////////////////////////////////////////////////////////
+// Attributes
+
+AttrArgument::AttrArgument() : kind(ATTR_ARG_UNKNOWN), intVal(0), stringVal() {}
+AttrArgument::AttrArgument(int64_t i) : kind(ATTR_ARG_UINT32), intVal(i), stringVal() {}
+AttrArgument::AttrArgument(const std::string &s) : kind(ATTR_ARG_STRING), intVal(0), stringVal(s) {}
+
+void AttrArgument::Print() const {
+    switch (kind) {
+    case ATTR_ARG_UINT32:
+        printf("(%" PRId64 ")", intVal);
+        break;
+    case ATTR_ARG_STRING:
+        printf("(\"%s\")", stringVal.c_str());
+        break;
+    case ATTR_ARG_UNKNOWN:
+        printf("(unknown)");
+        break;
+    }
+}
+
+Attribute::Attribute(const std::string &n) : name(n), arg() {}
+Attribute::Attribute(const std::string &n, AttrArgument a) : name(n), arg(a) {}
+Attribute::Attribute(const Attribute &a) : name(a.name), arg(a.arg) {}
+
+bool Attribute::IsKnownAttribute() const {
+    // Known/supported attributes.
+    static std::unordered_map<std::string, int> lKnownParamAttrs = {
+        {"noescape", 1},
+        {"address_space", 1},
+    };
+
+    if (lKnownParamAttrs.find(name) != lKnownParamAttrs.end()) {
+        return true;
+    }
+
+    return false;
+}
+
+void Attribute::Print() const {
+    printf("%s", name.c_str());
+    arg.Print();
+}
+
+AttributeList::AttributeList() {}
+
+AttributeList::AttributeList(const AttributeList &attrList) {
+    for (const auto &attr : attrList.attributes) {
+        AddAttribute(*attr);
+    }
+}
+
+AttributeList::~AttributeList() {
+    for (const auto &attr : attributes) {
+        delete attr;
+    }
+}
+
+void AttributeList::AddAttribute(const Attribute &a) {
+    // Create a copy of the given attribute that it owns.
+    Attribute *copy = new Attribute(a);
+    attributes.push_back(copy);
+}
+
+bool AttributeList::HasAttribute(const std::string &name) const {
+    for (const auto &attr : attributes) {
+        if (attr->name == name)
+            return true;
+    }
+    return false;
+}
+
+Attribute *AttributeList::GetAttribute(const std::string &name) const {
+    for (const auto &attr : attributes) {
+        if (attr->name == name)
+            return attr;
+    }
+    return nullptr;
+}
+
+void AttributeList::MergeAttrList(const AttributeList &attrList) {
+    // TODO: consider issuing a warning if the same attribute is specified
+    // several times or with different arguments.
+    for (const auto &attr : attrList.attributes) {
+        if (!HasAttribute(attr->name)) {
+            AddAttribute(*attr);
+        }
+    }
+}
+
+void AttributeList::CheckForUnknownAttributes(SourcePos pos) const {
+    for (const auto &attr : attributes) {
+        if (!attr->IsKnownAttribute()) {
+            Warning(pos, "Ignoring unknown attribute \"%s\".", attr->name.c_str());
+        }
+    }
+}
+
+void AttributeList::Print() const {
+    for (const auto &attr : attributes) {
+        attr->Print();
+        printf(", ");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
 // DeclSpecs
 
 DeclSpecs::DeclSpecs(const Type *t, StorageClass sc, int tq) {
@@ -150,6 +283,7 @@ DeclSpecs::DeclSpecs(const Type *t, StorageClass sc, int tq) {
     typeQualifiers = tq;
     soaWidth = 0;
     vectorSize = 0;
+    attributeList = nullptr;
     if (t != nullptr) {
         if (m->symbolTable->ContainsType(t)) {
             // Typedefs might have uniform/varying qualifiers inside.
@@ -160,6 +294,16 @@ DeclSpecs::DeclSpecs(const Type *t, StorageClass sc, int tq) {
             }
         }
     }
+}
+
+DeclSpecs::~DeclSpecs() { delete attributeList; }
+
+void DeclSpecs::AddAttrList(const AttributeList &attrList) {
+    if (attributeList) {
+        attributeList->MergeAttrList(attrList);
+        return;
+    }
+    attributeList = new AttributeList(attrList);
 }
 
 const Type *DeclSpecs::GetBaseType(SourcePos pos) const {
@@ -253,6 +397,10 @@ void DeclSpecs::Print() const {
     lPrintTypeQualifiers(typeQualifiers);
     printf("base type: %s", baseType->GetString().c_str());
 
+    if (attributeList) {
+        attributeList->Print();
+    }
+
     if (vectorSize > 0)
         printf("<%d>", vectorSize);
     printf("]");
@@ -268,9 +416,20 @@ Declarator::Declarator(DeclaratorKind dk, SourcePos p) : pos(p), kind(dk) {
     arraySize = -1;
     type = nullptr;
     initExpr = nullptr;
+    attributeList = nullptr;
 }
 
+Declarator::~Declarator() { delete attributeList; }
+
 void Declarator::InitFromDeclSpecs(DeclSpecs *ds) {
+    if (attributeList) {
+        attributeList->MergeAttrList(*ds->attributeList);
+    } else {
+        if (ds->attributeList) {
+            attributeList = new AttributeList(*ds->attributeList);
+        }
+    }
+
     const Type *baseType = ds->GetBaseType(pos);
     if (!baseType) {
         AssertPos(pos, m->errorCount > 0);
@@ -286,6 +445,35 @@ void Declarator::InitFromDeclSpecs(DeclSpecs *ds) {
     if (type == nullptr) {
         AssertPos(pos, m->errorCount > 0);
         return;
+    }
+
+    if (lIsFunctionKind(this)) {
+        if (attributeList) {
+            // Check for unknown attributes in function type.
+            attributeList->CheckForUnknownAttributes(pos);
+
+            // Handle "address_space" attribute for function return types.
+            if (attributeList->HasAttribute("address_space")) {
+                auto addrSpace = attributeList->GetAttribute("address_space")->arg.intVal;
+                lCheckAddressSpace(addrSpace, name, pos);
+                if (auto *ft = CastType<FunctionType>(type)) {
+                    auto retType = ft->GetReturnType();
+                    auto newRetType = lGetTypeWithAddressSpace(retType, addrSpace, name, pos);
+                    type = ft->GetWithReturnType(newRetType);
+                }
+            }
+
+            // Warn about attributes that are not used for function types.
+            if (attributeList->HasAttribute("noescape")) {
+                Warning(pos, "Ignoring \"noescape\" attribute for function \"%s\".", name.c_str());
+            }
+        }
+    } else {
+        if (attributeList && attributeList->HasAttribute("address_space")) {
+            int64_t addrSpace = attributeList->GetAttribute("address_space")->arg.intVal;
+            lCheckAddressSpace(addrSpace, name, pos);
+            type = lGetTypeWithAddressSpace(type, addrSpace, name, pos);
+        }
     }
 
     storageClass = ds->storageClass;
@@ -340,6 +528,10 @@ void Declarator::Print(Indent &indent) const {
     }
 
     printf("]\n");
+
+    if (attributeList) {
+        attributeList->Print();
+    }
 
     int kids = (initExpr ? 1 : 0) + functionParams.size() + (child ? 1 : 0);
     indent.pushList(kids);
@@ -680,6 +872,17 @@ std::vector<VariableDeclaration> Declaration::GetVariableDeclarations() const {
                 decl->type = decl->type->ResolveUnboundVariability(Variability::Varying);
             }
             Symbol *sym = new Symbol(decl->name, decl->pos, decl->type, decl->storageClass);
+
+            AttributeList *AL = decl->attributeList;
+            if (AL) {
+                // Check for unknown attributes for variable declarations.
+                AL->CheckForUnknownAttributes(decl->pos);
+
+                if (AL->HasAttribute("noescape")) {
+                    Warning(decl->pos, "Ignoring \"noescape\" attribute for variable \"%s\".", decl->name.c_str());
+                }
+            }
+
             m->symbolTable->AddVariable(sym);
             vars.push_back(VariableDeclaration(sym, decl->initExpr));
         } else {
@@ -709,8 +912,8 @@ void Declaration::DeclareFunctions() {
         bool isNoInline = (declSpecs->typeQualifiers & TYPEQUAL_NOINLINE);
         bool isVectorCall = (declSpecs->typeQualifiers & TYPEQUAL_VECTORCALL);
         bool isRegCall = (declSpecs->typeQualifiers & TYPEQUAL_REGCALL);
-        m->AddFunctionDeclaration(decl->name, ftype, decl->storageClass, isInline, isNoInline, isVectorCall, isRegCall,
-                                  decl->pos);
+        m->AddFunctionDeclaration(decl->name, ftype, decl->storageClass, decl, isInline, isNoInline, isVectorCall,
+                                  isRegCall, decl->pos);
     }
 }
 

--- a/src/lex.ll
+++ b/src/lex.ll
@@ -91,6 +91,7 @@ void ParserInit() {
     tokenToName[TOKEN_UINT64] = "uint64";
     tokenToName[TOKEN_LAUNCH] = "launch";
     tokenToName[TOKEN_INVOKE_SYCL] = "invoke_sycl";
+    tokenToName[TOKEN_ATTRIBUTE] = "__attribute__";
     tokenToName[TOKEN_NEW] = "new";
     tokenToName[TOKEN_NULL] = "NULL";
     tokenToName[TOKEN_PRINT] = "print";
@@ -220,6 +221,7 @@ void ParserInit() {
     tokenNameRemap["TOKEN_UINT64"] = "\'uint64\'";
     tokenNameRemap["TOKEN_LAUNCH"] = "\'launch\'";
     tokenNameRemap["TOKEN_INVOKE_SYCL"] = "\'invoke_sycl\'";
+    tokenNameRemap["TOKEN_ATTRIBUTE"] = "\'__attribute__\'";
     tokenNameRemap["TOKEN_NEW"] = "\'new\'";
     tokenNameRemap["TOKEN_NULL"] = "\'NULL\'";
     tokenNameRemap["TOKEN_PRINT"] = "\'print\'";
@@ -363,6 +365,7 @@ int64 { return TOKEN_INT64; }
 uint64 { return TOKEN_UINT64; }
 launch { return TOKEN_LAUNCH; }
 invoke_sycl { return TOKEN_INVOKE_SYCL; }
+__attribute__ { return TOKEN_ATTRIBUTE; }
 new { return TOKEN_NEW; }
 NULL { return TOKEN_NULL; }
 print { return TOKEN_PRINT; }

--- a/src/module.h
+++ b/src/module.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "ast.h"
+#include "decl.h"
 #include "ispc.h"
 
 #include <llvm/IR/DebugInfo.h>
@@ -60,16 +61,13 @@ class Module {
     /** Add a named type definition to the module. */
     void AddTypeDef(const std::string &name, const Type *type, SourcePos pos);
 
-    /** Add a new global variable corresponding to the given Symbol to the
-        module.  If non-nullptr, initExpr gives the initiailizer expression
-        for the global's inital value. */
-    void AddGlobalVariable(const std::string &name, const Type *type, Expr *initExpr, bool isConst,
-                           StorageClass storageClass, SourcePos pos);
+    /** Add a new global variable corresponding to the decl. */
+    void AddGlobalVariable(Declarator *decl, bool isConst);
 
     /** Add a declaration of the function defined by the given function
         symbol to the module. */
-    void AddFunctionDeclaration(const std::string &name, const FunctionType *ftype, StorageClass sc, bool isInline,
-                                bool isNoInline, bool isVectorCall, bool isRegCall, SourcePos pos);
+    void AddFunctionDeclaration(const std::string &name, const FunctionType *ftype, StorageClass sc, Declarator *decl,
+                                bool isInline, bool isNoInline, bool isVectorCall, bool isRegCall, SourcePos pos);
 
     /** Adds the function described by the declaration information and the
         provided statements to the module. */

--- a/src/type.h
+++ b/src/type.h
@@ -512,6 +512,7 @@ class PointerType : public Type {
 
     bool IsSlice() const { return isSlice; }
     bool IsFrozenSlice() const { return isFrozen; }
+    AddressSpace GetAddressSpace() const { return addrSpace; }
     const PointerType *GetAsSlice() const;
     const PointerType *GetAsNonSlice() const;
     const PointerType *GetAsFrozenSlice() const;
@@ -882,6 +883,7 @@ class ReferenceType : public Type {
     bool IsUnsignedType() const;
     bool IsSignedType() const;
     bool IsConstType() const;
+    AddressSpace GetAddressSpace() const { return addrSpace; }
 
     const Type *GetBaseType() const;
     const Type *GetReferenceTarget() const;
@@ -958,6 +960,7 @@ class FunctionType : public Type {
 
     const Type *GetAsUnmaskedType() const;
     const Type *GetAsNonUnmaskedType() const;
+    const Type *GetWithReturnType(const Type *t) const;
 
     std::string GetString() const;
     std::string Mangle() const;

--- a/tests/lit-tests/address-space-1.ispc
+++ b/tests/lit-tests/address-space-1.ispc
@@ -1,0 +1,15 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib --debug-phase=0:0 %s --no-discard-value-names -o t.o | FileCheck %s
+
+#define A(N) __attribute__((address_space(N)))
+
+// CHECK: declare void @foo___un_3C_uni_3E_({{.*}} addrspace(4){{.*}}, {{.*}}
+void foo(A(4) uniform int *uniform ptr);
+
+// CHECK: declare {{.*}} @boo___un_3C_unt_3E_({{.*}} addrspace(2){{.*}}, {{.*}}
+uniform int8 *uniform boo(A(2) uniform int8 *uniform x);
+
+// CHECK: declare void @"struct____{{.*}}({{.*}} addrspace(3){{.*}}, {{.*}}
+typedef struct {
+    int x;
+} my_struct;
+void struct_(A(3) uniform my_struct *uniform y);

--- a/tests/lit-tests/address-space.ispc
+++ b/tests/lit-tests/address-space.ispc
@@ -1,0 +1,13 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib %s --emit-llvm-text -o - | FileCheck %s
+
+#define A(N) __attribute__((address_space(N)))
+
+// check also that this macro is defined
+#ifdef ISPC_ATTRIBUTE_SUPPORTED
+
+// CHECK: define void @func1___un_3C_uni_3E_({{.*}} addrspace(4){{.*}}, {{.*}}
+void func1(A(4) uniform int *uniform ptr) { return; }
+
+// CHECK: define {{.*}} @func2___un_3C_unt_3E_({{.*}} addrspace(2){{.*}}, {{.*}}
+A(2) uniform int8 *uniform func2(A(2) uniform int8 *uniform x) { return x; }
+#endif // ISPC_ATTRIBUTE_SUPPORTED

--- a/tests/lit-tests/ast-dump-attrs.ispc
+++ b/tests/lit-tests/ast-dump-attrs.ispc
@@ -1,0 +1,16 @@
+// RUN: %{ispc} %s --nostdlib --target=host --ast-dump -o %t.o 2>&1 | FileCheck %s
+
+__attribute__((address_space(3))) uniform int * uniform b;
+
+void foo(__attribute__((noescape)) uniform int * uniform a) { }
+
+// CHECK: Function <{{.*}}ast-dump-attrs.ispc:9.70 - 9.72> [ void(uniform int32 addrspace(2) * uniform c)] "func"
+// CHECK: (param 0) [uniform int32 addrspace(2) * uniform] c
+void func(__attribute__((address_space(2))) uniform int * uniform c) {}
+
+uniform int func2() {
+    // CHECK: Variable d (uniform int32 addrspace(1) * uniform)
+    // CHECK: SymbolExpr <{{.*}}ast-dump-attrs.ispc:15.13 - 15.14> [uniform int32 addrspace(1) * uniform] symbol name: d
+    __attribute__((address_space(1))) uniform int * uniform d;
+    return *d;
+}

--- a/tests/lit-tests/err-address-space.ispc
+++ b/tests/lit-tests/err-address-space.ispc
@@ -1,0 +1,44 @@
+// RUN: not %{ispc} --target=host --nowrap --nostdlib  %s -o t.o 2>&1 | FileCheck %s
+
+#define ATTR __attribute__((address_space(1)))
+#define ATTRN(N) __attribute__((address_space(N)))
+
+// CHECK: Warning: "address_space" attribute is only allowed for pointer or reference types, "func_2".
+ATTR void func_2();
+
+// It is not yet supported to have __attribute__ in struct declaration.
+// CHECK: Error: syntax error, unexpected '__attribute__'
+struct S {
+  ATTR void *ptr_str;
+};
+
+// CHECK: Warning: "address_space" attribute is only allowed for pointer or reference types, "x".
+ATTRN(1) uniform int x;
+
+// CHECK: Error: "address_space" attribute 20 is out of scope of supported [0, 4], "ptr_2".
+ATTRN(20) uniform int * uniform ptr_2;
+
+void func() {
+    // CHECK: Warning: "address_space" attribute is only allowed for pointer or reference types, "l1".
+    ATTRN(1) uniform int l1;
+
+    // CHECK: Error: "address_space" attribute 20 is out of scope of supported [0, 4], "lptr".
+    ATTRN(20) uniform int * uniform lptr;
+}
+
+// CHECK: Warning: "address_space" attribute is only allowed for pointer or reference types, "p1".
+// CHECK: Error: "address_space" attribute 20 is out of scope of supported [0, 4], "pptr1".
+void decl1(ATTRN(1) uniform int p1, ATTRN(20) uniform int * uniform pptr1);
+
+// CHECK: Warning: "address_space" attribute is only allowed for pointer or reference types, "p2".
+// CHECK: Error: "address_space" attribute 20 is out of scope of supported [0, 4], "pptr2".
+void def1(ATTRN(1) uniform int p2, ATTRN(20) uniform int * uniform pptr2) { }
+
+// CHECK: Error: Can't convert between pointer types with different address spaces "uniform int16 * uniform" and "uniform int16 addrspace(2) * uniform" for return statement.
+ATTRN(2) uniform int16 *uniform func_3(uniform int16 *uniform x) { return x; }
+
+// CHECK: Error: Can't convert from pointer type "uniform int16 addrspace(3) * uniform" to incompatible pointer type "uniform int8 * uniform" for return statement.
+uniform int8 *uniform func_4(ATTRN(3) uniform int16 *uniform x) { return x; }
+
+// CHECK: Error: Can't convert from reference type "uniform int8 addrspace(3) &" to incompatible reference type "uniform int8 &" for return statement.
+uniform int8 &func_5(ATTRN(3) uniform int8 &x) { return x; }

--- a/tests/lit-tests/err-attribute.ispc
+++ b/tests/lit-tests/err-attribute.ispc
@@ -1,0 +1,20 @@
+// RUN: not %{ispc} --target=host --nowrap --nostdlib  %s -o t.o 2>&1 | FileCheck %s
+
+// At the moment, we don't support __attribute__ for struct and its members. It
+// can be supported in the future if needed.
+
+// CHECK: Error: syntax error, unexpected '__attribute__', expecting {{.*}}
+struct __attribute__((__packed__)) S {
+    int b;
+};
+
+// CHECK: Error: syntax error, unexpected '__attribute__'.
+struct S1 {
+    __attribute__((aligned(8))) int a;
+};
+
+// CHECK: Error: syntax error, unexpected '-', expecting identifier.
+__attribute__((-1)) int a;
+
+// CHECK: Error: syntax error, unexpected ')'
+__attribute__((aligned())) int a;

--- a/tests/lit-tests/err-noescape.ispc
+++ b/tests/lit-tests/err-noescape.ispc
@@ -1,0 +1,19 @@
+// RUN: not %{ispc} --target=host --nowrap --nostdlib  %s -o t.o 2>&1 | FileCheck %s
+
+// CHECK: Error: "noescape" attribute illegal with "varying" parameter "ptr".
+void foo(__attribute__((noescape)) uniform int *ptr);
+
+// CHECK: Error: "noescape" attribute illegal with non-pointer parameter "x".
+void func(__attribute__((noescape)) uniform int x);
+
+// CHECK: Warning: Ignoring "noescape" attribute for function "func_1".
+__attribute__((noescape)) void *func_1();
+
+// CHECK: Warning: Ignoring "noescape" attribute for function "func_2".
+__attribute__((noescape)) void func_2();
+
+// It is not yet supported to have __attribute__ in struct declaration.
+// CHECK: Error: syntax error, unexpected '__attribute__'
+struct S {
+  __attribute__((noescape)) void *ptr_str;
+};

--- a/tests/lit-tests/noescape-1.ispc
+++ b/tests/lit-tests/noescape-1.ispc
@@ -1,0 +1,4 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib %s --emit-llvm-text -o - | FileCheck %s
+
+// CHECK: define void @foo___un_3C_uni_3E_({{.*}} nocapture %ptr, {{.*}}
+void foo(__attribute__((noescape)) uniform int *uniform ptr) { return; }

--- a/tests/lit-tests/noescape.ispc
+++ b/tests/lit-tests/noescape.ispc
@@ -1,0 +1,16 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib --debug-phase=0:0 %s --no-discard-value-names -o t.o | FileCheck %s
+
+// CHECK: declare void @foo___un_3C_uni_3E_({{.*}} nocapture, {{.*}}
+void foo(__attribute__((noescape)) uniform int *uniform ptr);
+
+// CHECK: declare {{.*}} @boo___un_3C_uni_3E_({{.*}} nocapture, {{.*}}
+uniform int8 *uniform boo(__attribute__((noescape)) uniform int32 *uniform x);
+
+// CHECK: declare void @arr___un_3C_uni_3E_({{.*}} nocapture, {{.*}}
+void arr(__attribute__((noescape)) uniform int x[]);
+
+// CHECK: declare void @"struct____{{.*}}"({{.*}} nocapture, {{.*}}
+typedef struct {
+    int x;
+} my_struct;
+void struct_(__attribute__((noescape)) uniform my_struct *uniform y);

--- a/tests/lit-tests/warn-attribute-1.ispc
+++ b/tests/lit-tests/warn-attribute-1.ispc
@@ -1,0 +1,15 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib  %s -o t.o 2>&1 | FileCheck %s
+
+#define ATTR __attribute__((__unkNOWN_at))
+
+// CHECK-COUNT-5: Warning: Ignoring unknown attribute "__unkNOWN_at".
+
+ATTR void foo1() { }
+
+ATTR void *func1() { }
+
+void boo(ATTR uniform int* x);
+
+void boo1(ATTR uniform int* x) { }
+
+void boo2(ATTR int x) { }

--- a/tests/lit-tests/warn-attribute.ispc
+++ b/tests/lit-tests/warn-attribute.ispc
@@ -1,0 +1,20 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib  %s -o t.o 2>&1 | FileCheck %s
+
+#define ATTR __attribute__((__unkNOWN_at))
+
+// CHECK-COUNT-8: Warning: Ignoring unknown attribute "__unkNOWN_at".
+
+ATTR void foo1();
+
+ATTR void *func1();
+
+void boo(ATTR int x);
+
+ATTR uniform int x;
+ATTR uniform int * uniform y;
+
+void func() {
+    ATTR int l1;
+    ATTR uniform int l2;
+    ATTR uniform int * uniform l3;
+}

--- a/tests/lit-tests/warn-noescape.ispc
+++ b/tests/lit-tests/warn-noescape.ispc
@@ -1,0 +1,13 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib %s -o t.o 2>&1 | FileCheck %s
+
+// CHECK: Warning: Ignoring "noescape" attribute for global variable "d".
+__attribute__((noescape)) double uniform *uniform d;
+
+// CHECK: Warning: Ignoring "noescape" attribute for global variable "x".
+__attribute__((noescape)) int32 x;
+
+void func_2() {
+  // CHECK: Warning: Ignoring "noescape" attribute for variable "p".
+  __attribute__((noescape)) uniform float * uniform p;
+}
+


### PR DESCRIPTION
Supported syntaxes:
- `__attribute__((attr))`
- `__attribute__((attr(2)))`
- `__attribute__((attr("str")))`

They can be placed on variable declarations (local, global, parameters) and function declaration/definitions.

Placing them on struct declarations is not supported yet.