### PR TITLE
ImproveMemOps: consider zext in lOffsets32BitSafe

### DIFF
--- a/tests/lit-tests/interleaved.ispc
+++ b/tests/lit-tests/interleaved.ispc
@@ -3,9 +3,6 @@
 // RUN: %{ispc} %s --target=sse4 -O2 --opt=fast-math  -h %t.h --emit-asm -o - | FileCheck %s -check-prefix=CHECK_SSE
 // RUN: %{ispc} %s --target=sse2 -O2 --opt=fast-math  -h %t.h --emit-asm -o - | FileCheck %s -check-prefix=CHECK_SSE
 // REQUIRES: X86_ENABLED && LLVM_14_0+
-// The test is failing starting LLVM 18.0
-// Related issues: #2813, #2870 and PR2864
-// XFAIL: LLVM_18_0+
 export void test_interleaved(const uniform float xin[],
                              const uniform float yin[],
                              const uniform float zin[],


### PR DESCRIPTION
After LLVM change [d77067d08](https://github.com/llvm/llvm-project/commit/d77067d08), InstCombine substitutes 
```llvm-ir
%v2 = sext <4 x i32> %v1 to <4 x i64>
```
with
```llvm-ir
%v2 = zext nneg <4 x i32> %v1 to <4 x i64>
```

`lOffsets32BitSafe` should consider `zext` too to be able to replace `__pseudo_scatter64_i32` with `__pseudo_scatter_factored_base_offsets32_i32`. Otherwise, it replaces it with `__pseudo_scatter_factored_base_offsets32_i32` that somehow results in generation of `vunpckhps`.

This fixes https://github.com/ispc/ispc/blob/main/tests/lit-tests/interleaved.ispc (issue #2813) with LLVM 18.1.

Re-apply this after #3009 as it should not change codegen for loop counters now.