### PR TITLE
ci: pin dependencies and set token permissions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,12 +9,15 @@ on:
       paths:
         - '.github/workflows/*'
 
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Check workflow files
-        uses: docker://rhysd/actionlint:latest
+        uses: docker://rhysd/actionlint:latest@sha256:c6a00dfcb3c7ffb2f22363ded22ce3d789ea4c6a1862b11a2f7716c56c2509af
         with:
           args: -color

--- a/.github/workflows/cve-bin.yml
+++ b/.github/workflows/cve-bin.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     # Disabling this workflow for non ispc/ispc repo to reduce the traffic to artifacts downloads.
     if: github.repository == 'ispc/ispc'
-    permissions:
-      security-events: write
 
     steps:
     - name: Install cve-bin-tool


### PR DESCRIPTION
Fix missed pinned dependencies and token permissions. 
https://github.com/ispc/ispc/security/code-scanning
