### PR TITLE
Proper fix for #3055 - fix trunk build

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -516,8 +516,9 @@ Symbol *Module::AddLLVMIntrinsicDecl(const std::string &name, ExprList *args, So
             }
         }
         llvm::ArrayRef<llvm::Type *> argArr(exprType);
+        // Add intrinsic declaration to the module if it's not added yet.
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_20_0
-        funcDecl = llvm::Intrinsic::getDeclarationIfExists(module, ID, argArr);
+        funcDecl = llvm::Intrinsic::getOrInsertDeclaration(module, ID, argArr);
 #else
         funcDecl = llvm::Intrinsic::getDeclaration(module, ID, argArr);
 #endif

--- a/tests/lit-tests/intrinsic.ispc
+++ b/tests/lit-tests/intrinsic.ispc
@@ -1,7 +1,6 @@
-// RUN: %{ispc} %s --target=avx2-i32x8 --emit-llvm-text --enable-llvm-intrinsics -o - | FileCheck %s
+// RUN: %{ispc} %s --target=host --emit-llvm-text --enable-llvm-intrinsics -o - | FileCheck %s
 // CHECK: declare i16 @llvm.convert.to.fp16.f32(float)
 
-// REQUIRES: X86_ENABLED
 uniform int16 foo(uniform float arg) {
     uniform int16 ret = @llvm.convert.to.fp16.f32(arg);
     return ret;


### PR DESCRIPTION
Fixes #3055 

Previous fix for the issue (#3069) was incorrect. The code is creating intrinsic declaration, not relying on its existence in the module.

This instantiates in multiple lit test failures:
```
Failed Tests (5):
  ispc :: intrinsic.ispc
  ispc :: intrinsic_macro.ispc
  ispc :: intrinsic_matrix.ispc
  ispc :: intrinsic_target_specific.ispc
  ispc :: intrinsics_vnni.ispc
```
which I missed on the first iteration, as all of them are x86-specific. So I changed `intrinsic.ispc` to run on all platforms.