### PR TITLE
Copy shl flags in ImproveMemoryOps

### DIFF
--- a/tests/lit-tests/1673-1.ispc
+++ b/tests/lit-tests/1673-1.ispc
@@ -1,5 +1,5 @@
 // RUN: %{ispc}  %s --emit-asm --target=sse4-i32x4 -o - | FileCheck %s
-// REQUIRES: X86_ENABLED && LLVM_17_0+
+// REQUIRES: X86_ENABLED && LLVM_16_0+ && !LLVM_17_0+
 // The main loop should be something like:
 // movups  (%r9,%rcx), %xmm0
 // movups  (%r8,%rcx), %xmm1
@@ -7,10 +7,10 @@
 // movups  %xmm1, (%rdi,%rcx)
 
 // CHECK-LABEL: {{.*}}LBB0_3: {{.*}}
-// CHECK-NEXT: movups  ([[REG_1:%[a-z0-9]+]],[[REG_2:%[a-z0-9]+]],4), [[REG_v1:%xmm[0-9]+]]
-// CHECK-NEXT: movups  ([[REG_3:%[a-z0-9]+]],[[REG_2]],4), [[REG_v2:%xmm[0-9]+]]
-// CHECK-NEXT: mulps   [[REG_v1]], [[REG_v2]]
-// CHECK-NEXT: movups  [[REG_v2]], ([[REG_4:%[a-z0-9]+]],[[REG_2]],4)
+// CHECK-NEXT: movups {{.*}}
+// CHECK-NEXT: movups {{.*}}
+// CHECK-NEXT: mulps {{.*}}
+// CHECK-NEXT: movups {{.*}}
 unmasked void bench_main(
   uniform float a[],
   uniform int N) {

--- a/tests/lit-tests/2870-1.ispc
+++ b/tests/lit-tests/2870-1.ispc
@@ -1,0 +1,16 @@
+// RUN: %{ispc} --no-discard-value-names --target=avx2-i32x8 --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK-LABEL: {{.*}}LBB0_3: {{.*}} %foreach_full_body
+// CHECK-NEXT: {{.*}}  =>This Inner Loop Header: Depth=1
+// CHECK-NEXT:        vmovups ymmword ptr [[[BASE:r.*]] + 4*[[COUNTER:r.*]]], [[CONSTANT:ymm.*]]
+// CHECK-NEXT:        add     [[COUNTER]], 8
+// CHECK-NEXT:        cmp     [[COUNTER]], [[N:r.*]]
+// CHECK-NEXT:        jb      {{.*}}LBB0_3
+
+unmasked void foo(uniform float InBuffer[], const uniform int NumSamples, const uniform float InConstant) {
+    foreach (i = 0 ... NumSamples) {
+        InBuffer[i] = InConstant;
+    }
+}


### PR DESCRIPTION
This PR is the follow-up fix to https://github.com/ispc/ispc/issues/2870

The main reason to propagate nsw/nuw flags from operations above arguments of pseudo_scatter to corresponding operations of pseudo_factored_base_scatter. This influences the quality of loop counter code.  nsw/nuw flags are assigned to vector operations in a3975be118ffdb8f52151ab25 to exploit UB to extend loop counters and some induction variables to wider type to avoid sext/zext instructions.