### PR TITLE
lexer: remove self-fuzzing functionality

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2325,9 +2325,7 @@ Globals::Globals() {
     generateDebuggingSymbols = false;
     debugInfoType = Globals::DebugInfoType::None;
     generateDWARFVersion = 3;
-    enableFuzzTest = false;
     enableLLVMIntrinsics = false;
-    fuzzTestSeed = -1;
     mangleFunctionsWithTarget = false;
     isMultiTargetCompilation = false;
     errorLimit = -1;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -811,16 +811,8 @@ struct Globals {
         vector width to them. */
     bool mangleFunctionsWithTarget;
 
-    /** If enabled, the lexer will randomly replace some tokens returned
-        with other tokens, in order to test error condition handling in the
-        compiler. */
-    bool enableFuzzTest;
-
     /* If enabled, allows the user to directly call LLVM intrinsics. */
     bool enableLLVMIntrinsics;
-
-    /** Seed for random number generator used for fuzz testing. */
-    int fuzzTestSeed;
 
     /** Global LLVMContext object */
     llvm::LLVMContext *ctx;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -211,8 +211,6 @@ static void lPrintVersion() {
     printf("    [--[no-]discard-value-names]\tDo not discard/Discard value names when generating LLVM IR\n");
     printf("    [--dump-file[=<path>]]\t\tDump module IR to file(s) in "
            "current directory, or to <path> if specified\n");
-    printf("    [--fuzz-seed=<value>]\t\tSeed value for RNG for fuzz testing\n");
-    printf("    [--fuzz-test]\t\t\tRandomly perturb program input to test error conditions\n");
     printf("    [--off-phase=<value>]\t\tSwitch off optimization phases. --off-phase=first,210:220,300,305,310:last\n");
     printf("    [--opt=<option>]\t\t\tSet optimization option\n");
     printf("        disable-all-on-optimizations\t\tDisable optimizations that take advantage of \"all on\" mask\n");
@@ -833,11 +831,7 @@ int main(int Argc, char *Argv[]) {
             lParseInclude(argv[i] + 2);
         } else if (!strcmp(argv[i], "--ignore-preprocessor-errors")) {
             g->ignoreCPPErrors = true;
-        } else if (!strcmp(argv[i], "--fuzz-test"))
-            g->enableFuzzTest = true;
-        else if (!strncmp(argv[i], "--fuzz-seed=", 12))
-            g->fuzzTestSeed = atoi(argv[i] + 12);
-        else if (!strcmp(argv[i], "--target")) {
+        } else if (!strcmp(argv[i], "--target")) {
             // FIXME: should remove this way of specifying the target...
             if (++i != argc) {
                 auto result = ParseISPCTargets(argv[i]);
@@ -1190,23 +1184,6 @@ int main(int Argc, char *Argv[]) {
         }
     }
 #endif
-
-    if (g->enableFuzzTest) {
-        if (g->fuzzTestSeed == -1) {
-#ifdef ISPC_HOST_IS_WINDOWS
-            int seed = (unsigned)time(nullptr);
-#else
-            int seed = getpid();
-#endif
-            g->fuzzTestSeed = seed;
-            Warning(SourcePos(), "Using seed %d for fuzz testing", g->fuzzTestSeed);
-        }
-#ifdef ISPC_HOST_IS_WINDOWS
-        srand(g->fuzzTestSeed);
-#else
-        srand48(g->fuzzTestSeed);
-#endif
-    }
 
     if (depsFileName != nullptr) {
         flags.setDepsToStdout(false);

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -381,33 +381,3 @@ void SymbolTable::Print() {
         depth += 4;
     }
 }
-
-inline int ispcRand() {
-#ifdef ISPC_HOST_IS_WINDOWS
-    return rand();
-#else
-    return lrand48();
-#endif
-}
-
-Symbol *SymbolTable::RandomSymbol() {
-    int v = ispcRand() % variables.size();
-    if (variables[v]->size() == 0)
-        return nullptr;
-    int count = ispcRand() % variables[v]->size();
-    SymbolMapType::iterator iter = variables[v]->begin();
-    while (count-- > 0) {
-        ++iter;
-        Assert(iter != variables[v]->end());
-    }
-    return iter->second;
-}
-
-const Type *SymbolTable::RandomType() {
-
-    int randomScopeIndex = ispcRand() % types.size();
-
-    int randomTypeIndex = ispcRand() % types[randomScopeIndex].size();
-
-    return std::next(types[randomScopeIndex].cbegin(), randomTypeIndex)->second;
-}

--- a/src/sym.h
+++ b/src/sym.h
@@ -284,13 +284,6 @@ class SymbolTable {
         (Debugging method). */
     void Print();
 
-    /** Returns a random symbol from the symbol table. (It is not
-        guaranteed that it is equally likely to return all symbols). */
-    Symbol *RandomSymbol();
-
-    /** Returns a random type from the symbol table. */
-    const Type *RandomType();
-
   private:
     std::vector<std::string> closestTypeMatch(const char *str, bool structsVsEnums) const;
 


### PR DESCRIPTION
This PR removes `--fuzz-target` and `--fuzz-seed=<int>` developer functionality. It is not used anymore. It will eventually be replaced by fuzzing with external tools. 