### PR TITLE
dispatch.c: make system symbols weak

### DIFF
--- a/builtins/dispatch.c
+++ b/builtins/dispatch.c
@@ -24,7 +24,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-static int __system_best_isa = -1;
+// __system_best_isa __get_system_isa and __set_system_isa are weak symbols
+// because we want to have the only version of them across user application
+// (even when there are multiple independently compiled ISPC modules).
+__attribute__((weak)) int __system_best_isa = -1;
 
 static void __cpuid(int info[4], int infoType) {
     __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(infoType));
@@ -59,7 +62,7 @@ static int __os_has_avx512_support() {
 // __get_system_isa should return a value corresponding to one of the
 // Target::ISA enumerant values that gives the most capable ISA that the
 // current system can run.
-int32_t __get_system_isa() {
+__attribute__((weak)) int32_t __get_system_isa() {
     int info[4];
     __cpuid(info, 1);
 
@@ -173,7 +176,7 @@ int32_t __get_system_isa() {
     }
 }
 
-void __set_system_isa() {
+__attribute__((weak)) void __set_system_isa() {
     if (__system_best_isa == -1) {
         __system_best_isa = __get_system_isa();
     }

--- a/cmake/GenerateBuiltins.cmake
+++ b/cmake/GenerateBuiltins.cmake
@@ -143,9 +143,14 @@ function(generate_dispatcher os)
 
     write_dispatch_bitcode_lib(${name} ${os})
 
+    set(EXTRA_OPTS "")
+    if (NOT WIN32)
+        set(EXTRA_OPTS "-fPIC")
+    endif()
+
     add_custom_command(
         OUTPUT ${bc}
-        COMMAND ${CLANGPP_EXECUTABLE} -x c ${ISPC_OPAQUE_FLAGS} ${DISP_TYPE} -O2 -emit-llvm -c ${input} -o ${bc}
+        COMMAND ${CLANGPP_EXECUTABLE} -x c ${ISPC_OPAQUE_FLAGS} ${DISP_TYPE} ${EXTRA_OPTS} -O2 -emit-llvm -c ${input} -o ${bc}
         DEPENDS ${input}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )


### PR DESCRIPTION
This reduces the number of copies when a user application consists of several multi-target modules. Before this change, each module had its own copy, leading to multiple instances of system ISA detection.

This PR fixes #2969 leading to the only instance of dispatcher.