### PR TITLE
Fix linkage of template instantiations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,11 +549,13 @@ list(APPEND COMPILE_DEFINITIONS
     BUILD_VERSION=\"${GIT_COMMIT_HASH}\"
 )
 if (UNIX)
-    # Compile-time protection against static sized buffer overflows.
-    list(APPEND COMPILE_DEFINITIONS _FORTIFY_SOURCE=2)
+    if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+        # Compile-time protection against static sized buffer overflows.
+        list(APPEND COMPILE_DEFINITIONS _FORTIFY_SOURCE=2)
+    endif()
 else()
     list(APPEND COMPILE_DEFINITIONS NOMINMAX)
-    if (NOT CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+    if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
         list(APPEND COMPILE_DEFINITIONS NDEBUG)
     endif()
 endif()

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -8621,8 +8621,7 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
         }
 
         // Create substitution map for specified template parameters
-        TemplateInstantiation inst(*templateParms, templateArgs, TemplateInstantiationKind::Implicit,
-                                   templSym->isInline, templSym->isNoInline);
+        TemplateInstantiation inst(*templateParms, templateArgs, templSym->isInline, templSym->isNoInline);
 
         std::vector<const Type *> substitutedParamTypes;
         // Instantiate function parameter types with explicitly specified template arguments

--- a/src/func.h
+++ b/src/func.h
@@ -34,6 +34,12 @@ class Function {
     void Print(Indent &indent) const;
     bool IsStdlibSymbol() const;
 
+    /** Returns true of function is static or inline */
+    bool IsInternal() const;
+
+    /** Sets requested linkage */
+    void UpdateLinkage(llvm::GlobalValue::LinkageTypes linkage) const;
+
   private:
     enum class DebugPrintPoint { Initial, AfterTypeChecking, AfterOptimization };
     void debugPrintHelper(DebugPrintPoint dumpPoint);

--- a/src/func.h
+++ b/src/func.h
@@ -166,13 +166,20 @@ class FunctionTemplate {
     void Print(Indent &indent) const;
     bool IsStdlibSymbol() const;
 
+    struct InstantiationMap {
+        TemplateArgs args;
+        Symbol *symbol;
+        TemplateInstantiationKind kind;
+        InstantiationMap(const TemplateArgs &a, Symbol *s, TemplateInstantiationKind k) : args(a), symbol(s), kind(k) {}
+    };
+
   private:
     TemplateSymbol *sym;
     std::vector<Symbol *> args;
     Stmt *code;
     Symbol *maskSymbol;
 
-    std::vector<std::pair<TemplateArgs *, Symbol *>> instantiations;
+    std::vector<InstantiationMap> instantiations;
 };
 
 // A helper class to drive function instantiation, it provides the following:
@@ -180,8 +187,7 @@ class FunctionTemplate {
 // - type instantiation
 class TemplateInstantiation {
   public:
-    TemplateInstantiation(const TemplateParms &typeParms, const TemplateArgs &tArgs, TemplateInstantiationKind kind,
-                          bool IsInline, bool IsNoInline);
+    TemplateInstantiation(const TemplateParms &typeParms, const TemplateArgs &tArgs, bool IsInline, bool IsNoInline);
     const Type *InstantiateType(const std::string &name);
     Symbol *InstantiateSymbol(Symbol *sym);
     Symbol *InstantiateTemplateSymbol(TemplateSymbol *sym);
@@ -198,8 +204,6 @@ class TemplateInstantiation {
     std::unordered_map<std::string, const TemplateArg *> argsMap;
     // Template arguments in the order of the template parameters.
     TemplateArgs templateArgs;
-    // Kind of instantiation (explicit, implicit, specialization).
-    TemplateInstantiationKind kind;
 
     bool isInline;
     bool isNoInline;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1377,8 +1377,8 @@ FunctionTemplate *Module::MatchFunctionTemplate(const std::string &name, const F
             continue;
         }
         bool matched = true;
-        TemplateInstantiation inst(*(templateSymbol->templateParms), normTypes, TemplateInstantiationKind::Implicit,
-                                   templateSymbol->isInline, templateSymbol->isNoInline);
+        TemplateInstantiation inst(*(templateSymbol->templateParms), normTypes, templateSymbol->isInline,
+                                   templateSymbol->isNoInline);
         for (int i = 0; i < ftype->GetNumParameters(); i++) {
             const Type *instParam = ftype->GetParameterType(i);
             const Type *templateParam = templateSymbol->type->GetParameterType(i)->ResolveDependence(inst);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1054,20 +1054,11 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
 
     // Get the LLVM FunctionType
     bool disableMask = (storageClass == SC_EXTERN_C || storageClass == SC_EXTERN_SYCL);
-    llvm::FunctionType *llvmFunctionType = functionType->LLVMFunctionType(g->ctx, disableMask);
-    if (llvmFunctionType == nullptr)
-        return;
-
-    // According to the LLVM philosophy, function declaration itself can't have internal linkage.
-    // Function may have internal linkage only if it is defined in the module.
-    // So here we set external linkage for all function declarations. It will be changed to internal
-    // if the function is defined in the module in Function::GenerateIR().
-    llvm::GlobalValue::LinkageTypes linkage = llvm::GlobalValue::ExternalLinkage;
 
     auto [name_pref, name_suf] = functionType->GetFunctionMangledName(false);
     std::string functionName = name_pref + name + name_suf;
 
-    llvm::Function *function = llvm::Function::Create(llvmFunctionType, linkage, functionName.c_str(), module);
+    llvm::Function *function = functionType->CreateLLVMFunction(functionName, g->ctx, disableMask);
 
     if (g->target_os == TargetOS::windows) {
         // Make export functions callable from DLLs.

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -3091,6 +3091,21 @@ llvm::FunctionType *FunctionType::LLVMFunctionType(llvm::LLVMContext *ctx, bool 
     return llvm::FunctionType::get(llvmReturnType, callTypes, false);
 }
 
+llvm::Function *FunctionType::CreateLLVMFunction(const std::string &name, llvm::LLVMContext *ctx,
+                                                 bool disableMask) const {
+    llvm::FunctionType *llvmFunctionType = LLVMFunctionType(ctx, disableMask);
+    if (llvmFunctionType == nullptr) {
+        return nullptr;
+    }
+    // According to the LLVM philosophy, function declaration itself can't have internal linkage.
+    // Function may have internal linkage only if it is defined in the module.
+    // So here we set external linkage for all function declarations. It will be changed to internal
+    // if the function is defined in the module in Function::GenerateIR().
+    llvm::GlobalValue::LinkageTypes linkage = llvm::GlobalValue::ExternalLinkage;
+    llvm::Function *function = llvm::Function::Create(llvmFunctionType, linkage, name.c_str(), m->module);
+    return function;
+}
+
 unsigned int FunctionType::GetCallingConv() const {
     // Default calling convention on CPU targets is CallingConv::C.
     // If __vectorcall or __regcall is specified explicitly, corresponding

--- a/src/type.h
+++ b/src/type.h
@@ -994,6 +994,11 @@ class FunctionType : public Type {
         present, removed from the return function signature. */
     llvm::FunctionType *LLVMFunctionType(llvm::LLVMContext *ctx, bool disableMask = false) const;
 
+    /** This method creates LLVM Function that corresponds to this function type with provided name.
+        The \c disableMask parameter indicates whether the llvm::FunctionType should have the trailing mask parameter,
+       if present, removed from the return function signature. */
+    llvm::Function *CreateLLVMFunction(const std::string &name, llvm::LLVMContext *ctx, bool disableMask = false) const;
+
     /* This method returns appropriate llvm::CallingConv for the function*/
     unsigned int GetCallingConv() const;
 


### PR DESCRIPTION
This PR fixes #2959.
It also has a minor CMakeLists fix regarding `_FORTIFY_SOURCE=2` compile definition that can't be used in Debug mode (triggers warning with new gcc)