### PR TITLE
dispatch.c: remove stdint.h header

### DIFF
--- a/builtins/dispatch.c
+++ b/builtins/dispatch.c
@@ -21,8 +21,6 @@
 #error "Either REGULAR or MACOS macro need to defined"
 #endif
 
-#include <stdint.h>
-
 void abort();
 
 static int __system_best_isa = -1;
@@ -60,7 +58,7 @@ static int __os_has_avx512_support() {
 // __get_system_isa should return a value corresponding to one of the
 // Target::ISA enumerant values that gives the most capable ISA that the
 // current system can run.
-static int32_t __get_system_isa() {
+static int __get_system_isa() {
     int info[4];
     __cpuid(info, 1);
 


### PR DESCRIPTION
Change return type of __get_system_isa() to int. It should not matter because its result is anyway saved to __system_best_isa which is just int type.

This PR fixes #3134 