### PR TITLE
Support more attributes for target redesign

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -137,6 +137,7 @@ Contents:
 
     * `noescape`_
     * `address_space`_
+    * `unmangled`_
 
   + `Expressions`_
 
@@ -2868,6 +2869,19 @@ not supported.
 
     // allocation of data in non-default address space is not supported
     __attribute__((address_space(1))) uniform int x;
+
+
+unmangled
+---------
+
+``__attribute__((unmangled))`` can be applied to a function declaration to
+prevent its name from being mangled. This is useful when name mangling is not
+desired, but other qualifiers like ``export`` or ``extern`` are unsuitable due
+to the additional features they introduce.
+
+::
+
+    __attribute__((unmangled)) void foo(int a, int b);
 
 
 Expressions

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -200,6 +200,7 @@ bool Attribute::IsKnownAttribute() const {
         {"noescape", 1},
         {"address_space", 1},
         {"unmangled", 1},
+        {"memory", 1},
     };
 
     if (lKnownParamAttrs.find(name) != lKnownParamAttrs.end()) {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1111,6 +1111,19 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
 
     AddUWTableFuncAttr(function);
 
+    if (auto al = decl->attributeList) {
+        if (al->HasAttribute("memory")) {
+            auto memory = al->GetAttribute("memory")->arg.stringVal;
+            if (memory == "none") {
+                function->setDoesNotAccessMemory();
+            } else if (memory == "read") {
+                function->setOnlyReadsMemory();
+            } else {
+                Error(pos, "Unknown memory attribute \"%s\".", memory.c_str());
+            }
+        }
+    }
+
     if (functionType->isTask) {
         if (!g->target->isXeTarget()) {
             // This also applies transitively to members I think?

--- a/src/type.h
+++ b/src/type.h
@@ -929,7 +929,7 @@ class FunctionType : public Type {
     FunctionType(const Type *returnType, const llvm::SmallVector<const Type *, 8> &argTypes,
                  const llvm::SmallVector<std::string, 8> &argNames, const llvm::SmallVector<Expr *, 8> &argDefaults,
                  const llvm::SmallVector<SourcePos, 8> &argPos, bool isTask, bool isExported, bool isExternC,
-                 bool isExternSYCL, bool isUnmasked, bool isVectorCall, bool isRegCall);
+                 bool isExternSYCL, bool isUnmasked, bool isUnmangled, bool isVectorCall, bool isRegCall);
     // Structure holding the mangling suffix and prefix for function
     struct FunctionMangledName {
         std::string prefix;
@@ -1023,6 +1023,8 @@ class FunctionType : public Type {
         parameter (and thus should start execution with an "all on"
         mask). */
     const bool isUnmasked;
+
+    const bool isUnmangled;
 
     /** Indicates whether the function has __vectorcall attribute. */
     const bool isVectorCall;

--- a/tests/lit-tests/err-memory-attr.ispc
+++ b/tests/lit-tests/err-memory-attr.ispc
@@ -1,0 +1,12 @@
+// RUN: not %{ispc} --nowrap --target=host %s -o - --emit-llvm-text 2>&1 | FileCheck %s
+
+#define MEM(A) __attribute__((memory(#A)))
+
+// CHECK: Unknown memory attribute "WRITE".
+MEM(WRITE) void bar();
+
+// CHECK: Unknown memory attribute "READ".
+MEM(READ) void foo();
+
+// CHECK: Unknown memory attribute "NONE".
+MEM(NONE) void foo1();

--- a/tests/lit-tests/err-unmangled.ispc
+++ b/tests/lit-tests/err-unmangled.ispc
@@ -1,0 +1,12 @@
+// RUN: not %{ispc} --nowrap --target=host %s -o - --emit-llvm-text 2>&1 | FileCheck %s
+
+#define UNMANGLED __attribute__((unmangled))
+
+CHECK: Error: Function can't have both "extern" "C" and "unmangled" qualifiers
+UNMANGLED extern "C" void bar();
+
+// CHECK: Error: Function can't have both "extern" "SYCL" and "unmangled" qualifiers
+UNMANGLED extern "SYCL" void func();
+
+// CHECK: Error: Function can't have both "export" and "unmangled" qualifiers
+UNMANGLED export void foo();

--- a/tests/lit-tests/memory-attr.ispc
+++ b/tests/lit-tests/memory-attr.ispc
@@ -1,0 +1,20 @@
+// RUN: %{ispc} --target=host %s -o - --emit-llvm-text | FileCheck %s
+// RUN: %{ispc} --target=host --debug-phase=0:0 %s -o t.o | FileCheck %s --check-prefix=CHECK-DECL
+
+// Before LLVM 16.0, the memory attribute was displayed as readonly, readnone
+// not as memory(read), memory(none).
+// REQUIRES: LLVM_16_0+
+
+// CHECK: ; Function Attrs: {{.*}} memory(none)
+// CHECK-LABEL: define {{.*}} @foo___univyi{{.*}}
+// CHECK: ; Function Attrs: {{.*}} memory(argmem: read)
+// CHECK-LABEL: define i32 @bar___un_3C_uni_3E_{{.*}}
+__attribute__((memory("none"))) int foo(uniform int x, int y) { return y; }
+__attribute__((memory("read"))) uniform int bar(uniform int *uniform p) { return *p; }
+
+// CHECK-DECL: ; Function Attrs: nounwind memory(read)
+// CHECK-DECL-LABEL: declare void @func1{{.*}}
+// CHECK-DECL: ; Function Attrs: nounwind memory(none)
+// CHECK-DECL-LABEL: declare void @func2{{.*}}
+__attribute__((memory("read"))) void func1();
+__attribute__((memory("none"))) void func2();

--- a/tests/lit-tests/unmangled.ispc
+++ b/tests/lit-tests/unmangled.ispc
@@ -1,0 +1,11 @@
+// RUN: %{ispc} --target=host %s -o - --emit-llvm-text | FileCheck %s
+// RUN: %{ispc} --target=host --debug-phase=0:0 %s -o t.o | FileCheck %s --check-prefix=CHECK-BAR
+
+// CHECK: define <[[WIDTH:[0-9]+]] x i32> @foo(i32 %x, <[[WIDTH]] x i32> {{.*}} %y, <[[WIDTH]] x {{.*}}> %__mask)
+__attribute__((unmangled)) int foo(uniform int x, int y) { return y; }
+
+// CHECK-BAR: declare void @bar({{.*}})
+__attribute__((unmangled)) void bar();
+
+// CHECK-BAR: declare void @bar1()
+__attribute__((unmangled)) unmasked void bar1();


### PR DESCRIPTION
This PR supports attributes: `unmangled`, `memory("read")`, `memory("none")`. 

This fixes #2956.