### PR TITLE
Introduce external_only attribute

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -650,6 +650,13 @@ each function in a separate section. This flag is useful for reducing the size
 of the final executable by removing unused functions. Please, refer to
 `Basic Command-line Options`_ for more details.
 
+In some cases like shared libraries, the mentioned ``-ffunction-sections`` flag
+is not enough to remove unused ISPC copies of exported functions. To address
+this, the ``external_only`` attribute was introduced. It can be applied only
+to exported functions and it instructs the compiler to remove the ISPC version
+of the function. Please, refer to `Attributes`_ and
+`Functions and Function Calls`_ for more details.
+
 Getting Started with ISPC
 =========================
 
@@ -2958,6 +2965,17 @@ to the additional features they introduce.
     __attribute__((unmangled)) void foo(int a, int b);
 
 
+external_only
+----------------
+
+``__attribute__((external_only))`` can be applied to a function with
+``export`` qualifier. It informs the compiler that it should not generate a
+ISPC version of the function. This is useful for functions that are only called
+from C/C++ in case when the user wants to reduce the size of the generated
+code. Same effect can be achieved by using ``-ffunction-sections`` compiler
+option but not in all cases (e.g., shared libraries with ISPC code), so this
+attribute is provided as a more fine-grained control.
+
 Expressions
 -----------
 
@@ -3587,7 +3605,12 @@ Functions that are intended to be called from C/C++ application code must
 have the ``export`` qualifier.  This causes them to have regular C linkage
 and to have their declarations included in header files, if the ``ispc``
 compiler is directed to generated a C/C++ header file for the file it
-compiled.
+compiled. By default, ISPC generates both C/C++ and ISPC versions of the
+function with ``export`` qualifier. In case when there is no calls from ISPC
+code to the ``export`` function, the ISPC version of the function is not needed
+and can be removed either by using ``-ffunction-sections`` compiler option
+together with the linker specific option that collects garbage sections or by
+using ``__attribute__((external_only))``.
 
 ::
 

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -691,7 +691,7 @@ void Function::GenerateIR() const {
         // function which will resolve to particular implementation. The condition below ensures that in case of
         // multi-target compilation we will emit only one-per-target definition of extern "C" function mangled with
         // <target> suffix.
-        if (!((type->isExternC || type->isExternSYCL) && g->mangleFunctionsWithTarget)) {
+        if (!type->isExternalOnly && !((type->isExternC || type->isExternSYCL) && g->mangleFunctionsWithTarget)) {
             llvm::TimeTraceScope TimeScope("emitCode", llvm::StringRef(sym->name));
             FunctionEmitContext ec(this, sym, function, firstStmtPos);
             emitCode(&ec, function, firstStmtPos);

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -2796,9 +2796,9 @@ llvm::DIType *ReferenceType::GetDIType(llvm::DIScope *scope) const {
 // FunctionType
 
 FunctionType::FunctionType(const Type *r, const llvm::SmallVector<const Type *, 8> &a, SourcePos p)
-    : Type(FUNCTION_TYPE), isTask(false), isExported(false), isExternC(false), isExternSYCL(false), isUnmasked(false),
-      isUnmangled(false), isVectorCall(false), isRegCall(false), isCdecl(false), returnType(r), paramTypes(a),
-      paramNames(llvm::SmallVector<std::string, 8>(a.size(), "")),
+    : Type(FUNCTION_TYPE), isTask(false), isExported(false), isExternalOnly(false), isExternC(false),
+      isExternSYCL(false), isUnmasked(false), isUnmangled(false), isVectorCall(false), isRegCall(false), isCdecl(false),
+      returnType(r), paramTypes(a), paramNames(llvm::SmallVector<std::string, 8>(a.size(), "")),
       paramDefaults(llvm::SmallVector<Expr *, 8>(a.size(), nullptr)),
       paramPositions(llvm::SmallVector<SourcePos, 8>(a.size(), p)), pos(p) {
     Assert(returnType != nullptr);
@@ -2809,11 +2809,11 @@ FunctionType::FunctionType(const Type *r, const llvm::SmallVector<const Type *, 
 
 FunctionType::FunctionType(const Type *r, const llvm::SmallVector<const Type *, 8> &a,
                            const llvm::SmallVector<std::string, 8> &an, const llvm::SmallVector<Expr *, 8> &ad,
-                           const llvm::SmallVector<SourcePos, 8> &ap, bool it, bool is, bool ec, bool esycl, bool ium,
-                           bool imngl, bool ivc, bool irc, bool icl, SourcePos p)
-    : Type(FUNCTION_TYPE), isTask(it), isExported(is), isExternC(ec), isExternSYCL(esycl), isUnmasked(ium),
-      isUnmangled(imngl), isVectorCall(ivc), isRegCall(irc), isCdecl(icl), returnType(r), paramTypes(a), paramNames(an),
-      paramDefaults(ad), paramPositions(ap), pos(p) {
+                           const llvm::SmallVector<SourcePos, 8> &ap, bool it, bool is, bool ric, bool ec, bool esycl,
+                           bool ium, bool imngl, bool ivc, bool irc, bool icl, SourcePos p)
+    : Type(FUNCTION_TYPE), isTask(it), isExported(is), isExternalOnly(ric), isExternC(ec), isExternSYCL(esycl),
+      isUnmasked(ium), isUnmangled(imngl), isVectorCall(ivc), isRegCall(irc), isCdecl(icl), returnType(r),
+      paramTypes(a), paramNames(an), paramDefaults(ad), paramPositions(ap), pos(p) {
     Assert(paramTypes.size() == paramNames.size() && paramNames.size() == paramDefaults.size() &&
            paramDefaults.size() == paramPositions.size());
     Assert(returnType != nullptr);
@@ -2885,8 +2885,8 @@ const FunctionType *FunctionType::ResolveDependence(TemplateInstantiation &templ
     }
 
     FunctionType *ret =
-        new FunctionType(rt, pt, paramNames, paramDefaults, paramPositions, isTask, isExported, isExternC, isExternSYCL,
-                         isUnmasked, isUnmangled, isVectorCall, isRegCall, isCdecl, pos);
+        new FunctionType(rt, pt, paramNames, paramDefaults, paramPositions, isTask, isExported, isExternalOnly,
+                         isExternC, isExternSYCL, isUnmasked, isUnmangled, isVectorCall, isRegCall, isCdecl, pos);
     ret->isSafe = isSafe;
     ret->costOverride = costOverride;
     return ret;
@@ -2909,8 +2909,8 @@ const FunctionType *FunctionType::ResolveUnboundVariability(Variability v) const
     }
 
     FunctionType *ret =
-        new FunctionType(rt, pt, paramNames, paramDefaults, paramPositions, isTask, isExported, isExternC, isExternSYCL,
-                         isUnmasked, isUnmangled, isVectorCall, isRegCall, isCdecl, pos);
+        new FunctionType(rt, pt, paramNames, paramDefaults, paramPositions, isTask, isExported, isExternalOnly,
+                         isExternC, isExternSYCL, isUnmasked, isUnmangled, isVectorCall, isRegCall, isCdecl, pos);
     ret->isSafe = isSafe;
     ret->costOverride = costOverride;
 
@@ -2926,9 +2926,9 @@ const Type *FunctionType::GetAsUnmaskedType() const {
         return this;
     }
     if (asUnmaskedType == nullptr) {
-        FunctionType *ft =
-            new FunctionType(returnType, paramTypes, paramNames, paramDefaults, paramPositions, isTask, isExported,
-                             isExternC, isExternSYCL, true, isUnmangled, isVectorCall, isRegCall, isCdecl, pos);
+        FunctionType *ft = new FunctionType(returnType, paramTypes, paramNames, paramDefaults, paramPositions, isTask,
+                                            isExported, isExternalOnly, isExternC, isExternSYCL, true, isUnmangled,
+                                            isVectorCall, isRegCall, isCdecl, pos);
         ft->isSafe = isSafe;
         ft->costOverride = costOverride;
         asUnmaskedType = ft;
@@ -2944,9 +2944,9 @@ const Type *FunctionType::GetAsNonUnmaskedType() const {
         return this;
     }
     if (asMaskedType == nullptr) {
-        FunctionType *ft =
-            new FunctionType(returnType, paramTypes, paramNames, paramDefaults, paramPositions, isTask, isExported,
-                             isExternC, isExternSYCL, false, isUnmangled, isVectorCall, isRegCall, isCdecl, pos);
+        FunctionType *ft = new FunctionType(returnType, paramTypes, paramNames, paramDefaults, paramPositions, isTask,
+                                            isExported, isExternalOnly, isExternC, isExternSYCL, false, isUnmangled,
+                                            isVectorCall, isRegCall, isCdecl, pos);
         ft->isSafe = isSafe;
         ft->costOverride = costOverride;
         asMaskedType = ft;
@@ -2962,9 +2962,9 @@ const Type *FunctionType::GetWithReturnType(const Type *newReturnType) const {
         return this;
     }
 
-    FunctionType *ft =
-        new FunctionType(newReturnType, paramTypes, paramNames, paramDefaults, paramPositions, isTask, isExported,
-                         isExternC, isExternSYCL, isUnmasked, isUnmangled, isVectorCall, isRegCall, isCdecl, pos);
+    FunctionType *ft = new FunctionType(newReturnType, paramTypes, paramNames, paramDefaults, paramPositions, isTask,
+                                        isExported, isExternalOnly, isExternC, isExternSYCL, isUnmasked, isUnmangled,
+                                        isVectorCall, isRegCall, isCdecl, pos);
     ft->isSafe = isSafe;
     ft->costOverride = costOverride;
     return ft;

--- a/src/type.h
+++ b/src/type.h
@@ -957,9 +957,9 @@ class FunctionType : public Type {
     FunctionType(const Type *returnType, const llvm::SmallVector<const Type *, 8> &argTypes, SourcePos pos);
     FunctionType(const Type *returnType, const llvm::SmallVector<const Type *, 8> &argTypes,
                  const llvm::SmallVector<std::string, 8> &argNames, const llvm::SmallVector<Expr *, 8> &argDefaults,
-                 const llvm::SmallVector<SourcePos, 8> &argPos, bool isTask, bool isExported, bool isExternC,
-                 bool isExternSYCL, bool isUnmasked, bool isUnmangled, bool isVectorCall, bool isRegCall, bool isCdecl,
-                 SourcePos p);
+                 const llvm::SmallVector<SourcePos, 8> &argPos, bool isTask, bool isExported, bool isExternalOnly,
+                 bool isExternC, bool isExternSYCL, bool isUnmasked, bool isUnmangled, bool isVectorCall,
+                 bool isRegCall, bool isCdecl, SourcePos p);
     // Structure holding the mangling suffix and prefix for function
     struct FunctionMangledName {
         std::string prefix;
@@ -1047,6 +1047,11 @@ class FunctionType : public Type {
     /** This value is true if the function had a 'export' qualifier in the
         source program. */
     const bool isExported;
+
+    /** This value signals compiler to omit generation of ISPC function copy
+        for function with export qualifier, i.e., ISPC generates only the
+        external function for calling from C/C++ */
+    const bool isExternalOnly;
 
     /** This value is true if the function was declared as an 'extern "C"'
         function in the source program. */

--- a/tests/lit-tests/extern-only.ispc
+++ b/tests/lit-tests/extern-only.ispc
@@ -1,0 +1,9 @@
+// RUN: %{ispc} --target=host --emit-asm %s -o - -h %t.h 2>&1 | FileCheck %s
+// RUN: cat %t.h | FileCheck %s --check-prefix=CHECK-HEADER
+
+// CHECK-NOT: foo___:
+// CHECK-NOT: Ignoring unknown attribute "external_only"
+// CHECK: foo:
+// CHECK-HEADER: extern void foo();
+
+export __attribute__((external_only)) void foo() { return; }


### PR DESCRIPTION
If ~~export "C" ``__attribute__((remove_ispc_copy))``~~  ``__attribute__((external_only))`` is provided then generate only C/C++ version of exported function.

It addresses #2995 