### PR TITLE
Add common targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2024, Intel Corporation
+#  Copyright (c) 2018-2025, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -836,6 +836,9 @@ function(add_ispc_slim NAME)
     # Defines stdlib target
     generate_stdlibs(${NAME})
 
+    # Defines targets for generic builtin implementations
+    generate_generic_builtins(${NAME})
+
     # stdlib, stdlibs-bc, stdlibs-cpp targets are created in Stdlib.cmake
     configure_ispc_obj(stdlib)
 
@@ -843,7 +846,9 @@ function(add_ispc_slim NAME)
     configure_ispc_exe(${NAME})
     target_link_libraries(${NAME} ${LINK_LIBRARIES} optimization common frontend)
     add_dependencies(${NAME} builtins-bc)
+    add_dependencies(generic-target-bc ${NAME})
     if (${NAME} STREQUAL "ispc")
+        set_target_properties(generic-target-bc PROPERTIES EXCLUDE_FROM_ALL OFF)
         set_target_properties(stdlibs-bc PROPERTIES EXCLUDE_FROM_ALL OFF)
     endif()
 endfunction()
@@ -874,10 +879,11 @@ if (ISPC_SLIM_BINARY)
     message(STATUS "ISPC will be built as a slim binary")
 else()
     add_ispc_slim(ispc-slim)
+    configure_ispc_obj(generic-target)
 
     add_executable(ispc src/main.cpp src/binary_composite.cpp)
     configure_ispc_exe(ispc)
-    target_link_libraries(ispc ${LINK_LIBRARIES} builtin stdlib optimization common frontend)
+    target_link_libraries(ispc ${LINK_LIBRARIES} builtin stdlib optimization common frontend generic-target)
     add_dependencies(ispc ispc-slim)
     message(STATUS "ISPC will be built as a composite binary")
 endif()

--- a/builtins/generic.ispc
+++ b/builtins/generic.ispc
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+// This file provides the target-independent definitions for builtin functions.
+
+// Empty for now.
+;

--- a/cmake/GenerateBuiltins.cmake
+++ b/cmake/GenerateBuiltins.cmake
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2024, Intel Corporation
+#  Copyright (c) 2018-2025, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -502,4 +502,134 @@ function (generate_builtins)
     add_library(builtin OBJECT EXCLUDE_FROM_ALL
         ${DISPATCH_BUILTIN_CPP_FILES} ${COMMON_BUILTIN_CPP_FILES} ${TARGET_BUILTIN_CPP_FILES})
     add_dependencies(builtin builtins-cpp)
+endfunction()
+
+# Define custom commands to generate bitcode for a specific generic target and
+# a corresponding cpp wrapper for bitcode. All they are generated from
+# builtins/generic.ispc file. For slim binary, an entry to the
+# bitcode_libs_generated.cpp file is added.
+function (generate_generic_target_builtin ispc_name target arch bit os)
+    set(include ${CMAKE_CURRENT_SOURCE_DIR}/stdlib/include)
+
+    set(name "builtins_target_generic_${target}_${arch}_${os}")
+    set(input_ispc builtins/generic.ispc)
+
+    if ("${os}" STREQUAL "unix")
+        set(fixed_os "linux")
+        set(OS_UP UNIX)
+    elseif ("${os}" STREQUAL "windows")
+        set(fixed_os "windows")
+        set(OS_UP WINDOWS)
+    else()
+        message(FATAL_ERROR "Error: unknown OS for target ${os}")
+    endif()
+
+    file(APPEND ${CMAKE_BINARY_DIR}/bitcode_libs_generated.cpp
+      "static BitcodeLib ${name}(\"${name}.bc\", ISPCTarget::generic_${target}, TargetOS::${fixed_os}, Arch::${arch});\n")
+    set(target "generic-${target}")
+
+    set(cpp ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${name}.cpp)
+    set(bc ${BITCODE_FOLDER}/${name}.bc)
+
+    if ("${fixed_os}" STREQUAL "linux" AND NOT ISPC_LINUX_TARGET)
+        # If ISPC_LINUX_TARGET is disabled then we can't run ispc-slim with
+        # --target-os=linux to generate generic target bitcode. So we need pass
+        # the target-os that is supported by ispc-slim.
+        if (APPLE)
+            set(fixed_os "macos")
+        elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+            set(fixed_os "freebsd")
+        else ()
+            message(FATAL_ERROR "Error: unknown OS for target ${fixed_os}")
+        endif()
+    endif()
+
+    add_custom_command(
+        OUTPUT ${bc}
+        COMMAND ${ispc_name} -I ${include} --enable-llvm-intrinsics --nostdlib --gen-stdlib --target=${target} --arch=${arch} --target-os=${fixed_os}  --emit-llvm -o ${bc} ${input_ispc} -DBUILD_OS=${OS_UP} -DRUNTIME=${bit}
+        DEPENDS ${ispc_name} ${input_ispc}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+    add_custom_command(
+        OUTPUT ${cpp}
+        COMMAND ${Python3_EXECUTABLE} ${BITCODE2CPP} ${bc} --type=ispc-target --runtime=${bit} --os=${OS_UP} --arch=${arch} ${cpp}
+        DEPENDS ${bc} ${BITCODE2CPP}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+    list(APPEND GENERIC_TARGET_BC_FILE ${bc})
+    set(GENERIC_TARGET_BC_FILE ${GENERIC_TARGET_BC_FILE} PARENT_SCOPE)
+
+    list(APPEND GENERIC_TARGET_CPP_FILE ${cpp})
+    set(GENERIC_TARGET_CPP_FILE ${GENERIC_TARGET_CPP_FILE} PARENT_SCOPE)
+endfunction()
+
+# Generate custom commands to generate bitcode and corresponding cpp files for
+# all generic targets and define a library of cpp files. It just traverses all
+# targets/archs/os combinations and call generate_generic_target_builtin for
+# each of them.
+function (generate_generic_builtins ispc_name)
+    list(APPEND os_list)
+    if (ISPC_WINDOWS_TARGET)
+        list(APPEND os_list "windows")
+    endif()
+    if (ISPC_UNIX_TARGET)
+        list(APPEND os_list "unix")
+    endif()
+
+    list(APPEND TARGET_LIST
+        "i1x4"
+        "i1x8"
+        "i1x16"
+        "i1x32"
+        "i1x64"
+        "i8x16"
+        "i8x32"
+        "i16x8"
+        "i16x16"
+        "i32x4"
+        "i32x8"
+        "i32x16"
+        "i64x4"
+    )
+
+    list(APPEND ARCH_LIST)
+    if (X86_ENABLED)
+        list(APPEND ARCH_LIST
+            "x86_64,64"
+        )
+        if (NOT APPLE)
+            list(APPEND ARCH_LIST
+                "x86,32"
+            )
+        endif()
+    endif()
+
+    if (ARM_ENABLED)
+        list(APPEND ARCH_LIST
+            "aarch64,64"
+        )
+        if (NOT APPLE AND NOT WIN32)
+            list(APPEND ARCH_LIST
+                "arm,32"
+            )
+        endif()
+    endif()
+
+    foreach(os ${os_list})
+        foreach(target ${TARGET_LIST})
+            foreach(pair ${ARCH_LIST})
+                string(REGEX REPLACE "," ";" pair_split ${pair})
+                list(GET pair_split 0 arch)
+                list(GET pair_split 1 bit)
+                generate_generic_target_builtin(${ispc_name} ${target} ${arch} ${bit} ${os})
+            endforeach()
+        endforeach()
+    endforeach()
+
+    add_custom_target(generic-target-bc DEPENDS ${GENERIC_TARGET_BC_FILE})
+    add_custom_target(generic-target-cpp DEPENDS ${GENERIC_TARGET_CPP_FILE})
+
+    add_library(generic-target OBJECT EXCLUDE_FROM_ALL ${GENERIC_TARGET_CPP_FILE})
 endfunction()

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -1245,6 +1245,114 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
     // Check default LLVM generated targets
     bool unsupported_target = false;
     switch (m_ispc_target) {
+    // Generic targets are the base targets that supposed to work on all
+    // hardware and serve as a baseline for implementing more specialized,
+    // fine-tuned targets.
+    // TODO: figure out maskingFree and hasFeatures based on arch and CPU
+    case ISPCTarget::generic_i32x4:
+        this->m_nativeVectorWidth = 4;
+        this->m_nativeVectorAlignment = 16;
+        this->m_dataTypeWidth = 32;
+        this->m_vectorWidth = 4;
+        this->m_maskingIsFree = false;
+        this->m_maskBitCount = 32;
+        break;
+    case ISPCTarget::generic_i32x8:
+        this->m_nativeVectorWidth = 4;
+        this->m_nativeVectorAlignment = 16;
+        this->m_dataTypeWidth = 32;
+        this->m_vectorWidth = 8;
+        this->m_maskingIsFree = false;
+        this->m_maskBitCount = 32;
+        break;
+    case ISPCTarget::generic_i8x16:
+        this->m_nativeVectorWidth = 16;
+        this->m_nativeVectorAlignment = 16;
+        this->m_dataTypeWidth = 8;
+        this->m_vectorWidth = 16;
+        this->m_maskingIsFree = false;
+        this->m_maskBitCount = 8;
+        break;
+    case ISPCTarget::generic_i16x8:
+        this->m_nativeVectorWidth = 8;
+        this->m_nativeVectorAlignment = 16;
+        this->m_dataTypeWidth = 16;
+        this->m_vectorWidth = 8;
+        this->m_maskingIsFree = false;
+        this->m_maskBitCount = 16;
+        break;
+    case ISPCTarget::generic_i32x16:
+        this->m_nativeVectorWidth = 8;
+        this->m_nativeVectorAlignment = 32;
+        this->m_dataTypeWidth = 32;
+        this->m_vectorWidth = 16;
+        this->m_maskingIsFree = false;
+        this->m_maskBitCount = 32;
+        break;
+    case ISPCTarget::generic_i64x4:
+        this->m_nativeVectorWidth = 8; /* native vector width in terms of floats */
+        this->m_nativeVectorAlignment = 32;
+        this->m_dataTypeWidth = 64;
+        this->m_vectorWidth = 4;
+        this->m_maskingIsFree = false;
+        this->m_maskBitCount = 64;
+        break;
+    case ISPCTarget::generic_i8x32:
+        this->m_nativeVectorWidth = 32;
+        this->m_nativeVectorAlignment = 32;
+        this->m_dataTypeWidth = 8;
+        this->m_vectorWidth = 32;
+        this->m_maskingIsFree = false;
+        this->m_maskBitCount = 8;
+        break;
+    case ISPCTarget::generic_i16x16:
+        this->m_nativeVectorWidth = 16;
+        this->m_nativeVectorAlignment = 32;
+        this->m_dataTypeWidth = 16;
+        this->m_vectorWidth = 16;
+        this->m_maskingIsFree = false;
+        this->m_maskBitCount = 16;
+        break;
+    case ISPCTarget::generic_i1x4:
+        this->m_nativeVectorWidth = 16;
+        this->m_nativeVectorAlignment = 64;
+        this->m_dataTypeWidth = 32;
+        this->m_vectorWidth = 4;
+        this->m_maskingIsFree = true;
+        this->m_maskBitCount = 1;
+        break;
+    case ISPCTarget::generic_i1x8:
+        this->m_nativeVectorWidth = 16;
+        this->m_nativeVectorAlignment = 64;
+        this->m_dataTypeWidth = 32;
+        this->m_vectorWidth = 8;
+        this->m_maskingIsFree = true;
+        this->m_maskBitCount = 1;
+        break;
+    case ISPCTarget::generic_i1x16:
+        this->m_nativeVectorWidth = 16;
+        this->m_nativeVectorAlignment = 64;
+        this->m_dataTypeWidth = 32;
+        this->m_vectorWidth = 16;
+        this->m_maskingIsFree = true;
+        this->m_maskBitCount = 1;
+        break;
+    case ISPCTarget::generic_i1x32:
+        this->m_nativeVectorWidth = 64;
+        this->m_nativeVectorAlignment = 64;
+        this->m_dataTypeWidth = 16;
+        this->m_vectorWidth = 32;
+        this->m_maskingIsFree = true;
+        this->m_maskBitCount = 1;
+        break;
+    case ISPCTarget::generic_i1x64:
+        this->m_nativeVectorWidth = 64;
+        this->m_nativeVectorAlignment = 64;
+        this->m_dataTypeWidth = 8;
+        this->m_vectorWidth = 64;
+        this->m_maskingIsFree = true;
+        this->m_maskBitCount = 1;
+        break;
     case ISPCTarget::sse2_i32x4:
         this->m_isa = Target::SSE2;
         this->m_nativeVectorWidth = 4;
@@ -2045,7 +2153,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
     }
 
 #if defined(ISPC_ARM_ENABLED)
-    if ((CPUID == CPU_None) && ISPCTargetIsNeon(m_ispc_target)) {
+    if (CPUID == CPU_None) {
         if (arch == Arch::arm || arch == Arch::aarch64) {
             CPUID = lGetARMDeviceType(arch);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -1138,8 +1138,9 @@ int main(int Argc, char *Argv[]) {
 
     if (g->genStdlib) {
         std::string stdlib = "stdlib/stdlib.ispc";
-        if (stdlib != file) {
-            Error(SourcePos(), "The --gen-stdlib option can be used only with stdlib.ispc.");
+        std::string generic = "builtins/generic.ispc";
+        if (stdlib != file && generic != file) {
+            Error(SourcePos(), "The --gen-stdlib option can be used only with stdlib.ispc or builtins/generic.ispc.");
             exit(1);
         }
     }

--- a/src/target_enums.cpp
+++ b/src/target_enums.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2024, Intel Corporation
+  Copyright (c) 2019-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -229,7 +229,46 @@ ISPCTarget operator++(ISPCTarget &target, int dummy) {
     static_assert(static_cast<underlying>(ISPCTarget::xe2lpg_x32) ==
                       static_cast<underlying>(ISPCTarget::xe2lpg_x16) + 1,
                   "Enum ISPCTarget is not sequential");
-    static_assert(static_cast<underlying>(ISPCTarget::error) == static_cast<underlying>(ISPCTarget::xe2lpg_x32) + 1,
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i1x4) ==
+                      static_cast<underlying>(ISPCTarget::xe2lpg_x32) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i1x8) ==
+                      static_cast<underlying>(ISPCTarget::generic_i1x4) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i1x16) ==
+                      static_cast<underlying>(ISPCTarget::generic_i1x8) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i1x32) ==
+                      static_cast<underlying>(ISPCTarget::generic_i1x16) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i1x64) ==
+                      static_cast<underlying>(ISPCTarget::generic_i1x32) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i8x16) ==
+                      static_cast<underlying>(ISPCTarget::generic_i1x64) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i8x32) ==
+                      static_cast<underlying>(ISPCTarget::generic_i8x16) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i16x8) ==
+                      static_cast<underlying>(ISPCTarget::generic_i8x32) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i16x16) ==
+                      static_cast<underlying>(ISPCTarget::generic_i16x8) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i32x4) ==
+                      static_cast<underlying>(ISPCTarget::generic_i16x16) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i32x8) ==
+                      static_cast<underlying>(ISPCTarget::generic_i32x4) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i32x16) ==
+                      static_cast<underlying>(ISPCTarget::generic_i32x8) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::generic_i64x4) ==
+                      static_cast<underlying>(ISPCTarget::generic_i32x16) + 1,
+                  "Enum ISPCTarget is not sequential");
+    static_assert(static_cast<underlying>(ISPCTarget::error) == static_cast<underlying>(ISPCTarget::generic_i64x4) + 1,
                   "Enum ISPCTarget is not sequential");
     return target = static_cast<ISPCTarget>(static_cast<underlying>(target) + 1);
 }
@@ -404,6 +443,32 @@ ISPCTarget ParseISPCTarget(std::string target) {
         return ISPCTarget::xe2lpg_x16;
     } else if (target == "xe2lpg-x32") {
         return ISPCTarget::xe2lpg_x32;
+    } else if (target == "generic-i1x4") {
+        return ISPCTarget::generic_i1x4;
+    } else if (target == "generic-i1x8") {
+        return ISPCTarget::generic_i1x8;
+    } else if (target == "generic-i1x16") {
+        return ISPCTarget::generic_i1x16;
+    } else if (target == "generic-i1x32") {
+        return ISPCTarget::generic_i1x32;
+    } else if (target == "generic-i1x64") {
+        return ISPCTarget::generic_i1x64;
+    } else if (target == "generic-i8x16") {
+        return ISPCTarget::generic_i8x16;
+    } else if (target == "generic-i8x32") {
+        return ISPCTarget::generic_i8x32;
+    } else if (target == "generic-i16x8") {
+        return ISPCTarget::generic_i16x8;
+    } else if (target == "generic-i16x16") {
+        return ISPCTarget::generic_i16x16;
+    } else if (target == "generic-i32x4") {
+        return ISPCTarget::generic_i32x4;
+    } else if (target == "generic-i32x8") {
+        return ISPCTarget::generic_i32x8;
+    } else if (target == "generic-i32x16") {
+        return ISPCTarget::generic_i32x16;
+    } else if (target == "generic-i64x4") {
+        return ISPCTarget::generic_i64x4;
     }
 
     return ISPCTarget::error;
@@ -559,6 +624,32 @@ std::string ISPCTargetToString(ISPCTarget target) {
         return "xe2lpg-x16";
     case ISPCTarget::xe2lpg_x32:
         return "xe2lpg-x32";
+    case ISPCTarget::generic_i1x4:
+        return "generic-i1x4";
+    case ISPCTarget::generic_i1x8:
+        return "generic-i1x8";
+    case ISPCTarget::generic_i1x16:
+        return "generic-i1x16";
+    case ISPCTarget::generic_i1x32:
+        return "generic-i1x32";
+    case ISPCTarget::generic_i1x64:
+        return "generic-i1x64";
+    case ISPCTarget::generic_i8x16:
+        return "generic-i8x16";
+    case ISPCTarget::generic_i8x32:
+        return "generic-i8x32";
+    case ISPCTarget::generic_i16x8:
+        return "generic-i16x8";
+    case ISPCTarget::generic_i16x16:
+        return "generic-i16x16";
+    case ISPCTarget::generic_i32x4:
+        return "generic-i32x4";
+    case ISPCTarget::generic_i32x8:
+        return "generic-i32x8";
+    case ISPCTarget::generic_i32x16:
+        return "generic-i32x16";
+    case ISPCTarget::generic_i64x4:
+        return "generic-i64x4";
     case ISPCTarget::none:
         return "none";
     case ISPCTarget::error:
@@ -653,6 +744,27 @@ bool ISPCTargetIsGen(ISPCTarget target) {
     case ISPCTarget::xe2hpg_x32:
     case ISPCTarget::xe2lpg_x16:
     case ISPCTarget::xe2lpg_x32:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool ISPCTargetIsGeneric(ISPCTarget target) {
+    switch (target) {
+    case ISPCTarget::generic_i1x4:
+    case ISPCTarget::generic_i1x8:
+    case ISPCTarget::generic_i1x16:
+    case ISPCTarget::generic_i1x32:
+    case ISPCTarget::generic_i1x64:
+    case ISPCTarget::generic_i8x16:
+    case ISPCTarget::generic_i8x32:
+    case ISPCTarget::generic_i16x8:
+    case ISPCTarget::generic_i16x16:
+    case ISPCTarget::generic_i32x4:
+    case ISPCTarget::generic_i32x8:
+    case ISPCTarget::generic_i32x16:
+    case ISPCTarget::generic_i64x4:
         return true;
     default:
         return false;

--- a/src/target_enums.h
+++ b/src/target_enums.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2024, Intel Corporation
+  Copyright (c) 2019-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -93,6 +93,19 @@ enum class ISPCTarget {
     xe2hpg_x32,
     xe2lpg_x16,
     xe2lpg_x32,
+    generic_i1x4,
+    generic_i1x8,
+    generic_i1x16,
+    generic_i1x32,
+    generic_i1x64,
+    generic_i8x16,
+    generic_i8x32,
+    generic_i16x8,
+    generic_i16x16,
+    generic_i32x4,
+    generic_i32x8,
+    generic_i32x16,
+    generic_i64x4,
     error
 };
 ISPCTarget operator++(ISPCTarget &, int);
@@ -104,4 +117,5 @@ bool ISPCTargetIsX86(ISPCTarget target);
 bool ISPCTargetIsNeon(ISPCTarget target);
 bool ISPCTargetIsWasm(ISPCTarget target);
 bool ISPCTargetIsGen(ISPCTarget target);
+bool ISPCTargetIsGeneric(ISPCTarget target);
 } // namespace ispc

--- a/src/target_registry.cpp
+++ b/src/target_registry.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2024, Intel Corporation
+  Copyright (c) 2019-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -228,6 +228,10 @@ std::vector<std::string> TargetLibRegistry::checkBitcodeLibs() const {
                     }
                     if (!tlib->fileExists()) {
                         missedFiles.push_back(tlib->getFilename());
+                    }
+                    // Generic targets don't have standard libraries.
+                    if (ISPCTargetIsGeneric(target)) {
+                        continue;
                     }
                     if (!slib->fileExists()) {
                         missedFiles.push_back(slib->getFilename());

--- a/tests/lit-tests/generic-target-aarch64.ispc
+++ b/tests/lit-tests/generic-target-aarch64.ispc
@@ -1,0 +1,30 @@
+// RUN: %{ispc} --target=generic-i1x4 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X4
+// RUN: %{ispc} --target=generic-i1x8 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X8
+// RUN: %{ispc} --target=generic-i1x16 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X16
+// RUN: %{ispc} --target=generic-i1x32 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X32
+// RUN: %{ispc} --target=generic-i1x64 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X64
+// RUN: %{ispc} --target=generic-i8x16 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X16
+// RUN: %{ispc} --target=generic-i8x32 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X32
+// RUN: %{ispc} --target=generic-i16x8 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I16X8
+// RUN: %{ispc} --target=generic-i16x16 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I16X16
+// RUN: %{ispc} --target=generic-i32x4 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I32X4
+// RUN: %{ispc} --target=generic-i32x8 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I32X8
+// RUN: %{ispc} --target=generic-i32x16 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I32X16
+// RUN: %{ispc} --target=generic-i64x4 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I64X4
+
+// REQUIRES: ARM_ENABLED
+
+// CHECK-I1X4: define <4 x i32> @bar___vyi(<4 x i32> returned %x, <4 x i1> %__mask)
+// CHECK-I1X8: define <8 x i32> @bar___vyi(<8 x i32> returned %x, <8 x i1> %__mask)
+// CHECK-I1X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i1> %__mask)
+// CHECK-I1X32: define <32 x i32> @bar___vyi(<32 x i32> returned %x, <32 x i1> %__mask)
+// CHECK-I1X64: define <64 x i32> @bar___vyi(<64 x i32> returned %x, <64 x i1> %__mask)
+// CHECK-I8X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i8> %__mask)
+// CHECK-I8X32: define <32 x i32> @bar___vyi(<32 x i32> returned %x, <32 x i8> %__mask)
+// CHECK-I16X8: define <8 x i32> @bar___vyi(<8 x i32> returned %x, <8 x i16> %__mask)
+// CHECK-I16X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i16> %__mask)
+// CHECK-I32X4: define <4 x i32> @bar___vyi(<4 x i32> returned %x, <4 x i32> %__mask)
+// CHECK-I32X8: define <8 x i32> @bar___vyi(<8 x i32> returned %x, <8 x i32> %__mask)
+// CHECK-I32X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i32> %__mask)
+// CHECK-I64X4: define <4 x i32> @bar___vyi(<4 x i32> returned %x, <4 x i64> %__mask)
+int bar(int x) { return x; }

--- a/tests/lit-tests/generic-target-arm.ispc
+++ b/tests/lit-tests/generic-target-arm.ispc
@@ -1,0 +1,30 @@
+// RUN: %{ispc} --target=generic-i1x4 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X4
+// RUN: %{ispc} --target=generic-i1x8 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X8
+// RUN: %{ispc} --target=generic-i1x16 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X16
+// RUN: %{ispc} --target=generic-i1x32 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X32
+// RUN: %{ispc} --target=generic-i1x64 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X64
+// RUN: %{ispc} --target=generic-i8x16 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X16
+// RUN: %{ispc} --target=generic-i8x32 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X32
+// RUN: %{ispc} --target=generic-i16x8 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I16X8
+// RUN: %{ispc} --target=generic-i16x16 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I16X16
+// RUN: %{ispc} --target=generic-i32x4 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I32X4
+// RUN: %{ispc} --target=generic-i32x8 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I32X8
+// RUN: %{ispc} --target=generic-i32x16 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I32X16
+// RUN: %{ispc} --target=generic-i64x4 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I64X4
+
+// REQUIRES: ARM_ENABLED && LINUX_HOST
+
+// CHECK-I1X4: define <4 x i32> @bar___vyi(<4 x i32> returned %x, <4 x i1> %__mask)
+// CHECK-I1X8: define <8 x i32> @bar___vyi(<8 x i32> returned %x, <8 x i1> %__mask)
+// CHECK-I1X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i1> %__mask)
+// CHECK-I1X32: define <32 x i32> @bar___vyi(<32 x i32> returned %x, <32 x i1> %__mask)
+// CHECK-I1X64: define <64 x i32> @bar___vyi(<64 x i32> returned %x, <64 x i1> %__mask)
+// CHECK-I8X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i8> %__mask)
+// CHECK-I8X32: define <32 x i32> @bar___vyi(<32 x i32> returned %x, <32 x i8> %__mask)
+// CHECK-I16X8: define <8 x i32> @bar___vyi(<8 x i32> returned %x, <8 x i16> %__mask)
+// CHECK-I16X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i16> %__mask)
+// CHECK-I32X4: define <4 x i32> @bar___vyi(<4 x i32> returned %x, <4 x i32> %__mask)
+// CHECK-I32X8: define <8 x i32> @bar___vyi(<8 x i32> returned %x, <8 x i32> %__mask)
+// CHECK-I32X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i32> %__mask)
+// CHECK-I64X4: define <4 x i32> @bar___vyi(<4 x i32> returned %x, <4 x i64> %__mask)
+int bar(int x) { return x; }

--- a/tests/lit-tests/generic-target-x86.ispc
+++ b/tests/lit-tests/generic-target-x86.ispc
@@ -1,0 +1,30 @@
+// RUN: %{ispc} --target=generic-i1x4 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X4
+// RUN: %{ispc} --target=generic-i1x8 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X8
+// RUN: %{ispc} --target=generic-i1x16 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X16
+// RUN: %{ispc} --target=generic-i1x32 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X32
+// RUN: %{ispc} --target=generic-i1x64 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X64
+// RUN: %{ispc} --target=generic-i8x16 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X16
+// RUN: %{ispc} --target=generic-i8x32 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X32
+// RUN: %{ispc} --target=generic-i16x8 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I16X8
+// RUN: %{ispc} --target=generic-i16x16 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I16X16
+// RUN: %{ispc} --target=generic-i32x4 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I32X4
+// RUN: %{ispc} --target=generic-i32x8 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I32X8
+// RUN: %{ispc} --target=generic-i32x16 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I32X16
+// RUN: %{ispc} --target=generic-i64x4 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I64X4
+
+// REQUIRES: X86_ENABLED && !MACOS_HOST
+
+// CHECK-I1X4: define <4 x i32> @bar___vyi(<4 x i32> returned %x, <4 x i1> %__mask)
+// CHECK-I1X8: define <8 x i32> @bar___vyi(<8 x i32> returned %x, <8 x i1> %__mask)
+// CHECK-I1X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i1> %__mask)
+// CHECK-I1X32: define <32 x i32> @bar___vyi(<32 x i32> returned %x, <32 x i1> %__mask)
+// CHECK-I1X64: define <64 x i32> @bar___vyi(<64 x i32> returned %x, <64 x i1> %__mask)
+// CHECK-I8X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i8> %__mask)
+// CHECK-I8X32: define <32 x i32> @bar___vyi(<32 x i32> returned %x, <32 x i8> %__mask)
+// CHECK-I16X8: define <8 x i32> @bar___vyi(<8 x i32> returned %x, <8 x i16> %__mask)
+// CHECK-I16X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i16> %__mask)
+// CHECK-I32X4: define <4 x i32> @bar___vyi(<4 x i32> returned %x, <4 x i32> %__mask)
+// CHECK-I32X8: define <8 x i32> @bar___vyi(<8 x i32> returned %x, <8 x i32> %__mask)
+// CHECK-I32X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i32> %__mask)
+// CHECK-I64X4: define <4 x i32> @bar___vyi(<4 x i32> returned %x, <4 x i64> %__mask)
+int bar(int x) { return x; }

--- a/tests/lit-tests/generic-target-x86_64.ispc
+++ b/tests/lit-tests/generic-target-x86_64.ispc
@@ -1,0 +1,30 @@
+// RUN: %{ispc} --target=generic-i1x4 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X4
+// RUN: %{ispc} --target=generic-i1x8 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X8
+// RUN: %{ispc} --target=generic-i1x16 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X16
+// RUN: %{ispc} --target=generic-i1x32 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X32
+// RUN: %{ispc} --target=generic-i1x64 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X64
+// RUN: %{ispc} --target=generic-i8x16 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X16
+// RUN: %{ispc} --target=generic-i8x32 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X32
+// RUN: %{ispc} --target=generic-i16x8 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I16X8
+// RUN: %{ispc} --target=generic-i16x16 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I16X16
+// RUN: %{ispc} --target=generic-i32x4 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I32X4
+// RUN: %{ispc} --target=generic-i32x8 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I32X8
+// RUN: %{ispc} --target=generic-i32x16 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I32X16
+// RUN: %{ispc} --target=generic-i64x4 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I64X4
+
+// REQUIRES: X86_ENABLED
+
+// CHECK-I1X4: define <4 x i32> @bar___vyi(<4 x i32> returned %x, <4 x i1> %__mask)
+// CHECK-I1X8: define <8 x i32> @bar___vyi(<8 x i32> returned %x, <8 x i1> %__mask)
+// CHECK-I1X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i1> %__mask)
+// CHECK-I1X32: define <32 x i32> @bar___vyi(<32 x i32> returned %x, <32 x i1> %__mask)
+// CHECK-I1X64: define <64 x i32> @bar___vyi(<64 x i32> returned %x, <64 x i1> %__mask)
+// CHECK-I8X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i8> %__mask)
+// CHECK-I8X32: define <32 x i32> @bar___vyi(<32 x i32> returned %x, <32 x i8> %__mask)
+// CHECK-I16X8: define <8 x i32> @bar___vyi(<8 x i32> returned %x, <8 x i16> %__mask)
+// CHECK-I16X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i16> %__mask)
+// CHECK-I32X4: define <4 x i32> @bar___vyi(<4 x i32> returned %x, <4 x i32> %__mask)
+// CHECK-I32X8: define <8 x i32> @bar___vyi(<8 x i32> returned %x, <8 x i32> %__mask)
+// CHECK-I32X16: define <16 x i32> @bar___vyi(<16 x i32> returned %x, <16 x i32> %__mask)
+// CHECK-I64X4: define <4 x i32> @bar___vyi(<4 x i32> returned %x, <4 x i64> %__mask)
+int bar(int x) { return x; }


### PR DESCRIPTION
This PR adds generic targets, including their definitions and corresponding build commands/targets. It introduces builtins/common.ispc (empty at the moment). These targets will be used in target traversal during hierarchical target builtin linking.