### PR TITLE
Do not emit error for typedef struct foo {} foo

### DIFF
--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1041,8 +1041,11 @@ declaration_specifiers
                       "which is part of ISPC language since version 1.13. "
                       "Remove this typedef or use ISPC_UINT_IS_DEFINED to "
                       "detect that these types are defined.");
-                  }
-                  else
+                  } else if (CastType<StructType>(ds->baseType)) {
+                      // Skip the error if the base type is a struct type to
+                      // support typedef struct foo { } foo;
+                      ;
+                  } else
                       Error(@1, "Multiple types provided for declaration.");
               }
               ds->baseType = $1;

--- a/tests/lit-tests/2351.ispc
+++ b/tests/lit-tests/2351.ispc
@@ -1,0 +1,11 @@
+// RUN: %{ispc} --target=host --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+
+// CHECK-NOT: Error: Multiple types provided for declaration
+
+typedef struct Foo {
+    int a;
+} Foo;
+
+// CHECK: {{.*}} = type { <{{.*}} x i32> }
+// CHECK: @global_foo = {{.*}} global {{.*}}varying_Foo zeroinitializer
+Foo global_foo;


### PR DESCRIPTION
This PR fixes #2351 