### PR TITLE
CI: use LLVM 18.1 by default

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@
 configuration: Release
 
 environment:
-  LLVM_LATEST: 17.0
+  LLVM_LATEST: 18.1
   DOCKER_PATH: "ispc/test_repo"
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
@@ -13,7 +13,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       LLVM_VERSION: latest
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      LLVM_VERSION: 16.0
+      LLVM_VERSION: 17.0
 
 for:
 -
@@ -31,7 +31,8 @@ for:
         if "%LLVM_VERSION%"=="latest" (set WASM=ON)
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( (set generator="Visual Studio 16") & (set vspath="C:\Program Files (x86)\Microsoft Visual Studio\2019"))
         if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2022" ( (set generator="Visual Studio 17") & (set vspath="C:\Program Files\Microsoft Visual Studio\2022"))
-        set LLVM_TAR=llvm-17.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        set LLVM_TAR=llvm-18.1.8-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+        if "%LLVM_VERSION%"=="17.0" (set LLVM_TAR=llvm-17.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
         if "%LLVM_VERSION%"=="16.0" (set LLVM_TAR=llvm-16.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z)
   install:
     - ps: choco install --no-progress winflexbison3 wget 7zip
@@ -81,7 +82,7 @@ for:
         export LLVM_HOME=$APPVEYOR_BUILD_FOLDER/llvm
         export CROSS_TOOLS=/usr/local/src/cross
         export WASM=OFF
-        export LLVM_TAR=llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+        export LLVM_TAR=llvm-18.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
   install:
     - sh: |-
         sudo apt-get update

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -21,8 +21,8 @@ jobs:
     # Disabling this workflow for non ispc/ispc repo as it needs to run on releases only.
     # if: github.repository == 'ispc/ispc'
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:

--- a/.github/workflows/compiler-warnings.yml
+++ b/.github/workflows/compiler-warnings.yml
@@ -19,8 +19,8 @@ jobs:
   clang-16:
     runs-on: ubuntu-22.04
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -46,8 +46,8 @@ jobs:
   gcc-11:
     runs-on: ubuntu-22.04
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -76,8 +76,8 @@ jobs:
   msvc-2022:
     runs-on: windows-2022
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -28,8 +28,8 @@ jobs:
       COVERITY_SCAN_NOTIFICATION_EMAIL: ${{ secrets.COVERITY_SCAN_NOTIFICATION_EMAIL }}
       COVERITY_SCAN_PROJECT_NAME: ${{ secrets.COVERITY_SCAN_PROJECT_NAME }}
       COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     # Disabling this workflow for non ispc/ispc repo, since number of build submissions is limited.
     if: github.repository == 'ispc/ispc'

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -97,9 +97,9 @@ jobs:
       fail-fast: false
       matrix:
         llvm:
-          - version: "17.0"
-            full_version: "17.0.6"
-            short_version: 17
+          - version: "18.1"
+            full_version: "18.1.8"
+            short_version: 18
             opaque_ptr_mode: "ON"
     env:
       LLVM_VERSION: ${{ matrix.llvm.version }}
@@ -157,6 +157,10 @@ jobs:
             full_version: "17.0.6"
             short_version: 17
             opaque_ptr_mode: "ON"
+          - version: "18.1"
+            full_version: "18.1.8"
+            short_version: 18
+            opaque_ptr_mode: "ON"
     env:
       LLVM_VERSION: ${{ matrix.llvm.version }}
       LLVM_TAR: llvm-${{ matrix.llvm.full_version }}-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
@@ -190,12 +194,12 @@ jobs:
         name: ispc_llvm${{ matrix.llvm.short_version }}_linux
         path: build/ispc-trunk-linux.tar.gz
 
-  linux-build-ispc-llvm17-lto:
+  linux-build-ispc-llvm18-lto:
     needs: [define-flow]
     runs-on: ubuntu-22.04
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-lto-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release+Asserts-lto-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -224,15 +228,15 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
-        name: ispc_llvm17_lto_linux
+        name: ispc_llvm18_lto_linux
         path: build/build-ispc-stage2/src/ispc-stage2-build/ispc-trunk-linux.tar.gz
 
-  linux-build-ispc-llvm17-release:
+  linux-build-ispc-llvm18-release:
     needs: [define-flow]
     runs-on: ubuntu-22.04
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -260,15 +264,15 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
-        name: ispc_llvm17rel_linux
+        name: ispc_llvm18rel_linux
         path: build/ispc-trunk-linux.tar.gz
 
-  linux-build-ispc-xe-llvm17-release:
+  linux-build-ispc-xe-llvm18-release:
     needs: [define-flow]
     runs-on: ubuntu-22.04
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "OFF"
       INSTALL_COMPUTE_RUNTIME: 1
       COMPUTE_RUNTIME_GITHUB_RELEASE: 1
@@ -307,13 +311,13 @@ jobs:
     - name: Upload XE enabled package
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
-        name: ispc_xe_llvm17rel_linux
+        name: ispc_xe_llvm18rel_linux
         path: build/build-ispc-stage2/src/ispc-stage2-build/ispc-trunk-linux.tar.gz
 
     - name: Upload ISPC with XE dependencies
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
-        name: ispc_xe_deps_llvm17rel_linux
+        name: ispc_xe_deps_llvm18rel_linux
         path: ispc-xe
 
   linux-test:
@@ -323,7 +327,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [16, 17]
+        version: [16, 17, 18]
         arch: [x86, x86-64]
         target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
         # See issue #2818 for more deatils. It's SDE problem running on AMD runner.
@@ -404,8 +408,8 @@ jobs:
         name: alloy_results.llvm${{matrix.version}}.${{matrix.arch}}.${{matrix.target}}
         path: alloy_results_*
 
-  linux-test-llvm17-lto:
-    needs: [define-flow, linux-build-ispc-llvm17-lto]
+  linux-test-llvm18-lto:
+    needs: [define-flow, linux-build-ispc-llvm18-lto]
     runs-on: ubuntu-22.04
     continue-on-error: false
     strategy:
@@ -456,7 +460,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: ispc_llvm17_lto_linux
+        name: ispc_llvm18_lto_linux
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -480,19 +484,19 @@ jobs:
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: fail_db.llvm17_lto.${{matrix.arch}}.${{matrix.target}}.txt
+        name: fail_db.llvm18_lto.${{matrix.arch}}.${{matrix.target}}.txt
         path: tests/fail_db.txt
 
     - name: Upload alloy logs
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: alloy_results.llvm17_lto.${{matrix.arch}}.${{matrix.target}}
+        name: alloy_results.llvm18_lto.${{matrix.arch}}.${{matrix.target}}
         path: alloy_results_*
 
   # Test release version
-  linux-test-llvm17-release:
-    needs: [define-flow, linux-build-ispc-llvm17-release]
+  linux-test-llvm18-release:
+    needs: [define-flow, linux-build-ispc-llvm18-release]
     runs-on: ubuntu-22.04
     continue-on-error: false
     strategy:
@@ -505,7 +509,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: ispc_llvm17rel_linux
+        name: ispc_llvm18rel_linux
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -529,20 +533,20 @@ jobs:
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: fail_db.llvm17rel.${{matrix.arch}}.${{matrix.target}}.txt
+        name: fail_db.llvm18rel.${{matrix.arch}}.${{matrix.target}}.txt
         path: tests/fail_db.txt
 
     - name: Upload alloy logs
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: alloy_results.llvm17rel.${{matrix.arch}}.${{matrix.target}}
+        name: alloy_results.llvm18rel.${{matrix.arch}}.${{matrix.target}}
         path: alloy_results_*
 
   # Debug run is experimental with the purpose to see if it's capable to catch anything.
   # So it's running in "full" mode only for now.
   # Single target, as it should be representative enough.
-  linux-test-debug-llvm17:
+  linux-test-debug-llvm18:
     needs: [define-flow, linux-build-ispc]
     if: ${{ needs.define-flow.outputs.flow_type == 'full' }}
     runs-on: ubuntu-22.04
@@ -557,7 +561,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: ispc_llvm17_linux
+        name: ispc_llvm18_linux
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -581,19 +585,19 @@ jobs:
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: fail_db.llvm17.debug.${{matrix.arch}}.${{matrix.target}}.txt
+        name: fail_db.llvm18.debug.${{matrix.arch}}.${{matrix.target}}.txt
         path: tests/fail_db.txt
 
     - name: Upload alloy logs
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: alloy_results.llvm17.debug.${{matrix.arch}}.${{matrix.target}}
+        name: alloy_results.llvm18.debug.${{matrix.arch}}.${{matrix.target}}
         path: alloy_results_*
 
   # Test xe release version
-  linux-test-xe-llvm17-release:
-    needs: [define-flow, linux-build-ispc-xe-llvm17-release]
+  linux-test-xe-llvm18-release:
+    needs: [define-flow, linux-build-ispc-xe-llvm18-release]
     if: ${{ needs.define-flow.outputs.flow_type == 'smoke' }}
     runs-on: ubuntu-22.04
     continue-on-error: false
@@ -610,7 +614,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: ispc_xe_llvm17rel_linux
+        name: ispc_xe_llvm18rel_linux
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -635,14 +639,14 @@ jobs:
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: fail_db.xe.llvm17rel.${{matrix.arch}}.${{matrix.target}}.txt
+        name: fail_db.xe.llvm18rel.${{matrix.arch}}.${{matrix.target}}.txt
         path: tests/fail_db.txt
 
     - name: Upload alloy logs
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: alloy_results.xe.llvm17rel.${{matrix.arch}}.${{matrix.target}}
+        name: alloy_results.xe.llvm18rel.${{matrix.arch}}.${{matrix.target}}
         path: alloy_results_*
 
   macos-build-ispc:
@@ -660,6 +664,10 @@ jobs:
           - version: "17.0"
             full_version: "17.0.6"
             short_version: 17
+            opaque_ptr_mode: "ON"
+          - version: "18.1"
+            full_version: "18.1.8"
+            short_version: 18
             opaque_ptr_mode: "ON"
     env:
       LLVM_VERSION: ${{ matrix.llvm.version }}
@@ -706,12 +714,12 @@ jobs:
         name: ispc_llvm${{ matrix.llvm.short_version }}_${{ matrix.runner }}
         path: build/ispc-trunk-macos.tar.gz
 
-  macos-build-ispc-llvm17-lto:
+  macos-build-ispc-llvm18-lto:
     needs: [define-flow]
     runs-on: macos-12
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-macos-Release+Asserts-lto-universal-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-macos-Release+Asserts-lto-universal-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -747,7 +755,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
-        name: ispc_llvm17_lto_macos
+        name: ispc_llvm18_lto_macos
         path: build/build-ispc-stage2/src/ispc-stage2-build/ispc-trunk-macOS.universal.tar.gz
 
   macos-test-ispc:
@@ -757,7 +765,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [16, 17]
+        version: [16, 17, 18]
 
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -801,8 +809,8 @@ jobs:
         name: alloy_results.llvm${{matrix.version}}.macos.sse4
         path: alloy_results_*
 
-  macos-test-ispc-llvm17-lto:
-    needs: [define-flow, macos-build-ispc-llvm17-lto]
+  macos-test-ispc-llvm18-lto:
+    needs: [define-flow, macos-build-ispc-llvm18-lto]
     runs-on: macos-12
     continue-on-error: false
     strategy:
@@ -812,7 +820,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: ispc_llvm17_lto_macos
+        name: ispc_llvm18_lto_macos
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -839,14 +847,14 @@ jobs:
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: fail_db.llvm17_lto.macos.sse4.txt
+        name: fail_db.llvm18_lto.macos.sse4.txt
         path: tests/fail_db.txt
 
     - name: Upload alloy logs
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: alloy_results.llvm17_lto.macos.sse4
+        name: alloy_results.llvm18_lto.macos.sse4
         path: alloy_results_*
 
   win-build-ispc:
@@ -863,6 +871,10 @@ jobs:
           - version: "17.0"
             full_version: "17.0.6"
             short_version: 17
+            opaque_ptr_mode: "ON"
+          - version: "18.1"
+            full_version: "18.1.8"
+            short_version: 18
             opaque_ptr_mode: "ON"
     env:
       LLVM_VERSION: ${{ matrix.llvm.version }}
@@ -903,12 +915,12 @@ jobs:
         name: ispc_llvm${{ matrix.llvm.short_version }}_win
         path: build/ispc-trunk-windows.zip
 
-  win-build-ispc-llvm17-lto:
+  win-build-ispc-llvm18-lto:
     needs: [define-flow]
     runs-on: windows-2019
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-win.vs2019-Release+Asserts-lto-x86.arm.wasm.tar.7z
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-win.vs2019-Release+Asserts-lto-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"
@@ -949,15 +961,15 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
-        name: ispc_llvm17_lto_win
+        name: ispc_llvm18_lto_win
         path: build/build-ispc-stage2/src/ispc-stage2-build/ispc-trunk-windows.zip
 
-  win-build-ispc-xe-llvm17-release:
+  win-build-ispc-xe-llvm18-release:
     needs: [define-flow]
     runs-on: windows-2019
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-win.vs2019-Release-x86.arm.wasm.tar.7z
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-win.vs2019-Release-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"
@@ -1001,13 +1013,13 @@ jobs:
     - name: Upload XE enabled package
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
-        name: ispc_xe_llvm17rel_win
+        name: ispc_xe_llvm18rel_win
         path: ${{ env.ISPC_DIR }}/ispc-trunk-windows.zip
 
     - name: Upload ISPC with XE dependencies
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
-        name: ispc_xe_deps_llvm17rel_win
+        name: ispc_xe_deps_llvm18rel_win
         path: ispc-xe
 
   win-test:
@@ -1019,7 +1031,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [16, 17]
+        version: [16, 17, 18]
         arch: [x86, x86-64]
         target: ${{fromJson(needs.define-flow.outputs.tests_matrix_targets)}}
 
@@ -1064,8 +1076,8 @@ jobs:
         name: alloy_results.llvm${{matrix.version}}.${{matrix.arch}}.${{matrix.target}}
         path: alloy_results_*
 
-  win-test-llvm17-lto:
-    needs: [define-flow, win-build-ispc-llvm17-lto]
+  win-test-llvm18-lto:
+    needs: [define-flow, win-build-ispc-llvm18-lto]
     env:
       LLVM_HOME: "C:\\projects\\llvm"
     runs-on: windows-2022
@@ -1081,7 +1093,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: ispc_llvm17_lto_win
+        name: ispc_llvm18_lto_win
 
     - name: Install dependencies
       run: |
@@ -1107,18 +1119,18 @@ jobs:
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: fail_db.llvm17_lto.${{matrix.arch}}.${{matrix.target}}.txt
+        name: fail_db.llvm18_lto.${{matrix.arch}}.${{matrix.target}}.txt
         path: tests/fail_db.txt
 
     - name: Upload alloy logs
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: alloy_results.llvm17_lto.${{matrix.arch}}.${{matrix.target}}
+        name: alloy_results.llvm18_lto.${{matrix.arch}}.${{matrix.target}}
         path: alloy_results_*
 
-  win-test-xe-llvm17-release:
-    needs: [define-flow, win-build-ispc-xe-llvm17-release]
+  win-test-xe-llvm18-release:
+    needs: [define-flow, win-build-ispc-xe-llvm18-release]
     if: ${{ needs.define-flow.outputs.flow_type == 'smoke' }}
     env:
       LLVM_HOME: "C:\\projects\\llvm"
@@ -1135,7 +1147,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: ispc_xe_llvm17rel_win
+        name: ispc_xe_llvm18rel_win
 
     - name: Install dependencies
       run: |
@@ -1161,22 +1173,22 @@ jobs:
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: fail_db.xe.llvm17rel.${{matrix.arch}}.${{matrix.target}}.txt
+        name: fail_db.xe.llvm18rel.${{matrix.arch}}.${{matrix.target}}.txt
         path: tests/fail_db.txt
 
     - name: Upload alloy logs
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: alloy_results.llvm17rel.${{matrix.arch}}.${{matrix.target}}
+        name: alloy_results.llvm18rel.${{matrix.arch}}.${{matrix.target}}
         path: alloy_results_*
 
   win-package-examples:
     needs: [define-flow]
     runs-on: windows-2019
     env:
-      LLVM_VERSION: "16.0"
-      LLVM_TAR: llvm-16.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"
@@ -1209,8 +1221,8 @@ jobs:
     needs: [define-flow]
     runs-on: ubuntu-22.04
     env:
-      LLVM_VERSION: "16.0"
-      LLVM_TAR: llvm-16.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -73,12 +73,12 @@ jobs:
           echo "optsets=${OPTSETS_FULL}" >> "$GITHUB_OUTPUT"
         fi
 
-  linux-build-ispc-llvm17:
+  linux-build-ispc-llvm18:
     needs: [define-flow]
     runs-on: ubuntu-latest
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-ubuntu18.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -105,12 +105,12 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
-        name: ispc_llvm17_linux
+        name: ispc_llvm18_linux
         path: build/ispc-trunk-linux.tar.gz
 
 
-  linux-test-llvm17:
-    needs: [define-flow, linux-build-ispc-llvm17]
+  linux-test-llvm18:
+    needs: [define-flow, linux-build-ispc-llvm18]
     runs-on: ubuntu-latest
     continue-on-error: false
     strategy:
@@ -122,7 +122,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: ispc_llvm17_linux
+        name: ispc_llvm18_linux
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -147,6 +147,6 @@ jobs:
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: fail_db.llvm17.${{matrix.target}}.txt
+        name: fail_db.llvm18.${{matrix.target}}.txt
         path: fail_db.txt
 

--- a/.github/workflows/ispcrt.yml
+++ b/.github/workflows/ispcrt.yml
@@ -14,8 +14,8 @@ env:
   SDE_TAR_NAME: sde-external-9.33.0-2024-01-07
   USER_AGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
   LLVM_REPO: https://github.com/ispc/ispc.dependencies
-  LLVM_VERSION: "17.0"
-  LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+  LLVM_VERSION: "18.1"
+  LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
   ISPC_OPAQUE_PTR_MODE: "ON"
 
 jobs:

--- a/.github/workflows/nightly-17.yml
+++ b/.github/workflows/nightly-17.yml
@@ -3,7 +3,7 @@
 
 # Nightly Linux run.
 
-name: Nightly tests / LLVM 17.0
+name: Nightly tests / LLVM 18.1
 
 permissions: read-all
 
@@ -20,11 +20,11 @@ env:
   LLVM_REPO: https://github.com/ispc/ispc.dependencies
 
 jobs:
-  linux-build-ispc-llvm-17:
+  linux-build-ispc-llvm-18:
     runs-on: ubuntu-22.04
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
 
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -51,11 +51,11 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
-        name: ispc_llvm_17_linux
+        name: ispc_llvm_18_linux
         path: build/ispc-trunk-linux.tar.gz
 
-  linux-test-llvm-17:
-    needs: [linux-build-ispc-llvm-17]
+  linux-test-llvm-18:
+    needs: [linux-build-ispc-llvm-18]
     runs-on: ubuntu-22.04
     continue-on-error: false
     strategy:
@@ -116,7 +116,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: ispc_llvm_17_linux
+        name: ispc_llvm_18_linux
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -146,11 +146,11 @@ jobs:
         [ -z "$(git diff)" ]
 
 
-  win-build-ispc-llvm-17:
+  win-build-ispc-llvm-18:
     runs-on: windows-2019
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"
       BUILD_TYPE: "Release"
@@ -183,12 +183,12 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
-        name: ispc_llvm17_win
+        name: ispc_llvm18_win
         path: build/ispc-trunk-windows.zip
 
 
-  win-test-llvm17:
-    needs: [win-build-ispc-llvm-17]
+  win-test-llvm18:
+    needs: [win-build-ispc-llvm-18]
     env:
       LLVM_HOME: "C:\\projects\\llvm"
     runs-on: windows-2022
@@ -209,7 +209,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: ispc_llvm17_win
+        name: ispc_llvm18_win
 
     - name: Install dependencies
       run: |
@@ -235,6 +235,6 @@ jobs:
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: failure()
       with:
-        name: fail_db.llvm17.${{matrix.arch}}.${{matrix.target}}.txt
+        name: fail_db.llvm18.${{matrix.arch}}.${{matrix.target}}.txt
         path: tests/fail_db.txt
 

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -9,11 +9,11 @@ on:
   workflow_call:
     inputs:
       version:
-        description: Version to build in major.minor format For example '17.0'.
+        description: Version to build in major.minor format For example '18.1'.
         required: true
         type: string
       full_version:
-        description: Version to build in major.minor.patch format. For example '17.0.6'.
+        description: Version to build in major.minor.patch format. For example '18.1.8'.
         required: true
         type: string
       lto:
@@ -40,15 +40,15 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to build in major.minor format For example '17.0'.
+        description: Version to build in major.minor format For example '18.1'.
         required: true
         type: string
-        default: '17.0'
+        default: '18.1'
       full_version:
-        description: Version to build in major.minor.patch format. For example '17.0.6'.
+        description: Version to build in major.minor.patch format. For example '18.1.8'.
         required: true
         type: string
-        default: '17.0.6'
+        default: '18.1.8'
       lto:
         description: Build LTO-enabled LLVM toolchain.
         required: true

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -16,11 +16,11 @@ env:
   LLVM_REPO: https://github.com/ispc/ispc.dependencies
 
 jobs:
-  linux-ispc-llvm17-asan:
+  linux-ispc-llvm18-asan:
     runs-on: ubuntu-22.04
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:

--- a/.github/workflows/slim-binary.yml
+++ b/.github/workflows/slim-binary.yml
@@ -19,8 +19,8 @@ jobs:
   linux:
     runs-on: ubuntu-22.04
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -62,8 +62,8 @@ jobs:
             target: neon-i32x8
             arch: aarch64
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-macos-Release+Asserts-universal-x86.arm.wasm.tar.xz
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-macos-Release+Asserts-universal-x86.arm.wasm.tar.xz
       ISPC_OPAQUE_PTR_MODE: "ON"
 
     steps:
@@ -108,8 +108,8 @@ jobs:
   windows:
     runs-on: windows-2019
     env:
-      LLVM_VERSION: "17.0"
-      LLVM_TAR: llvm-17.0.6-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
+      LLVM_VERSION: "18.1"
+      LLVM_TAR: llvm-18.1.8-win.vs2019-Release+Asserts-x86.arm.wasm.tar.7z
       ISPC_OPAQUE_PTR_MODE: "ON"
       LLVM_HOME: "C:\\projects\\llvm"
       CROSS_TOOLS_GNUWIN32: "C:\\projects\\cross\\gnuwin32"

--- a/.github/workflows/yarpgen.yml
+++ b/.github/workflows/yarpgen.yml
@@ -29,8 +29,8 @@ jobs:
     linux-build-ispc:
       runs-on: ubuntu-22.04
       env:
-        LLVM_VERSION: "17.0"
-        LLVM_TAR: llvm-17.0.6-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+        LLVM_VERSION: "18.1"
+        LLVM_TAR: llvm-18.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
 
       steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/superbuild/osPresets.json
+++ b/superbuild/osPresets.json
@@ -14,13 +14,13 @@
     {
       "name": "dependency-versions-os",
       "cacheVariables": {
-        "LLVM_VERSION": "17.0",
+        "LLVM_VERSION": "18.1",
         "LLVM_URL": "https://github.com/llvm/llvm-project.git",
         "VC_INTRINSICS_URL": "https://github.com/intel/vc-intrinsics.git",
-        "VC_INTRINSICS_SHA": "261f128dbb57b460d76f7d2e9b27e442e893d82b",
+        "VC_INTRINSICS_SHA": "4f5bc1bbc2195683468ee9485094df2a9d14b46f",
         "SPIRV_TRANSLATOR_URL": "https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git",
-        "SPIRV_TRANSLATOR_BRANCH": "llvm_release_170",
-        "SPIRV_TRANSLATOR_SHA": "89ab5df345a36940c3a313b3cbd875e32bae366e",
+        "SPIRV_TRANSLATOR_BRANCH": "llvm_release_180",
+        "SPIRV_TRANSLATOR_SHA": "43fb73fe120e854eddc2e1df9b4bfdc1efd92cd5",
         "L0_URL": "https://github.com/oneapi-src/level-zero.git",
         "L0_TAG": "v1.17.28",
         "ISPC_CORPUS_URL": "null"


### PR DESCRIPTION
Switch CI jobs to use LLVM 18.1 by default.

Do not merge until all tests are passed: https://github.com/aneshlya/ispc/actions/runs/11078718054