### PR TITLE
CPU definitions for new aarch64 devices

### DIFF
--- a/tests/lit-tests/aarch64_windows.ispc
+++ b/tests/lit-tests/aarch64_windows.ispc
@@ -5,6 +5,8 @@
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a15 --print-target 2>&1 | FileCheck %s -check-prefix=CHECK_AARCH64_A15
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a35 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A35
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a57 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A57
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a55 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A55
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a78 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A78
 
 // There are slightly different features before LLVM 17.0
 // REQUIRES: ARM_ENABLED && WINDOWS_HOST && LLVM_17_0+
@@ -47,6 +49,31 @@
 // CHECK_AARCH64_A57-SAME: +neon
 // CHECK_AARCH64_A57-SAME: +sha2
 
+// CHECK_AARCH64_A55: Triple: aarch64-pc-windows-msvc
+// CHECK_AARCH64_A55-NEXT: CPU: cortex-a55
+// CHECK_AARCH64_A55-NEXT: Feature String:
+// CHECK_AARCH64_A55-SAME: +aes
+// CHECK_AARCH64_A55-SAME: +crc
+// CHECK_AARCH64_A55-SAME: +dotprod
+// CHECK_AARCH64_A55-SAME: +fp-armv8
+// CHECK_AARCH64_A55-SAME: +fullfp16
+// CHECK_AARCH64_A55-SAME: +lse
+// CHECK_AARCH64_A55-SAME: +neon
+// CHECK_AARCH64_A55-SAME: +rcpc
+// CHECK_AARCH64_A55-SAME: +sha2
+
+// CHECK_AARCH64_A78: Triple: aarch64-pc-windows-msvc
+// CHECK_AARCH64_A78-NEXT: CPU: cortex-a78
+// CHECK_AARCH64_A78-NEXT: Feature String:
+// CHECK_AARCH64_A78-SAME: +aes
+// CHECK_AARCH64_A78-SAME: +crc
+// CHECK_AARCH64_A78-SAME: +dotprod
+// CHECK_AARCH64_A78-SAME: +fp-armv8
+// CHECK_AARCH64_A78-SAME: +fullfp16
+// CHECK_AARCH64_A78-SAME: +lse
+// CHECK_AARCH64_A78-SAME: +neon
+// CHECK_AARCH64_A78-SAME: +rcpc
+// CHECK_AARCH64_A78-SAME: +sha2
 
 uniform int i;
 

--- a/tests/lit-tests/aarch64_windows.ispc
+++ b/tests/lit-tests/aarch64_windows.ispc
@@ -7,6 +7,7 @@
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a57 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A57
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a55 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A55
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a78 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A78
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a510 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A510
 
 // There are slightly different features before LLVM 17.0
 // REQUIRES: ARM_ENABLED && WINDOWS_HOST && LLVM_17_0+
@@ -74,6 +75,21 @@
 // CHECK_AARCH64_A78-SAME: +neon
 // CHECK_AARCH64_A78-SAME: +rcpc
 // CHECK_AARCH64_A78-SAME: +sha2
+
+// CHECK_AARCH64_A510: Triple: aarch64-pc-windows-msvc
+// CHECK_AARCH64_A510-NEXT: CPU: cortex-a510
+// CHECK_AARCH64_A510-NEXT: Feature String:
+// CHECK_AARCH64_A510-SAME: +crc
+// CHECK_AARCH64_A510-SAME: +dotprod
+// CHECK_AARCH64_A510-SAME: +fp-armv8
+// CHECK_AARCH64_A510-SAME: +fp16fml
+// CHECK_AARCH64_A510-SAME: +fullfp16
+// CHECK_AARCH64_A510-SAME: +i8mm
+// CHECK_AARCH64_A510-SAME: +lse
+// CHECK_AARCH64_A510-SAME: +neon
+// CHECK_AARCH64_A510-SAME: +rcpc
+// CHECK_AARCH64_A510-SAME: +sve
+// CHECK_AARCH64_A510-SAME: +sve2
 
 uniform int i;
 

--- a/tests/lit-tests/aarch64_windows_llvm18_plus.ispc
+++ b/tests/lit-tests/aarch64_windows_llvm18_plus.ispc
@@ -1,0 +1,24 @@
+// The test checks correct features for AARCH64 for different cpus on Windows stating LLVM 18. We don't check full set of features, just the ones used in lGetHostARMDeviceType
+
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a520 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A520
+
+// REQUIRES: ARM_ENABLED && WINDOWS_HOST && LLVM_18_0+
+
+// CHECK_AARCH64_A520: Triple: aarch64-pc-windows-msvc
+// CHECK_AARCH64_A520-NEXT: CPU: cortex-a520
+// CHECK_AARCH64_A520-NEXT: Feature String:
+// CHECK_AARCH64_A520-SAME: +crc
+// CHECK_AARCH64_A520-SAME: +dotprod
+// CHECK_AARCH64_A520-SAME: +fp-armv8
+// CHECK_AARCH64_A520-SAME: +fp16fml
+// CHECK_AARCH64_A520-SAME: +fullfp16
+// CHECK_AARCH64_A520-SAME: +i8mm
+// CHECK_AARCH64_A520-SAME: +lse
+// CHECK_AARCH64_A520-SAME: +neon
+// CHECK_AARCH64_A520-SAME: +rcpc
+// CHECK_AARCH64_A520-SAME: +sve
+// CHECK_AARCH64_A520-SAME: +sve2
+
+uniform int i;
+
+void foo() {}

--- a/tests/lit-tests/arm64_macos.ispc
+++ b/tests/lit-tests/arm64_macos.ispc
@@ -6,6 +6,8 @@
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --cpu=apple-a12 --print-target | FileCheck %s -check-prefixes=CHECK_ALL,CHECK_ARM64_APPLE_A12
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --cpu=apple-a13 --print-target | FileCheck %s -check-prefixes=CHECK_ALL,CHECK_ARM64_APPLE_A13
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --cpu=apple-a14 --print-target | FileCheck %s -check-prefixes=CHECK_ALL,CHECK_ARM64_APPLE_A14
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --cpu=apple-a15 --print-target | FileCheck %s -check-prefixes=CHECK_ALL,CHECK_ARM64_APPLE_A15
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --cpu=apple-a16 --print-target | FileCheck %s -check-prefixes=CHECK_ALL,CHECK_ARM64_APPLE_A16
 
 // There are slightly different features before LLVM 17.0
 // REQUIRES: ARM_ENABLED && MACOS_ARM_ENABLED && LLVM_17_0+
@@ -75,6 +77,39 @@
 // CHECK_ARM64_APPLE_A14-SAME: +rcpc
 // CHECK_ARM64_APPLE_A14-SAME: +sha2
 // CHECK_ARM64_APPLE_A14-SAME: +sha3
+
+// CHECK_ARM64_APPLE_A15: CPU: apple-a15
+// CHECK_ARM64_APPLE_A15-NEXT: Feature String
+// CHECK_ARM64_APPLE_A15-SAME: +aes
+// CHECK_ARM64_APPLE_A15-SAME: +bf16
+// CHECK_ARM64_APPLE_A15-SAME: +crc
+// CHECK_ARM64_APPLE_A15-SAME: +dotprod
+// CHECK_ARM64_APPLE_A15-SAME: +fp-armv8
+// CHECK_ARM64_APPLE_A15-SAME: +fp16fml
+// CHECK_ARM64_APPLE_A15-SAME: +fullfp16
+// CHECK_ARM64_APPLE_A15-SAME: +i8mm
+// CHECK_ARM64_APPLE_A15-SAME: +lse
+// CHECK_ARM64_APPLE_A15-SAME: +neon
+// CHECK_ARM64_APPLE_A15-SAME: +rcpc
+// CHECK_ARM64_APPLE_A15-SAME: +sha2
+// CHECK_ARM64_APPLE_A15-SAME: +sha3
+
+// CHECK_ARM64_APPLE_A16: CPU: apple-a16
+// CHECK_ARM64_APPLE_A16-NEXT: Feature String
+// CHECK_ARM64_APPLE_A16-SAME: +aes
+// CHECK_ARM64_APPLE_A16-SAME: +bf16
+// CHECK_ARM64_APPLE_A16-SAME: +crc
+// CHECK_ARM64_APPLE_A16-SAME: +dotprod
+// CHECK_ARM64_APPLE_A16-SAME: +fp-armv8
+// CHECK_ARM64_APPLE_A16-SAME: +fp16fml
+// CHECK_ARM64_APPLE_A16-SAME: +fullfp16
+// CHECK_ARM64_APPLE_A16-SAME: +i8mm
+// CHECK_ARM64_APPLE_A16-SAME: +lse
+// CHECK_ARM64_APPLE_A16-SAME: +neon
+// CHECK_ARM64_APPLE_A16-SAME: +rcpc
+// CHECK_ARM64_APPLE_A16-SAME: +sha2
+// CHECK_ARM64_APPLE_A16-SAME: +sha3
+
 
 uniform int i;
 

--- a/tests/lit-tests/arm64_macos_llvm18_plus.ispc
+++ b/tests/lit-tests/arm64_macos_llvm18_plus.ispc
@@ -1,0 +1,28 @@
+// The test checks correct features for ARM64 for different cpus on macOS starting LLVM18. We don't check full set of features, just the ones used in lGetHostARMDeviceType
+
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --cpu=apple-a17 --print-target | FileCheck %s -check-prefixes=CHECK_ALL,CHECK_ARM64_APPLE_A17
+
+// REQUIRES: ARM_ENABLED && MACOS_ARM_ENABLED && LLVM_18_0+
+
+// CHECK_ALL: Triple: arm64-apple-macosx
+
+// CHECK_ARM64_APPLE_A17: CPU: apple-a17
+// CHECK_ARM64_APPLE_A17-NEXT: Feature String
+// CHECK_ARM64_APPLE_A17-SAME: +aes
+// CHECK_ARM64_APPLE_A17-SAME: +bf16
+// CHECK_ARM64_APPLE_A17-SAME: +crc
+// CHECK_ARM64_APPLE_A17-SAME: +dotprod
+// CHECK_ARM64_APPLE_A17-SAME: +fp-armv8
+// CHECK_ARM64_APPLE_A17-SAME: +fp16fml
+// CHECK_ARM64_APPLE_A17-SAME: +fullfp16
+// CHECK_ARM64_APPLE_A17-SAME: +i8mm
+// CHECK_ARM64_APPLE_A17-SAME: +lse
+// CHECK_ARM64_APPLE_A17-SAME: +neon
+// CHECK_ARM64_APPLE_A17-SAME: +rcpc
+// CHECK_ARM64_APPLE_A17-SAME: +sha2
+// CHECK_ARM64_APPLE_A17-SAME: +sha3
+
+
+uniform int i;
+
+void foo() {}

--- a/tests/lit-tests/arm_linux.ispc
+++ b/tests/lit-tests/arm_linux.ispc
@@ -5,6 +5,7 @@
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a57 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A57
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a55 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A55
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a78 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A78
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a510 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A510
 
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=arm --print-target | FileCheck %s -check-prefix=CHECK_ARM
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=arm --cpu=cortex-a9 --print-target | FileCheck %s -check-prefix=CHECK_ARM_A9
@@ -77,6 +78,21 @@
 // CHECK_AARCH64_A78-SAME: +neon
 // CHECK_AARCH64_A78-SAME: +rcpc
 // CHECK_AARCH64_A78-SAME: +sha2
+
+// CHECK_AARCH64_A510: Triple: aarch64-unknown-linux-gnu
+// CHECK_AARCH64_A510-NEXT: CPU: cortex-a510
+// CHECK_AARCH64_A510-NEXT: Feature String:
+// CHECK_AARCH64_A510-SAME: +crc
+// CHECK_AARCH64_A510-SAME: +dotprod
+// CHECK_AARCH64_A510-SAME: +fp-armv8
+// CHECK_AARCH64_A510-SAME: +fp16fml
+// CHECK_AARCH64_A510-SAME: +fullfp16
+// CHECK_AARCH64_A510-SAME: +i8mm
+// CHECK_AARCH64_A510-SAME: +lse
+// CHECK_AARCH64_A510-SAME: +neon
+// CHECK_AARCH64_A510-SAME: +rcpc
+// CHECK_AARCH64_A510-SAME: +sve
+// CHECK_AARCH64_A510-SAME: +sve2
 
 // CHECK_ARM: Triple: armv7-unknown-linux-gnueabihf
 // CHECK_ARM: CPU: {{cortex-a*}}

--- a/tests/lit-tests/arm_linux.ispc
+++ b/tests/lit-tests/arm_linux.ispc
@@ -1,4 +1,10 @@
-// The test checks correct features for ARM for different cpus on Linux. We don't check full set of features, just the ones used in lGetHostARMDeviceType
+// The test checks correct features for ARM/AARCH64 for different cpus on Linux. We don't check full set of features, just the ones used in lGetHostARMDeviceType
+
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a15 --print-target 2>&1 | FileCheck %s -check-prefix=CHECK_AARCH64_A15
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a35 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A35
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a57 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A57
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a55 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A55
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a78 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A78
 
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=arm --print-target | FileCheck %s -check-prefix=CHECK_ARM
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=arm --cpu=cortex-a9 --print-target | FileCheck %s -check-prefix=CHECK_ARM_A9
@@ -6,7 +12,7 @@
 // RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=arm --cpu=cortex-a57 --print-target | FileCheck %s -check-prefix=CHECK_ARM_A57
 
 // arm supported on Linux only
-// REQUIRES: ARM_ENABLED && LINUX_HOST
+// REQUIRES: ARM_ENABLED && LINUX_HOST && LLVM_17_0+
 
 // CHECK_DEFAULT: Triple: aarch64-unknown-linux-gnu
 // CHECK_DEFAULT: CPU: {{cortex-a*}}
@@ -45,6 +51,32 @@
 // CHECK_AARCH64_A57-SAME: +fp-armv8
 // CHECK_AARCH64_A57-SAME: +neon
 // CHECK_AARCH64_A57-SAME: +sha2
+
+// CHECK_AARCH64_A55: Triple: aarch64-unknown-linux-gnu
+// CHECK_AARCH64_A55-NEXT: CPU: cortex-a55
+// CHECK_AARCH64_A55-NEXT: Feature String:
+// CHECK_AARCH64_A55-SAME: +aes
+// CHECK_AARCH64_A55-SAME: +crc
+// CHECK_AARCH64_A55-SAME: +dotprod
+// CHECK_AARCH64_A55-SAME: +fp-armv8
+// CHECK_AARCH64_A55-SAME: +fullfp16
+// CHECK_AARCH64_A55-SAME: +lse
+// CHECK_AARCH64_A55-SAME: +neon
+// CHECK_AARCH64_A55-SAME: +rcpc
+// CHECK_AARCH64_A55-SAME: +sha2
+
+// CHECK_AARCH64_A78: Triple: aarch64-unknown-linux-gnu
+// CHECK_AARCH64_A78-NEXT: CPU: cortex-a78
+// CHECK_AARCH64_A78-NEXT: Feature String:
+// CHECK_AARCH64_A78-SAME: +aes
+// CHECK_AARCH64_A78-SAME: +crc
+// CHECK_AARCH64_A78-SAME: +dotprod
+// CHECK_AARCH64_A78-SAME: +fp-armv8
+// CHECK_AARCH64_A78-SAME: +fullfp16
+// CHECK_AARCH64_A78-SAME: +lse
+// CHECK_AARCH64_A78-SAME: +neon
+// CHECK_AARCH64_A78-SAME: +rcpc
+// CHECK_AARCH64_A78-SAME: +sha2
 
 // CHECK_ARM: Triple: armv7-unknown-linux-gnueabihf
 // CHECK_ARM: CPU: {{cortex-a*}}

--- a/tests/lit-tests/arm_linux_llvm18_plus.ispc
+++ b/tests/lit-tests/arm_linux_llvm18_plus.ispc
@@ -1,0 +1,25 @@
+// The test checks correct features for ARM/AARCH64 for different cpus on Linux starting LLVM18. We don't check full set of features, just the ones used in lGetHostARMDeviceType
+
+// RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --nowrap --arch=aarch64 --cpu=cortex-a520 --print-target | FileCheck %s -check-prefix=CHECK_AARCH64_A520
+
+// arm supported on Linux only
+// REQUIRES: ARM_ENABLED && LINUX_HOST && LLVM_18_0+
+
+// CHECK_AARCH64_A520: Triple: aarch64-unknown-linux-gnu
+// CHECK_AARCH64_A520-NEXT: CPU: cortex-a520
+// CHECK_AARCH64_A520-NEXT: Feature String:
+// CHECK_AARCH64_A520-SAME: +crc
+// CHECK_AARCH64_A520-SAME: +dotprod
+// CHECK_AARCH64_A520-SAME: +fp-armv8
+// CHECK_AARCH64_A520-SAME: +fp16fml
+// CHECK_AARCH64_A520-SAME: +fullfp16
+// CHECK_AARCH64_A520-SAME: +i8mm
+// CHECK_AARCH64_A520-SAME: +lse
+// CHECK_AARCH64_A520-SAME: +neon
+// CHECK_AARCH64_A520-SAME: +rcpc
+// CHECK_AARCH64_A520-SAME: +sve
+// CHECK_AARCH64_A520-SAME: +sve2
+
+uniform int i;
+
+void foo() {}

--- a/tests/lit-tests/cpu_arm.ispc
+++ b/tests/lit-tests/cpu_arm.ispc
@@ -11,6 +11,8 @@
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a12
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a13
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a14
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a15
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a16
 
 // ARM must be enabled in order to test it.
 // REQUIRES: ARM_ENABLED

--- a/tests/lit-tests/cpu_arm.ispc
+++ b/tests/lit-tests/cpu_arm.ispc
@@ -5,6 +5,9 @@
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=cortex-a35
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=cortex-a53
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=cortex-a57
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=cortex-a55
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=cortex-a78
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=cortex-a510
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a7
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a10
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=neon-i32x4 --cpu=apple-a11


### PR DESCRIPTION
Added new CPU definitions:
1. apple-a15, apple-a16, apple-a17
2. cortex-a55, cortex-a78
3. cortex-a510, cortex-a520

These articular devices are requested by game-dev community.
Related to #3110 