### PR TITLE
Add -ffunction-sections flag

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -642,8 +642,13 @@ Updating ISPC Programs For Changes In ISPC 1.25.0
 ISPC language was extended to support ``__attribute__(())`` syntax for variable
 and function declarations. Two attributes are supported now: ``noescape`` and
 ``address_space(N)``. The macro ``ISPC_ATTRIBUTE_SUPPORTED`` is defined if the
-ISPC compiler supports attribute syntax. Please, reger to `Attributes`_ for
-more details.
+ISPC compiler supports attribute syntax. Please, refer to `Attributes`_ for
+more details and the full list of supported attributes.
+
+This release supports ``-ffunction-sections`` command line flag to generate
+each function in a separate section. This flag is useful for reducing the size
+of the final executable by removing unused functions. Please, refer to
+`Basic Command-line Options`_ for more details.
 
 Getting Started with ISPC
 =========================
@@ -851,6 +856,14 @@ for use in a shared library. The ``--PIC`` flag can be used to generate
 position-independent code suitable for dynamic linking avoiding any limit on
 the size of the global offset table. When no ``--pic`` or ``--PIC`` flag is
 provided, the compiler enforces target-specific default behavior.
+
+The ``-ffunction-sections`` flag can be used to generate each function in a
+separate section. This flag is useful for reducing the size of the final
+executable by removing unused functions when it is combined with linker flag
+that removes unused sections: ``--gc-sections`` for ``GNU ld`` and ``/OPT:REF``
+for ``MSVC link.exe``. On macOS, this flag does not have any effect (as in
+clang) because dead stripping ``-dead_strip`` for ``ld64`` works differently.
+The ``-fno-function-sections`` disables this behavior.
 
 Selecting The Compilation Target
 --------------------------------

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1716,6 +1716,9 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         if (g->opt.disableFMA == false)
             options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
 
+        if (g->functionSections)
+            options.FunctionSections = true;
+
         // For Xe target we do not need to create target/targetMachine
         if (!isXeTarget()) {
             m_targetMachine =
@@ -2320,6 +2323,7 @@ Globals::Globals() {
     includeStdlib = true;
     runCPP = true;
     onlyCPP = false;
+    functionSections = false;
     ignoreCPPErrors = false;
     debugPrint = false;
     debugPM = false;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -702,6 +702,10 @@ struct Globals {
         program source before compiling it.  (Default is true.) */
     bool runCPP;
 
+    /** Indicates whether the compiler places each function in its own
+        section. */
+    bool functionSections;
+
     /** When \c true, only runs the C pre-processor. (Default is false.) */
     bool onlyCPP;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,6 +105,7 @@ static void lPrintVersion() {
     printf("        fast\t\t\t\tUse high-performance but lower-accuracy math functions\n");
     printf("        svml\t\t\t\tUse the Intel(r) SVML math libraries\n");
     printf("        system\t\t\t\tUse the system's math library (*may be quite slow*)\n");
+    printf("    [-f[no-]function-sections]\t\tPlace each function in its own section\n");
     printf("    [--mcmodel=<value>]\t\t\tDefine the code model to use for code generation\n");
     printf("        small\t\t\t\tThe program and its symbols must be linked in the lower 2GB of the address space "
            "(default)\n");
@@ -982,6 +983,10 @@ int main(int Argc, char *Argv[]) {
             g->includeStdlib = false;
         else if (!strcmp(argv[i], "--nocpp"))
             g->runCPP = false;
+        else if (!strcmp(argv[i], "-ffunction-sections"))
+            g->functionSections = true;
+        else if (!strcmp(argv[i], "-fno-function-sections"))
+            g->functionSections = false;
         else if (!strncmp(argv[i], "--mcmodel=", 10)) {
             const char *value = argv[i] + 10;
             if (!strcmp(value, "small")) {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1517,6 +1517,10 @@ bool Module::writeOutput(OutputType outputType, OutputFlags flags, const char *o
 
     Assert(module);
 
+    if (g->functionSections) {
+        module->addModuleFlag(llvm::Module::Warning, "function-sections", 1);
+    }
+
     // In LLVM_3_4 after r195494 and r195504 revisions we should pass
     // "Debug Info Version" constant to the module. LLVM will ignore
     // our Debug Info metadata without it.

--- a/tests/lit-tests/ffunction-sections.ispc
+++ b/tests/lit-tests/ffunction-sections.ispc
@@ -1,0 +1,18 @@
+// RUN: %{ispc} %s --target=host --emit-asm -o - | FileCheck %s
+// RUN: %{ispc} %s -fno-function-sections --target=host --emit-asm -o - | FileCheck %s
+// RUN: %{ispc} %s -ffunction-sections --target=host --emit-asm -o - | FileCheck %s --check-prefix=CHECK-SEC
+
+// REQUIRES: WINDOWS_HOST || LINUX_HOST
+
+// Do not run on macOS, because the behavior of -ffunction-sections is
+// different. -ffunction-sections does not create separate sections for
+// functions on macOS, although unused functions are still removed if
+// -dead_strip is used. In macOS case, we are following clang, which does have
+// this option on macOS, but it does nothing.
+
+// CHECK-SEC: .section{{.*}}foo___
+// CHECK-SEC: .section{{.*}}foo
+// CHECK-NOT: .section        .text.
+// CHECK-NOT: .section{{.*}}foo___
+// CHECK-NOT: .section{{.*}}foo
+export void foo() { return; }


### PR DESCRIPTION
It forces the compiler to place each function in its own section.

This PR addresses the issue #2902. One can eliminate unused copies of exported functions providing this flag and enabling a linker flag that removes unused sections (`-gc-sections` for `ld` and compatible linkers).