### PR TITLE
Fix error message when unknown target/os/arch is used

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -730,7 +730,8 @@ int main(int Argc, char *Argv[]) {
 
             arch = ParseArch(argv[i] + 7);
             if (arch == Arch::error) {
-                errorHandler.AddError("Unsupported value for --arch, supported values are: %s",
+                errorHandler.AddError("Unsupported value for --arch, supported values are: %s. Use --support-matrix "
+                                      "for complete information about supported targets, archs and target OSes.",
                                       g->target_registry->getSupportedArchs().c_str());
             }
 
@@ -834,8 +835,9 @@ int main(int Argc, char *Argv[]) {
                 auto result = ParseISPCTargets(argv[i]);
                 targets = result.first;
                 if (!result.second.empty()) {
-                    errorHandler.AddError("Incorrect targets: %s.  Choices are: %s.", result.second.c_str(),
-                                          g->target_registry->getSupportedTargets().c_str());
+                    errorHandler.AddError("Incorrect targets: %s.  Choices are: %s. Use --support-matrix for complete "
+                                          "information about supported targets, archs and target OSes.",
+                                          result.second.c_str(), g->target_registry->getSupportedTargets().c_str());
                 }
             } else {
                 errorHandler.AddError("No target specified after --target option.");
@@ -844,14 +846,17 @@ int main(int Argc, char *Argv[]) {
             auto result = ParseISPCTargets(argv[i] + 9);
             targets = result.first;
             if (!result.second.empty()) {
-                errorHandler.AddError("Incorrect targets: %s.  Choices are: %s.", result.second.c_str(),
-                                      g->target_registry->getSupportedTargets().c_str());
+                errorHandler.AddError("Incorrect targets: %s.  Choices are: %s. Use --support-matrix for complete "
+                                      "information about supported targets, archs and target OSes.",
+                                      result.second.c_str(), g->target_registry->getSupportedTargets().c_str());
             }
         } else if (!strncmp(argv[i], "--target-os=", 12)) {
             g->target_os = ParseOS(argv[i] + 12);
             if (g->target_os == TargetOS::error) {
-                errorHandler.AddError("Unsupported value for --target-os, supported values are: %s",
-                                      g->target_registry->getSupportedOSes().c_str());
+                errorHandler.AddError(
+                    "Unsupported value for --target-os, supported values are: %s. Use --support-matrix for complete "
+                    "information about supported targets, archs and target OSes.",
+                    g->target_registry->getSupportedOSes().c_str());
             }
         } else if (!strcmp(argv[i], "--no-vectorcall")) {
             vectorCall = BooleanOptValue::disabled;

--- a/src/target_registry.cpp
+++ b/src/target_registry.cpp
@@ -12,6 +12,7 @@
 #include "util.h"
 
 #include <numeric>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -321,20 +322,24 @@ std::string TargetLibRegistry::getSupportedArchs() {
 }
 
 std::string TargetLibRegistry::getSupportedTargets() {
-    std::string targets;
+    std::set<std::string> targetSet;
     for (Arch arch = Arch::none; arch < Arch::error; arch++) {
         for (ISPCTarget target = ISPCTarget::sse2_i32x4; target < ISPCTarget::error; target++) {
             for (TargetOS os = TargetOS::windows; os < TargetOS::error; os++) {
                 if (isSupported(target, os, arch)) {
-                    if (!targets.empty()) {
-                        targets += ", ";
-                    }
-                    targets += ISPCTargetToString(target);
-                    goto next_target;
+                    targetSet.insert(ISPCTargetToString(target));
+                    break;
                 }
             }
         }
-    next_target:;
+    }
+
+    std::string targets;
+    for (const auto &target : targetSet) {
+        if (!targets.empty()) {
+            targets += ", ";
+        }
+        targets += target;
     }
 
     return targets;

--- a/tests/lit-tests/3126.ispc
+++ b/tests/lit-tests/3126.ispc
@@ -1,0 +1,20 @@
+// This test verifies that when an unknown target is specified on the command line,
+// the complete list of supported targets is displayed.
+// It's impractical to validate the entire output without imposing strict conditions on the test,
+// which is unnecessary, so we'll verify only the beginning of the output when x86 targets are enabled
+// (the targets are listed in alphabetical order).
+// Additionally, confirm that the message about '--support-matrix' is printed when an unknown target/OS or target is specified.
+
+// RUN: not %{ispc} --target=unknown --nowrap %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-TARGET
+// RUN: not %{ispc} --target-os=unknown --nowrap %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-OS
+// RUN: not %{ispc} --arch=unknown --nowrap %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ARCH
+// REQUIRES: X86_ENABLED
+
+// CHECK-TARGET: Incorrect targets: unknown. Choices are: {{avx1-i32x16, avx1-i32x4, avx1-i32x8, avx1-i64x4, avx2-i16x16, avx2-i32x16, avx2-i32x4, avx2-i32x8, .*}}. Use --support-matrix for complete information about supported targets, archs and target OSes
+// CHECK-OS: Error: Unsupported value for --target-os, supported values are: {{.*}}. Use --support-matrix for complete information about supported targets, archs and target OSes.
+// CHECK-ARCH: Error: Unsupported value for --arch, supported values are: {{.*}}. Use --support-matrix for complete information about supported targets, archs and target OSes.
+
+uniform float i;
+uniform float foo() {
+    return i;
+}


### PR DESCRIPTION
Fixes #3126.
Now the error message also mentions a `-support-matrix` with complete info about supported targets/os/archs.