### PR TITLE
Fixes for LLVM mac builds and CI

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -127,7 +127,7 @@ jobs:
       uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: ispc_llvm${{ matrix.llvm.short_version }}_linux.aarch64
-        path: build/ispc-trunk-linux.aarch64.tar.gz
+        path: build/ispc-trunk-linux.tar.gz
 
   linux-build-ispc:
     needs: [define-flow]

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -77,6 +77,8 @@ jobs:
   linux-aarch64-build-ispc:
     needs: [define-flow]
     runs-on: [self-hosted, Linux, ARM64]
+    # Disable self-hosted jobs for forks.
+    if: github.repository == 'ispc/ispc'
     container: ubuntu:22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -316,6 +316,44 @@ jobs:
         version: [15, 16, 17]
         arch: [x86, x86-64]
         target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
+        # See issue #2818 for more deatils. It's SDE problem running on AMD runner.
+        exclude:
+          - arch: x86
+            target: "avx2vnni-i32x4"
+          - arch: x86
+            target: "avx2vnni-i32x8"
+          - arch: x86
+            target: "avx2vnni-i32x16"
+          - arch: x86
+            target: "avx512skx-x4"
+          - arch: x86
+            target: "avx512skx-x8"
+          - arch: x86
+            target: "avx512skx-x16"
+          - arch: x86
+            target: "avx512skx-x32"
+          - arch: x86
+            target: "avx512skx-x64"
+          - arch: x86
+            target: "avx512icl-x4"
+          - arch: x86
+            target: "avx512icl-x8"
+          - arch: x86
+            target: "avx512icl-x16"
+          - arch: x86
+            target: "avx512icl-x32"
+          - arch: x86
+            target: "avx512icl-x64"
+          - arch: x86
+            target: "avx512spr-x4"
+          - arch: x86
+            target: "avx512spr-x8"
+          - arch: x86
+            target: "avx512spr-x16"
+          - arch: x86
+            target: "avx512spr-x32"
+          - arch: x86
+            target: "avx512spr-x64"
 
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -365,6 +403,44 @@ jobs:
       matrix:
         arch: [x86, x86-64]
         target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
+        # See issue #2818 for more deatils. It's SDE problem running on AMD runner.
+        exclude:
+          - arch: x86
+            target: "avx2vnni-i32x4"
+          - arch: x86
+            target: "avx2vnni-i32x8"
+          - arch: x86
+            target: "avx2vnni-i32x16"
+          - arch: x86
+            target: "avx512skx-x4"
+          - arch: x86
+            target: "avx512skx-x8"
+          - arch: x86
+            target: "avx512skx-x16"
+          - arch: x86
+            target: "avx512skx-x32"
+          - arch: x86
+            target: "avx512skx-x64"
+          - arch: x86
+            target: "avx512icl-x4"
+          - arch: x86
+            target: "avx512icl-x8"
+          - arch: x86
+            target: "avx512icl-x16"
+          - arch: x86
+            target: "avx512icl-x32"
+          - arch: x86
+            target: "avx512icl-x64"
+          - arch: x86
+            target: "avx512spr-x4"
+          - arch: x86
+            target: "avx512spr-x8"
+          - arch: x86
+            target: "avx512spr-x16"
+          - arch: x86
+            target: "avx512spr-x32"
+          - arch: x86
+            target: "avx512spr-x64"
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Download package

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -592,6 +592,12 @@ if (APPLE AND CMAKE_SYSTEM_VERSION VERSION_GREATER_EQUAL 13)
     set(LLVM_RUNTIMES
         ${LLVM_RUNTIMES}$<SEMICOLON>libcxx$<SEMICOLON>libcxxabi
         )
+
+    if (${LLVM_VERSION_MAJOR} VERSION_GREATER_EQUAL 18)
+        set(LLVM_RUNTIMES
+            ${LLVM_RUNTIMES}$<SEMICOLON>libunwind
+            )
+    endif()
 endif()
 
 # LLVM_ENABLE_RUNTIMES is a proper place for compiler-rt and openmp not LLVM_ENABLE_PROJECTS.


### PR DESCRIPTION
Fixes #2818, #2931 

- Don't run CI jobs that fail due to SDE failing on AMD runner on Linux x86 (32 bit)
- Don't run jobs for self-hosted runners in forks
- Add `libunwind` for LLVM 18.0+ build on macOS via superbuild.
- Fix artifact name for `aarch64` Linux build job - otherwise a warning generated and no artifact is uploaded.