### PR TITLE
Updates for Xe targets (27)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,7 +349,7 @@ endif()
 
 list(APPEND ARM_TARGETS neon-i8x16 neon-i16x8 neon-i32x4 neon-i32x8)
 list(APPEND WASM_TARGETS wasm-i32x4)
-list(APPEND XE_TARGETS gen9-x16 gen9-x8 xelp-x16 xelp-x8 xehpg-x16 xehpg-x8 xehpc-x16 xehpc-x32 xelpg-x16 xelpg-x8 xe2hpg-x16 xe2hpg-x32)
+list(APPEND XE_TARGETS gen9-x16 gen9-x8 xelp-x16 xelp-x8 xehpg-x16 xehpg-x8 xehpc-x16 xehpc-x32 xelpg-x16 xelpg-x8 xe2hpg-x16 xe2hpg-x32 xe2lpg-x16 xe2lpg-x32)
 
 if (X86_ENABLED)
     list(APPEND ISPC_TARGETS ${X86_TARGETS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,7 +349,7 @@ endif()
 
 list(APPEND ARM_TARGETS neon-i8x16 neon-i16x8 neon-i32x4 neon-i32x8)
 list(APPEND WASM_TARGETS wasm-i32x4)
-list(APPEND XE_TARGETS gen9-x16 gen9-x8 xelp-x16 xelp-x8 xehpg-x16 xehpg-x8 xehpc-x16 xehpc-x32 xelpg-x16 xelpg-x8)
+list(APPEND XE_TARGETS gen9-x16 gen9-x8 xelp-x16 xelp-x8 xehpg-x16 xehpg-x8 xehpc-x16 xehpc-x32 xelpg-x16 xelpg-x8 xe2hpg-x16 xe2hpg-x32)
 
 if (X86_ENABLED)
     list(APPEND ISPC_TARGETS ${X86_TARGETS})

--- a/builtins/target-xe2hpg-x16.ll
+++ b/builtins/target-xe2hpg-x16.ll
@@ -1,0 +1,11 @@
+;;  Copyright (c) 2023-2024, Intel Corporation
+;;
+;;  SPDX-License-Identifier: BSD-3-Clause
+
+define(`WIDTH',`16')
+define(`WIDTH_X2',`32')
+define(`WIDTH_X4',`64')
+define(`XE_SUFFIX',`CONCAT(`v16', XE_TYPE($1))')
+define(`BITCAST_WIDTH',`i16')
+
+include(`target-xe.ll')

--- a/builtins/target-xe2hpg-x32.ll
+++ b/builtins/target-xe2hpg-x32.ll
@@ -1,0 +1,11 @@
+;;  Copyright (c) 2023-2024, Intel Corporation
+;;
+;;  SPDX-License-Identifier: BSD-3-Clause
+
+define(`WIDTH',`32')
+define(`WIDTH_X2',`64')
+define(`WIDTH_X4',`128')
+define(`XE_SUFFIX',`CONCAT(`v32', XE_TYPE($1))')
+define(`BITCAST_WIDTH',`i32')
+
+include(`target-xe.ll')

--- a/builtins/target-xe2lpg-x16.ll
+++ b/builtins/target-xe2lpg-x16.ll
@@ -1,0 +1,11 @@
+;;  Copyright (c) 2024, Intel Corporation
+;;
+;;  SPDX-License-Identifier: BSD-3-Clause
+
+define(`WIDTH',`16')
+define(`WIDTH_X2',`32')
+define(`WIDTH_X4',`64')
+define(`XE_SUFFIX',`CONCAT(`v16', XE_TYPE($1))')
+define(`BITCAST_WIDTH',`i16')
+
+include(`target-xe.ll')

--- a/builtins/target-xe2lpg-x32.ll
+++ b/builtins/target-xe2lpg-x32.ll
@@ -1,0 +1,11 @@
+;;  Copyright (c) 2024, Intel Corporation
+;;
+;;  SPDX-License-Identifier: BSD-3-Clause
+
+define(`WIDTH',`32')
+define(`WIDTH_X2',`64')
+define(`WIDTH_X4',`128')
+define(`XE_SUFFIX',`CONCAT(`v32', XE_TYPE($1))')
+define(`BITCAST_WIDTH',`i32')
+
+include(`target-xe.ll')

--- a/fail_db.txt
+++ b/fail_db.txt
@@ -6,30 +6,6 @@
 % folder). The recommended way to build LLVM on Unix is to use "alloy.py".
 %
  List of known fails.
-./tests/short-vec-6.ispc runfail    xe64        gen9-x8 unspec   Linux LLVM 14.0 clang++14.0 O0 spv *
-./tests/short-vec-6.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 14.0 clang++14.0 O0 spv *
-./tests/int8-wrap.ispc runfail    xe64      xehpc-x16 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/padds-i64.ispc runfail    xe64      xehpc-x16 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/padds-vi64.ispc runfail    xe64      xehpc-x16 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/paddus-i64.ispc runfail    xe64      xehpc-x16 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/paddus-vi64.ispc runfail    xe64      xehpc-x16 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/pmuls-i64.ispc runfail    xe64      xehpc-x16 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/pmuls-vi64.ispc runfail    xe64      xehpc-x16 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/pmulus-i64.ispc runfail    xe64      xehpc-x16 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/pmulus-vi64.ispc runfail    xe64      xehpc-x16 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/psubs-i64.ispc runfail    xe64      xehpc-x16 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/psubs-vi64.ispc runfail    xe64      xehpc-x16 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/int8-wrap.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/padds-i64.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/padds-vi64.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/paddus-i64.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/paddus-vi64.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/pmuls-i64.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/pmuls-vi64.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/pmulus-i64.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/pmulus-vi64.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/psubs-i64.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
-./tests/psubs-vi64.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 14.0 clang++14.0 O2 spv *
 ./tests/short-vec-6.ispc runfail    xe64        gen9-x8 unspec   Linux LLVM 15.0 clang++15.0 O0 spv *
 ./tests/short-vec-6.ispc runfail    xe64       gen9-x16 unspec   Linux LLVM 15.0 clang++15.0 O0 spv *
 ./tests/int8-wrap.ispc runfail    xe64      xehpc-x32 pvc   Linux LLVM 15.0 clang++15.0 O2 spv *

--- a/run_tests.py
+++ b/run_tests.py
@@ -838,6 +838,9 @@ def run_tests(options1, args, print_version):
 
     target = TargetConfig(options.arch, options.target, options.device)
 
+    if target.target.startswith("xe2lpg") and not 'ISPCRT_IGC_OPTIONS' in os.environ:
+       os.environ['ISPCRT_IGC_OPTIONS'] = '+ -ftranslate-legacy-memory-intrinsics'
+
     if options.debug_check and (not target.is_xe() or not host.is_linux()):
         print("--debug_check is supported only for xe target and only on Linux OS")
         exit_code = 1
@@ -846,6 +849,7 @@ def run_tests(options1, args, print_version):
     print_debug("Testing ISPC compiler: " + host.ispc_exe + "\n", s, run_tests_log)
     print_debug("Testing ISPC target: %s\n" % options.target, s, run_tests_log)
     print_debug("Testing ISPC arch: %s\n" % options.arch, s, run_tests_log)
+    print_debug("ISPCRT_IGC_OPTIONS: %s\n" % os.environ.get('ISPCRT_IGC_OPTIONS', None), s, run_tests_log)
 
     set_compiler_exe(host, options)
     set_ispc_output(target, options)

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -358,8 +358,8 @@ typedef enum {
     GPU_ACM_G11,
     GPU_ACM_G12,
     GPU_PVC,
-    GPU_MTL_M,
-    GPU_MTL_P,
+    GPU_MTL_U,
+    GPU_MTL_H,
     GPU_XE2_HPG_X2_A0,
 #endif
     sizeofDeviceType
@@ -419,8 +419,8 @@ std::map<DeviceType, std::set<std::string>> CPUFeatures = {
     {GPU_ACM_G11, {}},
     {GPU_ACM_G12, {}},
     {GPU_PVC, {}},
-    {GPU_MTL_M, {}},
-    {GPU_MTL_P, {}},
+    {GPU_MTL_U, {}},
+    {GPU_MTL_H, {}},
     {GPU_XE2_HPG_X2_A0, {}},
 #endif
 };
@@ -532,8 +532,8 @@ class AllCPUs {
         // ACM 256EU version
         names[GPU_ACM_G12].push_back("acm-g12");
         names[GPU_PVC].push_back("pvc");
-        names[GPU_MTL_M].push_back("mtl-m");
-        names[GPU_MTL_P].push_back("mtl-p");
+        names[GPU_MTL_U].push_back("mtl-u");
+        names[GPU_MTL_H].push_back("mtl-h");
         names[GPU_XE2_HPG_X2_A0].push_back("xe2-hpg-x2-a0");
 #endif
 
@@ -618,11 +618,11 @@ class AllCPUs {
         compat[GPU_ACM_G11] = Set(GPU_ACM_G10, GPU_ACM_G11, GPU_ACM_G12, GPU_TGLLP, GPU_SKL, CPU_None);
         compat[GPU_ACM_G12] = Set(GPU_ACM_G10, GPU_ACM_G11, GPU_ACM_G12, GPU_TGLLP, GPU_SKL, CPU_None);
         compat[GPU_PVC] = Set(GPU_PVC, GPU_SKL, CPU_None);
-        compat[GPU_MTL_M] =
-            Set(GPU_MTL_M, GPU_MTL_P, GPU_ACM_G10, GPU_ACM_G11, GPU_ACM_G12, GPU_ACM_G11, GPU_TGLLP, GPU_SKL, CPU_None);
-        compat[GPU_MTL_P] =
-            Set(GPU_MTL_M, GPU_MTL_P, GPU_ACM_G10, GPU_ACM_G11, GPU_ACM_G12, GPU_ACM_G11, GPU_TGLLP, GPU_SKL, CPU_None);
-        compat[GPU_XE2_HPG_X2_A0] = Set(GPU_XE2_HPG_X2_A0, GPU_MTL_M, GPU_MTL_P, GPU_ACM_G10,
+        compat[GPU_MTL_U] =
+            Set(GPU_MTL_U, GPU_MTL_H, GPU_ACM_G10, GPU_ACM_G11, GPU_ACM_G12, GPU_ACM_G11, GPU_TGLLP, GPU_SKL, CPU_None);
+        compat[GPU_MTL_H] =
+            Set(GPU_MTL_U, GPU_MTL_H, GPU_ACM_G10, GPU_ACM_G11, GPU_ACM_G12, GPU_ACM_G11, GPU_TGLLP, GPU_SKL, CPU_None);
+        compat[GPU_XE2_HPG_X2_A0] = Set(GPU_XE2_HPG_X2_A0, GPU_MTL_U, GPU_MTL_H, GPU_ACM_G10,
                                         GPU_ACM_G11, GPU_ACM_G12, GPU_ACM_G11, GPU_TGLLP, GPU_SKL, CPU_None);
 #endif
     }
@@ -737,8 +737,8 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         case GPU_PVC:
             m_ispc_target = ISPCTarget::xehpc_x16;
             break;
-        case GPU_MTL_M:
-        case GPU_MTL_P:
+        case GPU_MTL_U:
+        case GPU_MTL_H:
             m_ispc_target = ISPCTarget::xelpg_x16;
             break;
         case GPU_XE2_HPG_X2_A0:
@@ -1546,7 +1546,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasTranscendentals = true;
         this->m_hasTrigonometry = true;
         this->m_hasGather = this->m_hasScatter = true;
-        CPUfromISA = GPU_MTL_P;
+        CPUfromISA = GPU_MTL_H;
         break;
     case ISPCTarget::xelpg_x16:
         this->m_isa = Target::XELPG;
@@ -1562,7 +1562,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasTranscendentals = true;
         this->m_hasTrigonometry = true;
         this->m_hasGather = this->m_hasScatter = true;
-        CPUfromISA = GPU_MTL_P;
+        CPUfromISA = GPU_MTL_H;
         break;
     case ISPCTarget::xe2hpg_x16:
         this->m_isa = Target::XE2HPG;
@@ -2266,8 +2266,8 @@ Target::XePlatform Target::getXePlatform() const {
         return XePlatform::xe_hpg;
     case GPU_PVC:
         return XePlatform::xe_hpc;
-    case GPU_MTL_M:
-    case GPU_MTL_P:
+    case GPU_MTL_U:
+    case GPU_MTL_H:
         return XePlatform::xe_lpg;
     case GPU_XE2_HPG_X2_A0:
         return XePlatform::xe2_hpg;

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -360,6 +360,7 @@ typedef enum {
     GPU_PVC,
     GPU_MTL_M,
     GPU_MTL_P,
+    GPU_XE2_HPG_X2_A0,
 #endif
     sizeofDeviceType
 } DeviceType;
@@ -420,6 +421,7 @@ std::map<DeviceType, std::set<std::string>> CPUFeatures = {
     {GPU_PVC, {}},
     {GPU_MTL_M, {}},
     {GPU_MTL_P, {}},
+    {GPU_XE2_HPG_X2_A0, {}},
 #endif
 };
 
@@ -532,6 +534,7 @@ class AllCPUs {
         names[GPU_PVC].push_back("pvc");
         names[GPU_MTL_M].push_back("mtl-m");
         names[GPU_MTL_P].push_back("mtl-p");
+        names[GPU_XE2_HPG_X2_A0].push_back("xe2-hpg-x2-a0");
 #endif
 
         Assert(names.size() == sizeofDeviceType);
@@ -619,6 +622,8 @@ class AllCPUs {
             Set(GPU_MTL_M, GPU_MTL_P, GPU_ACM_G10, GPU_ACM_G11, GPU_ACM_G12, GPU_ACM_G11, GPU_TGLLP, GPU_SKL, CPU_None);
         compat[GPU_MTL_P] =
             Set(GPU_MTL_M, GPU_MTL_P, GPU_ACM_G10, GPU_ACM_G11, GPU_ACM_G12, GPU_ACM_G11, GPU_TGLLP, GPU_SKL, CPU_None);
+        compat[GPU_XE2_HPG_X2_A0] = Set(GPU_XE2_HPG_X2_A0, GPU_MTL_M, GPU_MTL_P, GPU_ACM_G10,
+                                        GPU_ACM_G11, GPU_ACM_G12, GPU_ACM_G11, GPU_TGLLP, GPU_SKL, CPU_None);
 #endif
     }
 
@@ -735,6 +740,9 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         case GPU_MTL_M:
         case GPU_MTL_P:
             m_ispc_target = ISPCTarget::xelpg_x16;
+            break;
+        case GPU_XE2_HPG_X2_A0:
+            m_ispc_target = ISPCTarget::xe2hpg_x16;
             break;
 #endif
 
@@ -1556,6 +1564,38 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasGather = this->m_hasScatter = true;
         CPUfromISA = GPU_MTL_P;
         break;
+    case ISPCTarget::xe2hpg_x16:
+        this->m_isa = Target::XE2HPG;
+        this->m_nativeVectorWidth = 16;
+        this->m_nativeVectorAlignment = 64;
+        this->m_vectorWidth = 16;
+        this->m_dataTypeWidth = 32;
+        this->m_hasHalfConverts = true;
+        this->m_hasHalfFullSupport = true;
+        this->m_maskingIsFree = true;
+        this->m_maskBitCount = 1;
+        this->m_hasSaturatingArithmetic = true;
+        this->m_hasTranscendentals = true;
+        this->m_hasTrigonometry = true;
+        this->m_hasGather = this->m_hasScatter = true;
+        CPUfromISA = GPU_XE2_HPG_X2_A0;
+        break;
+    case ISPCTarget::xe2hpg_x32:
+        this->m_isa = Target::XE2HPG;
+        this->m_nativeVectorWidth = 32;
+        this->m_nativeVectorAlignment = 64;
+        this->m_vectorWidth = 32;
+        this->m_dataTypeWidth = 32;
+        this->m_hasHalfConverts = true;
+        this->m_hasHalfFullSupport = true;
+        this->m_maskingIsFree = true;
+        this->m_maskBitCount = 1;
+        this->m_hasSaturatingArithmetic = true;
+        this->m_hasTranscendentals = true;
+        this->m_hasTrigonometry = true;
+        this->m_hasGather = this->m_hasScatter = true;
+        CPUfromISA = GPU_XE2_HPG_X2_A0;
+        break;
 #else
     case ISPCTarget::gen9_x8:
     case ISPCTarget::gen9_x16:
@@ -1567,6 +1607,8 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
     case ISPCTarget::xehpc_x32:
     case ISPCTarget::xelpg_x8:
     case ISPCTarget::xelpg_x16:
+    case ISPCTarget::xe2hpg_x16:
+    case ISPCTarget::xe2hpg_x32:
         unsupported_target = true;
         break;
 #endif
@@ -2051,6 +2093,8 @@ const char *Target::ISAToString(ISA isa) {
         return "xehpc";
     case Target::XELPG:
         return "xelpg";
+    case Target::XE2HPG:
+        return "xe2hpg";
 #endif
     default:
         FATAL("Unhandled target in ISAToString()");
@@ -2084,6 +2128,8 @@ const char *Target::ISAToTargetString(ISA isa) {
         return "xehpc-x16";
     case Target::XELPG:
         return "xelpg-x16";
+    case Target::XE2HPG:
+        return "xe2hpg-x16";
 #endif
     case Target::SSE2:
         return "sse2-i32x4";
@@ -2223,6 +2269,8 @@ Target::XePlatform Target::getXePlatform() const {
     case GPU_MTL_M:
     case GPU_MTL_P:
         return XePlatform::xe_lpg;
+    case GPU_XE2_HPG_X2_A0:
+        return XePlatform::xe2_hpg;
     default:
         return XePlatform::gen9;
     }
@@ -2238,6 +2286,7 @@ uint32_t Target::getXeGrfSize() const {
     case XePlatform::xe_lpg:
         return 32;
     case XePlatform::xe_hpc:
+    case XePlatform::xe2_hpg:
         return 64;
     default:
         return 32;

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -360,7 +360,7 @@ typedef enum {
     GPU_PVC,
     GPU_MTL_U,
     GPU_MTL_H,
-    GPU_XE2_HPG_X2_A0,
+    GPU_BMG_G21,
 #endif
     sizeofDeviceType
 } DeviceType;
@@ -421,7 +421,7 @@ std::map<DeviceType, std::set<std::string>> CPUFeatures = {
     {GPU_PVC, {}},
     {GPU_MTL_U, {}},
     {GPU_MTL_H, {}},
-    {GPU_XE2_HPG_X2_A0, {}},
+    {GPU_BMG_G21, {}},
 #endif
 };
 
@@ -534,7 +534,7 @@ class AllCPUs {
         names[GPU_PVC].push_back("pvc");
         names[GPU_MTL_U].push_back("mtl-u");
         names[GPU_MTL_H].push_back("mtl-h");
-        names[GPU_XE2_HPG_X2_A0].push_back("xe2-hpg-x2-a0");
+        names[GPU_BMG_G21].push_back("bmg-g21");
 #endif
 
         Assert(names.size() == sizeofDeviceType);
@@ -622,8 +622,8 @@ class AllCPUs {
             Set(GPU_MTL_U, GPU_MTL_H, GPU_ACM_G10, GPU_ACM_G11, GPU_ACM_G12, GPU_ACM_G11, GPU_TGLLP, GPU_SKL, CPU_None);
         compat[GPU_MTL_H] =
             Set(GPU_MTL_U, GPU_MTL_H, GPU_ACM_G10, GPU_ACM_G11, GPU_ACM_G12, GPU_ACM_G11, GPU_TGLLP, GPU_SKL, CPU_None);
-        compat[GPU_XE2_HPG_X2_A0] = Set(GPU_XE2_HPG_X2_A0, GPU_MTL_U, GPU_MTL_H, GPU_ACM_G10,
-                                        GPU_ACM_G11, GPU_ACM_G12, GPU_ACM_G11, GPU_TGLLP, GPU_SKL, CPU_None);
+        compat[GPU_BMG_G21] = Set(GPU_BMG_G21, GPU_MTL_U, GPU_MTL_H, GPU_ACM_G10, GPU_ACM_G11, GPU_ACM_G12, GPU_ACM_G11,
+                                  GPU_TGLLP, GPU_SKL, CPU_None);
 #endif
     }
 
@@ -741,7 +741,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         case GPU_MTL_H:
             m_ispc_target = ISPCTarget::xelpg_x16;
             break;
-        case GPU_XE2_HPG_X2_A0:
+        case GPU_BMG_G21:
             m_ispc_target = ISPCTarget::xe2hpg_x16;
             break;
 #endif
@@ -1578,7 +1578,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasTranscendentals = true;
         this->m_hasTrigonometry = true;
         this->m_hasGather = this->m_hasScatter = true;
-        CPUfromISA = GPU_XE2_HPG_X2_A0;
+        CPUfromISA = GPU_BMG_G21;
         break;
     case ISPCTarget::xe2hpg_x32:
         this->m_isa = Target::XE2HPG;
@@ -1594,7 +1594,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasTranscendentals = true;
         this->m_hasTrigonometry = true;
         this->m_hasGather = this->m_hasScatter = true;
-        CPUfromISA = GPU_XE2_HPG_X2_A0;
+        CPUfromISA = GPU_BMG_G21;
         break;
 #else
     case ISPCTarget::gen9_x8:
@@ -2269,7 +2269,7 @@ Target::XePlatform Target::getXePlatform() const {
     case GPU_MTL_U:
     case GPU_MTL_H:
         return XePlatform::xe_lpg;
-    case GPU_XE2_HPG_X2_A0:
+    case GPU_BMG_G21:
         return XePlatform::xe2_hpg;
     default:
         return XePlatform::gen9;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -210,6 +210,7 @@ class Target {
         XEHPC,
         XELPG,
         XE2HPG,
+        XE2LPG,
 #endif
         NUM_ISAS
     };
@@ -221,6 +222,7 @@ class Target {
         xe_hpg,
         xe_lpg,
         xe2_hpg,
+        xe2_lpg,
         xe_hpc,
     };
 #endif
@@ -302,7 +304,7 @@ class Target {
     bool isXeTarget() {
 #ifdef ISPC_XE_ENABLED
         return m_isa == Target::GEN9 || m_isa == Target::XELP || m_isa == Target::XEHPG || m_isa == Target::XEHPC ||
-               m_isa == Target::XELPG || m_isa == Target::XE2HPG;
+               m_isa == Target::XELPG || m_isa == Target::XE2HPG || m_isa == Target::XE2LPG;
 #else
         return false;
 #endif

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -209,6 +209,7 @@ class Target {
         XEHPG,
         XEHPC,
         XELPG,
+        XE2HPG,
 #endif
         NUM_ISAS
     };
@@ -219,6 +220,7 @@ class Target {
         xe_lp,
         xe_hpg,
         xe_lpg,
+        xe2_hpg,
         xe_hpc,
     };
 #endif
@@ -300,7 +302,7 @@ class Target {
     bool isXeTarget() {
 #ifdef ISPC_XE_ENABLED
         return m_isa == Target::GEN9 || m_isa == Target::XELP || m_isa == Target::XEHPG || m_isa == Target::XEHPC ||
-               m_isa == Target::XELPG;
+               m_isa == Target::XELPG || m_isa == Target::XE2HPG;
 #else
         return false;
 #endif

--- a/src/target_enums.cpp
+++ b/src/target_enums.cpp
@@ -183,6 +183,10 @@ ISPCTarget ParseISPCTarget(std::string target) {
         return ISPCTarget::xe2hpg_x16;
     } else if (target == "xe2hpg-x32") {
         return ISPCTarget::xe2hpg_x32;
+    } else if (target == "xe2lpg-x16") {
+        return ISPCTarget::xe2lpg_x16;
+    } else if (target == "xe2lpg-x32") {
+        return ISPCTarget::xe2lpg_x32;
     }
 
     return ISPCTarget::error;
@@ -334,6 +338,10 @@ std::string ISPCTargetToString(ISPCTarget target) {
         return "xe2hpg-x16";
     case ISPCTarget::xe2hpg_x32:
         return "xe2hpg-x32";
+    case ISPCTarget::xe2lpg_x16:
+        return "xe2lpg-x16";
+    case ISPCTarget::xe2lpg_x32:
+        return "xe2lpg-x32";
     case ISPCTarget::none:
     case ISPCTarget::error:
         // Fall through
@@ -425,6 +433,8 @@ bool ISPCTargetIsGen(ISPCTarget target) {
     case ISPCTarget::xelpg_x16:
     case ISPCTarget::xe2hpg_x16:
     case ISPCTarget::xe2hpg_x32:
+    case ISPCTarget::xe2lpg_x16:
+    case ISPCTarget::xe2lpg_x32:
         return true;
     default:
         return false;

--- a/src/target_enums.cpp
+++ b/src/target_enums.cpp
@@ -179,6 +179,10 @@ ISPCTarget ParseISPCTarget(std::string target) {
         return ISPCTarget::xelpg_x8;
     } else if (target == "xelpg-x16") {
         return ISPCTarget::xelpg_x16;
+    } else if (target == "xe2hpg-x16") {
+        return ISPCTarget::xe2hpg_x16;
+    } else if (target == "xe2hpg-x32") {
+        return ISPCTarget::xe2hpg_x32;
     }
 
     return ISPCTarget::error;
@@ -326,6 +330,10 @@ std::string ISPCTargetToString(ISPCTarget target) {
         return "xelpg-x8";
     case ISPCTarget::xelpg_x16:
         return "xelpg-x16";
+    case ISPCTarget::xe2hpg_x16:
+        return "xe2hpg-x16";
+    case ISPCTarget::xe2hpg_x32:
+        return "xe2hpg-x32";
     case ISPCTarget::none:
     case ISPCTarget::error:
         // Fall through
@@ -415,6 +423,8 @@ bool ISPCTargetIsGen(ISPCTarget target) {
     case ISPCTarget::xehpc_x32:
     case ISPCTarget::xelpg_x8:
     case ISPCTarget::xelpg_x16:
+    case ISPCTarget::xe2hpg_x16:
+    case ISPCTarget::xe2hpg_x32:
         return true;
     default:
         return false;

--- a/src/target_enums.h
+++ b/src/target_enums.h
@@ -86,6 +86,8 @@ enum class ISPCTarget {
     xehpc_x32,
     xelpg_x8,
     xelpg_x16,
+    xe2hpg_x16,
+    xe2hpg_x32,
     error
 };
 

--- a/src/target_enums.h
+++ b/src/target_enums.h
@@ -88,6 +88,8 @@ enum class ISPCTarget {
     xelpg_x16,
     xe2hpg_x16,
     xe2hpg_x32,
+    xe2lpg_x16,
+    xe2lpg_x32,
     error
 };
 

--- a/superbuild/osPresets.json
+++ b/superbuild/osPresets.json
@@ -17,7 +17,7 @@
         "LLVM_VERSION": "17.0",
         "LLVM_URL": "https://github.com/llvm/llvm-project.git",
         "VC_INTRINSICS_URL": "https://github.com/intel/vc-intrinsics.git",
-        "VC_INTRINSICS_SHA": "f9c34404d0ea9abad83875a10bd48d88cea90ebd",
+        "VC_INTRINSICS_SHA": "261f128dbb57b460d76f7d2e9b27e442e893d82b",
         "SPIRV_TRANSLATOR_URL": "https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",
         "SPIRV_TRANSLATOR_BRANCH": "llvm_release_170",
         "SPIRV_TRANSLATOR_SHA": "89ab5df345a36940c3a313b3cbd875e32bae366e",

--- a/superbuild/osPresets.json
+++ b/superbuild/osPresets.json
@@ -22,7 +22,7 @@
         "SPIRV_TRANSLATOR_BRANCH": "llvm_release_170",
         "SPIRV_TRANSLATOR_SHA": "89ab5df345a36940c3a313b3cbd875e32bae366e",
         "L0_URL": "https://github.com/oneapi-src/level-zero.git",
-        "L0_TAG": "v1.17.6",
+        "L0_TAG": "v1.17.28",
         "ISPC_CORPUS_URL": "null"
       }
     }

--- a/superbuild/osPresets.json
+++ b/superbuild/osPresets.json
@@ -22,7 +22,7 @@
         "SPIRV_TRANSLATOR_BRANCH": "llvm_release_170",
         "SPIRV_TRANSLATOR_SHA": "89ab5df345a36940c3a313b3cbd875e32bae366e",
         "L0_URL": "https://github.com/oneapi-src/level-zero.git",
-        "L0_TAG": "v1.16.9",
+        "L0_TAG": "v1.17.6",
         "ISPC_CORPUS_URL": "null"
       }
     }

--- a/tests/atomics-12.ispc
+++ b/tests/atomics-12.ispc
@@ -1,3 +1,4 @@
+// rule: skip on arch=xe64
 #include "../test_static.isph"
 uniform unsigned int32 s = 0;
 

--- a/tests/atomics-13.ispc
+++ b/tests/atomics-13.ispc
@@ -1,3 +1,4 @@
+// rule: skip on arch=xe64
 #include "../test_static.isph"
 uniform unsigned int32 s = 0;
 

--- a/tests/atomics-14.ispc
+++ b/tests/atomics-14.ispc
@@ -1,3 +1,4 @@
+// rule: skip on arch=xe64
 #include "../test_static.isph"
 uniform unsigned int64 s = 0xffffffffff000000;
 

--- a/tests/lit-tests/xe_devices.ispc
+++ b/tests/lit-tests/xe_devices.ispc
@@ -89,6 +89,30 @@
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=mtl-h
 // RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=bmg-g21
 
+// Xe2LPG
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x16 --device=skl
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x16 --device=tgllp
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x16 --device=dg1
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x16 --device=acm-g10
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x16 --device=acm-g11
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x16 --device=acm-g12
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x16 --device=mtl-u
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x16 --device=mtl-h
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x16 --device=lnl-a0
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x16 --device=lnl-a1
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x16 --device=lnl-b0
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x32 --device=skl
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x32 --device=tgllp
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x32 --device=dg1
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x32 --device=acm-g10
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x32 --device=acm-g11
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x32 --device=acm-g12
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x32 --device=mtl-u
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x32 --device=mtl-h
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x32 --device=lnl-a0
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x32 --device=lnl-a1
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2lpg-x32 --device=lnl-b0
+
 // REQUIRES: XE_ENABLED
 // REQUIRES: LINUX_HOST
 // REQUIRES: OCLOC_INSTALLED

--- a/tests/lit-tests/xe_devices.ispc
+++ b/tests/lit-tests/xe_devices.ispc
@@ -69,6 +69,26 @@
 // RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x16 --device=mtl-m
 // RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x16 --device=mtl-p
 
+// Xe2HPG
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=skl
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=tgllp
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=dg1
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=acm-g10
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=acm-g11
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=acm-g12
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=mtl-m
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=mtl-p
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=xe2-hpg-x2-a0
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=skl
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=tgllp
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=dg1
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=acm-g10
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=acm-g11
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=acm-g12
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=mtl-m
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=mtl-p
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=xe2-hpg-x2-a0
+
 // REQUIRES: XE_ENABLED
 // REQUIRES: LINUX_HOST
 // REQUIRES: OCLOC_INSTALLED

--- a/tests/lit-tests/xe_devices.ispc
+++ b/tests/lit-tests/xe_devices.ispc
@@ -78,7 +78,7 @@
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=acm-g12
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=mtl-u
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=mtl-h
-// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=xe2-hpg-x2-a0
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=bmg-g21
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=skl
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=tgllp
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=dg1
@@ -87,7 +87,7 @@
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=acm-g12
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=mtl-u
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=mtl-h
-// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=xe2-hpg-x2-a0
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=bmg-g21
 
 // REQUIRES: XE_ENABLED
 // REQUIRES: LINUX_HOST

--- a/tests/lit-tests/xe_devices.ispc
+++ b/tests/lit-tests/xe_devices.ispc
@@ -58,16 +58,16 @@
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x8 --device=acm-g10
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x8 --device=acm-g11
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x8 --device=acm-g12
-// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x8 --device=mtl-m
-// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x8 --device=mtl-p
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x8 --device=mtl-u
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x8 --device=mtl-h
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x16 --device=skl
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x16 --device=tgllp
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x16 --device=dg1
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x16 --device=acm-g10
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x16 --device=acm-g11
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x16 --device=acm-g12
-// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x16 --device=mtl-m
-// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x16 --device=mtl-p
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x16 --device=mtl-u
+// RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xelpg-x16 --device=mtl-h
 
 // Xe2HPG
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=skl
@@ -76,8 +76,8 @@
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=acm-g10
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=acm-g11
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=acm-g12
-// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=mtl-m
-// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=mtl-p
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=mtl-u
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=mtl-h
 // RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x16 --device=xe2-hpg-x2-a0
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=skl
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=tgllp
@@ -85,8 +85,8 @@
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=acm-g10
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=acm-g11
 // RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=acm-g12
-// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=mtl-m
-// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=mtl-p
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=mtl-u
+// RUN: not %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=mtl-h
 // RUN: %{ispc} %s -o %t.bin --emit-zebin --nostdlib --target=xe2hpg-x32 --device=xe2-hpg-x2-a0
 
 // REQUIRES: XE_ENABLED

--- a/tests/lit-tests/xe_prefetch.ispc
+++ b/tests/lit-tests/xe_prefetch.ispc
@@ -2,6 +2,7 @@
 // RUN: %{ispc} %s --target=xelpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck %s
 // RUN: %{ispc} %s --target=xehpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck %s
 // RUN: %{ispc} %s --target=xe2hpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck %s
+// RUN: %{ispc} %s --target=xe2lpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck %s
 // RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
 // RUN: %{ispc} %s --target=xelp-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
 

--- a/tests/lit-tests/xe_prefetch.ispc
+++ b/tests/lit-tests/xe_prefetch.ispc
@@ -1,6 +1,7 @@
 // RUN: %{ispc} %s --target=xehpc-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck %s
 // RUN: %{ispc} %s --target=xelpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck %s
 // RUN: %{ispc} %s --target=xehpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck %s
+// RUN: %{ispc} %s --target=xe2hpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck %s
 // RUN: %{ispc} %s --target=gen9-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
 // RUN: %{ispc} %s --target=xelp-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
 

--- a/tests/lit-tests/xe_prefetchw.ispc
+++ b/tests/lit-tests/xe_prefetchw.ispc
@@ -5,6 +5,7 @@
 // RUN: %{ispc} %s --target=xehpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
 // RUN: %{ispc} %s --target=xehpc-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
 // RUN: %{ispc} %s --target=xelpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
+// RUN: %{ispc} %s --target=xe2hpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
 
 // REQUIRES: XE_ENABLED
 

--- a/tests/lit-tests/xe_prefetchw.ispc
+++ b/tests/lit-tests/xe_prefetchw.ispc
@@ -6,6 +6,7 @@
 // RUN: %{ispc} %s --target=xehpc-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
 // RUN: %{ispc} %s --target=xelpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
 // RUN: %{ispc} %s --target=xe2hpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
+// RUN: %{ispc} %s --target=xe2lpg-x16 --arch=xe64 --emit-llvm-text --nowrap -o - | FileCheck -check-prefix=CHECK_NO_PREFETCH %s
 
 // REQUIRES: XE_ENABLED
 


### PR DESCRIPTION
- Added `xe2hpg` and `xe2lpg` targets for Xe2 Battlemage and Lunar Lake HW.
- Updater Meteor Lake device names.
- Updated dependencies versions.