### PR TITLE
Fix anon struct renaming

### DIFF
--- a/src/type.cpp
+++ b/src/type.cpp
@@ -2074,7 +2074,7 @@ const StructType *StructType::GetAsNonConstType() const {
 }
 
 const StructType *StructType::GetAsNamed(const std::string &n) const {
-    return new StructType(n, elementTypes, elementNames, elementPositions, isConst, variability, isAnonymous, pos);
+    return new StructType(n, elementTypes, elementNames, elementPositions, isConst, variability, false, pos);
 }
 
 std::string StructType::GetString() const {

--- a/tests/lit-tests/anon-struct-rename.ispc
+++ b/tests/lit-tests/anon-struct-rename.ispc
@@ -1,0 +1,16 @@
+// RUN: %{ispc} --target=host --nowrap --emit-asm -o - %s 2>&1 | FileCheck %s
+
+// CHECK-NOT: Error: Unable to find any matching overload for call
+
+typedef struct {
+    uniform float<4> m128_f32;
+} __m128;
+
+typedef uniform __m128 VectorRegister4Float;
+
+static inline unmasked uniform __m128 _mm_add_ps(uniform __m128 _A, uniform __m128 _B);
+
+inline uniform VectorRegister4Float VectorAdd(const uniform VectorRegister4Float &Vec1,
+                                              const uniform VectorRegister4Float &Vec2) {
+    return _mm_add_ps(Vec1, Vec2);
+}


### PR DESCRIPTION
This PR is fix for #2973. `GetAsNamed` always return named struct. This prevents renaming struct when new aliases created with `typedef`.