### PR TITLE
Fix stdlib functions calling convention for --vectorcall

### DIFF
--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -602,6 +602,13 @@ void lLinkStdlib(llvm::Module *module) {
 
     llvm::StringSet<> stdlibFunctions;
     for (llvm::Function &F : stdlibBCModule->functions()) {
+        // If compiling with --vectorcall then set calling convention of all
+        // stdlib functions to vectorcall to avoid misoptimization due to
+        // calling conventions for the call site and the function
+        // declaration/definition.
+        if (g->calling_conv == CallingConv::x86_vectorcall) {
+            F.setCallingConv(llvm::CallingConv::X86_VectorCall);
+        }
         stdlibFunctions.insert(F.getName());
     }
 

--- a/tests/lit-tests/3068.ispc
+++ b/tests/lit-tests/3068.ispc
@@ -1,0 +1,6 @@
+//; RUN: %{ispc} %s --target=avx2-i32x8 --vectorcall --emit-llvm-text -o - | FileCheck %s
+
+// REQUIRES: X86_ENABLED && WINDOWS_ENABLED
+
+// CHECK-NOT: unreachable
+float foo(float x) { return round(x); }

--- a/tests/lit-tests/3068.ispc
+++ b/tests/lit-tests/3068.ispc
@@ -1,4 +1,4 @@
-//; RUN: %{ispc} %s --target=avx2-i32x8 --vectorcall --emit-llvm-text -o - | FileCheck %s
+//; RUN: %{ispc} %s --target=avx2-i32x8 --target-os=windows --vectorcall --emit-llvm-text -o - | FileCheck %s
 
 // REQUIRES: X86_ENABLED && WINDOWS_ENABLED
 


### PR DESCRIPTION
This PR fixes #3068.