### PR TITLE
Use typedef name for anon struct

### DIFF
--- a/src/parse.yy
+++ b/src/parse.yy
@@ -3008,9 +3008,15 @@ lAddDeclaration(DeclSpecs *ds, Declarator *decl) {
         return;
 
     decl->InitFromDeclSpecs(ds);
-    if (ds->storageClass == SC_TYPEDEF)
-        m->AddTypeDef(decl->name, decl->type, decl->pos);
-    else {
+    if (ds->storageClass == SC_TYPEDEF) {
+        const StructType *st = CastType<StructType>(decl->type);
+        if (st && st->IsAnonymousType()) {
+            st = st->GetAsNamed(decl->name);
+            m->AddTypeDef(decl->name, st, decl->pos);
+        } else {
+            m->AddTypeDef(decl->name, decl->type, decl->pos);
+        }
+    } else {
         if (decl->type == nullptr) {
             Assert(m->errorCount > 0);
             return;

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1897,19 +1897,21 @@ StructType::StructType(const std::string &n, const llvm::SmallVector<const Type 
     finalElementTypes.resize(elts.size(), nullptr);
 
     static int count = 0;
+    // Create a unique anonymous struct name if we have an anonymous struct (name == "")
+    // Ensuring struct is created with a name, prevents each use of original
+    // struct from having different names causing type match errors.
+    if (name == "") {
+        char buf[16];
+        Assert(isAnonymous);
+        snprintf(buf, sizeof(buf), "$anon%d", count);
+        name = std::string(buf);
+        ++count;
+    }
+
     if (variability != Variability::Unbound) {
         // For structs with non-unbound variability, we'll create the
         // correspoing LLVM struct type now, if one hasn't been made
         // already.
-
-        // Create a unique anonymous struct name if we have an anonymous
-        // struct (name == "").
-        if (name == "") {
-            char buf[16];
-            snprintf(buf, sizeof(buf), "$anon%d", count);
-            name = std::string(buf);
-            ++count;
-        }
 
         // If a non-opaque LLVM struct for this type has already been
         // created, we're done.  For an opaque struct type, we'll override
@@ -1946,15 +1948,6 @@ StructType::StructType(const std::string &n, const llvm::SmallVector<const Type 
             // Definition for what was before just a declaration
             m->structTypeMap[mname]->setBody(elementTypes);
         }
-    }
-    // Create a unique anonymous struct name if we have an anonymous struct (name == "")
-    // Ensuring struct is created with a name, prevents each use of original
-    // struct from having different names causing type match errors.
-    if (name == "") {
-        char buf[16];
-        snprintf(buf, sizeof(buf), "$anon%d", count);
-        name = std::string(buf);
-        ++count;
     }
 }
 

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1993,6 +1993,8 @@ bool StructType::IsDefined() const {
     return true;
 }
 
+bool StructType::IsAnonymousType() const { return isAnonymous; }
+
 const Type *StructType::GetBaseType() const { return this; }
 
 const StructType *StructType::GetAsVaryingType() const {
@@ -2069,6 +2071,10 @@ const StructType *StructType::GetAsNonConstType() const {
         oppositeConstStructType->oppositeConstStructType = this;
         return oppositeConstStructType;
     }
+}
+
+const StructType *StructType::GetAsNamed(const std::string &n) const {
+    return new StructType(n, elementTypes, elementNames, elementPositions, isConst, variability, isAnonymous, pos);
 }
 
 std::string StructType::GetString() const {

--- a/src/type.h
+++ b/src/type.h
@@ -746,6 +746,7 @@ class StructType : public CollectionType {
     bool IsSignedType() const;
     bool IsConstType() const;
     bool IsDefined() const;
+    bool IsAnonymousType() const;
 
     const Type *GetBaseType() const;
     const StructType *GetAsVaryingType() const;
@@ -757,6 +758,8 @@ class StructType : public CollectionType {
 
     const StructType *GetAsConstType() const;
     const StructType *GetAsNonConstType() const;
+
+    const StructType *GetAsNamed(const std::string &name) const;
 
     std::string GetString() const;
     std::string Mangle() const;

--- a/tests/lit-tests/2350.ispc
+++ b/tests/lit-tests/2350.ispc
@@ -1,0 +1,18 @@
+// RUN: %{ispc} --target=host --emit-llvm-text -o - %s -h %t.h 2>&1 | FileCheck %s
+// RUN: cat %t.h | FileCheck --check-prefix=CHECK-HEADER %s
+
+// CHECK: %{{.*}}uniform_TestStruct = type { float }
+// CHECK: ret %{{.*}}uniform_TestStruct { float 1.000000e+00 }
+
+// CHECK-HEADER: struct TestStruct {
+// CHECK-HEADER: extern struct TestStruct test();
+
+typedef struct {
+    float t;
+} TestStruct;
+
+export uniform TestStruct test() {
+    uniform TestStruct s;
+    s.t = 1.0;
+    return s;
+}

--- a/tests/lit-tests/address-space-1.ispc
+++ b/tests/lit-tests/address-space-1.ispc
@@ -8,7 +8,7 @@ void foo(A(4) uniform int *uniform ptr);
 // CHECK: declare {{.*}} @boo___un_3C_unt_3E_({{.*}} addrspace(2){{.*}}, {{.*}}
 uniform int8 *uniform boo(A(2) uniform int8 *uniform x);
 
-// CHECK: declare void @"struct____{{.*}}({{.*}} addrspace(3){{.*}}, {{.*}}
+// CHECK: declare void @struct____{{.*}}({{.*}} addrspace(3){{.*}}, {{.*}}
 typedef struct {
     int x;
 } my_struct;

--- a/tests/lit-tests/noescape.ispc
+++ b/tests/lit-tests/noescape.ispc
@@ -9,7 +9,7 @@ uniform int8 *uniform boo(__attribute__((noescape)) uniform int32 *uniform x);
 // CHECK: declare void @arr___un_3C_uni_3E_({{.*}} nocapture, {{.*}}
 void arr(__attribute__((noescape)) uniform int x[]);
 
-// CHECK: declare void @"struct____{{.*}}"({{.*}} nocapture, {{.*}}
+// CHECK: declare void @struct____{{.*}}({{.*}} nocapture, {{.*}}
 typedef struct {
     int x;
 } my_struct;


### PR DESCRIPTION
If anonymous struct has typedef then we can use typedef name instead of `$anonN`.
This fixes #2350.