### PR TITLE
opt: disable NewGVN for CPU

### DIFF
--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -594,7 +594,11 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         // For Xe targets NewGVN pass produces more efficient code due to better resolving of branches.
         // On CPU targets it is effective in optimizing certain types of code,
         // but it is not be beneficial in all cases.
-        optPM.addFunctionPass(llvm::NewGVNPass(), 301);
+        if (g->target->isXeTarget()) {
+            optPM.addFunctionPass(llvm::NewGVNPass(), 301);
+        } else {
+            optPM.addFunctionPass(llvm::GVNPass(), 301);
+        }
         optPM.addFunctionPass(ReplaceMaskedMemOpsPass());
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
         optPM.addFunctionPass(llvm::InferAlignmentPass());

--- a/tests/lit-tests/2954-1.ispc
+++ b/tests/lit-tests/2954-1.ispc
@@ -1,0 +1,33 @@
+// RUN: %{ispc} -O2 --target=avx2-i32x8 --emit-asm --x86-asm-syntax=intel %s -o - 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK: vpermpd
+
+struct vec {
+    double V[4];
+};
+
+struct trans {
+    vec X;
+    vec Y;
+};
+
+inline uniform vec operator+(const uniform vec &A, const uniform vec &B) {
+    uniform vec Result;
+    foreach(i = 0 ... 4) { Result.V[i] = A.V[i] + B.V[i]; }
+    return Result;
+}
+
+inline uniform vec VectorSwizzle(const uniform vec &Vec, const uniform int X, const uniform int Y, const uniform int Z, const uniform int W) {
+    const uniform vec Result = {{Vec.V[X], Vec.V[Y], Vec.V[Z], Vec.V[W]}};
+    return Result;
+}
+
+
+extern "C" uniform vec foo(const uniform trans &T, const uniform vec& V) {
+    const uniform vec A = T.X + V;
+    const uniform vec B = VectorSwizzle(A, 1,2,0,3);
+    const uniform vec C = B + T.Y;
+    return C;
+}

--- a/tests/lit-tests/2954.ispc
+++ b/tests/lit-tests/2954.ispc
@@ -1,5 +1,7 @@
 // RUN: %{ispc} -O2 --target=avx2-i32x8 --emit-asm --x86-asm-syntax=intel %s -o - 2>&1 | FileCheck %s
 
+// XFAIL: *
+
 // REQUIRES: X86_ENABLED
 
 // CHECK-NOT: vmovq

--- a/tests/lit-tests/blend-curves-loop.ispc
+++ b/tests/lit-tests/blend-curves-loop.ispc
@@ -1,13 +1,11 @@
 // RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s
 
-// the order of BBs is not deterministic, so we need to check them with CHECK-DAG
-
 // CHECK-LABEL: @foo(
 // CHECK: foreach_full_body.lr.ph:
 // CHECK: br i1 [[TMP:%.*]], label %[[FOREACH_SPLIT_US:.*]], label %[[FOREACH_SPLIT:.*]]
-// CHECK-DAG: [[FOREACH_SPLIT_US]]:
-// CHECK-DAG: [[FOREACH_SPLIT]]:
-// CHECK-DAG: foreach_reset:
+// CHECK: [[FOREACH_SPLIT_US]]:
+// CHECK: [[FOREACH_SPLIT]]:
+// CHECK: foreach_reset:
 export void foo(const uniform uint32 input[], uniform uint32 output[],
                 const uniform int index, const uniform int n)
 {


### PR DESCRIPTION
This reverts commit c6543aef74c3690a60d168c9b121dfead39aa8b3 (PR #2961).

NewGVN fails to optimize out loads that drastically decreases performance for some CPUs for speficic GameDev tests.