### PR TITLE
Add Dockerfile for v1.25.0 release

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -19,14 +19,12 @@ Note that adding all of these `Dockerfile`s to regular CI runs is currently prob
 
 By default `Dockerfile`s are assumed to be built as `x86` images, but some can be built as `aarch64` images (note that `ispc` is a cross-compiler, so regardless the host arch, it can target any supported CPU architecuture, if it's enabled in `ispc` build).
 
- * [ubuntu/16.04/cpu\_ispc\_build/Dockerfile](ubuntu/16.04/cpu_ispc_build/Dockerfile) `Ubuntu 16.04` image. CPU only.
  * [ubuntu/18.04/cpu\_ispc\_build/Dockerfile](ubuntu/18.04/cpu_ispc_build/Dockerfile) `Ubuntu 18.04` image. CPU only. Ubuntu 18.04 is used to enabled maximum compatibility. This Dockerfile does LLVM selfbuild in two stages, which enables splitting it to two separate CI jobs. The image is used in CI for nightly LLVM builds. Works on both `x86` and `aarch64`.
+ * [ubuntu/18.04/cpu\_ispc\_build/Dockerfile](ubuntu/18.04/cpu_ispc_build/Dockerfile) `Ubuntu 18.04` image. XPU (CPU+GPU). Ubuntu 18.04 is used to enabled maximum compatibility. This Dockerfile does LLVM selfbuild in two stages, which enables splitting it to two separate CI jobs. The image is used in CI for nightly LLVM builds. Works on both `x86` and `aarch64`.
  * [ubuntu/20.04/cpu\_ispc\_build/Dockerfile](ubuntu/20.04/cpu_ispc_build/Dockerfile) `Ubuntu 20.04` image. CPU only. Works on both `x86` and `aarch64`.
  * [ubuntu/20.04/xpu\_ispc\_build/Dockerfile](ubuntu/20.04/xpu_ispc_build/Dockerfile) `Ubuntu 20.04` image. XPU (CPU+GPU). This is the recommended environment for XPU experiments.
  * [ubuntu/22.04/cpu\_ispc\_build/Dockerfile](ubuntu/22.04/cpu_ispc_build/Dockerfile) `Ubuntu 22.04` image. CPU only. Works on both `x86` and `aarch64`.
  * [ubuntu/22.04/xpu\_ispc\_build/Dockerfile](ubuntu/22.04/xpu_ispc_build/Dockerfile) `Ubuntu 22.04` image. XPU (CPU+GPU).
- * [centos/7/cpu\_ispc\_build/Dockerfile](centos/7/cpu_ispc_build/Dockerfile) `CentOS 7` image. CPU only. Works on both `x86` and `aarch64`.
- * [centos/7/xpu\_ispc\_build/Dockerfile](centos/7/xpu_ispc_build/Dockerfile) `CentOS 7` image. XPU (CPU+GPU). `x86` image only. This image is used for building `ispc` package for future binary releases.
  * [centos/8/cpu\_ispc\_build/Dockerfile](centos/8/cpu_ispc_build/Dockerfile) `CentOS 8` image. CPU only. Works on both `x86` and `aarch64`.
  * [fedora/Dockerfile](fedora/Dockerfile) Fedora 39 with CPU only build linked with system LLVM and Clang shared libraries.
 

--- a/docker/ubuntu/18.04/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/18.04/xpu_ispc_build/Dockerfile
@@ -13,6 +13,7 @@ ARG SHA=main
 ARG LTO=OFF
 ARG PGO=OFF
 ARG TBB=default
+ARG XE_DEPS=ON
 
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
@@ -20,7 +21,7 @@ ARG TBB=default
 RUN uname -a
 
 # Packages required to build ISPC and Clang.
-RUN apt-get -y update && apt-get --no-install-recommends install -y wget build-essential gcc g++ git ca-certificates libtbb-dev ninja-build gnupg && \
+RUN apt-get -y update && apt-get --no-install-recommends install -y wget build-essential gcc g++ git ca-certificates ninja-build gnupg && \
     rm -rf /var/lib/apt/lists/*
 
 # Install multilib libc needed to build clang_rt
@@ -33,8 +34,8 @@ RUN if [[ $(uname -m) =~ "x86" ]]; then \
     rm -rf /var/lib/apt/lists/*
 
 # TBB is parameter to build both packge usual and oneapi-tbb.
-RUN if [ "$TBB" == "default" ]; then apt-get --no-install-recommends install -y libtbb-dev && rm -rf /var/lib/apt/lists/*; fi
-RUN if [ "$TBB" == "oneapi" ]; then wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | apt-key add - && \
+RUN if [ "$TBB" == "default" ] && [ "$XE_DEPS" == "ON" ]; then apt-get --no-install-recommends install -y libtbb-dev && rm -rf /var/lib/apt/lists/*; fi
+RUN if [ "$TBB" == "oneapi" ] && [ "$XE_DEPS" == "ON" ]; then wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | apt-key add - && \
                                     sh -c 'echo "deb https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/intel-oneapi.list' && \
                                     apt update && apt --no-install-recommends install -y intel-oneapi-tbb intel-oneapi-tbb-devel && rm -rf /var/lib/apt/lists/*; fi
 
@@ -84,6 +85,7 @@ RUN git clone https://github.com/$REPO.git ispc && \
         -B build \
         --preset os \
         -DLTO=$LTO \
+        -DXE_DEPS=$XE_DEPS \
         -DINSTALL_ISPC=ON \
         -DINSTALL_TOOLCHAIN=ON \
         -DCMAKE_INSTALL_PREFIX=/usr/local && \

--- a/docker/ubuntu/18.04/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/18.04/xpu_ispc_build/Dockerfile
@@ -60,11 +60,6 @@ RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 
 # If you are behind a proxy, you need to configure git.
 RUN if [ -v http_proxy ]; then git config --global --add http.proxy "$http_proxy"; fi
 
-ENV LLVM_HOME=/usr/local/src/llvm
-WORKDIR /usr/local/src
-
-ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
-
 # Install regular ISPC dependencies
 RUN apt-get -y update && apt-get --no-install-recommends install -y m4 bison flex && \
     rm -rf /var/lib/apt/lists/*
@@ -96,6 +91,3 @@ RUN git clone https://github.com/$REPO.git ispc && \
     (cmake --build build --target ispc-stage2-check-all || true) && \
     mv build/build-ispc-stage2/src/ispc-stage2-build/*.tar.gz ./ && \
     rm -rf build
-
-# Export path for ispc
-ENV PATH=/usr/local/src/ispc/bin-$LLVM_VERSION/bin:$PATH

--- a/docker/v1.25.0/ubuntu18.04/Dockerfile
+++ b/docker/v1.25.0/ubuntu18.04/Dockerfile
@@ -13,6 +13,7 @@ ARG SHA=v1.25.0
 ARG LTO=ON
 ARG PGO=OFF
 ARG TBB=default
+ARG XE_DEPS=ON
 
 # !!! Make sure that your docker config provides enough memory to the container,
 # otherwise LLVM build may fail, as it will use all the cores available to container.
@@ -20,12 +21,14 @@ ARG TBB=default
 RUN uname -a
 
 # Packages required to build ISPC and Clang.
-RUN apt-get -y update && apt-get --no-install-recommends install -y wget build-essential gcc g++ git ca-certificates libtbb-dev ninja-build gnupg && \
+RUN apt-get -y update && apt-get --no-install-recommends install -y \
+        wget=1.19.4-1ubuntu2.2 build-essential=12.4ubuntu1 gcc=4:7.4.0-1ubuntu2.3 g++=4:7.4.0-1ubuntu2.3 \
+        git=1:2.17.1-1ubuntu0.18 ca-certificates=20230311ubuntu0.18.04.1 ninja-build=1.8.2-1 gnupg=2.2.4-1ubuntu1.6 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install multilib libc needed to build clang_rt
 RUN if [[ $(uname -m) =~ "x86" ]]; then \
-        export CROSS_LIBS="libc6-dev-i386=2.27-3ubuntu*"; \
+        export CROSS_LIBS="libc6-dev-i386=2.27-3ubuntu1.6"; \
     else \
         export CROSS_LIBS="libc6-dev-armhf-cross=2.27-3ubuntu*"; \
     fi && \
@@ -33,10 +36,10 @@ RUN if [[ $(uname -m) =~ "x86" ]]; then \
     rm -rf /var/lib/apt/lists/*
 
 # TBB is parameter to build both packge usual and oneapi-tbb.
-RUN if [ "$TBB" == "default" ]; then apt-get --no-install-recommends install -y libtbb-dev && rm -rf /var/lib/apt/lists/*; fi
+RUN if [ "$TBB" == "default" ]; then apt-get --no-install-recommends install -y libtbb-dev=2017~U7-8 && rm -rf /var/lib/apt/lists/*; fi
 RUN if [ "$TBB" == "oneapi" ]; then wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | apt-key add - && \
                                     sh -c 'echo "deb https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/intel-oneapi.list' && \
-                                    apt update && apt --no-install-recommends install -y intel-oneapi-tbb intel-oneapi-tbb-devel && rm -rf /var/lib/apt/lists/*; fi
+                                    apt update && apt --no-install-recommends install -y intel-oneapi-tbb=2021.13.1-12 intel-oneapi-tbb-devel=2021.13.1-12 && rm -rf /var/lib/apt/lists/*; fi
 
 # Download and install required version of cmake (3.23.5 for both x86 and aarch64) as required for superbuild preset jsons.
 RUN if [[ $(uname -m) =~ "x86" ]]; then \
@@ -49,7 +52,7 @@ RUN if [[ $(uname -m) =~ "x86" ]]; then \
 
 # Zlib is required to build Python3
 RUN apt-get -y update && \
-    apt-get -y --no-install-recommends install zlib1g-dev zlib1g && \
+    apt-get -y --no-install-recommends install zlib1g-dev=1:1.2.11.dfsg-0ubuntu2.2 zlib1g=1:1.2.11.dfsg-0ubuntu2.2 && \
     rm -rf /var/lib/apt/lists/*
 ENV PYTHON_VERSION=3.8.19
 RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz && \
@@ -61,7 +64,7 @@ RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 
 RUN if [ -v http_proxy ]; then git config --global --add http.proxy "$http_proxy"; fi
 
 # Install regular ISPC dependencies
-RUN apt-get -y update && apt-get --no-install-recommends install -y m4 bison flex && \
+RUN apt-get -y update && apt-get --no-install-recommends install -y m4=1.4.18-1 bison=2:3.0.4.dfsg-1build1 flex=2.6.4-6 && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/local/src
@@ -84,6 +87,7 @@ RUN git clone https://github.com/$REPO.git ispc && \
         -B build \
         --preset os \
         -DLTO=$LTO \
+        -DXE_DEPS=$XE_DEPS \
         -DINSTALL_ISPC=ON \
         -DINSTALL_TOOLCHAIN=ON \
         -DCMAKE_INSTALL_PREFIX=/usr/local && \

--- a/docker/v1.25.0/ubuntu18.04/Dockerfile
+++ b/docker/v1.25.0/ubuntu18.04/Dockerfile
@@ -4,13 +4,13 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 
 
-FROM ubuntu:18.04
+FROM ubuntu:18.04@sha256:152dc042452c496007f07ca9127571cb9c29697f42acbfad72324b2bb2e43c98
 LABEL maintainer="Arina Neshlyaeva <arina.neshlyaeva@intel.com>"
 SHELL ["/bin/bash", "-c"]
 
 ARG REPO=ispc/ispc
-ARG SHA=main
-ARG LTO=OFF
+ARG SHA=v1.25.0
+ARG LTO=ON
 ARG PGO=OFF
 ARG TBB=default
 
@@ -60,11 +60,6 @@ RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 
 # If you are behind a proxy, you need to configure git.
 RUN if [ -v http_proxy ]; then git config --global --add http.proxy "$http_proxy"; fi
 
-ENV LLVM_HOME=/usr/local/src/llvm
-WORKDIR /usr/local/src
-
-ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
-
 # Install regular ISPC dependencies
 RUN apt-get -y update && apt-get --no-install-recommends install -y m4 bison flex && \
     rm -rf /var/lib/apt/lists/*
@@ -96,6 +91,3 @@ RUN git clone https://github.com/$REPO.git ispc && \
     (cmake --build build --target ispc-stage2-check-all || true) && \
     mv build/build-ispc-stage2/src/ispc-stage2-build/*.tar.gz ./ && \
     rm -rf build
-
-# Export path for ispc
-ENV PATH=/usr/local/src/ispc/bin-$LLVM_VERSION/bin:$PATH

--- a/docker/v1.25.0/ubuntu18.04/Dockerfile
+++ b/docker/v1.25.0/ubuntu18.04/Dockerfile
@@ -1,0 +1,101 @@
+#
+#  Copyright (c) 2024, Intel Corporation
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+
+
+FROM ubuntu:18.04
+LABEL maintainer="Arina Neshlyaeva <arina.neshlyaeva@intel.com>"
+SHELL ["/bin/bash", "-c"]
+
+ARG REPO=ispc/ispc
+ARG SHA=main
+ARG LTO=OFF
+ARG PGO=OFF
+ARG TBB=default
+
+# !!! Make sure that your docker config provides enough memory to the container,
+# otherwise LLVM build may fail, as it will use all the cores available to container.
+
+RUN uname -a
+
+# Packages required to build ISPC and Clang.
+RUN apt-get -y update && apt-get --no-install-recommends install -y wget build-essential gcc g++ git ca-certificates libtbb-dev ninja-build gnupg && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install multilib libc needed to build clang_rt
+RUN if [[ $(uname -m) =~ "x86" ]]; then \
+        export CROSS_LIBS="libc6-dev-i386=2.27-3ubuntu*"; \
+    else \
+        export CROSS_LIBS="libc6-dev-armhf-cross=2.27-3ubuntu*"; \
+    fi && \
+    apt-get -y update && apt-get --no-install-recommends install -y "$CROSS_LIBS" && \
+    rm -rf /var/lib/apt/lists/*
+
+# TBB is parameter to build both packge usual and oneapi-tbb.
+RUN if [ "$TBB" == "default" ]; then apt-get --no-install-recommends install -y libtbb-dev && rm -rf /var/lib/apt/lists/*; fi
+RUN if [ "$TBB" == "oneapi" ]; then wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | apt-key add - && \
+                                    sh -c 'echo "deb https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/intel-oneapi.list' && \
+                                    apt update && apt --no-install-recommends install -y intel-oneapi-tbb intel-oneapi-tbb-devel && rm -rf /var/lib/apt/lists/*; fi
+
+# Download and install required version of cmake (3.23.5 for both x86 and aarch64) as required for superbuild preset jsons.
+RUN if [[ $(uname -m) =~ "x86" ]]; then \
+        export CMAKE_URL="https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.sh"; \
+    else \
+        export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.23.5/cmake-3.23.5-linux-aarch64.sh"; \
+    fi && \
+    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $CMAKE_URL && \
+    sh cmake-*.sh --prefix=/usr/local --skip-license && rm -rf cmake-*.sh
+
+# Zlib is required to build Python3
+RUN apt-get -y update && \
+    apt-get -y --no-install-recommends install zlib1g-dev zlib1g && \
+    rm -rf /var/lib/apt/lists/*
+ENV PYTHON_VERSION=3.8.19
+RUN wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz && \
+    tar xf Python-${PYTHON_VERSION}.tgz && pushd Python-${PYTHON_VERSION} && \
+    ./configure CFLAGS=-fPIC CXXFLAGS=-fPIC && make -j"$(nproc)" && make install && \
+    popd && rm -rf /usr/local/src/*
+
+# If you are behind a proxy, you need to configure git.
+RUN if [ -v http_proxy ]; then git config --global --add http.proxy "$http_proxy"; fi
+
+ENV LLVM_HOME=/usr/local/src/llvm
+WORKDIR /usr/local/src
+
+ENV PATH=$LLVM_HOME/bin-$LLVM_VERSION/bin:$PATH
+
+# Install regular ISPC dependencies
+RUN apt-get -y update && apt-get --no-install-recommends install -y m4 bison flex && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/local/src
+
+# Create new non-root user and switch to it
+RUN useradd -m -d /home/ispc_user -s /bin/bash -U ispc_user && \
+    chown -R ispc_user:ispc_user /usr
+
+USER ispc_user
+
+# When oneapi-tbb version changed we need to update it here.
+ENV LD_LIBRARY_PATH=/opt/intel/oneapi/tbb/2021.13/lib/intel64/gcc4.8:$LD_LIBRARY_PATH
+ENV CMAKE_PREFIX_PATH=/opt/intel/oneapi/tbb/2021.13
+
+# Configure and build ISPC
+# Build Clang/LLVM, XE dependencies and then ISPC.
+RUN git clone https://github.com/$REPO.git ispc && \
+    git -C ispc checkout $SHA && \
+    cmake ispc/superbuild \
+        -B build \
+        --preset os \
+        -DLTO=$LTO \
+        -DINSTALL_ISPC=ON \
+        -DINSTALL_TOOLCHAIN=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr/local && \
+    cmake --build build && \
+    (cmake --build build --target ispc-stage2-check-all || true) && \
+    mv build/build-ispc-stage2/src/ispc-stage2-build/*.tar.gz ./ && \
+    rm -rf build
+
+# Export path for ispc
+ENV PATH=/usr/local/src/ispc/bin-$LLVM_VERSION/bin:$PATH


### PR DESCRIPTION
This PR adds Dockerfile for v1.25.0 release. It is based on `ubuntu18.04` because of `centos7` EOL. It means that release ISPC binary will require at least GLIBC version 2.27.