### PR TITLE
Fix build with LLVM trunk: moved `Instrumentation.h`

### DIFF
--- a/cmake/GenerateBuiltins.cmake
+++ b/cmake/GenerateBuiltins.cmake
@@ -151,7 +151,7 @@ function(builtin_wasm_to_cpp bit os arch)
     write_common_bitcode_lib(${name} ${os} ${arch})
 
     list(APPEND flags
-        -DWASM -s WASM_OBJECT_FILES=0 ${ISPC_OPAQUE_FLAGS} -I${CMAKE_SOURCE_DIR} --std=gnu++17 -S -emit-llvm -c)
+        -DWASM -s WASM_OBJECT_FILES=0 ${ISPC_OPAQUE_FLAGS} -I${CMAKE_SOURCE_DIR} --std=gnu++17 -S -emit-llvm)
     if("${bit}" STREQUAL "64")
         list(APPEND flags "-sMEMORY64")
     endif()
@@ -292,7 +292,7 @@ function(builtin_to_cpp bit os generic_arch)
 
     get_target_flags(${os} ${arch} target_flags)
     list(APPEND flags ${target_flags}
-        -I${CMAKE_SOURCE_DIR} -m${bit} -S -emit-llvm ${ISPC_OPAQUE_FLAGS} --std=gnu++17 -c
+        -I${CMAKE_SOURCE_DIR} -m${bit} -S -emit-llvm ${ISPC_OPAQUE_FLAGS} --std=gnu++17
     )
 
     set(name builtins-cpp-${bit}-${os}-${arch})

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -2807,7 +2807,8 @@ llvm::Value *FunctionEmitContext::AddrSpaceCastInst(llvm::Value *val, AddressSpa
 #endif
     llvm::AddrSpaceCastInst *inst = nullptr;
     if (atEntryBlock) {
-        inst = new llvm::AddrSpaceCastInst(val, newType, val->getName() + "__cast", allocaBlock->getTerminator());
+        inst = new llvm::AddrSpaceCastInst(val, newType, val->getName() + "__cast",
+                                           ISPC_INSERTION_POINT_INSTRUCTION(allocaBlock->getTerminator()));
     } else {
         inst = new llvm::AddrSpaceCastInst(val, newType, val->getName() + "__cast", bblock);
     }
@@ -2829,7 +2830,7 @@ AddressInfo *FunctionEmitContext::AllocaInst(llvm::Type *llvmType, llvm::Value *
         // end of allocaBlock
         llvm::Instruction *retInst = allocaBlock->getTerminator();
         AssertPos(currentPos, retInst);
-        inst = new llvm::AllocaInst(llvmType, AS, size, name, retInst);
+        inst = new llvm::AllocaInst(llvmType, AS, size, name, ISPC_INSERTION_POINT_INSTRUCTION(retInst));
     } else {
         // Unless the caller overrode the default and wants it in the
         // current basic block
@@ -2866,7 +2867,7 @@ AddressInfo *FunctionEmitContext::AllocaInst(llvm::Type *llvmType, const llvm::T
         // end of allocaBlock
         llvm::Instruction *retInst = allocaBlock->getTerminator();
         AssertPos(currentPos, retInst);
-        inst = new llvm::AllocaInst(llvmType, AS, name, retInst);
+        inst = new llvm::AllocaInst(llvmType, AS, name, ISPC_INSERTION_POINT_INSTRUCTION(retInst));
     } else {
         // Unless the caller overrode the default and wants it in the
         // current basic block

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -59,7 +59,11 @@
 #include <llvm/Transforms/IPO/SCCP.h>
 #include <llvm/Transforms/IPO/StripDeadPrototypes.h>
 #include <llvm/Transforms/InstCombine/InstCombine.h>
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_20_0
+#include <llvm/Transforms/Utils/Instrumentation.h>
+#else
 #include <llvm/Transforms/Instrumentation.h>
+#endif
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Scalar/ADCE.h>
 #include <llvm/Transforms/Scalar/CorrelatedValuePropagation.h>

--- a/src/opt/ISPCPass.h
+++ b/src/opt/ISPCPass.h
@@ -34,7 +34,11 @@
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/FunctionAttrs.h>
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_20_0
+#include <llvm/Transforms/Utils/Instrumentation.h>
+#else
 #include <llvm/Transforms/Instrumentation.h>
+#endif
 #include <llvm/Transforms/Utils.h>
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #if ISPC_LLVM_VERSION > ISPC_LLVM_17_0

--- a/src/opt/IntrinsicsOptPass.cpp
+++ b/src/opt/IntrinsicsOptPass.cpp
@@ -135,7 +135,8 @@ bool IntrinsicsOpt::optimizeIntrinsics(llvm::BasicBlock &bb) {
                 // cast the i8 * to the appropriate type
                 llvm::Value *castPtr =
                     new llvm::BitCastInst(callInst->getArgOperand(0), llvm::PointerType::get(returnType, 0),
-                                          llvm::Twine(callInst->getArgOperand(0)->getName()) + "_cast", callInst);
+                                          llvm::Twine(callInst->getArgOperand(0)->getName()) + "_cast",
+                                          ISPC_INSERTION_POINT_INSTRUCTION(callInst));
                 LLVMCopyMetadata(castPtr, callInst);
                 int align = 0;
                 if (g->opt.forceAlignedMemory) {
@@ -145,7 +146,7 @@ bool IntrinsicsOpt::optimizeIntrinsics(llvm::BasicBlock &bb) {
                 }
                 llvm::Instruction *loadInst = new llvm::LoadInst(
                     returnType, castPtr, llvm::Twine(callInst->getArgOperand(0)->getName()) + "_load",
-                    false /* not volatile */, llvm::MaybeAlign(align).valueOrOne(), (llvm::Instruction *)nullptr);
+                    false /* not volatile */, llvm::MaybeAlign(align).valueOrOne());
                 LLVMCopyMetadata(loadInst, callInst);
                 llvm::ReplaceInstWithInst(callInst, loadInst);
                 modifiedAny = true;
@@ -167,7 +168,8 @@ bool IntrinsicsOpt::optimizeIntrinsics(llvm::BasicBlock &bb) {
                 llvm::Type *storeType = rvalue->getType();
                 llvm::Value *castPtr =
                     new llvm::BitCastInst(callInst->getArgOperand(0), llvm::PointerType::get(storeType, 0),
-                                          llvm::Twine(callInst->getArgOperand(0)->getName()) + "_ptrcast", callInst);
+                                          llvm::Twine(callInst->getArgOperand(0)->getName()) + "_ptrcast",
+                                          ISPC_INSERTION_POINT_INSTRUCTION(callInst));
                 LLVMCopyMetadata(castPtr, callInst);
 
                 int align = 0;

--- a/src/opt/ReplaceStdlibShiftPass.cpp
+++ b/src/opt/ReplaceStdlibShiftPass.cpp
@@ -61,8 +61,8 @@ bool ReplaceStdlibShiftPass::replaceStdlibShiftBuiltin(llvm::BasicBlock &bb) {
                         }
                         llvm::Value *shuffleIdxs = LLVMInt32Vector(shuffleVals);
                         llvm::Value *zeroVec = llvm::ConstantAggregateZero::get(shiftedVec->getType());
-                        llvm::Value *shuffle =
-                            new llvm::ShuffleVectorInst(shiftedVec, zeroVec, shuffleIdxs, "vecShift", ci);
+                        llvm::Value *shuffle = new llvm::ShuffleVectorInst(shiftedVec, zeroVec, shuffleIdxs, "vecShift",
+                                                                           ISPC_INSERTION_POINT_INSTRUCTION(ci));
                         ci->replaceAllUsesWith(shuffle);
                         modifiedAny = true;
                         delete[] shuffleVals;


### PR DESCRIPTION
Fixes #3021
Fixes #3023

Fix the build with LLVM trunk. Three different things are here:

- Update the include paths for Instrumentation headers (#3021)
- Update Instruction Insertion API. See #3023 for details
- Remove unneeded `-c` switch, which was triggering a warning on my system - this one is not related to `trunk`.

Please pay attention during review to Instruction Insertion API. New macros are a little verbose, but it's kinda intentional - we should remove them as soon as the lowest supported version is 19.1.
