### PR TITLE
CI: add ClamAV scan job

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ environment:
   LLVM_LATEST: 17.0
   DOCKER_PATH: "ispc/test_repo"
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
       LLVM_VERSION: latest
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: latest

--- a/.github/workflows/clamav-release.yml
+++ b/.github/workflows/clamav-release.yml
@@ -1,0 +1,83 @@
+# Copyright 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Scan release archives with ClamAV
+
+permissions: read-all
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'ISPC release version (just number without v, e.g., 1.24.0)'
+        required: true
+        type: string
+
+env:
+  release_base_url: https://github.com/ispc/ispc/releases/download/
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    - name: Install ClamAV
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clamav
+
+    - name: Update ClamAV database
+      run: |
+        sudo systemctl stop clamav-freshclam
+        sudo freshclam
+        sudo systemctl start clamav-freshclam
+
+    - name: Download and unpack release artifacts
+      env:
+        V: ${{ inputs.version }}
+      run: |
+        TAR="ispc-examples-v$V.tar.gz ispc-v$V-linux-oneapi.tar.gz \
+             ispc-v$V-linux.aarch64.tar.gz ispc-v$V-linux.tar.gz \
+             ispc-v$V-macOS.arm64.tar.gz ispc-v$V-macOS.universal.tar.gz \
+             ispc-v$V-macOS.x86_64.tar.gz"
+        ZIP="ispc-examples-v$V.zip ispc-v$V-windows.zip"
+        for f in $TAR $ZIP; do
+          echo "Download $f"
+          wget --quiet -O $f ${{ env.release_base_url }}/v$V/$f
+        done
+        for f in $TAR; do
+          echo "Unpack $f"
+          # unpack linux examples to separate directory to avoid conflicts
+          # with windows examples and source code examples directory
+          if [[ $f == ispc-examples* ]]; then
+            mkdir linux-examples
+            tar -xzf $f -C linux-examples
+          else
+            tar -xzf $f
+          fi
+        done
+        for f in $ZIP; do
+          echo "Unpack $f"
+          # unpack windows examples to separate directory to avoid conflicts
+          # with linux/macOS examples and source code examples directory
+          if [[ $f == ispc-examples* ]]; then
+            unzip -q $f -d windows-examples
+          else
+            unzip -q $f
+          fi
+        done
+
+    - name: Scan archvies and source code with ClamAV
+      run: |
+        clamscan --recursive --scan-archive --archive-verbose --verbose ./ 2>&1 | tee ispc-releases-clamscan.log
+
+    - name: Upload ClamAV logs
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+      if: always()
+      with:
+        name: clamav-logs
+        path: |
+          ispc-releases-clamscan.log

--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -1,0 +1,54 @@
+# Copyright 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Scan trunk archives with ClamAV
+
+permissions: read-all
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every day at 22:00 UTC
+    - cron: '0 22 * * *'
+
+env:
+  zip_url: https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.zip?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202019%2C%20LLVM_VERSION%3Dlatest
+  tar_url: https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-linux.tar.gz?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DUbuntu1804%2C%20LLVM_VERSION%3Dlatest
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    - name: Install ClamAV
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clamav
+
+    - name: Update ClamAV database
+      run: |
+        sudo systemctl stop clamav-freshclam
+        sudo freshclam
+        sudo systemctl start clamav-freshclam
+
+    - name: Download archives
+      run: |
+        wget -O archive.zip ${{ env.zip_url }}
+        unzip -q archive.zip
+        wget -O archive.tar.gz ${{ env.tar_url }}
+        gunzip archive.tar.gz
+
+    - name: Scan archvies and source code with ClamAV
+      run: |
+        clamscan --recursive --scan-archive --archive-verbose --verbose ./ 2>&1 | tee ispc-trunk-clamscan.log
+
+    - name: Upload ClamAV logs
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+      if: always()
+      with:
+        name: clamav-logs
+        path: |
+          ispc-trunk-clamscan.log


### PR DESCRIPTION
It adds a job to scan trunk archives with ClamAV.

This partially addresses #2913.

This PR also fixes appveyor build for Linux that was broken after https://github.com/ispc/ispc/pull/2894