### PR TITLE
ci: fix groups in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,11 @@ updates:
     commit-message:
       prefix: "ci:"
     open-pull-requests-limit: 1
-    group:
-      group-name: "all-dependencies"
+    groups:
+      ga-dependencies:
+        applies-to: version-updates
+        patterns:
+        - "*"
     ignore:
-      - update-types: ["version-update:semver-patch"] # Ignore patch updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"] # Ignore patch updates


### PR DESCRIPTION
Fixed groups in dependabot.yml.
Now it should create one PR for all the GA dependencies update like this one: https://github.com/aneshlya/ispc/pull/19.