### PR TITLE
module.cpp: fix llvm::verifyModule call

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1525,7 +1525,7 @@ bool Module::writeOutput(OutputType outputType, OutputFlags flags, const char *o
 
     // SIC! (verifyModule() == TRUE) means "failed", see llvm-link code.
     if ((outputType != Header) && (outputType != Deps) && (outputType != HostStub) && (outputType != DevStub) &&
-        (outputType != CPPStub) && llvm::verifyModule(*module)) {
+        (outputType != CPPStub) && llvm::verifyModule(*module, &llvm::errs())) {
         FATAL("Resulting module verification failed!");
     }
 


### PR DESCRIPTION
This passes `raw_stream` handler to actually see the output of verifier if module is malformed.