### PR TITLE
Fix dispatch link errors

### DIFF
--- a/builtins/dispatch.c
+++ b/builtins/dispatch.c
@@ -60,7 +60,7 @@ static int __os_has_avx512_support() {
 // __get_system_isa should return a value corresponding to one of the
 // Target::ISA enumerant values that gives the most capable ISA that the
 // current system can run.
-int32_t __get_system_isa() {
+static int32_t __get_system_isa() {
     int info[4];
     __cpuid(info, 1);
 

--- a/builtins/dispatch.c
+++ b/builtins/dispatch.c
@@ -25,10 +25,7 @@
 
 void abort();
 
-// __system_best_isa __get_system_isa and __set_system_isa are weak symbols
-// because we want to have the only version of them across user application
-// (even when there are multiple independently compiled ISPC modules).
-__attribute__((weak)) int __system_best_isa = -1;
+static int __system_best_isa = -1;
 
 static void __cpuid(int info[4], int infoType) {
     __asm__ __volatile__("cpuid" : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3]) : "0"(infoType));
@@ -63,7 +60,7 @@ static int __os_has_avx512_support() {
 // __get_system_isa should return a value corresponding to one of the
 // Target::ISA enumerant values that gives the most capable ISA that the
 // current system can run.
-__attribute__((weak)) int32_t __get_system_isa() {
+int32_t __get_system_isa() {
     int info[4];
     __cpuid(info, 1);
 
@@ -177,7 +174,7 @@ __attribute__((weak)) int32_t __get_system_isa() {
     }
 }
 
-__attribute__((weak)) void __set_system_isa() {
+void __set_system_isa() {
     if (__system_best_isa == -1) {
         __system_best_isa = __get_system_isa();
     }

--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -498,6 +498,8 @@ void ispc::LinkDispatcher(llvm::Module *module) {
     llvm::Module *dispatchBCModule = dispatch->getLLVMModule();
     lAddDeclarationsToModule(dispatchBCModule, module);
     lAddBitcodeToModule(dispatchBCModule, module);
+    llvm::StringSet<> dispatchFunctions = {builtin::__set_system_isa};
+    lSetAsInternal(module, dispatchFunctions);
 }
 
 void lLinkCommonBuiltins(llvm::Module *module) {


### PR DESCRIPTION
Fixes linker error from #3082.
Windows linker doesn’t automatically handle weak symbols across modules and throws an error if conflicting symbols are found.
So first this PR reverts change made it https://github.com/ispc/ispc/pull/2970.
Also it adds internal linkage to `__set_system_isa` and adds `static` to `__get_system_isa` (it's only called from `__set_system_isa` so let's inline it). Overall these changes restores the linkage behavior that was before https://github.com/ispc/ispc/pull/2879.