### PR TITLE
Fix IITDescs traversing

### DIFF
--- a/tests/lit-tests/3141.ispc
+++ b/tests/lit-tests/3141.ispc
@@ -1,0 +1,20 @@
+// RUN: not %{ispc} --nowrap --target=host --enable-llvm-intrinsics --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: LLVM_17_0+
+
+#if LLVM_VERSION_MAJOR >= 19
+#define DEINTERLEAVE2 llvm.vector.deinterleave2
+#else
+#define DEINTERLEAVE2 llvm.experimental.vector.deinterleave2
+#endif
+
+// This checks that logic for deducting LLVM type for overloaded LLVM
+// intrinsics works.
+// CHECK-NOT: FATAL ERROR
+
+// This error is expected because the logic of mapping LLVM function signatures
+// to ISPC ones does not support the struct return type.
+// CHECK: Error: Return type not representable for Intrinsic
+void __deinterleave2(uniform float<8> val) {
+    @DEINTERLEAVE2(val);
+}

--- a/tests/lit-tests/llvm-intrinsics-type-deduction.ispc
+++ b/tests/lit-tests/llvm-intrinsics-type-deduction.ispc
@@ -30,19 +30,19 @@ ATTRS uniform float16 foo(uniform float16 x, uniform float16 y) { return @llvm.p
 ATTRS varying float bar(varying float x, varying float y) { return @llvm.pow(x, y); }
 
 // CHECK-LABEL: @cttz_u32
-// CHECK-DAG:   %calltmp = tail call i32 @llvm.cttz.i32(i32 %x, i1 false)
+// CHECK-DAG:   %calltmp = tail call {{.*}}i32 @llvm.cttz.i32(i32 %x, i1 false)
 ATTRS uniform int32 cttz_u32(uniform int32 x) { return @llvm.cttz.i32(x, false); }
 
 // CHECK-LABEL: @cttz_v32
-// CHECK-DAG:  %calltmp = tail call <[[WIDTH]] x i32> @llvm.cttz.v[[WIDTH]]i32(<[[WIDTH]] x i32> %x, i1 false)
+// CHECK-DAG:  %calltmp = tail call {{.*}}<[[WIDTH]] x i32> @llvm.cttz.v[[WIDTH]]i32(<[[WIDTH]] x i32> %x, i1 false)
 ATTRS int32 cttz_v32(int32 x) { return @llvm.cttz.i32(x, false); }
 
 // CHECK-LABEL: @ctlz_u32
-// CHECK-DAG:   %calltmp = tail call i32 @llvm.ctlz.i32(i32 %x, i1 false)
+// CHECK-DAG:   %calltmp = tail call {{.*}}i32 @llvm.ctlz.i32(i32 %x, i1 false)
 ATTRS uniform int32 ctlz_u32(uniform int32 x) { return @llvm.ctlz.i32(x, false); }
 
 // CHECK-LABEL: @ctlz_v32
-// CHECK-DAG:  %calltmp = tail call <[[WIDTH]] x i32> @llvm.ctlz.v[[WIDTH]]i32(<[[WIDTH]] x i32> %x, i1 false)
+// CHECK-DAG:  %calltmp = tail call {{.*}}<[[WIDTH]] x i32> @llvm.ctlz.v[[WIDTH]]i32(<[[WIDTH]] x i32> %x, i1 false)
 ATTRS int32 ctlz_v32(int32 x) { return @llvm.ctlz.i32(x, false); }
 
 // CHECK-LABEL: @prefetch


### PR DESCRIPTION
Struct and Vector are required to skip next entries also.

This PR fixes #3141 