### PR TITLE
Fix stdlib functions calling convention for --vectorcall. Part 2

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -1187,6 +1187,53 @@ jobs:
         name: alloy_results.llvm18rel.${{matrix.arch}}.${{matrix.target}}
         path: alloy_results_*
 
+  win-test-llvm18-vectorcall:
+    needs: [define-flow, win-build-ispc-xe-llvm18-release]
+    env:
+      LLVM_HOME: "C:\\projects\\llvm"
+    runs-on: windows-2022
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86-64]
+        target: [avx2-i32x8]
+
+    steps:
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+    - name: Download package
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        name: ispc_xe_llvm18rel_win
+
+    - name: Install dependencies
+      run: |
+        .github/workflows/scripts/install-test-deps.ps1
+
+    - name: Check environment
+      shell: cmd
+      run: |
+        wmic cpu get caption, deviceid, name, numberofcores, maxclockspeed, status
+
+    - name: Running tests
+      run: |
+        $env:ISPC_HOME = "$pwd"
+        .github/workflows/scripts/load-vs-env.ps1 "${{ matrix.arch }}"
+        python .\scripts\run_tests.py --calling_conv=vectorcall --target=${{matrix.target}} --arch=${{matrix.arch}}
+
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
+
+    - name: Upload fail_db.txt
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      if: failure()
+      with:
+        name: fail_db.llvm18_veccall.${{matrix.arch}}.${{matrix.target}}.txt
+        path: tests/fail_db.txt
+
+
   win-package-examples:
     needs: [define-flow]
     runs-on: windows-2019

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -659,7 +659,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [macos-12, macos-14]
+        runner: [macos-13, macos-14]
         llvm:
           - version: "16.0"
             full_version: "16.0.6"
@@ -720,7 +720,7 @@ jobs:
 
   macos-build-ispc-llvm18-lto:
     needs: [define-flow]
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       LLVM_VERSION: "18.1"
       LLVM_TAR: llvm-18.1.8-macos-Release+Asserts-lto-universal-x86.arm.wasm.tar.xz
@@ -764,7 +764,7 @@ jobs:
 
   macos-test-ispc:
     needs: [define-flow, macos-build-ispc]
-    runs-on: macos-12
+    runs-on: macos-13
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -776,7 +776,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: ispc_llvm${{matrix.version}}_macos-12
+        name: ispc_llvm${{matrix.version}}_macos-13
 
     - name: Install dependencies and unpack artifacts
       run: |
@@ -815,7 +815,7 @@ jobs:
 
   macos-test-ispc-llvm18-lto:
     needs: [define-flow, macos-build-ispc-llvm18-lto]
-    runs-on: macos-12
+    runs-on: macos-13
     continue-on-error: false
     strategy:
       fail-fast: false

--- a/.github/workflows/slim-binary.yml
+++ b/.github/workflows/slim-binary.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-12
+          - runner: macos-13
             target: avx2-i32x8
             arch: x86-64
           - runner: macos-14

--- a/scripts/alloy.py
+++ b/scripts/alloy.py
@@ -597,6 +597,7 @@ def validation_run(only, only_targets, reference_branch, number, update, speed_n
         stability.arch = ""
         stability.opt = ""
         stability.wrapexe = ""
+        stability.calling_conv = None
 # prepare parameters of run
         [targets_t, sde_targets_t] = check_targets()
         rebuild = True

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -410,6 +410,8 @@ def run_test(testname, host, target):
                     cc_cmd = "%s /Itests /I%s\\include /nologo /DTEST_SIG=%d /DTEST_WIDTH=%d %s %s /Fe%s ze_loader.lib /link /LIBPATH:%s\\lib" % \
                          (options.compiler_exe, options.l0loader, match, width, " /DTEST_ZEBIN" if options.ispc_output == "ze" else " /DTEST_SPV", \
                          add_prefix("tests\\test_static_l0.cpp", host, target), exe_name, options.l0loader)
+                if options.calling_conv == "vectorcall":
+                    cc_cmd += " /DVECTORCALL_CONV"
                 if should_fail:
                     cc_cmd += " /DEXPECT_FAILURE"
             else:
@@ -468,6 +470,9 @@ def run_test(testname, host, target):
                 ispc_cmd += " -O1"
             elif options.opt == 'O2':
                 ispc_cmd += " -O2"
+
+            if options.calling_conv == "vectorcall" and host.is_windows():
+                ispc_cmd += " --vectorcall"
 
         exe_wd = "."
         if target.arch == "wasm32" or target.arch == "wasm64":
@@ -1044,6 +1049,7 @@ if __name__ == "__main__":
                   default=False, action="store_true")
     parser.add_option('--csv', dest="csv", help="file to save testing results", default="")
     parser.add_option('--test_time', dest="test_time", help="time needed for each test", default=600, type="int", action="store")
+    parser.add_option('--calling_conv', dest="calling_conv", help="Specify the calling convention to use", default=None, type="str", action="store")
     (options, args) = parser.parse_args()
     L = run_tests(options, args, 1)
     exit(exit_code)

--- a/tests/test_static.cpp
+++ b/tests/test_static.cpp
@@ -47,12 +47,16 @@
 // For current tests we need max width multiplied by 4, i.e. 64*4
 #define ARRAY_SIZE 256
 
-#ifdef ISPC_IS_WINDOWS64
+#if defined(ISPC_IS_WINDOWS64)
+#ifdef VECTORCALL_CONV
+#define CALLINGCONV __vectorcall
+#else
 // __vectorcall calling convention is off by default.
 #define CALLINGCONV //__vectorcall
+#endif // VECTORCALL_CONV
 #else
 #define CALLINGCONV
-#endif
+#endif // ISPC_IS_WINDOWS64
 
 extern "C" {
 extern void CALLINGCONV f_v_cpu_entry_point(float *result);


### PR DESCRIPTION
Fix for https://github.com/ispc/ispc/issues/3091 and https://github.com/ispc/ispc/issues/3076.
This PR is addition to PR https://github.com/ispc/ispc/pull/3075. The problem of previous PR was that it didn't set calling convention for stdlib function calls, only for functions themselves which led to overoptimization to "unreachable".
Also we should set calling convention only to the functions **defined** in stdlib (not to all functions declared there like builtins).