### PR TITLE
builtins: remove internal from __shuffle_*

### DIFF
--- a/builtins/target-avx1-i64x4base.ll
+++ b/builtins/target-avx1-i64x4base.ll
@@ -27,14 +27,14 @@ shuffle1(double)
 shuffle1(i64)
 
 declare <4 x float> @llvm.x86.avx.vpermilvar.ps(<4 x float>, <4 x i32>)
-define internal <4 x i32> @__shuffle_i32(<4 x i32>, <4 x i32>) nounwind readnone alwaysinline {
+define <4 x i32> @__shuffle_i32(<4 x i32>, <4 x i32>) nounwind readnone alwaysinline {
   %vec = bitcast <4 x i32> %0 to <4 x float>
   %res = call <4 x float> @llvm.x86.avx.vpermilvar.ps(<4 x float> %vec, <4 x i32> %1)
   %res_casted = bitcast <4 x float> %res to <4 x i32>
   ret <4 x i32> %res_casted
 }
 
-define internal <4 x float> @__shuffle_float(<4 x float>, <4 x i32>) nounwind readnone alwaysinline {
+define <4 x float> @__shuffle_float(<4 x float>, <4 x i32>) nounwind readnone alwaysinline {
   %res = call <4 x float> @llvm.x86.avx.vpermilvar.ps(<4 x float> %0, <4 x i32> %1)
   ret <4 x float> %res
 }

--- a/builtins/target-avx2-common-i32x4.ll
+++ b/builtins/target-avx2-common-i32x4.ll
@@ -27,14 +27,14 @@ shuffle1(double)
 shuffle1(i64)
 
 declare <4 x float> @llvm.x86.avx.vpermilvar.ps(<4 x float>, <4 x i32>)
-define internal <4 x i32> @__shuffle_i32(<4 x i32>, <4 x i32>) nounwind readnone alwaysinline {
+define <4 x i32> @__shuffle_i32(<4 x i32>, <4 x i32>) nounwind readnone alwaysinline {
   %vec = bitcast <4 x i32> %0 to <4 x float>
   %res = call <4 x float> @llvm.x86.avx.vpermilvar.ps(<4 x float> %vec, <4 x i32> %1)
   %res_casted = bitcast <4 x float> %res to <4 x i32>
   ret <4 x i32> %res_casted
 }
 
-define internal <4 x float> @__shuffle_float(<4 x float>, <4 x i32>) nounwind readnone alwaysinline {
+define <4 x float> @__shuffle_float(<4 x float>, <4 x i32>) nounwind readnone alwaysinline {
   %res = call <4 x float> @llvm.x86.avx.vpermilvar.ps(<4 x float> %0, <4 x i32> %1)
   ret <4 x float> %res
 }

--- a/builtins/target-avx2-common-i32x8.ll
+++ b/builtins/target-avx2-common-i32x8.ll
@@ -20,13 +20,13 @@ shuffle1(double)
 shuffle1(i64)
 
 declare <8 x i32> @llvm.x86.avx2.permd(<8 x i32>, <8 x i32>)
-define internal <8 x i32> @__shuffle_i32(<8 x i32>, <8 x i32>) nounwind readnone alwaysinline {
+define <8 x i32> @__shuffle_i32(<8 x i32>, <8 x i32>) nounwind readnone alwaysinline {
   %res = call <8 x i32> @llvm.x86.avx2.permd(<8 x i32> %0, <8 x i32> %1)
   ret <8 x i32> %res
 }
 
 declare <8 x float> @llvm.x86.avx2.permps(<8 x float>, <8 x i32>)
-define internal <8 x float> @__shuffle_float(<8 x float>, <8 x i32>) nounwind readnone alwaysinline {
+define <8 x float> @__shuffle_float(<8 x float>, <8 x i32>) nounwind readnone alwaysinline {
   %res = call <8 x float> @llvm.x86.avx2.permps(<8 x float> %0, <8 x i32> %1)
   ret <8 x float> %res
 }


### PR DESCRIPTION
Extracted from https://github.com/ispc/ispc/pull/2743.
It's not related to targets redesign. It happened after https://github.com/ispc/ispc/pull/2924 because I changed the interface in the last moment and forgot to remove `internal` in several places.

-------------------------------------------------------------------

1. It doesn't match with other __shuffle_* definitions in other files.

2. The more important thing is the following one. After the target redesign, builtins module is linked into the stdlib^. It means that no builtin function used in stdlib.ispc should be defined with internal attribute (C static keyword). Otherwise, the linker gets rid of __shuffle_ from builtins instead of resolving __shuffle_ symbol used in stdlib. It would result into unresolved symbol. Only functions that are internal to builtins, i.e., without usage in stdlib, can be marked as internal although I don't really expect it matters from the optimization point of view.

^ actually user code with stdlib code