### PR TITLE
Fix xe-enabled build with LLVM 18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -806,6 +806,10 @@ endif()
 # System libraries, our own and transitive dependencies from LLVM libs.
 if (WIN32)
     list(APPEND LINK_LIBRARIES version.lib shlwapi.lib odbc32.lib odbccp32.lib)
+    # Required after LLVM commit a5ffabc
+    if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "18.1.0")
+        list(APPEND LINK_LIBRARIES ws2_32.lib)
+    endif()
 else()
     # ISPC doesn't use pthreads directly, but LLVM does. Although, it looks
     # like we do not use LLVM code that depend on pthreads, don't we?

--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2024, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -73,11 +73,6 @@ function(run_llvm_config output_var)
     endif()
     set(${output_var} ${${output_var}} PARENT_SCOPE)
 endfunction()
-
-if (WIN32)
-  # For windows build - need catch CRT flags
-  include(${LLVM_DIR}/ChooseMSVCCRT.cmake)
-endif()
 
 run_llvm_config(LLVM_VERSION_NUMBER "--version")
 message(STATUS "Detected LLVM version: ${LLVM_VERSION_NUMBER}")

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1727,7 +1727,7 @@ static void saveOutput(uint32_t numOutputs, uint8_t **dataOutputs, uint64_t *len
     using ZipTy = typename decltype(zip)::value_type;
     auto binIt = std::find_if(zip.begin(), zip.end(), [&requiredExtension](ZipTy File) {
         llvm::StringRef name{std::get<2>(File)};
-        return name.endswith(requiredExtension);
+        return name.ends_with(requiredExtension);
     });
     Assert(binIt != zip.end() && "Output binary is missing");
 

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -393,11 +393,7 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         // Note: this pass has been added since LLVM 18.1.
         // InstCombine contains similar functionality. It can be enabled back
         // (at the moment) with enable-infer-alignment-pass=false option.
-        // It looks like it is enough to call it once before the last call to
-        // InstCombine pass. But maybe more clear way to preserve previous
-        // functionality is to call it before InstCombine every time.
-        // Let us call it once before the first InstCombine invocation and
-        // before the last one.
+        // To preserve previous functionality let's call it before InstCombine every time.
         optPM.addFunctionPass(llvm::InferAlignmentPass());
 #endif
         if (g->opt.disableGatherScatterOptimizations == false && g->target->getVectorWidth() > 1) {
@@ -416,6 +412,9 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
 #else
         optPM.addFunctionPass(llvm::SROAPass());
 #endif
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+        optPM.addFunctionPass(llvm::InferAlignmentPass());
+#endif
         optPM.addFunctionPass(llvm::InstCombinePass());
         optPM.addFunctionPass(llvm::SimplifyCFGPass(simplifyCFGopt));
         optPM.addFunctionPass(llvm::PromotePass());
@@ -426,6 +425,9 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         optPM.commitLoopToFunctionPassManager();
         optPM.setBlocksFreq(false);
         optPM.addFunctionPass(ReplaceStdlibShiftPass(), 229);
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+        optPM.addFunctionPass(llvm::InferAlignmentPass());
+#endif
         optPM.addFunctionPass(llvm::InstCombinePass());
         optPM.addFunctionPass(llvm::SimplifyCFGPass(simplifyCFGopt));
         optPM.commitFunctionToModulePassManager();
@@ -448,6 +450,9 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         optPM.addFunctionPass(llvm::DCEPass());
         optPM.addFunctionPass(llvm::SimplifyCFGPass(simplifyCFGopt));
         optPM.addFunctionPass(llvm::ADCEPass());
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+        optPM.addFunctionPass(llvm::InferAlignmentPass());
+#endif
         optPM.addFunctionPass(llvm::InstCombinePass(), 241);
         optPM.addFunctionPass(llvm::JumpThreadingPass());
         optPM.addFunctionPass(llvm::SimplifyCFGPass(simplifyCFGopt));
@@ -455,6 +460,9 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         optPM.addFunctionPass(llvm::SROAPass(llvm::SROAOptions::ModifyCFG));
 #else
         optPM.addFunctionPass(llvm::SROAPass());
+#endif
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+        optPM.addFunctionPass(llvm::InferAlignmentPass());
 #endif
         optPM.addFunctionPass(llvm::InstCombinePass());
         optPM.commitFunctionToModulePassManager();
@@ -464,10 +472,16 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
             // Inline
             optPM.initFunctionPassManager();
             optPM.addFunctionPass(llvm::CorrelatedValuePropagationPass());
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+            optPM.addFunctionPass(llvm::InferAlignmentPass());
+#endif
             optPM.addFunctionPass(llvm::InstCombinePass());
             optPM.commitFunctionToModulePassManager();
             optPM.addModulePass(llvm::GlobalDCEPass());
             optPM.initFunctionPassManager();
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+            optPM.addFunctionPass(llvm::InferAlignmentPass());
+#endif
             optPM.addFunctionPass(llvm::InstCombinePass());
             optPM.addFunctionPass(llvm::EarlyCSEPass());
             optPM.commitFunctionToModulePassManager();
@@ -483,6 +497,9 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         }
 
         if (g->opt.disableGatherScatterOptimizations == false && g->target->getVectorWidth() > 1) {
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+            optPM.addFunctionPass(llvm::InferAlignmentPass());
+#endif
             optPM.addFunctionPass(llvm::InstCombinePass(), 255);
             optPM.addFunctionPass(ImproveMemoryOpsPass());
 
@@ -505,6 +522,9 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         optPM.addFunctionPass(InstructionSimplifyPass());
 
         if (g->opt.disableGatherScatterOptimizations == false && g->target->getVectorWidth() > 1) {
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+            optPM.addFunctionPass(llvm::InferAlignmentPass());
+#endif
             optPM.addFunctionPass(llvm::InstCombinePass(), 270);
             optPM.addFunctionPass(ImproveMemoryOpsPass());
         }
@@ -514,6 +534,9 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
 
         optPM.initFunctionPassManager();
         optPM.addFunctionPass(llvm::ADCEPass());
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+        optPM.addFunctionPass(llvm::InferAlignmentPass());
+#endif
         optPM.addFunctionPass(llvm::InstCombinePass());
         optPM.addFunctionPass(llvm::SimplifyCFGPass(simplifyCFGopt));
 
@@ -535,7 +558,9 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
 #else
         optPM.addFunctionPass(llvm::SROAPass());
 #endif
-
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+        optPM.addFunctionPass(llvm::InferAlignmentPass());
+#endif
         optPM.addFunctionPass(llvm::InstCombinePass());
         optPM.addFunctionPass(InstructionSimplifyPass());
         optPM.addFunctionPass(llvm::SimplifyCFGPass(simplifyCFGopt));
@@ -564,7 +589,9 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         optPM.commitLoopToFunctionPassManager();
         optPM.setMemorySSA(false);
         optPM.setBlocksFreq(false);
-
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+        optPM.addFunctionPass(llvm::InferAlignmentPass());
+#endif
         optPM.addFunctionPass(llvm::InstCombinePass());
         optPM.addFunctionPass(InstructionSimplifyPass());
 
@@ -587,6 +614,9 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         // but it is not be beneficial in all cases.
         optPM.addFunctionPass(llvm::NewGVNPass(), 301);
         optPM.addFunctionPass(ReplaceMaskedMemOpsPass());
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+        optPM.addFunctionPass(llvm::InferAlignmentPass());
+#endif
         optPM.addFunctionPass(llvm::InstCombinePass());
         optPM.addFunctionPass(IsCompileTimeConstantPass(true));
         optPM.addFunctionPass(IntrinsicsOpt());
@@ -609,6 +639,9 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
             optPM.addFunctionPass(llvm::MemCpyOptPass());
         }
         optPM.addFunctionPass(llvm::SCCPPass());
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+        optPM.addFunctionPass(llvm::InferAlignmentPass());
+#endif
         optPM.addFunctionPass(llvm::InstCombinePass());
         optPM.addFunctionPass(InstructionSimplifyPass());
         optPM.addFunctionPass(llvm::JumpThreadingPass());

--- a/src/opt/MangleOpenCLBuiltins.cpp
+++ b/src/opt/MangleOpenCLBuiltins.cpp
@@ -14,7 +14,7 @@
 namespace ispc {
 
 static std::string mangleMathOCLBuiltin(const llvm::Function &func) {
-    Assert(func.getName().startswith("__spirv_ocl") && "wrong argument: ocl builtin is expected");
+    Assert(func.getName().starts_with("__spirv_ocl") && "wrong argument: ocl builtin is expected");
     std::string mangledName;
     llvm::Type *retType = func.getReturnType();
     // spirv OpenCL builtins are used for half/float/double types only
@@ -85,14 +85,14 @@ static std::string manglePrintfOCLBuiltin(const llvm::Function &func) {
 }
 
 static std::string mangleOCLBuiltin(const llvm::Function &func) {
-    Assert(func.getName().startswith("__spirv_ocl") && "wrong argument: ocl builtin is expected");
+    Assert(func.getName().starts_with("__spirv_ocl") && "wrong argument: ocl builtin is expected");
     if (func.getName() == "__spirv_ocl_printf")
         return manglePrintfOCLBuiltin(func);
     return mangleMathOCLBuiltin(func);
 }
 
 std::string mangleSPIRVBuiltin(const llvm::Function &func) {
-    Assert(func.getName().startswith("__spirv_") && "wrong argument: spirv builtin is expected");
+    Assert(func.getName().starts_with("__spirv_") && "wrong argument: spirv builtin is expected");
     std::string mangledName;
     std::vector<llvm::Type *> tyArgs;
     for (const auto &arg : func.args()) {
@@ -116,9 +116,9 @@ bool MangleOpenCLBuiltins::mangleOpenCLBuiltins(llvm::BasicBlock &bb) {
             llvm::Function *func = ci->getCalledFunction();
             if (func == nullptr)
                 continue;
-            if (func->getName().startswith("__spirv_")) {
+            if (func->getName().starts_with("__spirv_")) {
                 std::string mangledName;
-                if (func->getName().startswith("__spirv_ocl")) {
+                if (func->getName().starts_with("__spirv_ocl")) {
                     mangledName = mangleOCLBuiltin(*func);
                 } else {
                     mangledName = mangleSPIRVBuiltin(*func);

--- a/src/opt/XeGatherCoalescePass.cpp
+++ b/src/opt/XeGatherCoalescePass.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2022-2023, Intel Corporation
+  Copyright (c) 2022-2024, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -592,7 +592,7 @@ void XeGatherCoalescing::optimizePtr(llvm::Value *Ptr, PtrData &PD, llvm::Instru
 llvm::CallInst *XeGatherCoalescing::getPseudoGatherConstOffset(llvm::Instruction *Inst) const {
     if (auto CI = llvm::dyn_cast<llvm::CallInst>(Inst)) {
         llvm::Function *Function = CI->getCalledFunction();
-        if (Function && Function->getName().startswith("__pseudo_gather_base_offsets"))
+        if (Function && Function->getName().starts_with("__pseudo_gather_base_offsets"))
             if (isConstOffsetPseudoGather(CI))
                 return CI;
     }
@@ -601,7 +601,7 @@ llvm::CallInst *XeGatherCoalescing::getPseudoGatherConstOffset(llvm::Instruction
 
 bool XeGatherCoalescing::isConstOffsetPseudoGather(llvm::CallInst *CI) const {
     Assert(CI != nullptr && CI->getCalledFunction() &&
-           CI->getCalledFunction()->getName().startswith("__pseudo_gather_base_offsets"));
+           CI->getCalledFunction()->getName().starts_with("__pseudo_gather_base_offsets"));
     llvm::Value *opOffset = CI->getOperand(2);
 
     return (llvm::isa<llvm::ConstantDataVector>(opOffset) || llvm::isa<llvm::ConstantAggregateZero>(opOffset) ||


### PR DESCRIPTION
`ChooseMSVCCRT.cmake` was removed from LLVM and I don't see usages of it in our cmake files: https://github.com/llvm/llvm-project/pull/66850

Also I discovered that `InferAlignmentPass` is needed in one more place to make `LoadStoreVectorizer` pass work correctly. It was caught by tests/lit-tests/load_store_vectorizer_loopunroll.ispc test. I think there may be other cases where optimization is broken because of incorrect alignment and maybe it would be good to run `InferAlignmentPass` before every `InstCombine`. But I'd like to hear more opinions about it.
