### PR TITLE
Support overloaded LLVM intrinsics

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -1883,7 +1883,9 @@ llvm::Value *FunctionEmitContext::IntToPtrInst(llvm::Value *value, llvm::Type *t
     }
 
     llvm::Type *fromType = value->getType();
-    if (llvm::isa<llvm::VectorType>(fromType)) {
+    bool toTypePtrVector = toType->isVectorTy() && toType->getScalarType()->isPointerTy();
+
+    if (llvm::isa<llvm::VectorType>(fromType) && !toTypePtrVector) {
         // varying pointer
         if (fromType == toType) {
             // done

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -7134,23 +7134,11 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
             cast = exprVal;
             break;
         case AtomicType::TYPE_INT8:
-        case AtomicType::TYPE_UINT8: {
-            llvm::Value *zero = LLVMIntAsType(0, fromType->LLVMType(g->ctx));
-            cast = ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_NE, exprVal, zero, cOpName);
-            break;
-        }
+        case AtomicType::TYPE_UINT8:
         case AtomicType::TYPE_INT16:
-        case AtomicType::TYPE_UINT16: {
-            llvm::Value *zero = LLVMIntAsType(0, fromType->LLVMType(g->ctx));
-            cast = ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_NE, exprVal, zero, cOpName);
-            break;
-        }
+        case AtomicType::TYPE_UINT16:
         case AtomicType::TYPE_INT32:
-        case AtomicType::TYPE_UINT32: {
-            llvm::Value *zero = LLVMIntAsType(0, fromType->LLVMType(g->ctx));
-            cast = ctx->CmpInst(llvm::Instruction::ICmp, llvm::CmpInst::ICMP_NE, exprVal, zero, cOpName);
-            break;
-        }
+        case AtomicType::TYPE_UINT32:
         case AtomicType::TYPE_INT64:
         case AtomicType::TYPE_UINT64: {
             llvm::Value *zero = LLVMIntAsType(0, fromType->LLVMType(g->ctx));

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -6620,6 +6620,9 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
     case AtomicType::TYPE_BOOL:
         opName += "_to_bool";
         break;
+    case AtomicType::TYPE_INT1:
+        opName += "_to_int1";
+        break;
     case AtomicType::TYPE_INT8:
         opName += "_to_int8";
         break;
@@ -6816,6 +6819,30 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
             cast = exprVal;
             break;
         default:
+            FATAL("unimplemented");
+        }
+        break;
+    }
+    case AtomicType::TYPE_INT1: {
+        switch (basicFromType) {
+        case AtomicType::TYPE_BOOL:
+            if (fromType->IsVaryingAtomic()) {
+                exprVal = ctx->SwitchBoolToMaskType(exprVal, LLVMTypes::Int1VectorType, cOpName);
+            }
+            cast = ctx->ZExtInst(exprVal, targetType, cOpName);
+            break;
+        case AtomicType::TYPE_INT8:
+        case AtomicType::TYPE_UINT8:
+        case AtomicType::TYPE_INT16:
+        case AtomicType::TYPE_UINT16:
+        case AtomicType::TYPE_INT32:
+        case AtomicType::TYPE_UINT32:
+        case AtomicType::TYPE_INT64:
+        case AtomicType::TYPE_UINT64:
+            cast = ctx->TruncInst(exprVal, targetType, cOpName);
+            break;
+        default:
+            printf("fromType %s\n", aFromType->GetString().c_str());
             FATAL("unimplemented");
         }
         break;
@@ -7133,6 +7160,7 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
             }
             cast = exprVal;
             break;
+        // TODO!: all int casts are literally same, refactor to remove copy-paste
         case AtomicType::TYPE_INT8:
         case AtomicType::TYPE_UINT8:
         case AtomicType::TYPE_INT16:

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -4130,6 +4130,13 @@ llvm::Value *FunctionCallExpr::GetValue(FunctionEmitContext *ctx) const {
         if (isInvoke) {
             return ctx->InvokeSyclInst(callee, ft, argVals);
         } else {
+            // if callee is llvm.masked.gather then cast with inttoptr the first arg to PtrVectorType
+            if (callee->getName().starts_with("llvm.masked.gather")) {
+                argVals[0] = ctx->IntToPtrInst(argVals[0], LLVMTypes::PtrVectorType);
+            }
+            if (callee->getName().starts_with("llvm.masked.scatter")) {
+                argVals[1] = ctx->IntToPtrInst(argVals[1], LLVMTypes::PtrVectorType);
+            }
             retVal = ctx->CallInst(callee, ft, argVals, isVoidFunc ? "" : "calltmp");
         }
     }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -262,6 +262,11 @@ static const Type *lLLVMTypeToISPCType(const llvm::Type *t, bool intAsUnsigned) 
         return PointerType::GetUniform(AtomicType::VaryingDouble);
     }
 
+    // vector of pointers
+    else if (t == LLVMTypes::PtrVectorType) {
+        return AtomicType::VaryingUInt64;
+    }
+
     // vector with length different from TARGET_WIDTH can be repsented as uniform TYPE<N>
     else if (const llvm::VectorType *vt = llvm::dyn_cast<llvm::VectorType>(t)) {
         // check if vector length is equal to TARGET_WIDTH

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -464,9 +464,11 @@ static std::vector<llvm::Type *> lDeductArgTypes(llvm::Intrinsic::ID ID, ExprLis
             nInits = {0, 1, 2};
             break;
         case llvm::Intrinsic::masked_load:
+        case llvm::Intrinsic::masked_gather:
             nInits = {3, 0};
             break;
         case llvm::Intrinsic::masked_store:
+        case llvm::Intrinsic::masked_scatter:
             nInits = {0, 1};
             break;
         case llvm::Intrinsic::vector_reduce_fadd:
@@ -480,7 +482,15 @@ static std::vector<llvm::Type *> lDeductArgTypes(llvm::Intrinsic::ID ID, ExprLis
         for (const int i : nInits) {
             const Type *argType = (args->exprs[i])->GetType();
             Assert(argType);
-            exprType.push_back(argType->LLVMType(g->ctx));
+            if (ID == llvm::Intrinsic::masked_gather && i == 0) {
+                // type with <TARGET_WIDTH x ptr> is expected
+                exprType.push_back(LLVMTypes::PtrVectorType);
+            } else if (ID == llvm::Intrinsic::masked_scatter && i == 1) {
+                // type with <TARGET_WIDTH x ptr> is expected
+                exprType.push_back(LLVMTypes::PtrVectorType);
+            } else {
+                exprType.push_back(argType->LLVMType(g->ctx));
+            }
         }
     }
     return exprType;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -226,6 +226,8 @@ static const Type *lLLVMTypeToISPCType(const llvm::Type *t, bool intAsUnsigned) 
         return intAsUnsigned ? AtomicType::VaryingUInt64 : AtomicType::VaryingInt64;
     } else if (t == LLVMTypes::MaskType) {
         return AtomicType::VaryingBool;
+    } else if (t == LLVMTypes::Int1VectorType) {
+        return AtomicType::VaryingInt1;
     }
 
     // pointers to uniform

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -32,6 +32,7 @@ llvm::Type *LLVMTypes::PointerIntType = nullptr;
 llvm::Type *LLVMTypes::BoolType = nullptr;
 llvm::Type *LLVMTypes::BoolStorageType = nullptr;
 
+llvm::Type *LLVMTypes::Int1Type = nullptr;
 llvm::Type *LLVMTypes::Int8Type = nullptr;
 llvm::Type *LLVMTypes::Int16Type = nullptr;
 llvm::Type *LLVMTypes::Int32Type = nullptr;
@@ -86,6 +87,7 @@ void InitLLVMUtil(llvm::LLVMContext *ctx, Target &target) {
     LLVMTypes::PointerIntType = target.is32Bit() ? llvm::Type::getInt32Ty(*ctx) : llvm::Type::getInt64Ty(*ctx);
 
     LLVMTypes::BoolType = llvm::Type::getInt1Ty(*ctx);
+    LLVMTypes::Int1Type = llvm::Type::getInt1Ty(*ctx);
     LLVMTypes::Int8Type = LLVMTypes::BoolStorageType = llvm::Type::getInt8Ty(*ctx);
     LLVMTypes::Int16Type = llvm::Type::getInt16Ty(*ctx);
     LLVMTypes::Int32Type = llvm::Type::getInt32Ty(*ctx);

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -214,6 +214,11 @@ void InitLLVMUtil(llvm::LLVMContext *ctx, Target &target) {
     LLVMMaskAllOff = llvm::ConstantVector::get(maskZeros);
 }
 
+llvm::ConstantInt *LLVMInt1(bool val) {
+    int ival = val ? -1 : 0;
+    return llvm::ConstantInt::get(llvm::Type::getInt1Ty(*g->ctx), ival, true /*signed*/);
+}
+
 llvm::ConstantInt *LLVMInt8(int8_t ival) {
     return llvm::ConstantInt::get(llvm::Type::getInt8Ty(*g->ctx), ival, true /*signed*/);
 }
@@ -251,6 +256,23 @@ llvm::Constant *LLVMFloat16(llvm::APFloat fv) { return llvm::ConstantFP::get(llv
 llvm::Constant *LLVMFloat(llvm::APFloat fval) { return llvm::ConstantFP::get(llvm::Type::getFloatTy(*g->ctx), fval); }
 
 llvm::Constant *LLVMDouble(llvm::APFloat dval) { return llvm::ConstantFP::get(llvm::Type::getDoubleTy(*g->ctx), dval); }
+
+llvm::Constant *LLVMInt1Vector(bool ival) {
+    llvm::Constant *v = LLVMInt1(ival);
+    std::vector<llvm::Constant *> vals;
+    for (int i = 0; i < g->target->getVectorWidth(); ++i) {
+        vals.push_back(v);
+    }
+    return llvm::ConstantVector::get(vals);
+}
+
+llvm::Constant *LLVMInt1Vector(const bool *ivec) {
+    std::vector<llvm::Constant *> vals;
+    for (int i = 0; i < g->target->getVectorWidth(); ++i) {
+        vals.push_back(LLVMInt1(ivec[i]));
+    }
+    return llvm::ConstantVector::get(vals);
+}
 
 llvm::Constant *LLVMInt8Vector(int8_t ival) {
     llvm::Constant *v = LLVMInt8(ival);

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -39,6 +39,7 @@ llvm::Type *LLVMTypes::Int64Type = nullptr;
 llvm::Type *LLVMTypes::Float16Type = nullptr;
 llvm::Type *LLVMTypes::FloatType = nullptr;
 llvm::Type *LLVMTypes::DoubleType = nullptr;
+llvm::Type *LLVMTypes::PtrType = nullptr;
 
 llvm::Type *LLVMTypes::Int8PointerType = nullptr;
 llvm::Type *LLVMTypes::Int16PointerType = nullptr;
@@ -60,6 +61,7 @@ llvm::VectorType *LLVMTypes::Int64VectorType = nullptr;
 llvm::VectorType *LLVMTypes::Float16VectorType = nullptr;
 llvm::VectorType *LLVMTypes::FloatVectorType = nullptr;
 llvm::VectorType *LLVMTypes::DoubleVectorType = nullptr;
+llvm::VectorType *LLVMTypes::PtrVectorType = nullptr;
 
 llvm::Type *LLVMTypes::Int8VectorPointerType = nullptr;
 llvm::Type *LLVMTypes::Int16VectorPointerType = nullptr;
@@ -91,6 +93,11 @@ void InitLLVMUtil(llvm::LLVMContext *ctx, Target &target) {
     LLVMTypes::Float16Type = llvm::Type::getHalfTy(*ctx);
     LLVMTypes::FloatType = llvm::Type::getFloatTy(*ctx);
     LLVMTypes::DoubleType = llvm::Type::getDoubleTy(*ctx);
+#ifdef ISPC_OPAQUE_PTR_MODE
+    LLVMTypes::PtrType = llvm::PointerType::get(*ctx, 0);
+#else
+    LLVMTypes::PtrType = llvm::PointerType::get(LLVMTypes::Int8Type, 0);
+#endif // ISPC_OPAQUE_PTR_MODE
 
     LLVMTypes::Int8PointerType = llvm::PointerType::get(LLVMTypes::Int8Type, 0);
     LLVMTypes::Int16PointerType = llvm::PointerType::get(LLVMTypes::Int16Type, 0);
@@ -134,6 +141,7 @@ void InitLLVMUtil(llvm::LLVMContext *ctx, Target &target) {
     LLVMTypes::Float16VectorType = LLVMVECTOR::get(LLVMTypes::Float16Type, target.getVectorWidth());
     LLVMTypes::FloatVectorType = LLVMVECTOR::get(LLVMTypes::FloatType, target.getVectorWidth());
     LLVMTypes::DoubleVectorType = LLVMVECTOR::get(LLVMTypes::DoubleType, target.getVectorWidth());
+    LLVMTypes::PtrVectorType = LLVMVECTOR::get(LLVMTypes::PtrType, target.getVectorWidth());
 
     LLVMTypes::Int8VectorPointerType = llvm::PointerType::get(LLVMTypes::Int8VectorType, 0);
     LLVMTypes::Int16VectorPointerType = llvm::PointerType::get(LLVMTypes::Int16VectorType, 0);

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -97,6 +97,8 @@ extern llvm::Constant *LLVMTrue, *LLVMFalse, *LLVMTrueInStorage, *LLVMFalseInSto
 class Target;
 extern void InitLLVMUtil(llvm::LLVMContext *ctx, Target &target);
 
+/** Returns an LLVM i1 constant of the given value */
+extern llvm::ConstantInt *LLVMInt1(bool i);
 /** Returns an LLVM i8 constant of the given value */
 extern llvm::ConstantInt *LLVMInt8(int8_t i);
 /** Returns an LLVM i8 constant of the given value */
@@ -127,6 +129,10 @@ extern llvm::Constant *LLVMBoolVector(bool v);
 /** Returns an LLVM boolean vector constant of the given value smeared
     across all elements with bool represented as storage type(i8)*/
 extern llvm::Constant *LLVMBoolVectorInStorage(bool v);
+
+/** Returns an LLVM i1 vector constant of the given value smeared
+    across all elements */
+extern llvm::Constant *LLVMInt1Vector(bool i);
 
 /** Returns an LLVM i8 vector constant of the given value smeared
     across all elements */
@@ -185,6 +191,10 @@ extern llvm::Constant *LLVMBoolVector(const bool *v);
     with bool represented as storage type(i8).
     The array should have g->target.vectorWidth elements. */
 extern llvm::Constant *LLVMBoolVectorInStorage(const bool *v);
+
+/** Returns an LLVM i1 vector based on the given array of values.
+    The array should have g->target.vectorWidth elements. */
+extern llvm::Constant *LLVMInt1Vector(const bool *i);
 
 /** Returns an LLVM i8 vector based on the given array of values.
     The array should have g->target.vectorWidth elements. */

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -49,6 +49,7 @@ struct LLVMTypes {
     static llvm::Type *Float16Type;
     static llvm::Type *FloatType;
     static llvm::Type *DoubleType;
+    static llvm::Type *PtrType;
 
     static llvm::Type *Int8PointerType;
     static llvm::Type *Int16PointerType;
@@ -70,6 +71,7 @@ struct LLVMTypes {
     static llvm::VectorType *Float16VectorType;
     static llvm::VectorType *FloatVectorType;
     static llvm::VectorType *DoubleVectorType;
+    static llvm::VectorType *PtrVectorType;
 
     static llvm::Type *Int8VectorPointerType;
     static llvm::Type *Int16VectorPointerType;

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -42,6 +42,7 @@ struct LLVMTypes {
     static llvm::Type *BoolType;
     static llvm::Type *BoolStorageType;
 
+    static llvm::Type *Int1Type;
     static llvm::Type *Int8Type;
     static llvm::Type *Int16Type;
     static llvm::Type *Int32Type;

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -114,7 +114,6 @@ const Type *Type::ResolveDependenceForTopType(TemplateInstantiation &templInst) 
 
 const AtomicType *AtomicType::UniformBool = new AtomicType(AtomicType::TYPE_BOOL, Variability::Uniform, false);
 const AtomicType *AtomicType::VaryingBool = new AtomicType(AtomicType::TYPE_BOOL, Variability::Varying, false);
-const AtomicType *AtomicType::UniformInt1 = new AtomicType(AtomicType::TYPE_INT1, Variability::Uniform, false);
 const AtomicType *AtomicType::VaryingInt1 = new AtomicType(AtomicType::TYPE_INT1, Variability::Varying, false);
 const AtomicType *AtomicType::UniformInt8 = new AtomicType(AtomicType::TYPE_INT8, Variability::Uniform, false);
 const AtomicType *AtomicType::VaryingInt8 = new AtomicType(AtomicType::TYPE_INT8, Variability::Varying, false);
@@ -259,10 +258,11 @@ bool AtomicType::IsUnsignedType() const {
 }
 
 bool AtomicType::IsSignedType() const {
-    return (basicType == TYPE_INT8 || basicType == TYPE_INT16 || basicType == TYPE_INT32 || basicType == TYPE_INT64);
+    return (basicType == TYPE_INT1 || basicType == TYPE_INT8 || basicType == TYPE_INT16 || basicType == TYPE_INT32 ||
+            basicType == TYPE_INT64);
 }
 
-bool AtomicType::IsBoolType() const { return basicType == TYPE_BOOL; }
+bool AtomicType::IsBoolType() const { return basicType == TYPE_BOOL || basicType == TYPE_INT1; }
 
 bool AtomicType::IsConstType() const { return isConst; }
 
@@ -480,6 +480,9 @@ std::string AtomicType::Mangle() const {
     case TYPE_BOOL:
         ret += "b";
         break;
+    case TYPE_INT1:
+        ret += "B";
+        break;
     case TYPE_INT8:
         ret += "t";
         break;
@@ -656,6 +659,9 @@ llvm::DIType *AtomicType::GetDIType(llvm::DIScope *scope) const {
 
         case TYPE_BOOL:
             return m->diBuilder->createBasicType("bool", 32 /* size */, llvm::dwarf::DW_ATE_unsigned);
+            break;
+        case TYPE_INT1:
+            return m->diBuilder->createBasicType("int1", 1 /* size */, llvm::dwarf::DW_ATE_signed);
             break;
         case TYPE_INT8:
             return m->diBuilder->createBasicType("int8", 8 /* size */, llvm::dwarf::DW_ATE_signed);

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -114,6 +114,8 @@ const Type *Type::ResolveDependenceForTopType(TemplateInstantiation &templInst) 
 
 const AtomicType *AtomicType::UniformBool = new AtomicType(AtomicType::TYPE_BOOL, Variability::Uniform, false);
 const AtomicType *AtomicType::VaryingBool = new AtomicType(AtomicType::TYPE_BOOL, Variability::Varying, false);
+const AtomicType *AtomicType::UniformInt1 = new AtomicType(AtomicType::TYPE_INT1, Variability::Uniform, false);
+const AtomicType *AtomicType::VaryingInt1 = new AtomicType(AtomicType::TYPE_INT1, Variability::Varying, false);
 const AtomicType *AtomicType::UniformInt8 = new AtomicType(AtomicType::TYPE_INT8, Variability::Uniform, false);
 const AtomicType *AtomicType::VaryingInt8 = new AtomicType(AtomicType::TYPE_INT8, Variability::Varying, false);
 const AtomicType *AtomicType::UniformUInt8 = new AtomicType(AtomicType::TYPE_UINT8, Variability::Uniform, false);
@@ -418,6 +420,9 @@ std::string AtomicType::GetString() const {
     case TYPE_BOOL:
         ret += "bool";
         break;
+    case TYPE_INT1:
+        ret += "int1";
+        break;
     case TYPE_INT8:
         ret += "int8";
         break;
@@ -600,6 +605,8 @@ static llvm::Type *lGetAtomicLLVMType(llvm::LLVMContext *ctx, const AtomicType *
             } else {
                 return isUniform ? LLVMTypes::BoolType : LLVMTypes::BoolVectorType;
             }
+        case AtomicType::TYPE_INT1:
+            return isUniform ? LLVMTypes::Int1Type : LLVMTypes::Int1VectorType;
         case AtomicType::TYPE_INT8:
         case AtomicType::TYPE_UINT8:
             return isUniform ? LLVMTypes::Int8Type : LLVMTypes::Int8VectorType;

--- a/src/type.h
+++ b/src/type.h
@@ -339,6 +339,7 @@ class AtomicType : public Type {
     enum BasicType {
         TYPE_VOID,
         TYPE_BOOL,
+        TYPE_INT1,
         TYPE_INT8,
         TYPE_UINT8,
         TYPE_INT16,
@@ -357,6 +358,7 @@ class AtomicType : public Type {
     const BasicType basicType;
 
     static const AtomicType *UniformBool, *VaryingBool;
+    static const AtomicType *UniformInt1, *VaryingInt1;
     static const AtomicType *UniformInt8, *VaryingInt8;
     static const AtomicType *UniformInt16, *VaryingInt16;
     static const AtomicType *UniformInt32, *VaryingInt32;

--- a/src/type.h
+++ b/src/type.h
@@ -358,7 +358,6 @@ class AtomicType : public Type {
     const BasicType basicType;
 
     static const AtomicType *UniformBool, *VaryingBool;
-    static const AtomicType *UniformInt1, *VaryingInt1;
     static const AtomicType *UniformInt8, *VaryingInt8;
     static const AtomicType *UniformInt16, *VaryingInt16;
     static const AtomicType *UniformInt32, *VaryingInt32;
@@ -372,6 +371,14 @@ class AtomicType : public Type {
     static const AtomicType *UniformDouble, *VaryingDouble;
     static const AtomicType *Dependent;
     static const AtomicType *Void;
+
+    /** The VaryingInt1 type is needed as a workaround for the absence of an
+     * ISPC type (for some mask widths, e.g., i32) representing i1, which is
+     * required for certain LLVM intrinsics like masked.load. In my opinion,
+     * this is another consequence of the unclear bool/mask types in
+     * ISPC. There is no intention of supporting in general, so only fixes
+     * to ensure functionality for two specific intrinsics are made. */
+    static const AtomicType *VaryingInt1;
 
   private:
     const Variability variability;

--- a/tests/lit-tests/3117-1.ispc
+++ b/tests/lit-tests/3117-1.ispc
@@ -1,0 +1,9 @@
+// RUN: %{ispc} --target=host --nowrap --enable-llvm-intrinsics --emit-llvm-text %s -o - 2>&1 | FileCheck %s
+
+// CHECK-LABEL: @foo
+// CHECK-DAG: %calltmp = tail call float @llvm.maxnum.f32(float %a, float %b)
+
+// CHECK-NOT: Intrinsic name not mangled correctly for type arguments! Should be: llvm.maxnum.f32
+uniform float foo(uniform float a, uniform float b) {
+    return @llvm.maxnum(a, b);
+}

--- a/tests/lit-tests/3117-2.ispc
+++ b/tests/lit-tests/3117-2.ispc
@@ -1,0 +1,14 @@
+// RUN: %{ispc} --target=neon-i32x8 --nowrap --enable-llvm-intrinsics --emit-llvm-text %s -o - 2>&1 | FileCheck %s
+
+// REQUIRES: ARM_ENABLED
+
+// CHECK: define void @mask_type___(<[[WIDTH:.*]] x [[MASK:.*]]> %__mask)
+void mask_type() {}
+
+// CHECK-LABEL: @foo
+// CHECK-DAG: %calltmp = tail call <[[WIDTH]] x i16> @llvm.aarch64.neon.sqrdmulh.v[[WIDTH]]i16(<[[WIDTH]] x i16> %t, <[[WIDTH]] x i16> %t)
+
+// CHECK-NOT: Intrinsic name not mangled correctly for type arguments! Should be: llvm.aarch64.neon.sqrdmulh.v8i16
+int16 foo(int16 t) {
+    return @llvm.aarch64.neon.sqrdmulh(t, t);
+}

--- a/tests/lit-tests/llvm-intrinsics-gather.ispc
+++ b/tests/lit-tests/llvm-intrinsics-gather.ispc
@@ -1,0 +1,65 @@
+// RUN: %{ispc} %s --nowrap --target=avx512skx-x4 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx512skx-x8 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx512skx-x16 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx512skx-x32 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx2-i8x32 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx2-i16x16 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx2-i32x4 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx2-i32x8 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx2-i32x16 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx2-i64x4 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=sse4.2-i8x16 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=sse4.2-i16x8 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=neon-i32x4 --arch=aarch64 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=neon-i32x8 --arch=aarch64 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+
+// REQUIRES: OPAQUE_PTRS_ENABLED && X86_ENABLED && ARM_ENABLED
+
+#define unmangled __attribute__((unmangled))
+#define ATTRS unmasked unmangled
+
+// CHECK: define void @mask_type___(<[[WIDTH:.*]] x [[MASK:.*]]> %__mask)
+void mask_type() {}
+
+// CHECK-LABEL: @masked_load_i8
+// CHECK-DAG: %calltmp = tail call <[[WIDTH]] x i8> @llvm.masked.load.v[[WIDTH]]i8.[[P0:(p0|p0i8)]]([[PTR:(ptr|i8*)]] %ptr, i32 1, <[[WIDTH]] x i1> {{%.*}}, <[[WIDTH]] x i8> %passthru)
+unmangled int8 masked_load_i8(int8 *uniform ptr, int8 passthru) {
+    // 1l forces integral literals to be int32
+    return @llvm.masked.load((uniform int8 * uniform) ptr, 1l, __mask, passthru);
+}
+
+// CHECK-LABEL: @gather
+// CHECK-DAG: [[PTR_VEC:%.*]] = inttoptr <[[WIDTH]] x [[ADDR_SIZE:(i64|i32)]]> {{%.*}} to <[[WIDTH]] x ptr>
+// CHECK-DAGL %calltmp = tail call <[[WIDTH]] x i32> @llvm.masked.gather.v[[WIDTH]]i32.v[[WIDTH]][[P0]](<[[WIDTH]] x ptr> [[PTR_VEC]], i32 1, <[[WIDTH]] x i1> {{%.*}}, <[[WIDTH]] x i32> %passthru)
+unmangled int32 gather(uint64 addrs, int32 passthru) {
+    return @llvm.masked.gather(addrs, 1l, __mask, passthru);
+}
+
+// CHECK-LABEL: @masked_store_float
+// CHECK-DAG: tail call void @llvm.masked.store.v[[WIDTH]]f32.[[P0]](<[[WIDTH]] x float> %val, [[PTR]] %ptr, i32 1, <[[WIDTH]] x i1> {{%.*}})
+unmangled void masked_store_float(varying float *uniform ptr, varying float val) {
+    @llvm.masked.store(val, (uniform int8 * uniform) ptr, 1l, __mask);
+}
+
+// CHECK-LABEL: @scatter
+// CHECK-DAG:  [[VPTR:%.*]] = inttoptr <[[WIDTH]] x [[ADDR_SIZE]]> {{%.*}} to <[[WIDTH]] x ptr>
+// CHECK-DAG:  tail call void @llvm.masked.scatter.v[[WIDTH]]i8.v[[WIDTH]][[P0]](<[[WIDTH]] x i8> %val, <[[WIDTH]] x ptr> [[VPTR]], i32 1, <[[WIDTH]] x i1> {{%.*}})
+unmangled void scatter(varying uint64 addr, varying int8 val) {
+    @llvm.masked.scatter(val, addr, 1l, __mask);
+}
+
+// CHECK-LABEL: @reduce_add_float
+// CHECK-DAG:   %calltmp = tail call float @llvm.vector.reduce.fadd.v[[WIDTH]]f32(float -0.000000e+00, <[[WIDTH]] x float> %x)
+ATTRS uniform float reduce_add_float(float x) { return @llvm.vector.reduce.fadd(-0.0f, x); }
+
+// CHECK-LABEL: @masked_compressstore
+// CHECK-DAG: tail call void @llvm.masked.compressstore.v[[WIDTH]]i32(<[[WIDTH]] x i32> %val, [[PTR]] %ptr, <[[WIDTH]] x i1> {{%.*}})
+unmangled void masked_compressstore(uniform int8 *uniform ptr, int val, int mask) {
+    @llvm.masked.compressstore(val, ptr, __mask);
+}
+
+// CHECK-LABEL!: @masked_expandload
+// CHECK-DAG: %calltmp = tail call <[[WIDTH]] x i64> @llvm.masked.expandload.v[[WIDTH]]i64([[PTR]] %from, <[[WIDTH]] x i1> {{%.*}}, <[[WIDTH]] x i64> %passthru)
+unmangled int64 masked_expandload(uniform int8 *uniform from, int64 passthru, UIntMaskType mask) {
+    return @llvm.masked.expandload(from, mask, passthru);
+}

--- a/tests/lit-tests/llvm-intrinsics-type-deduction.ispc
+++ b/tests/lit-tests/llvm-intrinsics-type-deduction.ispc
@@ -1,0 +1,102 @@
+// RUN: %{ispc} %s --nowrap --target=avx512skx-x4 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx512skx-x8 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx512skx-x16 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx512skx-x32 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx2-i8x32 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx2-i16x16 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx2-i32x4 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx2-i32x8 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx2-i32x16 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=avx2-i64x4 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=sse4.2-i8x16 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=sse4.2-i16x8 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=neon-i32x4 --arch=aarch64 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --nowrap --target=neon-i32x8 --arch=aarch64 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED && ARM_ENABLED
+
+#define unmangled __attribute__((unmangled))
+#define ATTRS unmasked unmangled
+
+// CHECK: define void @mask_type___(<[[WIDTH:.*]] x [[MASK:.*]]> %__mask)
+void mask_type() {}
+
+// CHECK-LABEL: @foo
+// CHECK-DAG:   %calltmp = tail call half @llvm.pow.f16(half %x, half %y)
+ATTRS uniform float16 foo(uniform float16 x, uniform float16 y) { return @llvm.pow(x, y); }
+
+// CHECK-LABEL: @bar
+// CHECK-DAG:   %calltmp = tail call <[[WIDTH]] x float> @llvm.pow.v[[WIDTH]]f32(<[[WIDTH]] x float> %x, <[[WIDTH]] x float> %y)
+ATTRS varying float bar(varying float x, varying float y) { return @llvm.pow(x, y); }
+
+// CHECK-LABEL: @cttz_u32
+// CHECK-DAG:   %calltmp = tail call i32 @llvm.cttz.i32(i32 %x, i1 false)
+ATTRS uniform int32 cttz_u32(uniform int32 x) { return @llvm.cttz.i32(x, false); }
+
+// CHECK-LABEL: @cttz_v32
+// CHECK-DAG:  %calltmp = tail call <[[WIDTH]] x i32> @llvm.cttz.v[[WIDTH]]i32(<[[WIDTH]] x i32> %x, i1 false)
+ATTRS int32 cttz_v32(int32 x) { return @llvm.cttz.i32(x, false); }
+
+// CHECK-LABEL: @ctlz_u32
+// CHECK-DAG:   %calltmp = tail call i32 @llvm.ctlz.i32(i32 %x, i1 false)
+ATTRS uniform int32 ctlz_u32(uniform int32 x) { return @llvm.ctlz.i32(x, false); }
+
+// CHECK-LABEL: @ctlz_v32
+// CHECK-DAG:  %calltmp = tail call <[[WIDTH]] x i32> @llvm.ctlz.v[[WIDTH]]i32(<[[WIDTH]] x i32> %x, i1 false)
+ATTRS int32 ctlz_v32(int32 x) { return @llvm.ctlz.i32(x, false); }
+
+// CHECK-LABEL: @prefetch
+// CHECK-DAG:   tail call void @llvm.prefetch.[[P0:(p0|p0i8)]]([[PTR:(ptr|i8\*)]] %ptr, i32 0, i32 3, i32 1)
+// 0l forces integral literals to be int32
+ATTRS void prefetch(uniform int8 *uniform ptr) { @llvm.prefetch(ptr, 0l, 3l, 1l); }
+
+// CHECK-LABEL: @uadd_sat_u64
+// CHECK-DAG:   %calltmp = tail call i64 @llvm.uadd.sat.i64(i64 %x, i64 %y)
+ATTRS uniform uint64 uadd_sat_u64(uniform uint64 x, uniform uint64 y) { return @llvm.uadd.sat(x, y); }
+
+// CHECK-LABEL: @uadd_sat_v64
+// CHECK-DAG:   %calltmp = tail call <[[WIDTH]] x i64> @llvm.uadd.sat.v[[WIDTH]]i64(<[[WIDTH]] x i64> %x, <[[WIDTH]] x i64> %y)
+ATTRS uint64 uadd_sat_v64(uint64 x, uint64 y) { return @llvm.uadd.sat(x, y); }
+
+// CHECK-LABEL: @uadd_sat_u16
+// CHECK-DAG:   %calltmp = tail call i16 @llvm.sadd.sat.i16(i16 %x, i16 %y)
+ATTRS uniform int16 uadd_sat_u16(uniform int16 x, uniform int16 y) { return @llvm.sadd.sat(x, y); }
+
+// CHECK-LABEL: @uadd_sat_v16
+// CHECK-DAG:   %calltmp = tail call <[[WIDTH]] x i16> @llvm.sadd.sat.v[[WIDTH]]i16(<[[WIDTH]] x i16> %x, <[[WIDTH]] x i16> %y)
+ATTRS int16 uadd_sat_v16(int16 x, int16 y) { return @llvm.sadd.sat(x, y); }
+
+// CHECK-LABEL: @usub_sat_u8
+// CHECK-DAG:   %calltmp = tail call i8 @llvm.usub.sat.i8(i8 %x, i8 %y)
+ATTRS uniform uint8 usub_sat_u8(uniform uint8 x, uniform uint8 y) { return @llvm.usub.sat(x, y); }
+
+// CHECK-LABEL: @usub_sat_v8
+// CHECK-DAG:   %calltmp = tail call <[[WIDTH]] x i8> @llvm.usub.sat.v[[WIDTH]]i8(<[[WIDTH]] x i8> %x, <[[WIDTH]] x i8> %y)
+ATTRS uint8 usub_sat_v8(uint8 x, uint8 y) { return @llvm.usub.sat(x, y); }
+
+// CHECK-LABEL: @ssub_sat_u32
+// CHECK-DAG:   %calltmp = tail call i32 @llvm.ssub.sat.i32(i32 %x, i32 %y)
+ATTRS uniform int32 ssub_sat_u32(uniform int32 x, uniform int32 y) { return @llvm.ssub.sat(x, y); }
+
+// CHECK-LABEL: @ssub_sat_v32
+// CHECK-DAG:   %calltmp = tail call <[[WIDTH]] x i32> @llvm.ssub.sat.v[[WIDTH]]i32(<[[WIDTH]] x i32> %x, <[[WIDTH]] x i32> %y)
+ATTRS int32 ssub_sat_v32(int32 x, int32 y) { return @llvm.ssub.sat(x, y); }
+
+// CHECK-LABEL: @memset
+// CHECK-DAG:   tail call void @llvm.memset.[[P0]].i32([[PTR]] align 1 %dst, i8 %val, i32 %len, i1 false)
+ATTRS void memset(uniform int8 *uniform dst, uniform int8 val, uniform int32 len) {
+    @llvm.memset(dst, val, len, false);
+}
+
+// CHECK-LABEL: @memcpy
+// CHECK-DAG:   tail call void @llvm.memcpy.[[P0]].[[P0]].i64([[PTR]] align 1 %dst, [[PTR]] align 1 %src, i64 %len, i1 false)
+ATTRS void memcpy(uniform int8 *uniform dst, uniform int8 *uniform src, uniform int64 len) {
+    @llvm.memcpy(dst, src, len, false);
+}
+
+// CHECK-LABEL: @memmove
+// CHECK-DAG:   tail call void @llvm.memcpy.[[P0]].[[P0]].i32([[PTR]] align 1 %dst, [[PTR]] align 1 %src, i32 %len, i1 false)
+// memcpy because all pointers are non-overlapping in ISPC (noalias)
+ATTRS void memmove(uniform int8 *uniform dst, uniform int8 *uniform src, uniform int32 len) {
+    @llvm.memmove(dst, src, len, false);
+}


### PR DESCRIPTION
This PR supports overloaded LLVM intrinsics. 

We need to produce correct function declarations for overloaded LLVM intrinsics. ISPC used all arguments to mangling in extra suffixes (which is wrong, e.g., see #3117). We need to provide only some arguments.

This PR adds support to `<N x ptr>` ISPC type. It also introduces ISPC type that matches to `<N x i1>` for targets with `mask_bits != 1`. Both are needed to support `llvm.masked.gather` and similar. These intrinsics will be used to implement common target.

This fixes #3117.
