### PR TITLE
Propagate IRFlags for binary operators in lExtractFirstVectorElement

### DIFF
--- a/ispc-opt.cpp
+++ b/ispc-opt.cpp
@@ -30,6 +30,8 @@
 
 using namespace llvm;
 
+static cl::opt<int> Addressing("addressing", cl::desc("Select 32- or 64-bit addressing."), cl::init(32),
+                               cl::value_desc("model"));
 static cl::opt<std::string> Passes("passes", cl::desc("Passes to run"));
 static cl::opt<bool> PrintPasses("print-passes", cl::desc("Print passes"));
 static cl::opt<std::string> InputFilename(cl::Positional, cl::desc("<input bitcode file>"), cl::init("-"),
@@ -124,6 +126,15 @@ int main(int argc, char **argv) {
 
     ispc::g = new ispc::Globals;
     LLVMContext *ctx = ispc::g->ctx;
+
+    if (Addressing == 64) {
+        ispc::g->opt.force32BitAddressing = false;
+    } else if (Addressing == 32) {
+        ispc::g->opt.force32BitAddressing = true;
+    } else {
+        ispc::Error(ispc::SourcePos(), "Invalid addressing model");
+        return 1;
+    }
 
     ispc::ISPCTarget target = ispc::ParseISPCTarget(TargetTarget);
 

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -1446,7 +1446,14 @@ static llvm::Value *lExtractFirstVectorElement(llvm::Value *v, std::map<llvm::PH
         Assert(v1 != nullptr);
         // Note that the new binary operator is inserted immediately before
         // the previous vector one
-        return llvm::BinaryOperator::Create(bop->getOpcode(), v0, v1, newName, bop);
+        // Overcaution measures: copy flags from the original instruction only
+        // if --wrap-signed-int is disabled (this is the source of the nsw
+        // flags we want to transfer to the new instruction)
+        if (!g->wrapSignedInt) {
+            return llvm::BinaryOperator::CreateWithCopiedFlags(bop->getOpcode(), v0, v1, bop, newName, bop);
+        } else {
+            return llvm::BinaryOperator::Create(bop->getOpcode(), v0, v1, newName, bop);
+        }
     }
 
     llvm::CastInst *cast = llvm::dyn_cast<llvm::CastInst>(v);

--- a/tests/lit-tests/2870.ispc
+++ b/tests/lit-tests/2870.ispc
@@ -1,0 +1,17 @@
+// RUN: %{ispc} --no-discard-value-names --target=avx2-i32x8 --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK-LABEL: {{.*}}LBB0_3: {{.*}} %foreach_full_body
+// CHECK-NEXT: {{.*}}  =>This Inner Loop Header: Depth=1
+// CHECK-NEXT:         vaddps  ymm1, ymm0, ymmword ptr [r{{.*}} + 4*rax]
+// CHECK-NEXT:         vmovups ymmword ptr [r{{.*}} + 4*rax], ymm1
+// CHECK-NEXT:         add     rax, 8
+// CHECK-NEXT:         cmp     rax, r{{.*}}
+// CHECK-NEXT:         jb      {{.*}}LBB0_3
+
+unmasked void foo(uniform float Data[], const uniform int N) {
+        foreach(i = 0 ... N) {
+                Data[i] = Data[i] + 1;
+        }
+}

--- a/tests/lit-tests/2870.ispc
+++ b/tests/lit-tests/2870.ispc
@@ -4,10 +4,10 @@
 
 // CHECK-LABEL: {{.*}}LBB0_3: {{.*}} %foreach_full_body
 // CHECK-NEXT: {{.*}}  =>This Inner Loop Header: Depth=1
-// CHECK-NEXT:         vaddps  ymm1, ymm0, ymmword ptr [r{{.*}} + 4*rax]
-// CHECK-NEXT:         vmovups ymmword ptr [r{{.*}} + 4*rax], ymm1
-// CHECK-NEXT:         add     rax, 8
-// CHECK-NEXT:         cmp     rax, r{{.*}}
+// CHECK-NEXT:         vaddps  [[NEW:ymm.*]], [[ONE:ymm.*]], ymmword ptr [[[BASE:r.*]] + 4*[[COUNTER:r.*]]]
+// CHECK-NEXT:         vmovups ymmword ptr [[[BASE]] + 4*[[COUNTER]]], [[NEW]]
+// CHECK-NEXT:         add     [[COUNTER]], 8
+// CHECK-NEXT:         cmp     [[COUNTER]], [[N:r.*]]
 // CHECK-NEXT:         jb      {{.*}}LBB0_3
 
 unmasked void foo(uniform float Data[], const uniform int N) {

--- a/tests/lit-tests/assume_uniform.ispc
+++ b/tests/lit-tests/assume_uniform.ispc
@@ -1,6 +1,6 @@
-//; RUN: %{ispc} --emit-asm --target=avx2 %s -o - | FileCheck %s -check-prefix=CHECK_AVX2
-//; RUN: %{ispc} --emit-asm --target=sse2 %s -o - | FileCheck %s -check-prefix=CHECK_SSE2
-//; RUN: %{ispc} --emit-asm --target=avx512skx-x16 %s -o - | FileCheck %s -check-prefix=CHECK_AVX512
+//; RUN: %{ispc} --emit-asm --no-discard-value-names --target=avx2 %s -o - | FileCheck %s -check-prefix=CHECK_AVX2
+//; RUN: %{ispc} --emit-asm --no-discard-value-names --target=sse2 %s -o - | FileCheck %s -check-prefix=CHECK_SSE2
+//; RUN: %{ispc} --emit-asm --no-discard-value-names --target=avx512skx-x16 %s -o - | FileCheck %s -check-prefix=CHECK_AVX512
 // REQUIRES: X86_ENABLED
 
 //; CHECK_SSE2: foo1
@@ -45,16 +45,13 @@ void foo2(uniform int a[]) {
 
 
 //; CHECK_SSE2: foo3
-//; CHECK_SSE2: cmp
-//; CHECK_SSE2-NOT: cmp
+//; CHECK_SSE2-NOT: %partial_inner_only
 
 //; CHECK_AVX2: foo3
-//; CHECK_AVX2: cmp
-//; CHECK_AVX2-NOT: cmp
+//; CHECK_AVX2-NOT: %partial_inner_only
 
 //; CHECK_AVX512: foo3
-//; CHECK_AVX512: cmp
-//; CHECK_AVX512-NOT: cmp
+//; CHECK_AVX512-NOT: %partial_inner_only
 
 // Case 3 : loop : remove remainder loop.
 int foo3(uniform int a[], uniform int count) {


### PR DESCRIPTION
This PR fixes issue #2870.

It propagates IR flags from vector operations to extracted scalar ones. This influences the quality of loop counter code. `nsw`/`nuw` flags were assigned to vector operations in https://github.com/ispc/ispc/commit/a3975be118ffdb8f52151ab25ce84cfceb0a1478 to exploit UB to extend loop counters (to 64-bit) avoiding extra redundant sext/zext instructions.

After this, we can reapply https://github.com/ispc/ispc/commit/99a78930624aed76b401e52a4ebae5a77a31b10d


