### PR TITLE
ReplaceMaskedMemOps: support masked ops of length 3

### DIFF
--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -589,6 +589,7 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
             optPM.addFunctionPass(llvm::GVNPass(), 301);
         }
         optPM.addFunctionPass(ReplaceMaskedMemOpsPass());
+        optPM.addFunctionPass(llvm::InstCombinePass());
         optPM.addFunctionPass(IsCompileTimeConstantPass(true));
         optPM.addFunctionPass(IntrinsicsOpt());
         optPM.addFunctionPass(InstructionSimplifyPass());

--- a/tests/lit-tests/2611.ll
+++ b/tests/lit-tests/2611.ll
@@ -20,10 +20,11 @@ define void @foo(<4 x i32>* %a, <4 x i32>* %b) {
   ret void
 }
 
-; CHECK-LABEL: @bad_mask
-; CHECK-NEXT: call <4 x i32> @llvm.masked.load
-; CHECK-NEXT: ret void
-define void @bad_mask(<4 x i32>* %a) {
+; CHECK-LABEL: @mask3
+; CHECK-NEXT  [[HL:%.*]] = load <3 x i32>, ptr %a, align 1
+; CHECK-NEXT  [[VEC:%.*]] = shufflevector <3 x i32> [[HL]], <3 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT ret void
+define void @mask3(<4 x i32>* %a) {
   %vec1 = call <4 x i32> @llvm.masked.load.v4i32.p0v4i32(<4 x i32>* %a, i32 1,
                                                         <4 x i1> <i1 true, i1 true, i1 true, i1 false>,
                                                         <4 x i32> <i32 poison, i32 poison, i32 0, i32 0>)

--- a/tests/lit-tests/2955.ispc
+++ b/tests/lit-tests/2955.ispc
@@ -1,0 +1,19 @@
+// RUN: %{ispc} --target=avx2-i32x8 --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK-NOT: vandps  ymm{{.*}}, ymm{{.*}}, ymm{{.*}}
+
+struct FVector3 {
+    float V[3];
+};
+
+uniform FVector3 VectorBitwiseAnd(const uniform FVector3 &Vec1, const uniform FVector3 &Vec2) {
+    uniform FVector3 Result;
+
+    foreach (i = 0 ... 3) {
+        Result.V[i] = floatbits(intbits(Vec1.V[i]) & intbits(Vec2.V[i]));
+    }
+
+    return Result;
+}

--- a/tests/lit-tests/2955.ll
+++ b/tests/lit-tests/2955.ll
@@ -1,0 +1,20 @@
+; RUN: %{ispc-opt} --passes=replace-masked-memory-ops %s -o - | FileCheck %s
+
+; REQUIRES: LLVM_17_0+
+
+declare <8 x float> @llvm.masked.load.v8f32.p0(ptr nocapture, i32 immarg, <8 x i1>, <8 x float>) #1
+declare void @llvm.masked.store.v8f32.p0(<8 x float>, ptr nocapture, i32 immarg, <8 x i1>) #2
+
+; CHECK-LABEL: @foo
+; CHECK-NEXT:  [[HL:%.*]] = load <3 x float>, ptr %0, align 1
+; CHECK-NEXT:  [[V4:%.*]] = shufflevector <3 x float> [[HL]], <3 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:  [[VEC:%.*]] = shufflevector <4 x float> [[V4]], <4 x float> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:  [[HS:%.*]] = shufflevector <8 x float> [[VEC]], <8 x float> undef, <3 x i32> <i32 0, i32 1, i32 2>
+; CHECK-NEXT:  store <3 x float> [[HS]], ptr %1, align 1
+; CHECK-NEXT:  ret void
+
+define void @foo(ptr noalias %0, ptr noalias %1) local_unnamed_addr {
+  %x = tail call <8 x float> @llvm.masked.load.v8f32.p0(ptr %0, i32 1, <8 x i1> <i1 true, i1 true, i1 true, i1 false, i1 false, i1 false, i1 false, i1 false>, <8 x float> poison)
+  call void @llvm.masked.store.v8f32.p0(<8 x float> %x, ptr %1, i32 1, <8 x i1> <i1 true, i1 true, i1 true, i1 false, i1 false, i1 false, i1 false, i1 false>)
+  ret void
+}


### PR DESCRIPTION
This PR supports the replacement of masked memory operations of effective length 3 with unmasked ones in ReplaceMaskedMemOps. This fixes issue #2955.