### PR TITLE
Dependabot version update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,9 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "github: workflows"
+      prefix: "ci:"
+    open-pull-requests-limit: 1
+    group:
+      group-name: "all-dependencies"
+    ignore:
+      - update-types: ["version-update:semver-patch"] # Ignore patch updates

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Install Bandit
-        run: pip install -r .github/workflows/third-party/requirements.txt
+        run: pip install bandit
 
       - name: Run Bandit
         run: |

--- a/.github/workflows/cve-bin-releases.yml
+++ b/.github/workflows/cve-bin-releases.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - name: Install cve-bin-tool
       run: |
-        pip install -r .github/workflows/third-party/requirements.txt
+        pip3 install cve-bin-tool[PDF]
 
     - name: Download ISPC release archives
       env:

--- a/.github/workflows/cve-bin.yml
+++ b/.github/workflows/cve-bin.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - name: Install cve-bin-tool
       run: |
-        pip install -r .github/workflows/third-party/requirements.txt
+        pip3 install cve-bin-tool[PDF]
 
     - name: Download trunk archives
       run: |

--- a/.github/workflows/third-party/requirements.txt
+++ b/.github/workflows/third-party/requirements.txt
@@ -1,2 +1,0 @@
-bandit==1.7.9
-cve-bin-tool[PDF]==3.3


### PR DESCRIPTION
This PR improves configuration of dependabot.yml. In theory (I can't test it until it's merged) it should create one PR for all dependencies update.
It also reverts 7431a910b5be098cc03ef556661d5f91bd91c8f7. Pinning the version didn't help to eliminate warnings like this one: https://github.com/ispc/ispc/security/code-scanning/88. Seems like it should be pinned by hash which is IMO overkill for the tools that are used for testing. 
