### PR TITLE
Remove llvm::Type::X86_MMXTyID

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -155,9 +155,12 @@ static std::string lGetMangledTypeStr(llvm::Type *Ty, bool &HasUnnamedType) {
         case llvm::Type::PPC_FP128TyID:
             Result += "ppcf128";
             break;
+
+#if ISPC_LLVM_VERSION < ISPC_LLVM_20_0
         case llvm::Type::X86_MMXTyID:
             Result += "x86mmx";
             break;
+#endif
         case llvm::Type::X86_AMXTyID:
             Result += "x86amx";
             break;


### PR DESCRIPTION
Remove mentions of llvm::Type::X86_MMXTyID: for LLVM 20.0 since it was removed from trunk
https://github.com/ispc/ispc/actions/runs/12194482841/job/34026470500#step:6:281