### PR TITLE
Restrict security scans to ispc/ispc repo

### DIFF
--- a/.github/workflows/clamav-release.yml
+++ b/.github/workflows/clamav-release.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    # Disabling this workflow for non ispc/ispc repo as it needs to run on releases only.
+    if: github.repository == 'ispc/ispc'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -18,6 +18,8 @@ env:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    # Disabling this workflow for non ispc/ispc repo to reduce the traffic to artifacts downloads.
+    if: github.repository == 'ispc/ispc'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/cve-bin-releases.yml
+++ b/.github/workflows/cve-bin-releases.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    # Disabling this workflow for non ispc/ispc repo as it needs to run on releases only.
+    if: github.repository == 'ispc/ispc'
 
     steps:
     - name: Install cve-bin-tool

--- a/.github/workflows/cve-bin.yml
+++ b/.github/workflows/cve-bin.yml
@@ -18,6 +18,8 @@ env:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    # Disabling this workflow for non ispc/ispc repo to reduce the traffic to artifacts downloads.
+    if: github.repository == 'ispc/ispc'
     permissions:
       security-events: write
 


### PR DESCRIPTION
Main problem is that regular scans run in forks and create traffic to nightly builds on appveyor hosting, which is pretty limited on traffic.

Would be good to move nightly builds to github releases.