### PR TITLE
CMake: use explicit x86 target for dispatch

### DIFF
--- a/builtins/dispatch.c
+++ b/builtins/dispatch.c
@@ -22,7 +22,8 @@
 #endif
 
 #include <stdint.h>
-#include <stdlib.h>
+
+void abort();
 
 // __system_best_isa __get_system_isa and __set_system_isa are weak symbols
 // because we want to have the only version of them across user application

--- a/cmake/GenerateBuiltins.cmake
+++ b/cmake/GenerateBuiltins.cmake
@@ -116,7 +116,7 @@ function(generate_dispatcher os)
 
     add_custom_command(
         OUTPUT ${bc}
-        COMMAND ${CLANGPP_EXECUTABLE} -x c ${ISPC_OPAQUE_FLAGS} ${DISP_TYPE} ${EXTRA_OPTS} -O2 -emit-llvm -c ${input} -o ${bc}
+        COMMAND ${CLANGPP_EXECUTABLE} -x c ${ISPC_OPAQUE_FLAGS} ${DISP_TYPE} ${EXTRA_OPTS} --target=x86_64-unknown-unknown -march=core2 -mtune=generic -O2 -emit-llvm ${input} -c -o ${bc}
         DEPENDS ${input}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )


### PR DESCRIPTION
This PR fixes #2990 