### PR TITLE
Run zx in all threads in CI during LLVM build

### DIFF
--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -101,6 +101,7 @@ jobs:
         rm -rf cache.local
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-${{ inputs.version }} .
+        export XZ_DEFAULTS="-T0" # run zx in all threads
         tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
@@ -134,6 +135,7 @@ jobs:
         rm -rf cache.local
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-${{ inputs.version }} .
+        export XZ_DEFAULTS="-T0" # run zx in all threads
         tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}-Release${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
 
     - name: Upload package
@@ -169,6 +171,7 @@ jobs:
         rm -rf cache.local
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-${{ inputs.version }} .
+        export XZ_DEFAULTS="-T0" # run zx in all threads
         tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release+Asserts${{ inputs.lto == 'ON' && '-lto' || '' }}-x86.arm.wasm.tar.xz bin-${{ inputs.version }}
         rm -rf result.tar usr bin-${{ inputs.version }}
 
@@ -204,6 +207,7 @@ jobs:
         cd docker/ubuntu/${{ inputs.ubuntu }}/cpu_ispc_build
         tar xvf result.tar usr/local/src/llvm
         mv usr/local/src/llvm/bin-${{ inputs.version }} .
+        export XZ_DEFAULTS="-T0" # run zx in all threads
         tar cJvf llvm-${{ inputs.full_version }}-ubuntu${{ inputs.ubuntu }}aarch64-Release-x86${{ inputs.lto == 'ON' && '-lto' || '' }}.arm.wasm.tar.xz bin-${{ inputs.version }}
         rm -rf result.tar usr bin-${{ inputs.version }}
 


### PR DESCRIPTION
`xz` by default runs in one thread. With `tar cJvf` command running more than 20 minutes during LLVM build, it makes sense to speed this up by running in all threads.

To run in all threads we can use `xz`'s arg `-T`:
```
  -T, --threads=NUM   use at most NUM threads; the default is 0 which uses
                      as many threads as there are processor cores
```

On Linux we can pass it through `XZ_DEFAULTS` env variable. But on macOS tar is `bsdtar` and for some reason it doesn't act like regular `tar` with `XZ_DEFAULTS` has no effect. But we can run it explicitly.