### PR TITLE
Add CPU definitions for ARL, LNL and GNR

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -327,6 +327,7 @@ typedef enum {
     CPU_SPR,
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
     CPU_ARL,
+    CPU_LNL,
 #endif
 
     // Zen 1-2-3
@@ -402,6 +403,7 @@ std::map<DeviceType, std::set<std::string>> CPUFeatures = {
     {CPU_SPR, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2", "avx512", "avx_vnni", "avx512_vnni"}},
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
     {CPU_ARL, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2", "avx_vnni"}},
+    {CPU_LNL, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2", "avx_vnni"}},
 #endif
     {CPU_ZNVER1, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2"}},
     {CPU_ZNVER2, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2"}},
@@ -511,6 +513,8 @@ class AllCPUs {
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
         names[CPU_ARL].push_back("arrowlake");
         names[CPU_ARL].push_back("arl");
+        names[CPU_LNL].push_back("lunarlake");
+        names[CPU_LNL].push_back("lnl");
 #endif
         names[CPU_ZNVER1].push_back("znver1");
         names[CPU_ZNVER2].push_back("znver2");
@@ -570,7 +574,10 @@ class AllCPUs {
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
         compat[CPU_ARL] =
             Set(CPU_ARL, CPU_x86_64, CPU_Bonnell, CPU_Penryn, CPU_Core2, CPU_Nehalem, CPU_Silvermont, CPU_SandyBridge,
-                CPU_IvyBridge, CPU_Haswell, CPU_Broadwell, CPU_Skylake, CPU_ADL, CPU_None);
+                CPU_IvyBridge, CPU_Haswell, CPU_Broadwell, CPU_Skylake, CPU_ADL, CPU_LNL, CPU_None);
+        compat[CPU_LNL] =
+            Set(CPU_LNL, CPU_x86_64, CPU_Bonnell, CPU_Penryn, CPU_Core2, CPU_Nehalem, CPU_Silvermont, CPU_SandyBridge,
+                CPU_IvyBridge, CPU_Haswell, CPU_Broadwell, CPU_Skylake, CPU_ADL, CPU_ARL, CPU_None);
 #endif
         compat[CPU_TGL] =
             Set(CPU_TGL, CPU_x86_64, CPU_Bonnell, CPU_Penryn, CPU_Core2, CPU_Nehalem, CPU_Silvermont, CPU_SandyBridge,
@@ -813,6 +820,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         case CPU_MTL:
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
         case CPU_ARL:
+        case CPU_LNL:
 #endif
             m_ispc_target = ISPCTarget::avx2vnni_i32x8;
             break;

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -325,6 +325,7 @@ typedef enum {
     CPU_ADL,
     CPU_MTL,
     CPU_SPR,
+    CPU_GNR,
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
     CPU_ARL,
     CPU_LNL,
@@ -401,6 +402,7 @@ std::map<DeviceType, std::set<std::string>> CPUFeatures = {
     {CPU_ADL, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2", "avx_vnni"}},
     {CPU_MTL, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2", "avx_vnni"}},
     {CPU_SPR, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2", "avx512", "avx_vnni", "avx512_vnni"}},
+    {CPU_GNR, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2", "avx512", "avx_vnni", "avx512_vnni"}},
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
     {CPU_ARL, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2", "avx_vnni"}},
     {CPU_LNL, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2", "avx_vnni"}},
@@ -510,6 +512,8 @@ class AllCPUs {
         names[CPU_MTL].push_back("mtl");
         names[CPU_SPR].push_back("sapphirerapids");
         names[CPU_SPR].push_back("spr");
+        names[CPU_GNR].push_back("graniterapids");
+        names[CPU_GNR].push_back("gnr");
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
         names[CPU_ARL].push_back("arrowlake");
         names[CPU_ARL].push_back("arl");
@@ -566,6 +570,9 @@ class AllCPUs {
         compat[CPU_SPR] = Set(CPU_SPR, CPU_x86_64, CPU_Bonnell, CPU_Penryn, CPU_Core2, CPU_Nehalem, CPU_Silvermont,
                               CPU_SandyBridge, CPU_IvyBridge, CPU_Haswell, CPU_Broadwell, CPU_Skylake, CPU_SKX, CPU_ICL,
                               CPU_ICX, CPU_TGL, CPU_ADL, CPU_None);
+        compat[CPU_GNR] = Set(CPU_GNR, CPU_x86_64, CPU_Bonnell, CPU_Penryn, CPU_Core2, CPU_Nehalem, CPU_Silvermont,
+                              CPU_SandyBridge, CPU_IvyBridge, CPU_Haswell, CPU_Broadwell, CPU_Skylake, CPU_SKX, CPU_ICL,
+                              CPU_ICX, CPU_TGL, CPU_ADL, CPU_SPR, CPU_None);
         compat[CPU_MTL] =
             Set(CPU_MTL, CPU_x86_64, CPU_Bonnell, CPU_Penryn, CPU_Core2, CPU_Nehalem, CPU_Silvermont, CPU_SandyBridge,
                 CPU_IvyBridge, CPU_Haswell, CPU_Broadwell, CPU_Skylake, CPU_ADL, CPU_None);
@@ -810,6 +817,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
             break;
 
         case CPU_SPR:
+        case CPU_GNR:
         case CPU_TGL:
         case CPU_ICX:
         case CPU_ICL:

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -818,6 +818,8 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
 
         case CPU_SPR:
         case CPU_GNR:
+            m_ispc_target = ISPCTarget::avx512spr_x16;
+            break;
         case CPU_TGL:
         case CPU_ICX:
         case CPU_ICL:

--- a/tests/lit-tests/cpus_x86_llvm16.ispc
+++ b/tests/lit-tests/cpus_x86_llvm16.ispc
@@ -2,6 +2,8 @@
 
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=mtl
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=meteorlake
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=gnr
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=graniterapids
 
 // REQUIRES: X86_ENABLED && LLVM_16_0+
 

--- a/tests/lit-tests/cpus_x86_llvm18.ispc
+++ b/tests/lit-tests/cpus_x86_llvm18.ispc
@@ -2,6 +2,8 @@
 
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=arl
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=arrowlake
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=lnl
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=lunarlake
 
 // REQUIRES: X86_ENABLED && LLVM_18_0+
 

--- a/tests/lit-tests/cpus_x86_llvm18.ispc
+++ b/tests/lit-tests/cpus_x86_llvm18.ispc
@@ -1,0 +1,10 @@
+// The test checks that cpu definitions (including all synonyms) are successfully consumed by compiler.
+
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=arl
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=arrowlake
+
+// REQUIRES: X86_ENABLED && LLVM_18_0+
+
+uniform int i;
+
+void foo() {}


### PR DESCRIPTION
ARL and LNL was added into LLVM 18.
GNR is in LLVM since LLVM 16.
Link to [X86TargetParser.cpp](https://github.com/llvm/llvm-project/blob/llvmorg-18.1.8/llvm/lib/TargetParser/X86TargetParser.cpp) for easier review