### PR TITLE
Fix #3055 - changed llvm::Intrinsic::getDeclaration() function

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -502,7 +502,11 @@ Symbol *Module::AddLLVMIntrinsicDecl(const std::string &name, ExprList *args, So
             }
         }
         llvm::ArrayRef<llvm::Type *> argArr(exprType);
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_20_0
+        funcDecl = llvm::Intrinsic::getDeclarationIfExists(module, ID, argArr);
+#else
         funcDecl = llvm::Intrinsic::getDeclaration(module, ID, argArr);
+#endif
         llvm::StringRef funcName = funcDecl->getName();
 
         if (g->target->checkIntrinsticSupport(funcName, pos) == false) {


### PR DESCRIPTION
Fixes #3055 

This pull request includes a change to the `Symbol *Module::AddLLVMIntrinsicDecl` function in the `src/module.cpp` file to ensure compatibility with different versions of LLVM. The most important change is the conditional compilation logic to handle the difference in the `getDeclaration` method between LLVM versions.

Compatibility with LLVM versions:

* [`src/module.cpp`](diffhunk://#diff-91eede7716565a700586788e3f9d285985bf5c449a366cdd3b28fc37c073a616R505-R509): Added conditional compilation to use `llvm::Intrinsic::getDeclarationIfExists` for LLVM version 20.0 and above, while retaining `llvm::Intrinsic::getDeclaration` for earlier versions.