### PR TITLE
Fix deps file generation

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -161,7 +161,7 @@ std::set<std::string> pseudoDependencies;
 /*! this is where the parser tells us that it has seen the given file
     name in the CPP hash */
 const char *RegisterDependency(const std::string &fileName) {
-    if (fileName[0] != '<' && fileName != "stdlib.ispc") {
+    if (fileName[0] != '<' && fileName != "stdlib.ispc" && fileName != "/core.isph" && fileName != "/stdlib.isph") {
         auto res = registeredDependencies.insert(fileName);
         return res.first->c_str();
     } else {

--- a/src/module.h
+++ b/src/module.h
@@ -143,6 +143,10 @@ class Module {
         // case-insensitive comparison with valid suffixes that are stored in
         // validSuffixes vector
         bool isSuffixValid(const std::string &suffix) const {
+            // dependency suffixes are empty
+            if (validSuffixes.empty()) {
+                return true;
+            }
             return std::find_if(validSuffixes.begin(), validSuffixes.end(), [&suffix](const std::string &valid) {
                        return std::equal(suffix.begin(), suffix.end(), valid.begin(), valid.end(),
                                          [](char a, char b) { return std::tolower(a) == std::tolower(b); });

--- a/tests/lit-tests/3062.ispc
+++ b/tests/lit-tests/3062.ispc
@@ -1,0 +1,8 @@
+// RUN: %{ispc} --target=host %s -M -MT target_name -MF %t.d 2>&1 | FileCheck %s
+// RUN: %{ispc} --target=host %s -M -MT target_name 2>&1 | FileCheck %s --check-prefix=INMEM_HEADER
+
+// CHECK-NOT: Warning: Emitting dependencies file, but filename {{.*}}
+// INMEM_HEADER-NOT: ^ /core.isph{{.*}}
+// INMEM_HEADER-NOT: ^ /stdlib.isph{{.*}}
+
+__attribute__((unknown)) void foo() {}


### PR DESCRIPTION
This PR fixes warning wrongly emitted for dependency file suffixes (#3062).

It also fixes the content of this file, is should not contain in-memory ISPC headers (`/core.isph`, `/stdlib.isph`) as dependencies for make.