### PR TITLE
Generate fminnm/vminnm instructions on arm

### DIFF
--- a/builtins/target-neon-common.ll
+++ b/builtins/target-neon-common.ll
@@ -13,8 +13,8 @@ define(`NEON_PREFIX',
         RUNTIME, `32', `llvm.arm.neon')')
 
 define(`NEON_PREFIX_FMIN',
-`ifelse(RUNTIME, `64', `llvm.aarch64.neon.fmin',
-        RUNTIME, `32', `llvm.arm.neon.vmins')')
+`ifelse(RUNTIME, `64', `llvm.minnum.f32',
+        RUNTIME, `32', `llvm.minnum.f32')')
 
 define(`NEON_PREFIX_IMINS',
 `ifelse(RUNTIME, `64', `llvm.aarch64.neon.smin',
@@ -37,8 +37,8 @@ define(`NEON_PREFIX_PMINU',
         RUNTIME, `32', `llvm.arm.neon.vpminu')')
 
 define(`NEON_PREFIX_FMAX',
-`ifelse(RUNTIME, `64', `llvm.aarch64.neon.fmax',
-        RUNTIME, `32', `llvm.arm.neon.vmaxs')')
+`ifelse(RUNTIME, `64', `llvm.maxnum.f32',
+        RUNTIME, `32', `llvm.maxnum.f32')')
 
 define(`NEON_PREFIX_IMAXS',
 `ifelse(RUNTIME, `64', `llvm.aarch64.neon.smax',

--- a/builtins/target-neon-i32x8.ll
+++ b/builtins/target-neon-i32x8.ll
@@ -272,14 +272,14 @@ define float @__reduce_add_float(<8 x float>) nounwind readnone alwaysinline {
 
 define float @__reduce_min_float(<8 x float>) nounwind readnone alwaysinline {
   v8tov4(float, %0, %v0123, %v4567)
-  %x = call <4 x float> @llvm.aarch64.neon.fmin.v4f32(<4 x float> %v0123, <4 x float> %v4567)
+  %x = call <4 x float> @llvm.minnum.f32.v4f32(<4 x float> %v0123, <4 x float> %v4567)
   %r = call float @llvm.aarch64.neon.fminv.f32.v4f32(<4 x float> %x)
   ret float %r
 }
 
 define float @__reduce_max_float(<8 x float>) nounwind readnone alwaysinline {
   v8tov4(float, %0, %v0123, %v4567)
-  %x = call <4 x float> @llvm.aarch64.neon.fmax.v4f32(<4 x float> %v0123, <4 x float> %v4567)
+  %x = call <4 x float> @llvm.maxnum.f32.v4f32(<4 x float> %v0123, <4 x float> %v4567)
   %r = call float @llvm.aarch64.neon.fmaxv.f32.v4f32(<4 x float> %x)
   ret float %r
 }

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1781,7 +1781,12 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
             if (g->target_os == TargetOS::custom_linux) {
                 this->m_funcAttributes.push_back(std::make_pair("target-features", "+crypto,+fp-armv8,+neon,+sha2"));
             } else {
-                this->m_funcAttributes.push_back(std::make_pair("target-features", "+neon,+fp16"));
+                if (CPUID != CPU_CortexA9 && CPUID != CPU_CortexA15) {
+                    // fp-armv8 is supported starting cortex-a35
+                    this->m_funcAttributes.push_back(std::make_pair("target-features", "+neon,+fp16,+fp-armv8"));
+                } else {
+                    this->m_funcAttributes.push_back(std::make_pair("target-features", "+neon,+fp16"));
+                }
             }
             featuresString = "+neon,+fp16";
         } else if (arch == Arch::aarch64) {

--- a/tests/lit-tests/fminnm_vminnm_aarch64.ispc
+++ b/tests/lit-tests/fminnm_vminnm_aarch64.ispc
@@ -1,0 +1,17 @@
+// Tests checks that IEEE 754 compliant instructions are generated for max/min operations on AARCH64.
+
+// RUN: %{ispc} %s --arch=aarch64 --target=neon-i32x4 --emit-asm  -o - | FileCheck %s
+// RUN: %{ispc} %s --arch=aarch64 --target=neon-i32x8 --emit-asm  -o - | FileCheck %s
+
+// REQUIRES: ARM_ENABLED
+
+// CHECK-LABEL: test_max___vyfvyf:
+// CHECK: fmaxnm
+float test_max(float a, float b){
+    return max(a, b);
+}
+// CHECK-LABEL: test_min___vyfvyf:
+// CHECK: fminnm
+float test_min(float a, float b){
+    return min(a, b);
+}

--- a/tests/lit-tests/fminnm_vminnm_arm.ispc
+++ b/tests/lit-tests/fminnm_vminnm_arm.ispc
@@ -1,0 +1,23 @@
+// Tests checks that IEEE 754 compliant instructions are generated for max/min operations on Arm.
+
+// RUN: %{ispc} %s --arch=arm --target=neon-i32x4 --cpu=cortex-a35 --emit-asm  -o - | FileCheck %s
+// RUN: %{ispc} %s --arch=arm --target=neon-i32x8 --cpu=cortex-a35 --emit-asm  -o - | FileCheck %s
+// RUN: %{ispc} %s --arch=arm --target=neon-i32x4 --target-os=custom_linux --emit-asm  -o - | FileCheck %s
+// RUN: %{ispc} %s --arch=arm --target=neon-i32x8 --target-os=custom_linux --emit-asm  -o - | FileCheck %s
+
+// ARM must be enabled in order to test it.
+// Windows and Mac do not support 32 bit ARM. so test on Linux only (Android assumed to be the same)
+// REQUIRES: ARM_ENABLED && LINUX_HOST
+
+// CHECK-LABEL: test_max___vyfvyf:
+// CHECK: vmaxnm.f32
+float test_max(float a, float b){
+    return max(a, b);
+}
+
+// CHECK-LABEL: test_min___vyfvyf:
+// CHECK: vminnm.f32
+float test_min(float a, float b){
+    return min(a, b);
+}
+


### PR DESCRIPTION
Fixes https://github.com/ispc/ispc/issues/3048.
`fminnm`/`fmaxnm` are supported for aarch64 targets.
`vminnm`/`vmaxnm` are supported on arm targets with fp-armv8 (starting cortext-a35).