### PR TITLE
Fix functions and function templates overloads

### DIFF
--- a/src/expr.h
+++ b/src/expr.h
@@ -746,8 +746,8 @@ class SymbolExpr : public Expr {
  */
 class FunctionSymbolExpr : public Expr {
   public:
-    FunctionSymbolExpr(const char *name, const std::vector<Symbol *> &candFuncs, SourcePos pos);
-    FunctionSymbolExpr(const char *name, const std::vector<TemplateSymbol *> &candFuncs, const TemplateArgs &templArgs,
+    FunctionSymbolExpr(const char *name, const std::vector<Symbol *> &candFuncs,
+                       const std::vector<TemplateSymbol *> &candTemplFuncs, const TemplateArgs &templArgs,
                        SourcePos pos);
 
     static inline bool classof(FunctionSymbolExpr const *) { return true; }
@@ -785,6 +785,16 @@ class FunctionSymbolExpr : public Expr {
     static int computeOverloadCost(const FunctionType *ftype, const std::vector<const Type *> &argTypes,
                                    const std::vector<bool> *argCouldBeNULL, const std::vector<bool> *argIsConstant,
                                    int *cost);
+    /**Determines the best match cost for function or template candidates.
+      Evaluates a list of candidate functions or template functions
+      against the provided argument types and computes the cost of calling each candidate.
+      It identifies the best match based on the computed costs and populates the
+      provided matches vector with the candidates that are considered valid matches.
+      Returns the best match cost.
+    */
+    static int FindBestMatchCost(const std::vector<Symbol *> &candidates, const std::vector<const Type *> &argTypes,
+                                 const std::vector<bool> *argCouldBeNULL, const std::vector<bool> *argIsConstant,
+                                 SourcePos pos, const std::string &name, std::vector<Symbol *> &matches);
     /** This function applies "normalization" to the template arguments, specifically
         adjusting their variability to ensure consistency with the expected types.
 

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -325,7 +325,7 @@ primary_expression
             std::vector<Symbol *> funs;
             m->symbolTable->LookupFunction(name, &funs);
             if (funs.size() > 0)
-                $$ = new FunctionSymbolExpr(name, funs, @1);
+                $$ = new FunctionSymbolExpr(name, funs, {}, TemplateArgs(), @1);
         }
         if ($$ == nullptr) {
             std::vector<std::string> alternates =
@@ -578,7 +578,7 @@ intrincall_expression
           const std::vector<Symbol *> funcs{sym};
           FunctionSymbolExpr *fSym = nullptr;
           if (sym != nullptr)
-              fSym = new FunctionSymbolExpr(fname, funcs, @1);
+              fSym = new FunctionSymbolExpr(fname, funcs, {}, TemplateArgs(), @1);
           $$ = new FunctionCallExpr(fSym, new ExprList(Union(@1,@2)), Union(@1,@3));
           delete name;
       }
@@ -591,7 +591,7 @@ intrincall_expression
           const std::vector<Symbol *> funcs{sym};
           FunctionSymbolExpr *fSym = nullptr;
           if (sym != nullptr)
-              fSym = new FunctionSymbolExpr(fname, funcs, @1);
+              fSym = new FunctionSymbolExpr(fname, funcs, {}, TemplateArgs(), @1);
           $$ = new FunctionCallExpr(fSym, $3, Union(@1,@4));
           delete name;
       }
@@ -609,16 +609,18 @@ funcall_expression
       {
           // Create FunctionSymbolExpr with a candidate functions list
           Expr *functionSymbolExpr = nullptr;
-          std::vector<TemplateSymbol *> funcTempls;
           const std::string name = $1->first->name;
+          std::vector<Symbol *> funcs;
+          m->symbolTable->LookupFunction(name.c_str(), &funcs);
+          std::vector<TemplateSymbol *> funcTempls;
           m->symbolTable->LookupFunctionTemplate(name, &funcTempls);
-          if (funcTempls.size() > 0) {
+          if (funcs.size() > 0 || funcTempls.size() > 0) {
               TemplateArgs *templArgs = $1->second;
               Assert(templArgs);
-              functionSymbolExpr = new FunctionSymbolExpr(name.c_str(), funcTempls, *templArgs, @1);
+              functionSymbolExpr = new FunctionSymbolExpr(name.c_str(), funcs, funcTempls, *templArgs, @1);
               $$ = new FunctionCallExpr(functionSymbolExpr, new ExprList(Union(@1,@2)), Union(@1,@3));
           } else {
-              Error(@1, "No matching template functions were declared.");
+              Error(@1, "No matching functions were declared.");
               $$ = nullptr;
           }
 
@@ -629,16 +631,18 @@ funcall_expression
       {
           // Create FunctionSymbolExpr with a candidate functions list
           Expr *functionSymbolExpr = nullptr;
-          std::vector<TemplateSymbol *> funcTempls;
           const std::string name = $1->first->name;
+          std::vector<Symbol *> funcs;
+          m->symbolTable->LookupFunction(name.c_str(), &funcs);
+          std::vector<TemplateSymbol *> funcTempls;
           m->symbolTable->LookupFunctionTemplate(name, &funcTempls);
-          if (funcTempls.size() > 0) {
+          if (funcs.size() > 0 || funcTempls.size() > 0) {
               TemplateArgs *templArgs = $1->second;
               Assert(templArgs);
-              functionSymbolExpr = new FunctionSymbolExpr(name.c_str(), funcTempls, *templArgs, @1);
+              functionSymbolExpr = new FunctionSymbolExpr(name.c_str(), funcs, funcTempls, *templArgs, @1);
               $$ = new FunctionCallExpr(functionSymbolExpr, $3, Union(@1,@4));
           } else {
-              Error(@1, "No matching template functions were declared.");
+              Error(@1, "No matching functions were declared.");
               $$ = nullptr;
           }
 

--- a/tests/lit-tests/func_template_12.ispc
+++ b/tests/lit-tests/func_template_12.ispc
@@ -1,0 +1,22 @@
+// Test that we can mix and match regular functions and function templates with the same name.
+// RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
+
+// CHECK-LABEL: define <4 x i32> @foo___
+// CHECK: call <4 x i32> @max_func___uniCuni4
+// CHECK-LABEL: define linkonce_odr <4 x i32> @max_func___uniCuni4
+// CHECK: call <{{.*}} x i32> @max_func___vyivyi
+
+uniform int max_func(uniform int a, uniform int b);
+varying int max_func(varying int a, varying int b);
+
+template <typename T, uint N>
+noinline T<N> max_func(T<N> a, T<N> b) {
+    T<N> r;
+    foreach (i = 0 ... N) {
+        r[i] = max_func(a[i], b[i]);
+    }
+    return r;
+}
+uniform int<4> foo(uniform int<4> a, uniform int<4> b) {
+    return max_func<uniform int, 4>(a, b);
+}

--- a/tests/lit-tests/func_template_spec_1.ispc
+++ b/tests/lit-tests/func_template_spec_1.ispc
@@ -12,6 +12,7 @@
 // CHECK-LABEL: define <{{[0-9]*}} x float> @foo
 // CHECK: call <{{[0-9]*}} x i32> @goo___vyivyf___vyivyf(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x float> %argFoo1, <{{[0-9]*}} x {{.*}}> {{.*}})
 // CHECK: call <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x {{.*}}> {{.*}})
+// CHECK: call <{{[0-9]*}} x i32> @goo___vyivyf(<{{[0-9]*}} x i32> %argFoo0, <{{[0-9]*}} x float> %argFoo1, <{{[0-9]*}} x {{.*}}> {{.*}})
 
 // Instantiated function
 // CHECK-LABEL: define linkonce_odr <{{[0-9]*}} x i32> @goo___vyivyi___vyivyi(<{{[0-9]*}} x i32> %argGooOne, <{{[0-9]*}} x i32> %argGooTwo, <{{[0-9]*}} x {{.*}}> %__mask)
@@ -33,6 +34,7 @@ template <> noinline int goo<int, float>(int argGooOne, float argGooTwo) {
 float foo(int argFoo0, float argFoo1) {
     float a = goo<int, float>(argFoo0, argFoo1);
     int b = goo<int, int>(argFoo0, argFoo0);
-    return a + b;
+    int c = goo(argFoo0, argFoo1);
+    return a + b + c;
 }
 


### PR DESCRIPTION
This PR fixes #3015.
It has 3 main changes:
1. Unifies `FunctionSymbolExpr` for functions and function templates (it can be improved even better when we refactor `Symbol` and `TemplateSymbol` classes)
2. Extracts `FindBestMatchCost` from `ResolveOverloads`
3. Introduces logic how to choose between template function and function when resolving overloads.