### PR TITLE
Fixes for LLVM 19 build and nightly testing

### DIFF
--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -101,11 +101,51 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch: [x86, x86-64]
         target: [sse2-i32x4, sse2-i32x8,
                  sse4-i8x16, sse4-i16x8, sse4-i32x4, sse4-i32x8,
                  avx1-i32x4, avx1-i32x8, avx1-i32x16, avx1-i64x4,
                  avx2-i8x32, avx2-i16x16, avx2-i32x4, avx2-i32x8, avx2-i32x16, avx2-i64x4,
                  avx512skx-x4, avx512skx-x8, avx512skx-x16, avx512skx-x64, avx512skx-x32]
+        # See issue #2818 for more deatils. It's SDE problem running on AMD runner.
+        exclude:
+          - arch: x86
+            target: "avx2vnni-i32x4"
+          - arch: x86
+            target: "avx2vnni-i32x8"
+          - arch: x86
+            target: "avx2vnni-i32x16"
+          - arch: x86
+            target: "avx512skx-x4"
+          - arch: x86
+            target: "avx512skx-x8"
+          - arch: x86
+            target: "avx512skx-x16"
+          - arch: x86
+            target: "avx512skx-x32"
+          - arch: x86
+            target: "avx512skx-x64"
+          - arch: x86
+            target: "avx512icl-x4"
+          - arch: x86
+            target: "avx512icl-x8"
+          - arch: x86
+            target: "avx512icl-x16"
+          - arch: x86
+            target: "avx512icl-x32"
+          - arch: x86
+            target: "avx512icl-x64"
+          - arch: x86
+            target: "avx512spr-x4"
+          - arch: x86
+            target: "avx512spr-x8"
+          - arch: x86
+            target: "avx512spr-x16"
+          - arch: x86
+            target: "avx512spr-x32"
+          - arch: x86
+            target: "avx512spr-x64"
+
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Download package
@@ -124,7 +164,7 @@ jobs:
     - name: Running tests
       run: |
         echo PATH=$PATH
-        ./alloy.py -r --only="stability current -O0 -O1 -O2" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+        ./alloy.py -r --only="stability ${{ matrix.arch }} current -O0 -O1 -O2" --only-targets="${{ matrix.target }}" --time --update-errors=FP
 
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4

--- a/.github/workflows/nightly-17.yml
+++ b/.github/workflows/nightly-17.yml
@@ -103,12 +103,51 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch: [x86, x86-64]
         target: [sse2-i32x4, sse2-i32x8,
                  sse4-i8x16, sse4-i16x8, sse4-i32x4, sse4-i32x8,
                  avx1-i32x4, avx1-i32x8, avx1-i32x16, avx1-i64x4,
                  avx2-i8x32, avx2-i16x16, avx2-i32x4, avx2-i32x8, avx2-i32x16, avx2-i64x4,
                  avx512knl-x16,
                  avx512skx-x4, avx512skx-x8, avx512skx-x16, avx512skx-x64, avx512skx-x32]
+        # See issue #2818 for more deatils. It's SDE problem running on AMD runner.
+        exclude:
+          - arch: x86
+            target: "avx2vnni-i32x4"
+          - arch: x86
+            target: "avx2vnni-i32x8"
+          - arch: x86
+            target: "avx2vnni-i32x16"
+          - arch: x86
+            target: "avx512skx-x4"
+          - arch: x86
+            target: "avx512skx-x8"
+          - arch: x86
+            target: "avx512skx-x16"
+          - arch: x86
+            target: "avx512skx-x32"
+          - arch: x86
+            target: "avx512skx-x64"
+          - arch: x86
+            target: "avx512icl-x4"
+          - arch: x86
+            target: "avx512icl-x8"
+          - arch: x86
+            target: "avx512icl-x16"
+          - arch: x86
+            target: "avx512icl-x32"
+          - arch: x86
+            target: "avx512icl-x64"
+          - arch: x86
+            target: "avx512spr-x4"
+          - arch: x86
+            target: "avx512spr-x8"
+          - arch: x86
+            target: "avx512spr-x16"
+          - arch: x86
+            target: "avx512spr-x32"
+          - arch: x86
+            target: "avx512spr-x64"
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Download package
@@ -127,7 +166,7 @@ jobs:
     - name: Running tests
       run: |
         echo PATH=$PATH
-        ./alloy.py -r --only="stability current -O0 -O1 -O2" --only-targets="${{ matrix.target }}" --time --update-errors=FP
+        ./alloy.py -r --only="stability ${{ matrix.arch }} current -O0 -O1 -O2" --only-targets="${{ matrix.target }}" --time --update-errors=FP
 
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4

--- a/.github/workflows/nightly-17.yml
+++ b/.github/workflows/nightly-17.yml
@@ -3,10 +3,6 @@
 
 # Nightly Linux run.
 
-####################################################################
-# Currently disabled. To be reenabled for 17.0.                    #
-####################################################################
-
 name: Nightly tests / LLVM 17.0
 
 permissions: read-all
@@ -21,57 +17,19 @@ env:
   SDE_MIRROR_ID: 813591
   SDE_TAR_NAME: sde-external-9.33.0-2024-01-07
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
+  LLVM_REPO: https://github.com/ispc/ispc.dependencies
 
 jobs:
-  linux-build-llvm-17:
-    runs-on: ubuntu-22.04
-
-    steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      with:
-        submodules: true
-
-    - name: Check environment
-      run: |
-        cat /proc/cpuinfo
-
-    - name: Build LLVM
-      run: |
-        cd docker/ubuntu/22.04/cpu_ispc_build
-        ls -al
-        docker buildx create --use
-        docker buildx build --tag ispc/ubuntu22.04:stage2 --target=llvm_build --build-arg REPO=$GITHUB_REPOSITORY --build-arg SHA=$GITHUB_SHA --build-arg LLVM_VERSION=17.0 --output=type=tar,dest=result.tar .
-
-    - name: Pack LLVM
-      run: |
-        cd docker/ubuntu/22.04/cpu_ispc_build
-        tar xvf result.tar usr/local/src/llvm
-        mv usr/local/src/llvm/bin-17.0 .
-        # Note using gzip here, instead of xz - trading of space for speed, as it's just for passing to another stage.
-        tar czvf llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.gz bin-17.0
-
-    - name: Upload package
-      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
-      with:
-        name: llvm_17_linux
-        path: docker/ubuntu/22.04/cpu_ispc_build/llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.gz
-
   linux-build-ispc-llvm-17:
-    needs: [linux-build-llvm-17]
     runs-on: ubuntu-22.04
     env:
       LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.gz
+      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: true
-
-    - name: Download package
-      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-      with:
-        name: llvm_17_linux
 
     - name: Install dependencies
       run: |
@@ -183,60 +141,8 @@ jobs:
         [ -z "`git diff`" ]
 
 
-  win-build-llvm-17:
-    runs-on: windows-2022
-
-    steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      with:
-        submodules: true
-
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
-
-    - name: Install dependencies
-      run: |
-        Install-ChocoPackage ninja
-
-    - name: Check environment
-      shell: cmd
-      run: |
-        wmic cpu get caption, deviceid, name, numberofcores, maxclockspeed, status
-
-    - name: Install dependencies
-      shell: cmd
-      run: |
-        mkdir llvm
-        echo LLVM_HOME=%GITHUB_WORKSPACE%\llvm>> %GITHUB_ENV%
-        echo ISPC_HOME=%GITHUB_WORKSPACE%>> %GITHUB_ENV%
-
-    - name: Build LLVM
-      shell: cmd
-      run: |
-        set VSVARS="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        call %VSVARS%
-        cmake %ISPC_HOME%\superbuild -B build --preset os -DLTO=ON -DLLVM_VERSION=17.0 -DCMAKE_SYSTEM_VERSION=10.0.18362.0 -DCMAKE_INSTALL_PREFIX=%LLVM_HOME%\bin-17.0 -DBUILD_STAGE2_TOOLCHAIN_ONLY=ON -DXE_DEPS=OFF -DLLVM_DISABLE_ASSERTIONS=ON
-        cmake --build build
-        rmdir /s /q build
-
-    - name: Pack LLVM
-      shell: cmd
-      run: |
-        cd llvm
-        set TAR_BASE_NAME=llvm-17.0.6-win.vs2019-Release+Asserts-x86.arm.wasm
-        7z.exe a -ttar -snl %TAR_BASE_NAME%.tar bin-17.0
-        7z.exe a -t7z %TAR_BASE_NAME%.tar.7z %TAR_BASE_NAME%.tar
-
-    - name: Upload package
-      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
-      with:
-        name: llvm_17_win
-        path: llvm/llvm-17.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
-
-
   win-build-ispc-llvm-17:
-    needs: [win-build-llvm-17]
-    runs-on: windows-2022
+    runs-on: windows-2019
     env:
       LLVM_VERSION: "17.0"
       LLVM_TAR: llvm-17.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
@@ -248,12 +154,6 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: true
-
-    - name: Download package
-      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-      with:
-        name: llvm_17_win
-        path: ${{env.LLVM_HOME}}
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0

--- a/builtins/target-avx512-common-16.ll
+++ b/builtins/target-avx512-common-16.ll
@@ -11,20 +11,15 @@ include(`target-avx512-utils.ll')
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; shuffles
 
-;; Implementation for i8 type is different across avx512 targets.
+;; Implementation for i8 and i16 types is different across avx512 targets.
 ;; There is no @llvm.x86.avx512.mask.permvar.qi.128 and @llvm.x86.avx512.vpermi2var.qi.128
-;; before icl. Look for definitions in particular target files.
+;; before icl. 
+;; @llvm.x86.avx512.vpermi2var.hi.256 is not available for KNL.
+;; Look for definitions in particular target files.
 
 shuffle1(half)
 shuffle1(double)
 shuffle1(i64)
-
-declare <WIDTH x i16> @llvm.x86.avx512.mask.permvar.hi.256(<WIDTH x i16>, <WIDTH x i16>, <WIDTH x i16>, i16)
-define <WIDTH x i16> @__shuffle_i16(<WIDTH x i16>, <WIDTH x i32>) nounwind readnone alwaysinline {
-  %ind = trunc <WIDTH x i32> %1 to <WIDTH x i16>
-  %res = call <WIDTH x i16> @llvm.x86.avx512.mask.permvar.hi.256(<WIDTH x i16> %0, <WIDTH x i16> %ind, <WIDTH x i16> zeroinitializer, i16 -1)
-  ret <WIDTH x i16> %res
-}
 
 declare <WIDTH x i32> @llvm.x86.avx512.permvar.si.512(<WIDTH x i32>, <WIDTH x i32>)
 define <WIDTH x i32> @__shuffle_i32(<WIDTH x i32>, <WIDTH x i32>) nounwind readnone alwaysinline {
@@ -43,21 +38,6 @@ define_shuffle2_const()
 shuffle2(half)
 shuffle2(i64)
 shuffle2(double)
-
-declare <WIDTH x i16> @llvm.x86.avx512.vpermi2var.hi.256(<WIDTH x i16>, <WIDTH x i16>, <WIDTH x i16>)
-define <WIDTH x i16> @__shuffle2_i16(<WIDTH x i16>, <WIDTH x i16>, <WIDTH x i32>) nounwind readnone alwaysinline {
-  %isc = call i1 @__is_compile_time_constant_varying_int32(<WIDTH x i32> %2)
-  br i1 %isc, label %is_const, label %not_const
-
-is_const:
-  %res_const = tail call <WIDTH x i16> @__shuffle2_const_i16(<WIDTH x i16> %0, <WIDTH x i16> %1, <WIDTH x i32> %2)
-  ret <WIDTH x i16> %res_const
-
-not_const:
-  %ind = trunc <WIDTH x i32> %2 to <WIDTH x i16>
-  %res = call <WIDTH x i16> @llvm.x86.avx512.vpermi2var.hi.256(<WIDTH x i16> %0, <WIDTH x i16> %ind, <WIDTH x i16> %1)
-  ret <WIDTH x i16> %res
-}
 
 declare <WIDTH x i32> @llvm.x86.avx512.vpermi2var.d.512(<WIDTH x i32>, <WIDTH x i32>, <WIDTH x i32>)
 define <WIDTH x i32> @__shuffle2_i32(<WIDTH x i32>, <WIDTH x i32>, <WIDTH x i32>) nounwind readnone alwaysinline {

--- a/builtins/target-avx512icl-x16.ll
+++ b/builtins/target-avx512icl-x16.ll
@@ -32,6 +32,28 @@ not_const:
   ret <WIDTH x i8> %res
 }
 
+declare <WIDTH x i16> @llvm.x86.avx512.mask.permvar.hi.256(<WIDTH x i16>, <WIDTH x i16>, <WIDTH x i16>, i16)
+define <WIDTH x i16> @__shuffle_i16(<WIDTH x i16>, <WIDTH x i32>) nounwind readnone alwaysinline {
+  %ind = trunc <WIDTH x i32> %1 to <WIDTH x i16>
+  %res = call <WIDTH x i16> @llvm.x86.avx512.mask.permvar.hi.256(<WIDTH x i16> %0, <WIDTH x i16> %ind, <WIDTH x i16> zeroinitializer, i16 -1)
+  ret <WIDTH x i16> %res
+}
+
+declare <WIDTH x i16> @llvm.x86.avx512.vpermi2var.hi.256(<WIDTH x i16>, <WIDTH x i16>, <WIDTH x i16>)
+define <WIDTH x i16> @__shuffle2_i16(<WIDTH x i16>, <WIDTH x i16>, <WIDTH x i32>) nounwind readnone alwaysinline {
+  %isc = call i1 @__is_compile_time_constant_varying_int32(<WIDTH x i32> %2)
+  br i1 %isc, label %is_const, label %not_const
+
+is_const:
+  %res_const = tail call <WIDTH x i16> @__shuffle2_const_i16(<WIDTH x i16> %0, <WIDTH x i16> %1, <WIDTH x i32> %2)
+  ret <WIDTH x i16> %res_const
+
+not_const:
+  %ind = trunc <WIDTH x i32> %2 to <WIDTH x i16>
+  %res = call <WIDTH x i16> @llvm.x86.avx512.vpermi2var.hi.256(<WIDTH x i16> %0, <WIDTH x i16> %ind, <WIDTH x i16> %1)
+  ret <WIDTH x i16> %res
+}
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rcp/rsqrt declarations for half
 rcph_rsqrth_decl

--- a/builtins/target-avx512knl-x16.ll
+++ b/builtins/target-avx512knl-x16.ll
@@ -12,6 +12,8 @@ include(`target-avx512-common-16.ll')
 
 shuffle1(i8)
 shuffle2(i8)
+shuffle1(i16)
+shuffle2(i16)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rcp/rsqrt declarations for half

--- a/builtins/target-avx512skx-x16.ll
+++ b/builtins/target-avx512skx-x16.ll
@@ -13,6 +13,28 @@ include(`target-avx512-common-16.ll')
 shuffle1(i8)
 shuffle2(i8)
 
+declare <WIDTH x i16> @llvm.x86.avx512.mask.permvar.hi.256(<WIDTH x i16>, <WIDTH x i16>, <WIDTH x i16>, i16)
+define <WIDTH x i16> @__shuffle_i16(<WIDTH x i16>, <WIDTH x i32>) nounwind readnone alwaysinline {
+  %ind = trunc <WIDTH x i32> %1 to <WIDTH x i16>
+  %res = call <WIDTH x i16> @llvm.x86.avx512.mask.permvar.hi.256(<WIDTH x i16> %0, <WIDTH x i16> %ind, <WIDTH x i16> zeroinitializer, i16 -1)
+  ret <WIDTH x i16> %res
+}
+
+declare <WIDTH x i16> @llvm.x86.avx512.vpermi2var.hi.256(<WIDTH x i16>, <WIDTH x i16>, <WIDTH x i16>)
+define <WIDTH x i16> @__shuffle2_i16(<WIDTH x i16>, <WIDTH x i16>, <WIDTH x i32>) nounwind readnone alwaysinline {
+  %isc = call i1 @__is_compile_time_constant_varying_int32(<WIDTH x i32> %2)
+  br i1 %isc, label %is_const, label %not_const
+
+is_const:
+  %res_const = tail call <WIDTH x i16> @__shuffle2_const_i16(<WIDTH x i16> %0, <WIDTH x i16> %1, <WIDTH x i32> %2)
+  ret <WIDTH x i16> %res_const
+
+not_const:
+  %ind = trunc <WIDTH x i32> %2 to <WIDTH x i16>
+  %res = call <WIDTH x i16> @llvm.x86.avx512.vpermi2var.hi.256(<WIDTH x i16> %0, <WIDTH x i16> %ind, <WIDTH x i16> %1)
+  ret <WIDTH x i16> %res
+}
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rcp/rsqrt declarations for half
 rcph_rsqrth_decl

--- a/builtins/target-avx512spr-x16.ll
+++ b/builtins/target-avx512spr-x16.ll
@@ -32,6 +32,29 @@ not_const:
   ret <WIDTH x i8> %res
 }
 
+declare <WIDTH x i16> @llvm.x86.avx512.mask.permvar.hi.256(<WIDTH x i16>, <WIDTH x i16>, <WIDTH x i16>, i16)
+define <WIDTH x i16> @__shuffle_i16(<WIDTH x i16>, <WIDTH x i32>) nounwind readnone alwaysinline {
+  %ind = trunc <WIDTH x i32> %1 to <WIDTH x i16>
+  %res = call <WIDTH x i16> @llvm.x86.avx512.mask.permvar.hi.256(<WIDTH x i16> %0, <WIDTH x i16> %ind, <WIDTH x i16> zeroinitializer, i16 -1)
+  ret <WIDTH x i16> %res
+}
+
+declare <WIDTH x i16> @llvm.x86.avx512.vpermi2var.hi.256(<WIDTH x i16>, <WIDTH x i16>, <WIDTH x i16>)
+define <WIDTH x i16> @__shuffle2_i16(<WIDTH x i16>, <WIDTH x i16>, <WIDTH x i32>) nounwind readnone alwaysinline {
+  %isc = call i1 @__is_compile_time_constant_varying_int32(<WIDTH x i32> %2)
+  br i1 %isc, label %is_const, label %not_const
+
+is_const:
+  %res_const = tail call <WIDTH x i16> @__shuffle2_const_i16(<WIDTH x i16> %0, <WIDTH x i16> %1, <WIDTH x i32> %2)
+  ret <WIDTH x i16> %res_const
+
+not_const:
+  %ind = trunc <WIDTH x i32> %2 to <WIDTH x i16>
+  %res = call <WIDTH x i16> @llvm.x86.avx512.vpermi2var.hi.256(<WIDTH x i16> %0, <WIDTH x i16> %ind, <WIDTH x i16> %1)
+  ret <WIDTH x i16> %res
+}
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; svml
 

--- a/examples/cpu/aobench/CMakeLists.txt
+++ b/examples/cpu/aobench/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -9,7 +9,7 @@
 set (ISPC_SRC_NAME "ao")
 set (TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/ao.cpp
                     ${CMAKE_CURRENT_SOURCE_DIR}/ao_serial.cpp)
-set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x4,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
+set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x4,avx1-i32x8,avx2-i32x8,avx512skx-x16" CACHE STRING "ISPC IA targets")
 set (ISPC_ARM_TARGETS "neon" CACHE STRING "ISPC ARM targets")
 add_ispc_example(NAME "aobench" ISPC_SRC_NAME ${ISPC_SRC_NAME}
               ISPC_IA_TARGETS ${ISPC_IA_TARGETS}

--- a/examples/cpu/deferred/CMakeLists.txt
+++ b/examples/cpu/deferred/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -12,7 +12,7 @@ set (TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/common.cpp
                     ${CMAKE_CURRENT_SOURCE_DIR}/deferred.h
                     ${CMAKE_CURRENT_SOURCE_DIR}/dynamic_c.cpp)
 set (ISPC_FLAGS "--opt=fast-math")
-set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x16,avx2-i32x16,avx512knl-x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
+set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x16,avx2-i32x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
 set (ISPC_ARM_TARGETS "neon" CACHE STRING "ISPC ARM targets")
 add_ispc_example(NAME "deferred_shading"
               ISPC_IA_TARGETS ${ISPC_IA_TARGETS}

--- a/examples/cpu/mandelbrot/CMakeLists.txt
+++ b/examples/cpu/mandelbrot/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -9,7 +9,7 @@
 set (ISPC_SRC_NAME "mandelbrot")
 set (TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/mandelbrot.cpp
                     ${CMAKE_CURRENT_SOURCE_DIR}/mandelbrot_serial.cpp)
-set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x16,avx2-i32x16,avx512knl-x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
+set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x16,avx2-i32x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
 set (ISPC_ARM_TARGETS "neon" CACHE STRING "ISPC ARM targets")
 add_ispc_example(NAME "mandelbrot"
               ISPC_IA_TARGETS ${ISPC_IA_TARGETS}

--- a/examples/cpu/mandelbrot_tasks/CMakeLists.txt
+++ b/examples/cpu/mandelbrot_tasks/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -9,7 +9,7 @@
 set (ISPC_SRC_NAME "mandelbrot_tasks")
 set (TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/mandelbrot_tasks.cpp
                     ${CMAKE_CURRENT_SOURCE_DIR}/mandelbrot_tasks_serial.cpp)
-set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x16,avx2-i32x16,avx512knl-x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
+set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x16,avx2-i32x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
 set (ISPC_ARM_TARGETS "neon" CACHE STRING "ISPC ARM targets")
 add_ispc_example(NAME "mandelbrot_tasks"
               ISPC_IA_TARGETS ${ISPC_IA_TARGETS}

--- a/examples/cpu/noise/CMakeLists.txt
+++ b/examples/cpu/noise/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -9,7 +9,7 @@
 set (ISPC_SRC_NAME "noise")
 set (TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/noise.cpp
                     ${CMAKE_CURRENT_SOURCE_DIR}/noise_serial.cpp)
-set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x4,avx1-i32x16,avx2-i32x16,avx512knl-x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
+set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x4,avx1-i32x16,avx2-i32x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
 set (ISPC_ARM_TARGETS "neon" CACHE STRING "ISPC ARM targets")
 add_ispc_example(NAME "noise"
               ISPC_IA_TARGETS ${ISPC_IA_TARGETS}

--- a/examples/cpu/options/CMakeLists.txt
+++ b/examples/cpu/options/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -10,7 +10,7 @@ set (ISPC_SRC_NAME "options")
 set (TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/options.cpp
                     ${CMAKE_CURRENT_SOURCE_DIR}/options_defs.h
                     ${CMAKE_CURRENT_SOURCE_DIR}/options_serial.cpp)
-set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x4,avx1-i32x16,avx2-i32x16,avx512knl-x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
+set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x4,avx1-i32x16,avx2-i32x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
 set (ISPC_ARM_TARGETS "neon" CACHE STRING "ISPC ARM targets")
 add_ispc_example(NAME "options"
               ISPC_IA_TARGETS ${ISPC_IA_TARGETS}

--- a/examples/cpu/rt/CMakeLists.txt
+++ b/examples/cpu/rt/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -9,7 +9,7 @@
 set (ISPC_SRC_NAME "rt")
 set (TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/rt.cpp
                     ${CMAKE_CURRENT_SOURCE_DIR}/rt_serial.cpp)
-set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
+set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512skx-x16" CACHE STRING "ISPC IA targets")
 set (ISPC_ARM_TARGETS "neon" CACHE STRING "ISPC ARM targets")
 set (DATA_FILES ${CMAKE_CURRENT_SOURCE_DIR}/cornell.bvh
                 ${CMAKE_CURRENT_SOURCE_DIR}/cornell.camera

--- a/examples/cpu/sgemm/CMakeLists.txt
+++ b/examples/cpu/sgemm/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -8,7 +8,7 @@
 #
 set (ISPC_SRC_NAME "SGEMM_kernels")
 set (TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/SGEMM_main.cpp)
-set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
+set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512skx-x16" CACHE STRING "ISPC IA targets")
 set (ISPC_ARM_TARGETS "neon" CACHE STRING "ISPC ARM targets")
 add_ispc_example(NAME "sgemm"
               ISPC_IA_TARGETS ${ISPC_IA_TARGETS}

--- a/examples/cpu/sort/CMakeLists.txt
+++ b/examples/cpu/sort/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -9,7 +9,7 @@
 set (ISPC_SRC_NAME "sort")
 set (TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/sort.cpp
                     ${CMAKE_CURRENT_SOURCE_DIR}/sort_serial.cpp)
-set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
+set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512skx-x16" CACHE STRING "ISPC IA targets")
 set (ISPC_ARM_TARGETS "neon" CACHE STRING "ISPC ARM targets")
 add_ispc_example(NAME "sort"
               ISPC_IA_TARGETS ${ISPC_IA_TARGETS}

--- a/examples/cpu/stencil/CMakeLists.txt
+++ b/examples/cpu/stencil/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -9,7 +9,7 @@
 set (ISPC_SRC_NAME "stencil")
 set (TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/stencil.cpp
                     ${CMAKE_CURRENT_SOURCE_DIR}/stencil_serial.cpp)
-set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
+set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512skx-x16" CACHE STRING "ISPC IA targets")
 set (ISPC_ARM_TARGETS "neon" CACHE STRING "ISPC ARM targets")
 add_ispc_example(NAME "stencil"
               ISPC_IA_TARGETS ${ISPC_IA_TARGETS}

--- a/examples/cpu/volume_rendering/CMakeLists.txt
+++ b/examples/cpu/volume_rendering/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -9,7 +9,7 @@
 set (ISPC_SRC_NAME "volume")
 set (TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/volume.cpp
                     ${CMAKE_CURRENT_SOURCE_DIR}/volume_serial.cpp)
-set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512knl-x16,avx512skx-x16" CACHE STRING "ISPC IA targets")
+set (ISPC_IA_TARGETS "sse2-i32x4,sse4-i32x8,avx1-i32x8,avx2-i32x8,avx512skx-x16" CACHE STRING "ISPC IA targets")
 set (ISPC_ARM_TARGETS "neon" CACHE STRING "ISPC ARM targets")
 set (DATA_FILES ${CMAKE_CURRENT_SOURCE_DIR}/camera.dat
                 ${CMAKE_CURRENT_SOURCE_DIR}/density_highres.vol

--- a/examples/xpu/mandelbrot/CMakeLists.txt
+++ b/examples/xpu/mandelbrot/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2020-2023, Intel Corporation
+#  Copyright (c) 2020-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.13)
 set(TEST_NAME "mandelbrot")
 set(ISPC_SRC_NAME "mandelbrot.ispc")
 set(ISPC_TARGET_XE "gen9-x16")
-set(ISPC_TARGET_CPU "sse4-i8x16;avx1-i32x16;avx2-i32x16;avx512knl-x16;avx512skx-x16")
+set(ISPC_TARGET_CPU "sse4-i8x16;avx1-i32x16;avx2-i32x16;avx512skx-x16")
 set(HOST_SOURCES mandelbrot.cpp mandelbrot_serial.cpp)
 
 add_perf_example(

--- a/tests/lit-tests/fp16_code_gen.ispc
+++ b/tests/lit-tests/fp16_code_gen.ispc
@@ -95,7 +95,7 @@ unmasked float16 fp16_fnms(float16 a, float16 b, float16 c) {
 }
 
 // CHECK_SPR-LABEL: fp16_round
-// CHECK_SPR: vrndscalesh $8
+// CHECK_SPR: vrndscale{{sh|ph}} $8
 unmasked float16 fp16_round(float16 a) {
   return round(a);
 }

--- a/tests/lit-tests/interleaved.ispc
+++ b/tests/lit-tests/interleaved.ispc
@@ -3,6 +3,9 @@
 // RUN: %{ispc} %s --target=sse4 -O2 --opt=fast-math  -h %t.h --emit-asm -o - | FileCheck %s -check-prefix=CHECK_SSE
 // RUN: %{ispc} %s --target=sse2 -O2 --opt=fast-math  -h %t.h --emit-asm -o - | FileCheck %s -check-prefix=CHECK_SSE
 // REQUIRES: X86_ENABLED && LLVM_14_0+
+// The test is failing starting LLVM 18.0
+// Related issues: #2813, #2870 and PR2864
+// XFAIL: LLVM_18_0+
 export void test_interleaved(const uniform float xin[],
                              const uniform float yin[],
                              const uniform float zin[],

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -51,6 +51,12 @@ if llvm_version_major >= 17:
 else:
     print("LLVM_17_0+: NO")
 
+if llvm_version_major >= 18:
+    print("LLVM_18_0+: YES")
+    config.available_features.add("LLVM_18_0+")
+else:
+    print("LLVM_18_0+: NO")
+
 if llvm_version_major >= 19:
     print("LLVM_19_0+: YES")
     config.available_features.add("LLVM_19_0+")

--- a/tests/lit-tests/loop_unroll_varying.ispc
+++ b/tests/lit-tests/loop_unroll_varying.ispc
@@ -43,23 +43,7 @@ void foo_for() {
 // CHECKO0:         br label %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO0:         }
 
-// CHECKO2:         for_loop{{.*}}:
-// CHECKO2:         call void @goo_for_unroll8___
-// CHECKO2:         for_loop{{.*}}:
-// CHECKO2:         call void @goo_for_unroll8___
-// CHECKO2:         for_loop{{.*}}:
-// CHECKO2:         call void @goo_for_unroll8___
-// CHECKO2:         for_loop{{.*}}:
-// CHECKO2:         call void @goo_for_unroll8___
-// CHECKO2:         for_loop{{.*}}:
-// CHECKO2:         call void @goo_for_unroll8___
-// CHECKO2:         for_loop{{.*}}:
-// CHECKO2:         call void @goo_for_unroll8___
-// CHECKO2:         for_loop{{.*}}:
-// CHECKO2:         call void @goo_for_unroll8___
-// CHECKO2:         for_loop{{.*}}:
-// CHECKO2:         call void @goo_for_unroll8___
-// CHECKO2-NOT:     call void @goo_for_unroll8___
+// CHECKO2-COUNT-8:         call void @goo_for_unroll8___
 // CHECKO2:         br {{(i1)|(label)}} %{{[a-zA-Z_][a-zA-Z0-9_.]*}}
 // CHECKO2:         }
 

--- a/tests/lit-tests/signed-integer-overflow.ispc
+++ b/tests/lit-tests/signed-integer-overflow.ispc
@@ -150,14 +150,15 @@ unmasked uint16 shl_u16(uint16 a, uint16 b) { return a << b; }
 
 unmasked uint8 shl_u8(uint8 a, uint8 b) { return a << b; }
 
-
-// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i64> @neg_64
+// Starting LLVM 19.0 there is a range attribute in @neg* functions:
+// For example: define range(i8 -127, -128) <8 x i8>
+// CHECK_NSW-LABEL:         define {{.*}}<{{[0-9]*}} x i64> @neg_64
 // CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i64
-// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i32> @neg_32
+// CHECK_NSW-LABEL:         define {{.*}}<{{[0-9]*}} x i32> @neg_32
 // CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i32
-// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i16> @neg_16
+// CHECK_NSW-LABEL:         define {{.*}}<{{[0-9]*}} x i16> @neg_16
 // CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i16
-// CHECK_NSW-LABEL:         define <{{[0-9]*}} x i8> @neg_8
+// CHECK_NSW-LABEL:         define {{.*}}<{{[0-9]*}} x i8> @neg_8
 // CHECK_NSW-COUNT-1:         %{{.*}}= sub{{.*}}nsw{{.*}}i8
 
 unmasked int64 neg_64(int64 a) { return -a; }


### PR DESCRIPTION
1. Fixed lit tests for LLVM 19+ build unlocking the testing in CI
2. Skip avx512 targets on x86 target in nightly and trunk testing.
3. Remove LLVM rebuild in nightly LLVM 17.0 testing. BTW I'm not fully understand why do we need this workflow at all, this testing is covered by ispc-ci.yml
4. Fixed shuffles for avx512-knl targets (deprecated, not tested anywhere except nightly 17.0 testing)
