### PR TITLE
Do not generate LLVM IR if preprocessor only mode

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -406,7 +406,8 @@ int Module::CompileFile() {
 
     if (g->runCPP) {
         llvm::TimeTraceScope TimeScope("Frontend parser");
-        if (int err = preprocessAndParse()) {
+        int err = preprocessAndParse();
+        if (g->onlyCPP || err) {
             return err;
         }
     } else {

--- a/tests/lit-tests/3148.ispc
+++ b/tests/lit-tests/3148.ispc
@@ -1,0 +1,6 @@
+// RUN: %{ispc} -E --debug-phase=0:last %s -o - 2>&1 | FileCheck %s
+
+#ifndef ISPC
+// CHECK-NOT: LLVM IR after phase
+void foo() {}
+#endif


### PR DESCRIPTION
This PR fixes #3148 