### PR TITLE
Bandit scan + minor CI fixes

### DIFF
--- a/.github/workflows/bandit.config
+++ b/.github/workflows/bandit.config
@@ -1,0 +1,405 @@
+# Copyright 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+### Bandit config file generated from:
+# './bandit/bandit/cli/config_generator.py --out bandit.config'
+
+### This config may optionally select a subset of tests to run or skip by
+### filling out the 'tests' and 'skips' lists given below. If no tests are
+### specified for inclusion then it is assumed all tests are desired. The skips
+### set will remove specific tests from the include set. This can be controlled
+### using the -t/-s CLI options. Note that the same test ID should not appear
+### in both 'tests' and 'skips', this would be nonsensical and is detected by
+### Bandit at runtime.
+
+# Available tests:
+# B101 : assert_used
+# B102 : exec_used
+# B103 : set_bad_file_permissions
+# B104 : hardcoded_bind_all_interfaces
+# B105 : hardcoded_password_string
+# B106 : hardcoded_password_funcarg
+# B107 : hardcoded_password_default
+# B108 : hardcoded_tmp_directory
+# B110 : try_except_pass
+# B112 : try_except_continue
+# B201 : flask_debug_true
+# B301 : pickle
+# B302 : marshal
+# B303 : md5
+# B304 : ciphers
+# B305 : cipher_modes
+# B306 : mktemp_q
+# B307 : eval
+# B308 : mark_safe
+# B310 : urllib_urlopen
+# B311 : random
+# B312 : telnetlib
+# B313 : xml_bad_cElementTree
+# B314 : xml_bad_ElementTree
+# B315 : xml_bad_expatreader
+# B316 : xml_bad_expatbuilder
+# B317 : xml_bad_sax
+# B318 : xml_bad_minidom
+# B319 : xml_bad_pulldom
+# B320 : xml_bad_etree
+# B321 : ftplib
+# B323 : unverified_context
+# B324 : hashlib_new_insecure_functions
+# B401 : import_telnetlib
+# B402 : import_ftplib
+# B403 : import_pickle
+# B404 : import_subprocess
+# B405 : import_xml_etree
+# B406 : import_xml_sax
+# B407 : import_xml_expat
+# B408 : import_xml_minidom
+# B409 : import_xml_pulldom
+# B410 : import_lxml
+# B411 : import_xmlrpclib
+# B412 : import_httpoxy
+# B413 : import_pycrypto
+# B501 : request_with_no_cert_validation
+# B502 : ssl_with_bad_version
+# B503 : ssl_with_bad_defaults
+# B504 : ssl_with_no_version
+# B505 : weak_cryptographic_key
+# B506 : yaml_load
+# B507 : ssh_no_host_key_verification
+# B601 : paramiko_calls
+# B602 : subprocess_popen_with_shell_equals_true
+# B603 : subprocess_without_shell_equals_true
+# B604 : any_other_function_with_shell_equals_true
+# B605 : start_process_with_a_shell
+# B606 : start_process_with_no_shell
+# B607 : start_process_with_partial_path
+# B608 : hardcoded_sql_expressions
+# B609 : linux_commands_wildcard_injection
+# B610 : django_extra_used
+# B611 : django_rawsql_used
+# B701 : jinja2_autoescape_false
+# B702 : use_of_mako_templates
+# B703 : django_mark_safe
+
+# (optional) list included test IDs here, eg '[B101, B406]':
+# Intel Required Checkers. Do not disable these
+# Additional checkers may be added if desired
+tests:
+  [ 'B301', 'B302', 'B303', 'B304', 'B305', 'B306', 'B308', 'B310', 'B311', 'B312', 'B313', 'B314', 'B315', 'B316', 'B317', 'B318', 'B319', 'B320', 'B321', 'B323', 'B324', 'B401', 'B402', 'B403', 'B404', 'B405', 'B406', 'B407', 'B408', 'B409', 'B410', 'B411', 'B412', 'B413']
+
+# (optional) list skipped test IDs here, eg '[B101, B406]':
+# The following checkers are not required but be added to tests list if desired
+skips:
+  [ 'B101', 'B102', 'B103', 'B104', 'B105', 'B106', 'B107', 'B108', 'B110', 'B112', 'B201', 'B501', 'B502', 'B503', 'B504', 'B505', 'B506', 'B507', 'B601', 'B602', 'B603', 'B604', 'B605', 'B606', 'B607', 'B608', 'B609', 'B610', 'B611', 'B701', 'B702', 'B703']
+
+# Exclude 3rd party dirs
+exclude_dirs: ['benchmarks/vendor', 'ispcrt/tests/vendor']
+
+### (optional) plugin settings - some test plugins require configuration data
+### that may be given here, per-plugin. All bandit test plugins have a built in
+### set of sensible defaults and these will be used if no configuration is
+### provided. It is not necessary to provide settings for every (or any) plugin
+### if the defaults are acceptable.
+
+any_other_function_with_shell_equals_true:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+assert_used:
+  skips: []
+hardcoded_tmp_directory:
+  tmp_dirs:
+  - /tmp
+  - /var/tmp
+  - /dev/shm
+linux_commands_wildcard_injection:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+ssl_with_bad_defaults:
+  bad_protocol_versions:
+  - PROTOCOL_SSLv2
+  - SSLv2_METHOD
+  - SSLv23_METHOD
+  - PROTOCOL_SSLv3
+  - PROTOCOL_TLSv1
+  - SSLv3_METHOD
+  - TLSv1_METHOD
+ssl_with_bad_version:
+  bad_protocol_versions:
+  - PROTOCOL_SSLv2
+  - SSLv2_METHOD
+  - SSLv23_METHOD
+  - PROTOCOL_SSLv3
+  - PROTOCOL_TLSv1
+  - SSLv3_METHOD
+  - TLSv1_METHOD
+start_process_with_a_shell:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+start_process_with_no_shell:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+start_process_with_partial_path:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+subprocess_popen_with_shell_equals_true:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+subprocess_without_shell_equals_true:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+try_except_continue:
+  check_typed_exception: false
+try_except_pass:
+  check_typed_exception: false
+weak_cryptographic_key:
+  weak_key_size_dsa_high: 1024
+  weak_key_size_dsa_medium: 2048
+  weak_key_size_ec_high: 160
+  weak_key_size_ec_medium: 224
+  weak_key_size_rsa_high: 1024
+  weak_key_size_rsa_medium: 2048

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,0 +1,37 @@
+# Copyright 2024, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Scan Python code with Bandit
+
+on:
+    workflow_dispatch:
+    push:
+    pull_request:
+      paths:
+        - '**/*.py'
+        - '.github/workflows/bandit.*'
+
+permissions:
+  contents: read
+
+jobs:
+  bandit:
+    name: Bandit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone the git repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Install Bandit
+        run: pip install bandit
+
+      - name: Run Bandit
+        run: |
+          bandit -c .github/workflows/bandit.config -r . -f txt -o bandit_output.txt
+
+      - name: Upload Bandit text report as artifact
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        with:
+          name: bandit-report
+          path: bandit_output.txt

--- a/.github/workflows/nightly-17.yml
+++ b/.github/workflows/nightly-17.yml
@@ -77,6 +77,8 @@ jobs:
           - arch: x86
             target: "avx2vnni-i32x16"
           - arch: x86
+            target: "avx512knl-x16"
+          - arch: x86
             target: "avx512skx-x4"
           - arch: x86
             target: "avx512skx-x8"

--- a/alloy.py
+++ b/alloy.py
@@ -908,7 +908,11 @@ import smtplib
 import datetime
 import copy
 import multiprocessing
-import subprocess
+# Subprocess is intentionally used with shell=True, it's required for cross platform support.
+# The command called from subprocess is constructed inside the script and
+# it's quoted appropriately to avoid shell injection vulnerabilities
+# so it's safe to ignore Bandit warning.
+import subprocess #nosec
 import re
 from shutil import copyfile
 # our drivers

--- a/bitcode2cpp.py
+++ b/bitcode2cpp.py
@@ -6,7 +6,9 @@
 
 import sys
 import re
-import subprocess
+# Subprocess is used with default shell which is False, it's safe and doesn't allow shell injection
+# so it's safe to ignore Bandit warning.
+import subprocess #nosec
 import platform
 import argparse
 from os.path import basename, dirname

--- a/common.py
+++ b/common.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-#  Copyright (c) 2013-2023, Intel Corporation
+#  Copyright (c) 2013-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -15,7 +15,8 @@ class EmptyClass(object): pass
 
 # load/save almost every object to a file (good for bug reproducing)
 def dump(fname, obj):
-    import pickle
+    # Pickle is used to dump the file (not to load it), it's safe and doesn't allow shell injection
+    import pickle #nosec
     with open(fname, 'w') as fp:
         pickle.dump(obj, fp)
 
@@ -442,7 +443,8 @@ class ExecutionStateGatherer(object):
         print("ESG: loaded from 'TestTable()' with revisions", REVISIONS)
 
     def dump(self, fname, obj):
-        import pickle
+        # Pickle is used to dump the file (not to load it), it's safe and doesn't allow shell injection
+        import pickle #nosec
         with open(fname, 'wb') as fp:
             pickle.dump(obj, fp)
 

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -86,6 +86,7 @@ Contents:
   + `Selecting 32 or 64 Bit Addressing`_
   + `The Preprocessor`_
   + `Debugging`_
+  + `Optimization Settings`_
   + `Other ways of passing arguments to ISPC`_
 
 * `The ISPC Parallel Execution Model`_
@@ -1145,6 +1146,66 @@ to use the ``print`` statement for ``printf()`` style debugging.  (See
 `Output Functions`_ for more information.)  You can also use the ability to
 call back to application code at particular points in the program, passing
 a set of variable values to be logged or otherwise analyzed from there.
+
+
+Optimization Settings
+---------------------
+
+The ``ispc`` compiler has a number of optimization settings that can be
+controlled via command-line flags. These options can be specified using the
+`--opt=<option>` flag. Below is a list of available optimization options:
+
+Available options:
+
+- ``disable-assertions``
+
+  Remove assertion statements from the final code. This can reduce the overhead
+  of runtime checks.
+
+- ``disable-fma``
+
+  Disable the generation of 'fused multiply-add' (FMA) instructions on targets
+  that support them.
+
+- ``disable-gathers``
+
+  Disable the generation of gather instructions on targets that support them.
+
+- ``disable-loop-unroll``
+
+  Disable loop unrolling.
+
+- ``disable-scatters``
+
+  Disable the generation of scatter instructions on targets that support them.
+
+- ``disable-zmm``
+
+  Disable the use of ZMM registers for AVX512 targets in favor of YMM registers.
+  This also affects the ABI. ZMM registers are 512-bit wide, while YMM registers
+  are 256-bit wide.
+
+- ``fast-masked-vload``
+
+  Enable faster masked vector loads on SSE targets. Note that this may result in
+  memory accesses beyond the end of an array, which could cause undefined
+  behavior if not handled carefully.
+
+- ``fast-math``
+
+  Perform non-IEEE-compliant optimizations of numeric expressions. These
+  optimizations may improve performance but can result in less precise results
+  or different behavior compared to IEEE-compliant math.
+
+- ``force-aligned-memory``
+
+  Always issue "aligned" vector load and store instructions.
+
+- ``reset-ftz-daz``
+
+  Reset FTZ (Flush-to-Zero) and DAZ (Denormals-Are-Zero) flags on ISPC extern
+  function entrance and restore them on return.
+
 
 Other ways of passing arguments to ISPC
 ---------------------------------------

--- a/run_tests.py
+++ b/run_tests.py
@@ -965,7 +965,9 @@ import re
 import signal
 import random
 import threading
-import subprocess
+# Subprocess is used with default shell which is False, it's safe and doesn't allow shell injection
+# so we can ignore the Bandit warning
+import subprocess #nosec
 import shlex
 import platform
 import tempfile

--- a/tests/fmod-float-uniform.ispc
+++ b/tests/fmod-float-uniform.ispc
@@ -8,28 +8,28 @@ task void f_f(uniform float RET[], uniform float aFOO[]) {
     uniform float y = 0.8;
     uniform float testVal = fmod(x, y);
     uniform float baseRes = x - trunc(x * rcp(y)) * y;
-    RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
+    RET[programIndex] += ((abs(baseRes - testVal) < 1e-6) || abs((baseRes-testVal)/baseRes) < 1e-5) ? 0 : 1;
 
     // Case 2: x is negative, y is positive
     x = -aFOO[programCount / 2];
     y = 0.8;
     testVal = fmod(x, y);
     baseRes = x - trunc(x * rcp(y)) * y;
-    RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
+    RET[programIndex] += ((abs(baseRes - testVal) < 1e-6) || abs((baseRes-testVal)/baseRes) < 1e-5) ? 0 : 1;
 
     // Case 3: x is positive, y is negative
     x = aFOO[programCount / 2];
     y = -0.8;
     testVal = fmod(x, y);
     baseRes = x - trunc(x * rcp(y)) * y;
-    RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
+    RET[programIndex] += ((abs(baseRes - testVal) < 1e-6) || abs((baseRes-testVal)/baseRes) < 1e-5) ? 0 : 1;
 
     // Case 4: x and y are negative
     x = -aFOO[programCount / 2];
     y = -0.8;
     testVal = fmod(x, y);
     baseRes = x - trunc(x * rcp(y)) * y;
-    RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
+    RET[programIndex] += ((abs(baseRes - testVal) < 1e-6) || abs((baseRes-testVal)/baseRes) < 1e-5) ? 0 : 1;
 
     // Case 5.1: x is +inf, y is positive
     x = aFOO[programCount / 2] / 0.0;

--- a/tests/fmod-float-varying.ispc
+++ b/tests/fmod-float-varying.ispc
@@ -8,28 +8,28 @@ task void f_f(uniform float RET[], uniform float aFOO[]) {
     float y = 0.8;
     float testVal = fmod(x, y);
     float baseRes = x - trunc(x * rcp(y)) * y;
-    RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
+    RET[programIndex] += ((abs(baseRes - testVal) < 1e-6) || abs((baseRes-testVal)/baseRes) < 1e-5) ? 0 : 1;
 
     // Case 2: x is negative, y is positive
     x = -aFOO[programCount / 2];
     y = 0.8;
     testVal = fmod(x, y);
     baseRes = x - trunc(x * rcp(y)) * y;
-    RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
+    RET[programIndex] += ((abs(baseRes - testVal) < 1e-6) || abs((baseRes-testVal)/baseRes) < 1e-5) ? 0 : 1;
 
     // Case 3: x is positive, y is negative
     x = aFOO[programCount / 2];
     y = -0.8;
     testVal = fmod(x, y);
     baseRes = x - trunc(x * rcp(y)) * y;
-    RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
+    RET[programIndex] += ((abs(baseRes - testVal) < 1e-6) || abs((baseRes-testVal)/baseRes) < 1e-5) ? 0 : 1;
 
     // Case 4: x and y are negative
     x = -aFOO[programCount / 2];
     y = -0.8;
     testVal = fmod(x, y);
     baseRes = x - trunc(x * rcp(y)) * y;
-    RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
+    RET[programIndex] += ((abs(baseRes - testVal) < 1e-6) || abs((baseRes-testVal)/baseRes) < 1e-5) ? 0 : 1;
 
     // Case 5.1: x is +inf, y is positive
     x = aFOO[programCount / 2] / 0.0;

--- a/utils/lit/lit/TestRunner.py
+++ b/utils/lit/lit/TestRunner.py
@@ -3,7 +3,9 @@ import errno
 import io
 import itertools
 import getopt
-import os, signal, subprocess, sys
+# Subprocess is used with default shell which is False, it's safe and doesn't allow shell injection
+# so we can ignore the Bandit warning
+import os, signal, subprocess, sys #nosec
 import re
 import stat
 import platform

--- a/utils/lit/lit/formats/googletest.py
+++ b/utils/lit/lit/formats/googletest.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 import os
 import shlex
-import subprocess
+# Subprocess is used with default shell which is False, it's safe and doesn't allow shell injection
+# so we can ignore the Bandit warning
+import subprocess #nosec
 import sys
 
 import lit.Test

--- a/utils/lit/lit/reports.py
+++ b/utils/lit/lit/reports.py
@@ -1,7 +1,8 @@
 import itertools
 import json
 
-from xml.sax.saxutils import quoteattr as quo
+# Seems like a bug in Bandit: https://github.com/PyCQA/bandit/issues/452
+from xml.sax.saxutils import quoteattr as quo #nosec
 
 import lit.Test
 

--- a/utils/lit/lit/util.py
+++ b/utils/lit/lit/util.py
@@ -7,7 +7,11 @@ import numbers
 import os
 import platform
 import signal
-import subprocess
+# Subprocess is used with default shell which is False, it's safe and doesn't allow shell injection.
+# In one case it's used with Shell=True "subprocess.call('kill -kill $(ps -o pid= -L{})'.format(pid), shell=True)"
+# The command called from subprocess is constructed inside the script and
+# it's quoted appropriately to avoid shell injection vulnerabilities
+import subprocess #nosec
 import sys
 import threading
 


### PR DESCRIPTION
1. Added bandit scan
2. Excluded `avx512knl-x16` from x86 testing
3. Updated result check in fmod float tests (was failing on x64 targets with -O0)
4. Added description of ispc optimization options to docs