### PR TITLE
Support short vectors based on template parameters

### DIFF
--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -177,7 +177,7 @@ Symbol *ispc::CreateISPCSymbolForLLVMIntrinsic(llvm::Function *func, SymbolTable
     }
     FunctionType *funcType = new FunctionType(returnType, argTypes, noPos);
     Debug(noPos, "Created Intrinsic symbol \"%s\" [%s]\n", name.c_str(), funcType->GetString().c_str());
-    Symbol *sym = new Symbol(name, noPos, funcType);
+    Symbol *sym = new Symbol(name, noPos, Symbol::SymbolKind::Function, funcType);
     sym->function = func;
     symbolTable->AddIntrinsics(sym);
     return sym;

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -887,7 +887,8 @@ std::vector<VariableDeclaration> Declaration::GetVariableDeclarations() const {
             if (!decl->type->IsDependentType()) {
                 decl->type = decl->type->ResolveUnboundVariability(Variability::Varying);
             }
-            Symbol *sym = new Symbol(decl->name, decl->pos, decl->type, decl->storageClass);
+            Symbol *sym =
+                new Symbol(decl->name, decl->pos, Symbol::SymbolKind::Variable, decl->type, decl->storageClass);
 
             AttributeList *AL = decl->attributeList;
             if (AL) {

--- a/src/decl.h
+++ b/src/decl.h
@@ -30,6 +30,7 @@
 #include "ispc.h"
 
 #include <llvm/ADT/SmallVector.h>
+#include <variant>
 
 namespace ispc {
 
@@ -163,7 +164,7 @@ class DeclSpecs : public Traceable {
     /** If this is a declaration with a vector type, this gives the vector
         width.  For non-vector types, this is zero.
      */
-    int vectorSize;
+    std::variant<std::monostate, int, Symbol *> vectorSize;
 
     /** If this is a declaration with an "soa<n>" qualifier, this gives the
         SOA width specified.  Otherwise this is zero.

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -5320,6 +5320,8 @@ DependentMemberExpr::DependentMemberExpr(Expr *e, const char *id, SourcePos p, S
     Assert(id != nullptr);
 }
 
+const Type *DependentMemberExpr::GetType() const { return AtomicType::Dependent; }
+const Type *DependentMemberExpr::GetLValueType() const { return AtomicType::Dependent; }
 int DependentMemberExpr::getElementNumber() const { UNREACHABLE(); };
 const Type *DependentMemberExpr::getElementType() const { UNREACHABLE(); };
 
@@ -6294,8 +6296,11 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     if (toType->IsVectorType() && toType->IsUniformType() && fromType->IsVectorType() && fromType->IsUniformType()) {
         const VectorType *vToType = CastType<VectorType>(toType);
         const VectorType *vFromType = CastType<VectorType>(fromType);
-        basicToType = vToType->GetElementType()->basicType;
-        basicFromType = vFromType->GetElementType()->basicType;
+        const AtomicType *aToType = CastType<AtomicType>(vToType->GetElementType());
+        const AtomicType *aFromType = CastType<AtomicType>(vFromType->GetElementType());
+        AssertPos(pos, aToType != nullptr && aFromType != nullptr);
+        basicToType = aToType->basicType;
+        basicFromType = aFromType->basicType;
     } else if (toType->IsAtomicType() && fromType->IsAtomicType()) {
         const AtomicType *aToType = CastType<AtomicType>(toType);
         const AtomicType *aFromType = CastType<AtomicType>(fromType);

--- a/src/expr.h
+++ b/src/expr.h
@@ -421,6 +421,9 @@ class DependentMemberExpr : public MemberExpr {
     static inline bool classof(DependentMemberExpr const *) { return true; }
     static inline bool classof(ASTNode const *N) { return N->getValueID() == DependentMemberExprID; }
 
+    const Type *GetType() const;
+    const Type *GetLValueType() const;
+
     int getElementNumber() const;
     const Type *getElementType() const;
 };

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -1197,7 +1197,7 @@ Symbol *TemplateInstantiation::InstantiateSymbol(Symbol *sym) {
     }
 
     const Type *instType = sym->type->ResolveDependenceForTopType(*this);
-    Symbol *instSym = new Symbol(sym->name, sym->pos, instType, sym->storageClass);
+    Symbol *instSym = new Symbol(sym->name, sym->pos, sym->GetSymbolKind(), instType, sym->storageClass);
     // Update constValue for non-type template parameters
     if (argsMap.find(sym->name) != argsMap.end()) {
         const TemplateArg *arg = argsMap[sym->name];
@@ -1231,7 +1231,8 @@ Symbol *TemplateInstantiation::InstantiateTemplateSymbol(TemplateSymbol *sym) {
     const Type *instType = sym->type->ResolveDependenceForTopType(*this);
 
     // Create a function symbol
-    Symbol *instSym = new Symbol(sym->name, sym->pos, instType, sym->storageClass);
+    Symbol *instSym =
+        new Symbol(sym->name, sym->pos, Symbol::SymbolKind::TemplateInstantiation, instType, sym->storageClass);
     functionSym = instSym;
 
     // Create llvm::Function and attach to the symbol, so the symbol is complete and ready for use.

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -799,7 +799,7 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
         // previous llvm::GlobalVariable
         oldGV = gv;
     } else {
-        sym = new Symbol(name, pos, type, storageClass);
+        sym = new Symbol(name, pos, Symbol::SymbolKind::Variable, type, storageClass);
         symbolTable->AddVariable(sym);
     }
     sym->constValue = constValue;
@@ -1250,7 +1250,7 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
 
     // Finally, we know all is good and we can add the function to the
     // symbol table
-    Symbol *funSym = new Symbol(name, pos, functionType, storageClass);
+    Symbol *funSym = new Symbol(name, pos, Symbol::SymbolKind::Function, functionType, storageClass);
     funSym->function = function;
     bool ok = symbolTable->AddFunction(funSym);
     Assert(ok);

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1579,7 +1579,7 @@ enumerator_list
 enumerator
     : enum_identifier
       {
-          $$ = new Symbol($1, @1);
+          $$ = new Symbol($1, @1, Symbol::SymbolKind::Enumerator);
           // allocated by strdup in enum_identifier
           free((char*)$1);
       }
@@ -1588,7 +1588,7 @@ enumerator
           int value;
           if ($1 != nullptr && $3 != nullptr &&
               lGetConstantInt($3, &value, @3, "Enumerator value")) {
-              Symbol *sym = new Symbol($1, @1);
+              Symbol *sym = new Symbol($1, @1, Symbol::SymbolKind::Enumerator);
               sym->constValue = new ConstExpr(AtomicType::UniformUInt32->GetAsConstType(),
                                               (uint32_t)value, @3);
               $$ = sym;
@@ -2152,7 +2152,7 @@ foreach_tiled_scope
 foreach_identifier
     : TOKEN_IDENTIFIER
     {
-        $$ = new Symbol(yytext, @1, AtomicType::VaryingInt32->GetAsConstType());
+        $$ = new Symbol(yytext, @1, Symbol::SymbolKind::Variable, AtomicType::VaryingInt32->GetAsConstType());
         lCleanUpString($1);
     }
     ;
@@ -2164,7 +2164,7 @@ foreach_active_scope
 foreach_active_identifier
     : TOKEN_IDENTIFIER
     {
-        $$ = new Symbol(yytext, @1, AtomicType::UniformInt64->GetAsConstType());
+        $$ = new Symbol(yytext, @1, Symbol::SymbolKind::Variable, AtomicType::UniformInt64->GetAsConstType());
         lCleanUpString($1);
     }
     ;
@@ -2345,7 +2345,7 @@ iteration_statement
              (expr = TypeCheck(expr)) != nullptr &&
              (type = expr->GetType()) != nullptr) {
              const Type *iterType = type->GetAsUniformType()->GetAsConstType();
-             Symbol *sym = new Symbol($3, @3, iterType);
+             Symbol *sym = new Symbol($3, @3, Symbol::SymbolKind::Variable, iterType);
              m->symbolTable->AddVariable(sym);
          }
      }
@@ -2526,12 +2526,12 @@ template_int_constant_type
 template_int_parameter
     : template_int_constant_type TOKEN_IDENTIFIER
       {
-          $$ = new Symbol(*$<stringVal>2, Union(@1, @2), $1);
+          $$ = new Symbol(*$<stringVal>2, Union(@1, @2), Symbol::SymbolKind::TemplateNonTypeParm, $1);
           lCleanUpString($2);
       }
       | template_int_constant_type TOKEN_IDENTIFIER '=' int_constant
       {
-          $$ = new Symbol(*$<stringVal>2, Union(@1, @2), $1);
+          $$ = new Symbol(*$<stringVal>2, Union(@1, @2), Symbol::SymbolKind::TemplateNonTypeParm, $1);
           lCleanUpString($2);
           // TODO: implement
           Error(@4, "Default values for template non-type parameters are not yet supported.");
@@ -2546,7 +2546,7 @@ template_enum_parameter
           if (enumType == nullptr) {
             Error(@1, "Only enum types and integral types are allowed as non-type template parameters.");
           }
-          $$ = new Symbol(*$<stringVal>2, Union(@1, @2), enumType->GetAsConstType()->GetAsUniformType());
+          $$ = new Symbol(*$<stringVal>2, Union(@1, @2), Symbol::SymbolKind::TemplateNonTypeParm, enumType->GetAsConstType()->GetAsUniformType());
           lCleanUpString($1);
           lCleanUpString($2);
       }
@@ -3176,7 +3176,7 @@ lAddFunctionParams(Declarator *decl) {
         if (declarator == nullptr)
             AssertPos(decl->pos, m->errorCount > 0);
         else {
-            Symbol *sym = new Symbol(declarator->name, declarator->pos,
+            Symbol *sym = new Symbol(declarator->name, declarator->pos, Symbol::SymbolKind::FunctionParm, 
                                      declarator->type, declarator->storageClass);
 
             AttributeList *AL = declarator->attributeList;
@@ -3223,7 +3223,7 @@ static void lAddMaskToSymbolTable(SourcePos pos) {
     }
 
     t = t->GetAsConstType();
-    Symbol *maskSymbol = new Symbol("__mask", pos, t);
+    Symbol *maskSymbol = new Symbol("__mask", pos, Symbol::SymbolKind::Default, t);
     m->symbolTable->AddVariable(maskSymbol);
 }
 
@@ -3233,31 +3233,31 @@ static void lAddMaskToSymbolTable(SourcePos pos) {
 static void lAddThreadIndexCountToSymbolTable(SourcePos pos) {
     const Type *type = AtomicType::UniformUInt32->GetAsConstType();
 
-    Symbol *threadIndexSym = new Symbol("threadIndex", pos, type);
+    Symbol *threadIndexSym = new Symbol("threadIndex", pos, Symbol::SymbolKind::Default, type);
     m->symbolTable->AddVariable(threadIndexSym);
 
-    Symbol *threadCountSym = new Symbol("threadCount", pos, type);
+    Symbol *threadCountSym = new Symbol("threadCount", pos, Symbol::SymbolKind::Default, type);
     m->symbolTable->AddVariable(threadCountSym);
 
-    Symbol *taskIndexSym = new Symbol("taskIndex", pos, type);
+    Symbol *taskIndexSym = new Symbol("taskIndex", pos, Symbol::SymbolKind::Default, type);
     m->symbolTable->AddVariable(taskIndexSym);
 
-    Symbol *taskCountSym = new Symbol("taskCount", pos, type);
+    Symbol *taskCountSym = new Symbol("taskCount", pos, Symbol::SymbolKind::Default, type);
     m->symbolTable->AddVariable(taskCountSym);
 
-    Symbol *taskIndexSym0 = new Symbol("taskIndex0", pos, type);
+    Symbol *taskIndexSym0 = new Symbol("taskIndex0", pos, Symbol::SymbolKind::Default, type);
     m->symbolTable->AddVariable(taskIndexSym0);
-    Symbol *taskIndexSym1 = new Symbol("taskIndex1", pos, type);
+    Symbol *taskIndexSym1 = new Symbol("taskIndex1", pos, Symbol::SymbolKind::Default, type);
     m->symbolTable->AddVariable(taskIndexSym1);
-    Symbol *taskIndexSym2 = new Symbol("taskIndex2", pos, type);
+    Symbol *taskIndexSym2 = new Symbol("taskIndex2", pos, Symbol::SymbolKind::Default, type);
     m->symbolTable->AddVariable(taskIndexSym2);
 
 
-    Symbol *taskCountSym0 = new Symbol("taskCount0", pos, type);
+    Symbol *taskCountSym0 = new Symbol("taskCount0", pos, Symbol::SymbolKind::Default, type);
     m->symbolTable->AddVariable(taskCountSym0);
-    Symbol *taskCountSym1 = new Symbol("taskCount1", pos, type);
+    Symbol *taskCountSym1 = new Symbol("taskCount1", pos, Symbol::SymbolKind::Default, type);
     m->symbolTable->AddVariable(taskCountSym1);
-    Symbol *taskCountSym2 = new Symbol("taskCount2", pos, type);
+    Symbol *taskCountSym2 = new Symbol("taskCount2", pos, Symbol::SymbolKind::Default, type);
     m->symbolTable->AddVariable(taskCountSym2);
 }
 

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1031,6 +1031,19 @@ declaration_specifiers
           ds->vectorSize = (int32_t)$3;
           $$ = ds;
     }
+    | type_specifier '<' TOKEN_IDENTIFIER '>'
+    {
+          DeclSpecs *ds = new DeclSpecs($1);
+          const char *name = $3->c_str();
+          Symbol *s = m->symbolTable->LookupVariable(name);
+          if (s) {
+            ds->vectorSize = s;
+          } else {
+            Error(@3, "Unknown identifier \"%s\" is used to specify the size of a vector type.", name);
+          }
+          $$ = ds;
+          lCleanUpString($3);
+    }
     | type_specifier declaration_specifiers
       {
           DeclSpecs *ds = (DeclSpecs *)$2;
@@ -1238,6 +1251,14 @@ short_vec_specifier
     {
         $$ = $1 ? new VectorType($1, (int32_t)$3) : nullptr;
     }
+    // When templates are supported for structures, this rule can be uncommented.
+    /*| atomic_var_type_specifier '<' TOKEN_IDENTIFIER '>'
+    {
+         Symbol* s = new Symbol(*$<stringVal>3, Union(@1, @3), AtomicType::UniformInt32->GetAsConstType());
+         lCleanUpString($3);
+         $$ = $1 ? new VectorType($1, s) : nullptr;
+
+    }*/
     ;
 
 struct_or_union_name

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -24,9 +24,9 @@ using namespace ispc;
 ///////////////////////////////////////////////////////////////////////////
 // Symbol
 
-Symbol::Symbol(const std::string &n, SourcePos p, const Type *t, StorageClass sc)
+Symbol::Symbol(const std::string &n, SourcePos p, SymbolKind st, const Type *t, StorageClass sc)
     : pos(p), name(n), storageInfo(nullptr), function(nullptr), exportedFunction(nullptr), type(t), constValue(nullptr),
-      storageClass(sc), varyingCFDepth(0), parentFunction(nullptr) {}
+      storageClass(sc), varyingCFDepth(0), parentFunction(nullptr), kind(st) {}
 
 ///////////////////////////////////////////////////////////////////////////
 // TemplateSymbol

--- a/src/sym.h
+++ b/src/sym.h
@@ -38,9 +38,22 @@ class ConstExpr;
 
 class Symbol : public Traceable {
   public:
+    enum class SymbolKind {
+        Default,
+        Enumerator,
+        Function,
+        FunctionParm,
+        TemplateNonTypeParm,
+        TemplateTypeParm,
+        TemplateInstantiation,
+        TemplateSymbol,
+        Variable
+        // ... other symbol types ...
+    };
     /** The Symbol constructor takes the name of the symbol, its
         position in a source file, and its type (if known). */
-    Symbol(const std::string &name, SourcePos pos, const Type *t = nullptr, StorageClass sc = SC_NONE);
+    Symbol(const std::string &name, SourcePos pos, SymbolKind st = SymbolKind::Default, const Type *t = nullptr,
+           StorageClass sc = SC_NONE);
 
     SourcePos pos;            /*!< Source file position where the symbol was defined */
     std::string name;         /*!< Symbol's name */
@@ -80,6 +93,11 @@ class Symbol : public Traceable {
     /*!< For symbols that are parameters to functions or are
          variables declared inside functions, this gives the
          function they're in. */
+    /* */
+    SymbolKind GetSymbolKind() const { return kind; }
+
+  private:
+    SymbolKind kind;
 };
 
 /**

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1369,9 +1369,9 @@ const Type *SequentialType::GetElementType(int index) const { return GetElementT
 ///////////////////////////////////////////////////////////////////////////
 // ArrayType
 
-ArrayType::ArrayType(const Type *c, int a) : SequentialType(ARRAY_TYPE), child(c), numElements(a) {
+ArrayType::ArrayType(const Type *c, int a) : SequentialType(ARRAY_TYPE), child(c), elementCount(a) {
     // 0 -> unsized array.
-    Assert(numElements >= 0);
+    Assert(elementCount.fixedCount >= 0);
     Assert(c->IsVoidType() == false);
 }
 
@@ -1386,7 +1386,7 @@ llvm::ArrayType *ArrayType::LLVMType(llvm::LLVMContext *ctx) const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-    return llvm::ArrayType::get(ct, numElements);
+    return llvm::ArrayType::get(ct, elementCount.fixedCount);
 }
 
 Variability ArrayType::GetVariability() const {
@@ -1421,7 +1421,7 @@ const ArrayType *ArrayType::GetAsVaryingType() const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-    return new ArrayType(child->GetAsVaryingType(), numElements);
+    return new ArrayType(child->GetAsVaryingType(), elementCount.fixedCount);
 }
 
 const ArrayType *ArrayType::GetAsUniformType() const {
@@ -1429,7 +1429,7 @@ const ArrayType *ArrayType::GetAsUniformType() const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-    return new ArrayType(child->GetAsUniformType(), numElements);
+    return new ArrayType(child->GetAsUniformType(), elementCount.fixedCount);
 }
 
 const ArrayType *ArrayType::GetAsUnboundVariabilityType() const {
@@ -1437,7 +1437,7 @@ const ArrayType *ArrayType::GetAsUnboundVariabilityType() const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-    return new ArrayType(child->GetAsUnboundVariabilityType(), numElements);
+    return new ArrayType(child->GetAsUnboundVariabilityType(), elementCount.fixedCount);
 }
 
 const ArrayType *ArrayType::GetAsSOAType(int width) const {
@@ -1445,7 +1445,7 @@ const ArrayType *ArrayType::GetAsSOAType(int width) const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-    return new ArrayType(child->GetAsSOAType(width), numElements);
+    return new ArrayType(child->GetAsSOAType(width), elementCount.fixedCount);
 }
 
 const ArrayType *ArrayType::ResolveDependence(TemplateInstantiation &templInst) const {
@@ -1458,7 +1458,7 @@ const ArrayType *ArrayType::ResolveDependence(TemplateInstantiation &templInst) 
     if (resType == child) {
         return this;
     }
-    return new ArrayType(resType, numElements);
+    return new ArrayType(resType, elementCount.fixedCount);
 }
 
 const ArrayType *ArrayType::ResolveUnboundVariability(Variability v) const {
@@ -1466,7 +1466,7 @@ const ArrayType *ArrayType::ResolveUnboundVariability(Variability v) const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-    return new ArrayType(child->ResolveUnboundVariability(v), numElements);
+    return new ArrayType(child->ResolveUnboundVariability(v), elementCount.fixedCount);
 }
 
 const ArrayType *ArrayType::GetAsUnsignedType() const {
@@ -1474,7 +1474,7 @@ const ArrayType *ArrayType::GetAsUnsignedType() const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-    return new ArrayType(child->GetAsUnsignedType(), numElements);
+    return new ArrayType(child->GetAsUnsignedType(), elementCount.fixedCount);
 }
 
 const ArrayType *ArrayType::GetAsSignedType() const {
@@ -1482,7 +1482,7 @@ const ArrayType *ArrayType::GetAsSignedType() const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-    return new ArrayType(child->GetAsSignedType(), numElements);
+    return new ArrayType(child->GetAsSignedType(), elementCount.fixedCount);
 }
 
 const ArrayType *ArrayType::GetAsConstType() const {
@@ -1490,7 +1490,7 @@ const ArrayType *ArrayType::GetAsConstType() const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-    return new ArrayType(child->GetAsConstType(), numElements);
+    return new ArrayType(child->GetAsConstType(), elementCount.fixedCount);
 }
 
 const ArrayType *ArrayType::GetAsNonConstType() const {
@@ -1498,10 +1498,10 @@ const ArrayType *ArrayType::GetAsNonConstType() const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-    return new ArrayType(child->GetAsNonConstType(), numElements);
+    return new ArrayType(child->GetAsNonConstType(), elementCount.fixedCount);
 }
 
-int ArrayType::GetElementCount() const { return numElements; }
+int ArrayType::GetElementCount() const { return elementCount.fixedCount; }
 
 const Type *ArrayType::GetElementType() const { return child; }
 
@@ -1519,8 +1519,8 @@ std::string ArrayType::GetString() const {
     // dimensions
     while (at) {
         char buf[16];
-        if (at->numElements > 0)
-            snprintf(buf, sizeof(buf), "%d", at->numElements);
+        if (at->elementCount.fixedCount > 0)
+            snprintf(buf, sizeof(buf), "%d", at->elementCount.fixedCount);
         else
             buf[0] = '\0';
         s += std::string("[") + std::string(buf) + std::string("]");
@@ -1536,8 +1536,8 @@ std::string ArrayType::Mangle() const {
     }
     std::string s = child->Mangle();
     char buf[16];
-    if (numElements > 0)
-        snprintf(buf, sizeof(buf), "%d", numElements);
+    if (elementCount.fixedCount > 0)
+        snprintf(buf, sizeof(buf), "%d", elementCount.fixedCount);
     else
         buf[0] = '\0';
     //    return s + "[" + buf + "]";
@@ -1561,8 +1561,8 @@ std::string ArrayType::GetDeclaration(const std::string &name, DeclarationSyntax
     Assert(at);
     while (at) {
         char buf[16];
-        if (at->numElements > 0)
-            snprintf(buf, sizeof(buf), "%d", at->numElements);
+        if (at->elementCount.fixedCount > 0)
+            snprintf(buf, sizeof(buf), "%d", at->elementCount.fixedCount);
         else
             buf[0] = '\0';
         s += std::string("[") + std::string(buf) + std::string("]");
@@ -1587,9 +1587,9 @@ std::string ArrayType::GetDeclaration(const std::string &name, DeclarationSyntax
 int ArrayType::TotalElementCount() const {
     const ArrayType *ct = CastType<ArrayType>(child);
     if (ct != nullptr)
-        return numElements * ct->TotalElementCount();
+        return elementCount.fixedCount * ct->TotalElementCount();
     else
-        return numElements;
+        return elementCount.fixedCount;
 }
 
 llvm::DIType *ArrayType::GetDIType(llvm::DIScope *scope) const {
@@ -1598,11 +1598,11 @@ llvm::DIType *ArrayType::GetDIType(llvm::DIScope *scope) const {
         return nullptr;
     }
     llvm::DIType *eltType = child->GetDIType(scope);
-    return lCreateDIArray(eltType, numElements);
+    return lCreateDIArray(eltType, elementCount.fixedCount);
 }
 
 ArrayType *ArrayType::GetSizedArray(int sz) const {
-    Assert(numElements == 0);
+    Assert(elementCount.fixedCount == 0);
     return new ArrayType(child, sz);
 }
 
@@ -1662,11 +1662,18 @@ const Type *ArrayType::SizeUnsizedArrays(const Type *type, Expr *initExpr) {
     return new ArrayType(SizeUnsizedArrays(at->GetElementType(), nextList), at->GetElementCount());
 }
 
+int ArrayType::ResolveElementCount(TemplateInstantiation &templInst) const {
+    if (elementCount.fixedCount > 0)
+        return elementCount.fixedCount;
+
+    return 0;
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // VectorType
 
-VectorType::VectorType(const AtomicType *b, int a) : SequentialType(VECTOR_TYPE), base(b), numElements(a) {
-    Assert(numElements > 0);
+VectorType::VectorType(const AtomicType *b, int a) : SequentialType(VECTOR_TYPE), base(b), elementCount(a) {
+    Assert(elementCount.fixedCount > 0);
     Assert(base != nullptr);
 }
 
@@ -1686,22 +1693,26 @@ bool VectorType::IsConstType() const { return base->IsConstType(); }
 
 const Type *VectorType::GetBaseType() const { return base; }
 
-const VectorType *VectorType::GetAsVaryingType() const { return new VectorType(base->GetAsVaryingType(), numElements); }
+const VectorType *VectorType::GetAsVaryingType() const {
+    return new VectorType(base->GetAsVaryingType(), elementCount.fixedCount);
+}
 
-const VectorType *VectorType::GetAsUniformType() const { return new VectorType(base->GetAsUniformType(), numElements); }
+const VectorType *VectorType::GetAsUniformType() const {
+    return new VectorType(base->GetAsUniformType(), elementCount.fixedCount);
+}
 
 const VectorType *VectorType::GetAsUnboundVariabilityType() const {
-    return new VectorType(base->GetAsUnboundVariabilityType(), numElements);
+    return new VectorType(base->GetAsUnboundVariabilityType(), elementCount.fixedCount);
 }
 
 const VectorType *VectorType::GetAsSOAType(int width) const {
-    return new VectorType(base->GetAsSOAType(width), numElements);
+    return new VectorType(base->GetAsSOAType(width), elementCount.fixedCount);
 }
 
 const VectorType *VectorType::ResolveDependence(TemplateInstantiation &templInst) const { return this; }
 
 const VectorType *VectorType::ResolveUnboundVariability(Variability v) const {
-    return new VectorType(base->ResolveUnboundVariability(v), numElements);
+    return new VectorType(base->ResolveUnboundVariability(v), elementCount.fixedCount);
 }
 
 const VectorType *VectorType::GetAsUnsignedType() const {
@@ -1709,7 +1720,7 @@ const VectorType *VectorType::GetAsUnsignedType() const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-    return new VectorType(base->GetAsUnsignedType(), numElements);
+    return new VectorType(base->GetAsUnsignedType(), elementCount.fixedCount);
 }
 
 const VectorType *VectorType::GetAsSignedType() const {
@@ -1717,37 +1728,39 @@ const VectorType *VectorType::GetAsSignedType() const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-    return new VectorType(base->GetAsSignedType(), numElements);
+    return new VectorType(base->GetAsSignedType(), elementCount.fixedCount);
 }
 
-const VectorType *VectorType::GetAsConstType() const { return new VectorType(base->GetAsConstType(), numElements); }
+const VectorType *VectorType::GetAsConstType() const {
+    return new VectorType(base->GetAsConstType(), elementCount.fixedCount);
+}
 
 const VectorType *VectorType::GetAsNonConstType() const {
-    return new VectorType(base->GetAsNonConstType(), numElements);
+    return new VectorType(base->GetAsNonConstType(), elementCount.fixedCount);
 }
 
 std::string VectorType::GetString() const {
     std::string s = base->GetString();
     char buf[16];
-    snprintf(buf, sizeof(buf), "<%d>", numElements);
+    snprintf(buf, sizeof(buf), "<%d>", elementCount.fixedCount);
     return s + std::string(buf);
 }
 
 std::string VectorType::Mangle() const {
     std::string s = base->Mangle();
     char buf[16];
-    snprintf(buf, sizeof(buf), "_3C_%d_3E_", numElements); // "<%d>"
+    snprintf(buf, sizeof(buf), "_3C_%d_3E_", elementCount.fixedCount); // "<%d>"
     return s + std::string(buf);
 }
 
 std::string VectorType::GetDeclaration(const std::string &name, DeclarationSyntax syntax) const {
     std::string s = base->GetDeclaration("", syntax);
     char buf[16];
-    snprintf(buf, sizeof(buf), "%d", numElements);
+    snprintf(buf, sizeof(buf), "%d", elementCount.fixedCount);
     return s + std::string(buf) + "  " + name;
 }
 
-int VectorType::GetElementCount() const { return numElements; }
+int VectorType::GetElementCount() const { return elementCount.fixedCount; }
 
 const AtomicType *VectorType::GetElementType() const { return base; }
 
@@ -1798,14 +1811,14 @@ llvm::Type *VectorType::LLVMType(llvm::LLVMContext *ctx) const { return lGetVect
 llvm::DIType *VectorType::GetDIType(llvm::DIScope *scope) const {
     llvm::DIType *eltType = base->GetDIType(scope);
 
-    llvm::Metadata *sub = m->diBuilder->getOrCreateSubrange(0, numElements);
+    llvm::Metadata *sub = m->diBuilder->getOrCreateSubrange(0, elementCount.fixedCount);
 
     // vectors of varying types are already naturally aligned to the
     // machine's vector width, but arrays of uniform types need to be
     // explicitly aligned to the machines natural vector alignment.
 
     llvm::DINodeArray subArray = m->diBuilder->getOrCreateArray(sub);
-    uint64_t sizeBits = eltType->getSizeInBits() * numElements;
+    uint64_t sizeBits = eltType->getSizeInBits() * elementCount.fixedCount;
     uint64_t align = eltType->getAlignInBits();
 
     if (IsUniformType()) {
@@ -1816,7 +1829,7 @@ llvm::DIType *VectorType::GetDIType(llvm::DIScope *scope) const {
     if (IsUniformType() || IsVaryingType())
         return m->diBuilder->createVectorType(sizeBits, align, eltType, subArray);
     else if (IsSOAType()) {
-        ArrayType at(base, numElements);
+        ArrayType at(base, elementCount.fixedCount);
         return at.GetDIType(scope);
     } else {
         FATAL("Unexpected variability in VectorType::GetDIType()");
@@ -1826,7 +1839,7 @@ llvm::DIType *VectorType::GetDIType(llvm::DIScope *scope) const {
 
 int VectorType::getVectorMemoryCount() const {
     if (base->IsVaryingType())
-        return numElements;
+        return elementCount.fixedCount;
     else if (base->IsUniformType()) {
         // Round up the element count to power of 2 bits in size but not less then 128 bit in total vector size
         // where one element size is data type width in bits.
@@ -1837,7 +1850,7 @@ int VectorType::getVectorMemoryCount() const {
         // registers are used. It generally leads to better performance. This strategy also matches OpenCL short
         // vectors.
         // 3. Using data type width of the target to determine element size makes optimization trade off.
-        int nextPow2 = llvm::NextPowerOf2(numElements - 1);
+        int nextPow2 = llvm::NextPowerOf2(elementCount.fixedCount - 1);
         return (nextPow2 * g->target->getDataTypeWidth() < 128) ? (128 / g->target->getDataTypeWidth()) : nextPow2;
     } else if (base->IsSOAType()) {
         FATAL("VectorType SOA getVectorMemoryCount");
@@ -1848,6 +1861,12 @@ int VectorType::getVectorMemoryCount() const {
     }
 }
 
+int VectorType::ResolveElementCount(TemplateInstantiation &templInst) const {
+    if (elementCount.fixedCount > 0)
+        return elementCount.fixedCount;
+
+    return 0;
+}
 ///////////////////////////////////////////////////////////////////////////
 // StructType
 

--- a/src/type.h
+++ b/src/type.h
@@ -699,7 +699,9 @@ class ArrayType : public SequentialType {
  */
 class VectorType : public SequentialType {
   public:
-    VectorType(const AtomicType *base, int size);
+    VectorType(const Type *base, int size);
+    VectorType(const Type *base, Symbol *num);
+    VectorType(const Type *base, ElementCount elCount);
 
     Variability GetVariability() const;
 
@@ -736,11 +738,11 @@ class VectorType : public SequentialType {
 
     int GetElementCount() const;
 
-    const AtomicType *GetElementType() const;
+    const Type *GetElementType() const;
 
   private:
     /** Base type that the vector holds elements of */
-    const AtomicType *const base;
+    const Type *const base;
     /** Number of elements in the vector */
     ElementCount elementCount;
     /** Resolves the total number of elements in the vector in template instantiation. */

--- a/tests/lit-tests/err-vec.ispc
+++ b/tests/lit-tests/err-vec.ispc
@@ -5,9 +5,3 @@
 void foo(float<3> a, int<2> b) {
     a += b;
 }
-
-// CHECK: Error: syntax error, unexpected identifier, expecting int
-
-void foo(uniform int i) {
-    float<i> a;
-}

--- a/tests/lit-tests/func_template_nontype_8.ispc
+++ b/tests/lit-tests/func_template_nontype_8.ispc
@@ -1,10 +1,9 @@
 // This test is checking that template type and non-type parameters
 // can be used for short vectors declaration.
-// RUN: %{ispc} %s --target=host --nostdlib 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --target=host 2>&1 | FileCheck %s
 // CHECK-NOT: Error:
-// XFAIL: *
 template <typename T, uint N>
-uniform T<N> max_short(uniform const T<N> a, uniform const T<N> b)
+uniform T<N> max_test(uniform const T<N> a, uniform const T<N> b)
 {
     uniform T<N> r;
     foreach (i = 0 ... N) {
@@ -14,5 +13,5 @@ uniform T<N> max_short(uniform const T<N> a, uniform const T<N> b)
 }
 
 uniform double<4> foo(uniform const double<4> a, uniform const double<4> b) {
-    return max<double, 4>(a, b);
+    return max_test<double, 4>(a, b);
 }

--- a/tests/lit-tests/func_template_shortvec_1.ispc
+++ b/tests/lit-tests/func_template_shortvec_1.ispc
@@ -1,0 +1,15 @@
+// The test checks that template type and non-type parameters can be used to create uniform short vector
+// RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
+
+// CHECK-LABEL: define {{.*}} <4 x i32> @bar___vyiCuni4{{.*}}(<4 x i32> %a, <4 x i32> %b, {{.*}}
+// CHECK: ret <4 x i32> %r
+template <typename T, uint N> noinline uniform T<N> bar(uniform const T<N> a, uniform const T<N> b, uniform int c) {
+    uniform T<N> r = {c, 2 * c, 3 * c, 0};
+    for (uniform int i = 0; i < N; i++) {
+        r.x += i + c;
+    }
+    r.y = a.x + b.z;
+    return r;
+}
+
+uniform int<4> foo(uniform const int<4> a, uniform const int<4> b, uniform int c) { return bar<int, 4>(a, b, c); }

--- a/tests/lit-tests/func_template_shortvec_2.ispc
+++ b/tests/lit-tests/func_template_shortvec_2.ispc
@@ -1,0 +1,15 @@
+// The test checks that template type and non-type parameters can be used to create varying short vector
+// RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
+
+// CHECK-LABEL: define {{.*}} [4 x <{{.*}} x i32>] @bar___vyiCuni4{{.*}}([4 x <{{.*}} x i32>] %a, [4 x <{{.*}} x i32>] %b, {{.*}}
+// CHECK: ret [4 x <{{.*}} x i32>] %r
+template <typename T, uint N> noinline T<N> bar(const T<N> a, const T<N> b, int c) {
+    T<N> r = {c, 2 * c, 3 * c, 0};
+    foreach (i = 0... N) {
+        r.x += i + c;
+    }
+    r.y = a.x + b.z;
+    return r;
+}
+
+int<4> foo(const int<4> a, const int<4> b, int c) { return bar<int, 4>(a, b, c); }

--- a/tests/lit-tests/func_template_shortvec_3.ispc
+++ b/tests/lit-tests/func_template_shortvec_3.ispc
@@ -1,0 +1,24 @@
+// The test checks that enum type as template parameter can be used to create short vector
+// RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
+// CHECK: <{{.*}} x i32> @bar___vyiCunenum_{{.*}}([3 x <{{.*}} x i32>] %x, [3 x <{{.*}} x i32>] %y
+enum Foo {
+    ZERO,
+    ONE,
+    TWO,
+    THREE
+};
+
+template<typename T, Foo N>
+noinline T bar(T<N> x, T<N> y) {
+    T<N> soaValue;
+    foreach (i = 0 ... N) {
+        soaValue[i] = x[i] + y[i];
+    }
+    return soaValue[2];
+}
+
+int test(uniform int c) {
+    uniform int<3> x3 = {c, 2 * c, 3 * c};
+    uniform int<3> y3 = {3* c, 2 * c, c};
+    return bar<varying int, THREE>(x3, y3);
+}

--- a/tests/lit-tests/func_template_shortvec_4.ispc
+++ b/tests/lit-tests/func_template_shortvec_4.ispc
@@ -1,0 +1,32 @@
+// This test checks short vectors with template specialization
+// RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
+// CHECK-LABEL: @CalculateDifferentWidths___vyiCuni4_{{.*}}([4 x <{{.*}} x i32>] %x, [4 x <{{.*}} x i32>] %y
+// CHECK-LABEL: @test_CalculateDifferentWidths
+// CHECK-LABEL: @CalculateDifferentWidths___vyfCuni3_{{.*}}([3 x <{{.*}} x float>] %x, [3 x <{{.*}} x float>] %y
+// CHECK-LABEL: @CalculateDifferentWidths___vyiCuni3_{{.*}}([3 x <{{.*}} x i32>] %x, [3 x <{{.*}} x i32>] %y
+template<typename T, int N>
+noinline T CalculateDifferentWidths(T<N> x, T<N> y) {
+    T<N> soaValue;
+    foreach (i = 0 ... N) {
+        soaValue[i] = x[i] + y[i];
+    }
+    return soaValue[2];
+}
+
+template <> noinline int CalculateDifferentWidths<int, 4>(int<4> x, int<4> y) {
+    int<3> soaValue;
+    foreach (i = 0 ... 3) {
+        soaValue[i] = x[i] + y[i];
+    }
+    return soaValue[2];
+}
+
+int test_CalculateDifferentWidths(uniform int c) {
+    uniform int<4> x4 = {c, 2 * c, 3 * c, 0};
+    uniform int<4> y4 = {3* c, 2 * c, c, 0};
+    uniform float<3> x3 = {c, 2 * c, 3 * c};
+    uniform float<3> y3 = {3* c, 2 * c, c};
+    return CalculateDifferentWidths<int, 4>(x4, y4) + // specialization
+           CalculateDifferentWidths<float, 3>(x3, y3) + // instantiation
+           CalculateDifferentWidths<int, 3>(x3, y3); // instantiation
+}

--- a/tests/lit-tests/func_template_shortvec_5.ispc
+++ b/tests/lit-tests/func_template_shortvec_5.ispc
@@ -1,0 +1,53 @@
+// Check that short vector declared using template parameters uses DependentMemberExpr in AST
+
+// RUN: %{ispc} %s --nostdlib --target=host --ast-dump -o %t.o | FileCheck %s
+// CHECK-LABEL: "test1"
+// CHECK: AssignExpr {{.*}} [uniform <dependent type>], '='
+// CHECK: IndexExpr {{.*}} [uniform <dependent type>]
+// CHECK: AssignExpr {{.*}} [uniform <dependent type>], '='
+// CHECK: DependentMemberExpr {{.*}} [uniform <dependent type>] . zyx
+// CHECK-NOT: NULL
+
+// CHECK-LABEL: "test2"
+// CHECK: AssignExpr {{.*}} [uniform <dependent type>], '='
+// CHECK: IndexExpr {{.*}} [uniform <dependent type>]
+// CHECK: AssignExpr {{.*}} [uniform <dependent type>], '='
+// CHECK: DependentMemberExpr {{.*}} [uniform <dependent type>] . zyx
+// CHECK-NOT: NULL
+
+// CHECK-LABEL: "test3"
+// CHECK: AssignExpr {{.*}} [uniform <dependent type>], '='
+// CHECK: IndexExpr {{.*}} [uniform <dependent type>]
+// CHECK: AssignExpr {{.*}} [uniform <dependent type>], '='
+// CHECK: DependentMemberExpr {{.*}} [uniform <dependent type>] . zyx
+// CHECK-NOT: NULL
+
+template<typename T>
+T test1(T<3> x, T<3> y, uniform int N) {
+    T<3> val;
+    foreach (i = 0 ... N) {
+        val[i] = x[i] + y[i];
+    }
+    val = val.zyx;
+    return val[2];
+}
+
+template<uint N>
+int test2(int<N> x, int<N> y) {
+    int<N> val;
+    foreach (i = 0 ... N) {
+        val[i] = x[i] + y[i];
+    }
+    val = val.zyx;
+    return val[2];
+}
+
+template<typename T, uint N>
+int test3(T<N> x, T<N> y) {
+    T<N> val;
+    foreach (i = 0 ... N) {
+        val[i] = x[i] + y[i];
+    }
+    val = val.zyx;
+    return val[2];
+}

--- a/tests/lit-tests/func_template_shortvec_6.ispc
+++ b/tests/lit-tests/func_template_shortvec_6.ispc
@@ -1,0 +1,16 @@
+// This test checks short vectors with nested templates
+// RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
+// CHECK-LABEL: <4 x i32> @test___uni
+// CHECK-LABEL: <4 x i32> @bar___vyiCuni4___uni
+// CHECK-LABEL: <4 x i32> @foo___vyiCuni4___uni
+// Nested template
+template <typename T, int N> noinline uniform T<N> foo(uniform T c) {
+    uniform T<N> r = { c, 2*c, 3*c, 0};
+    return r;
+}
+
+template <typename T, int N> noinline uniform T<N> bar(uniform T c) {
+    return foo<T, N>(c);
+}
+
+uniform int<4> test(uniform int c) { return bar<varying int, 4>(c); }

--- a/tests/lit-tests/func_template_shortvec_7.ispc
+++ b/tests/lit-tests/func_template_shortvec_7.ispc
@@ -1,0 +1,32 @@
+// Check that type conversion optimization for template-instantiated short vectors 
+// behaves the same as for basic short vectors.
+// See vector_type_init and vector_type_convert tests for more details.
+
+// RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -O0 -o - | FileCheck %s
+// CHECK-LABEL: <4 x double> @convert1___vyfvydCuni3
+// CHECK: fpext <4 x float>
+// CHECK-NOT: fpext float
+// CHECK-LABEL: void @convert2___vyfvydCuni3
+// CHECK: fpext <4 x float>
+// CHECK-NOT: fpext float
+template <typename T, typename M, int N>
+noinline uniform M<N> convert1() {
+  const uniform T<N> f = {1.f, 2.f, 3.f};
+  const uniform M<N> d = {2.f, f.z, f.y};
+  return d;
+}
+
+template <typename T, typename M, int N>
+noinline void convert2(uniform M RET[], uniform T b) {
+    uniform T<N> x = {1.0f, 2.0f, 3.0f};
+    uniform M<N> z = x + b;
+    RET[programIndex] = z[programIndex];
+}
+
+double<3> test1() {
+    return convert1<float, double, 3>();
+}
+
+void test2(uniform double RET[], uniform int c) {
+    convert2<float, double, 3>(RET, c);
+}

--- a/tests/lit-tests/func_template_shortvec_8.ispc
+++ b/tests/lit-tests/func_template_shortvec_8.ispc
@@ -1,0 +1,20 @@
+// Check compiler diagnostics
+// RUN: not %{ispc} --target=host %s --nowrap 2>&1 | FileCheck %s
+// CHECK: 10:38: Error: Unknown identifier "M" is used to specify the size of a vector type.
+// CHECK: 11:7: Error: syntax error, unexpected TOKEN_TYPE_NAME.
+
+struct S {
+    int x;
+};
+template<typename T, int N>
+T CalculateDifferentWidths(T<N> x, T<M> y) {
+    T<S> soaValue;
+    foreach (i = 0 ... N) {
+        soaValue[i] = x[i] + y[i];
+    }
+    return soaValue[2];
+}
+
+int test_CalculateDifferentWidths(int<4> x, int<4> y) {
+    return CalculateDifferentWidths<int, 4>(x, y);
+}

--- a/tests/lit-tests/func_template_shortvec_9.ispc
+++ b/tests/lit-tests/func_template_shortvec_9.ispc
@@ -1,0 +1,34 @@
+// Check compiler diagnostics
+// RUN: not %{ispc} --target=host %s --nowrap 2>&1 | FileCheck %s
+// CHECK: 14:10: Error: Only atomic types (int, float, ...) and template type parameters are legal for vector types.
+// CHECK: 28:14: Error: Only atomic types (int, float, ...) and template type parameters are legal for vector types.
+// CHECK: 29:14: Error: Illegal to specify vector size of 0.
+// CHECK: 19:21: Warning: Array index "2" may be out of bounds for 1 element array.
+
+struct S {
+    int x;
+};
+template<typename T, int N>
+T CalculateDifferentWidths(T<N> x, T<N> y) {
+    uniform int Q = 10;
+    T<Q> soaValueQ;
+    T<N> soaValue;
+    foreach (i = 0 ... N) {
+        soaValue[i] = x[i] + y[i];
+    }
+    return soaValue[2];
+}
+
+int test_CalculateDifferentWidths(int<4> x, int<4> y) {
+    return CalculateDifferentWidths<int, 1>(x, y);
+}
+
+float CalculateDifferentWidths(float c) {
+    uniform int Q = 10;
+    float<Q> soaValueQ;
+    float<0> soaValue;
+    foreach (i = 0 ... Q) {
+        soaValue[i] = c*i;
+    }
+    return soaValue[2];
+}


### PR DESCRIPTION
Partially fixes #2522. Support of soa<N> and array types will be added in a similar way.
It also adds a symbol kind to the Symbol class, which is used now only to check if the symbol in the vector size declaration is a TemplateNonTypeParameter. However, I believe it could be useful in other scenarios as well. 
The PR opens up the possibility of using constants in vector/array declarations (as seen in func_template_short_vec_9.ispc), but resolving these constants is non trivial, so I prefer not to introduce it at this stage.