### PR TITLE
CI: add hardening checks

### DIFF
--- a/.github/workflows/hardening-check-release.yml
+++ b/.github/workflows/hardening-check-release.yml
@@ -1,0 +1,78 @@
+## Copyright 2024 Intel Corporation
+## SPDX-License-Identifier: BSD-3-Clause
+
+name: Hardening Checks (release)
+
+permissions: read-all
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag (e.g., v1.21.1)'
+        required: true
+        type: string
+        default: 'v1.21.1'
+
+jobs:
+  hardening_check:
+    runs-on: ubuntu-latest
+    # Disabling this workflow for non ispc/ispc repo as it needs to run on releases only.
+    if: github.repository == 'ispc/ispc'
+
+    env:
+      LINK: https://github.com/ispc/ispc/releases/download/${{ inputs.release_tag }}/ispc-${{ inputs.release_tag }}-linux-oneapi.tar.gz
+
+    steps:
+    - name: Install hardening-check script
+      run: |
+        sudo apt -y update
+        sudo apt install -y devscripts
+
+    - name: Download and check Linux oneAPI artifacts
+      run: |
+        echo "Download artifact $LINK" >> $GITHUB_STEP_SUMMARY
+        wget ${{ env.LINK }}
+        tar xf ispc*.tar.gz
+        hardening-check ./ispc*/bin/ispc | tee -a ./hardening-check-${{ inputs.release_tag }}.txt
+        hardening-check ./ispc*/lib64/libispcrt.so | tee -a ./hardening-check-${{ inputs.release_tag }}.txt
+        hardening-check ./ispc*/lib64/libispcrt_device_gpu.so | tee -a ./hardening-check-${{ inputs.release_tag }}.txt
+        hardening-check ./ispc*/lib64/libispcrt_device_cpu.so | tee -a ./hardening-check-${{ inputs.release_tag }}.txt
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      with:
+        name: hardening_check
+        path: |
+          hardening-check-${{ inputs.release_tag }}.txt
+
+  winchecksec:
+    runs-on: windows-2019
+
+    env:
+      WINCHECKSEC_URL: https://github.com/trailofbits/winchecksec/releases/download/v3.1.0/windows.x64.Release.zip
+      LINK: https://github.com/ispc/ispc/releases/download/${{ inputs.release_tag }}/ispc-${{ inputs.release_tag }}-windows.zip
+
+    steps:
+    - name: Install winchecksec
+      run: |
+        Install-ChocoPackage wget
+        wget -q $env:WINCHECKSEC_URL
+        unzip windows.x64.Release.zip
+        echo "$pwd\build\Release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Download and check Windows artifacts
+      run: |
+        echo "Download artifact %LINK%" >> %GITHUB_STEP_SUMMARY%
+        wget -q $env:LINK
+        7z.exe x ispc*
+        cd ispc-*
+        winchecksec.exe bin\ispc.exe >> ..\winchecksec-report-${{ inputs.release_tag }}.txt
+        winchecksec.exe bin\ispcrt.dll >> ..\winchecksec-report-${{ inputs.release_tag }}.txt
+        winchecksec.exe bin\ispcrt_device_cpu.dll >> ..\winchecksec-report-${{ inputs.release_tag }}.txt
+        winchecksec.exe bin\ispcrt_device_gpu.dll >> ..\winchecksec-report-${{ inputs.release_tag }}.txt
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      with:
+        name: winchecksec_report
+        path: |
+          winchecksec-report-${{ inputs.release_tag }}.txt

--- a/.github/workflows/hardening-check.yml
+++ b/.github/workflows/hardening-check.yml
@@ -1,0 +1,76 @@
+## Copyright 2024 Intel Corporation
+## SPDX-License-Identifier: BSD-3-Clause
+
+name: Hardening Checks (trunk)
+
+permissions: read-all
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every day at 22:00 UTC
+    - cron: '0 22 * * *'
+
+env:
+  ZIP_URL: https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.zip?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202019%2C%20LLVM_VERSION%3Dlatest
+  TAR_URL: https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-linux.tar.gz?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DUbuntu2204%2C%20LLVM_VERSION%3Dlatest
+
+jobs:
+  hardening_check:
+    runs-on: ubuntu-latest
+    # Disabling this workflow for non ispc/ispc repo to reduce the traffic to artifacts downloads.
+    if: github.repository == 'ispc/ispc'
+
+    steps:
+    - name: Install hardening-check script
+      run: |
+        sudo apt -y update
+        sudo apt install -y devscripts
+
+    - name: Download and check Linux oneAPI artifacts
+      run: |
+        echo "Download artifact $tar_url" >> $GITHUB_STEP_SUMMARY
+        wget --quiet -O ispc.tar.gz ${{ env.TAR_URL }}
+        tar xf ispc.tar.gz
+        hardening-check ./ispc*/bin/ispc | tee -a ./hardening-check-${{ inputs.release_tag }}.txt
+        hardening-check ./ispc*/lib64/libispcrt.so | tee -a ./hardening-check-${{ inputs.release_tag }}.txt
+        hardening-check ./ispc*/lib64/libispcrt_device_gpu.so | tee -a ./hardening-check-${{ inputs.release_tag }}.txt
+        hardening-check ./ispc*/lib64/libispcrt_device_cpu.so | tee -a ./hardening-check-${{ inputs.release_tag }}.txt
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      with:
+        name: hardening_check
+        path: |
+          hardening-check-${{ inputs.release_tag }}.txt
+
+  winchecksec:
+    runs-on: windows-2019
+
+    env:
+      WINCHECKSEC_URL: https://github.com/trailofbits/winchecksec/releases/download/v3.1.0/windows.x64.Release.zip
+
+    steps:
+    - name: Install winchecksec
+      run: |
+        Install-ChocoPackage wget
+        wget -q $env:WINCHECKSEC_URL
+        unzip windows.x64.Release.zip
+        echo "$pwd\build\Release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Download and check Windows artifacts
+      run: |
+        echo "Download artifact %ZIP_URL%" >> %GITHUB_STEP_SUMMARY%
+        wget -q -O archive.zip $env:ZIP_URL
+        7z.exe x archive.zip
+        cd ispc-*
+        winchecksec.exe bin\ispc.exe >> ..\winchecksec-report-${{ inputs.release_tag }}.txt
+        winchecksec.exe bin\ispcrt.dll >> ..\winchecksec-report-${{ inputs.release_tag }}.txt
+        winchecksec.exe bin\ispcrt_device_cpu.dll >> ..\winchecksec-report-${{ inputs.release_tag }}.txt
+        # Not GPU device is built in trunk Windows build
+        # winchecksec.exe bin\ispcrt_device_gpu.dll >> ..\winchecksec-report-${{ inputs.release_tag }}.txt
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      with:
+        name: winchecksec_report
+        path: |
+          winchecksec-report-${{ inputs.release_tag }}.txt

--- a/.github/workflows/scripts/install-build-deps-aarch64.sh
+++ b/.github/workflows/scripts/install-build-deps-aarch64.sh
@@ -22,6 +22,6 @@ apt-get --no-install-recommends install -y m4 bison flex
 
 # This is actually a clang dependency.
 apt-get --no-install-recommends install -y libtinfo5
-[ -n "$LLVM_REPO" ] && wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
+[ -n "$LLVM_REPO" ] && wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
 tar xf $LLVM_TAR
 echo "${GITHUB_WORKSPACE}/bin-$LLVM_VERSION/bin" >> $GITHUB_PATH

--- a/.github/workflows/scripts/install-build-deps.ps1
+++ b/.github/workflows/scripts/install-build-deps.ps1
@@ -23,5 +23,5 @@ mkdir ${env:CROSS_TOOLS_GNUWIN32}
 cd ${env:CROSS_TOOLS_GNUWIN32}
 # The following line is needed to enable all TLS versions. The server appears to require different TLS version depending on the specific redirect.
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls, [Net.SecurityProtocolType]::Tls11, [Net.SecurityProtocolType]::Tls12
-wget --retry-connrefused --waitretry=10 --read-timeout=20 --timeout=15 -t 5 -O libgw32c-0.4-lib.zip 'https://github.com/ispc/ispc.dependencies/releases/download/gnuwin32-mirror/libgw32c-0.4-lib.zip'
+wget -q --retry-connrefused --waitretry=10 --read-timeout=20 --timeout=15 -t 5 -O libgw32c-0.4-lib.zip 'https://github.com/ispc/ispc.dependencies/releases/download/gnuwin32-mirror/libgw32c-0.4-lib.zip'
 7z.exe x libgw32c-0.4-lib.zip

--- a/.github/workflows/scripts/install-build-deps.sh
+++ b/.github/workflows/scripts/install-build-deps.sh
@@ -23,7 +23,7 @@ do
 done
 
 echo -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
-wget -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
+wget -q -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
 tar xf "$SDE_TAR_NAME"-lin.tar.xz
 
 if [ -v INSTALL_COMPUTE_RUNTIME ]; then
@@ -39,7 +39,7 @@ if [ -v INSTALL_COMPUTE_RUNTIME ]; then
         mesa-vdpau-drivers mesa-vulkan-drivers va-driver-all
 fi
 
-[ -n "$LLVM_REPO" ] && wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
+[ -n "$LLVM_REPO" ] && wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
 tar xf $LLVM_TAR
 echo "${GITHUB_WORKSPACE}/$SDE_TAR_NAME-lin" >> $GITHUB_PATH
 echo "${GITHUB_WORKSPACE}/bin-$LLVM_VERSION/bin" >> $GITHUB_PATH

--- a/.github/workflows/scripts/install-svml-test-deps.sh
+++ b/.github/workflows/scripts/install-svml-test-deps.sh
@@ -3,7 +3,7 @@ echo "APT::Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-retries
 
 # SVML requires installing Intel Compiler
 
-wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
 sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
 echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
 sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
@@ -31,7 +31,7 @@ do
 done
 
 find /usr -name cdefs.h || echo "Find errors were ignored"
-wget -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
+wget -q -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
 tar xf "$SDE_TAR_NAME"-lin.tar.bz2
 tar xf ispc-trunk-linux.tar.gz
 

--- a/.github/workflows/scripts/install-test-deps.ps1
+++ b/.github/workflows/scripts/install-test-deps.ps1
@@ -7,7 +7,7 @@ ls
 echo "$pwd\ispc-trunk-windows\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
 # Download and unpack SDE
-wget -U "${env:USER_AGENT}" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/${env:SDE_MIRROR_ID}/${env:SDE_TAR_NAME}-win.tar.xz
+wget -q -U "${env:USER_AGENT}" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/${env:SDE_MIRROR_ID}/${env:SDE_TAR_NAME}-win.tar.xz
 7z.exe x -txz ${env:SDE_TAR_NAME}-win.tar.xz
 7z.exe x -ttar ${env:SDE_TAR_NAME}-win.tar
 echo "$pwd\${env:SDE_TAR_NAME}-win" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/scripts/install-test-deps.sh
+++ b/.github/workflows/scripts/install-test-deps.sh
@@ -26,7 +26,7 @@ find /usr -name cdefs.h || echo "Find errors were ignored"
 # Remark about user agent: it might or might now work with default user agent, but
 # from time to time the settings are changed and browser-like user agent is required to make it work.
 echo -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
-wget -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
+wget -q -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
 tar xf "$SDE_TAR_NAME"-lin.tar.xz
 tar xf ispc-trunk-linux.tar.gz
 

--- a/.github/workflows/scripts/run-coverity.sh
+++ b/.github/workflows/scripts/run-coverity.sh
@@ -52,7 +52,7 @@ fi
 # Download and set up Coverity tool if not already done
 if [ ! -d "$TOOL_BASE" ]; then
   echo "Downloading Coverity Scan Analysis Tool..."
-  wget -nv -O "$TOOL_ARCHIVE" "$TOOL_URL" --post-data "project=$COVERITY_SCAN_PROJECT_NAME&token=$COVERITY_SCAN_TOKEN"
+  wget -q -nv -O "$TOOL_ARCHIVE" "$TOOL_URL" --post-data "project=$COVERITY_SCAN_PROJECT_NAME&token=$COVERITY_SCAN_TOKEN"
   
   echo "Extracting Coverity Scan Analysis Tool..."
   mkdir -p "$TOOL_BASE"


### PR DESCRIPTION
This PR adds a CI job to check hardening flags of Linux and Windows release binaries. Example of run: [link](https://github.com/nurmukhametov/ispc/actions/runs/10810929910)