### PR TITLE
Optimize code generation on on ARM (#2052)

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2716,6 +2716,8 @@ Opt::Opt() {
     disableScatters = false;
     disableFMA = false;
     forceAlignedMemory = false;
+    enableLoadStoreVectorizer = false;
+    enableSLPVectorizer = false;
     disableMaskAllOnOptimizations = false;
     disableHandlePseudoMemoryOps = false;
     disableBlendedMaskedStores = false;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -581,6 +581,12 @@ struct Opt {
         locations. */
     bool forceAlignedMemory;
 
+    /** If enabled, enables LoadStoreVectorizerPass in ISPC optimization pipeline. */
+    bool enableLoadStoreVectorizer;
+
+    /** If enabled, enables SLPVectorizerPass in ISPC optimization pipeline. */
+    bool enableSLPVectorizer;
+
     /** If enabled, disables the various optimizations that kick in when
         the execution mask can be determined to be "all on" at compile
         time. */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -218,6 +218,8 @@ static void lPrintVersion() {
     printf("    [--off-phase=<value>]\t\tSwitch off optimization phases. "
            "--off-phase=pre:first,210:220,300,305,310:last\n");
     printf("    [--opt=<option>]\t\t\tSet optimization option\n");
+    printf("        enable-ldst-vectorizer\t\t\tEnable load/store vectorizer\n");
+    printf("        enable-slp-vectorizer\t\t\tEnable SLP vectorizer\n");
     printf("        disable-all-on-optimizations\t\tDisable optimizations that take advantage of \"all on\" mask\n");
     printf("        disable-blended-masked-stores\t\tScalarize masked stores on SSE (vs. using vblendps)\n");
     printf("        disable-blending-removal\t\tDisable eliminating blend at same scope\n");
@@ -901,7 +903,11 @@ int main(int Argc, char *Argv[]) {
 
             // These are only used for performance tests of specific
             // optimizations
-            else if (!strcmp(opt, "disable-all-on-optimizations")) {
+            else if (!strcmp(opt, "enable-ldst-vectorizer")) {
+                g->opt.enableLoadStoreVectorizer = true;
+            } else if (!strcmp(opt, "enable-slp-vectorizer")) {
+                g->opt.enableSLPVectorizer = true;
+            } else if (!strcmp(opt, "disable-all-on-optimizations")) {
                 g->opt.disableMaskAllOnOptimizations = true;
             } else if (!strcmp(opt, "disable-coalescing")) {
                 g->opt.disableCoalescing = true;

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -627,9 +627,11 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         // elements are often extracted and processed individually using scalar operations.
         // To vectorize these scalar operations, SLP vectorizer is used.
         // Enabling it on other targets may be beneficial but require extensive testing.
-        if (ISPCTargetIsNeon(g->target->getISPCTarget())) {
-            optPM.addFunctionPass(llvm::LoadStoreVectorizerPass(), 325);
-            optPM.addFunctionPass(llvm::SLPVectorizerPass(), 326);
+        if (ISPCTargetIsNeon(g->target->getISPCTarget()) || g->opt.enableLoadStoreVectorizer) {
+            optPM.addFunctionPass(llvm::LoadStoreVectorizerPass());
+        }
+        if (ISPCTargetIsNeon(g->target->getISPCTarget()) || g->opt.enableSLPVectorizer) {
+            optPM.addFunctionPass(llvm::SLPVectorizerPass());
         }
         // Currently VC BE does not support memset/memcpy
         // so this pass is temporary disabled for Xe.

--- a/tests/lit-tests/2052-1.ispc
+++ b/tests/lit-tests/2052-1.ispc
@@ -1,0 +1,65 @@
+// The tests checks that no extra load/store instructions is generated.
+// RUN: %{ispc} %s --arch=aarch64 --target=neon-i32x4 --emit-asm  -o - | FileCheck %s
+// REQUIRES: ARM_ENABLED
+
+// CHECK-LABEL: VectorTransformVector___
+// CHECK-DAG: ldp
+// CHECK-DAG: ldr
+// CHECK-DAG: fmul
+// CHECK-DAG: fmla
+// CHECK-DAG: ldp
+// CHECK-DAG: fmla
+
+// CHECK-NOT: add
+// CHECK-NOT: ldp
+// CHECK-NOT: ldr
+struct FVector4 {
+    float<4> V;
+};
+
+struct FMatrix {
+    float<16> M;
+};
+
+inline uniform FVector4 operator*(const uniform FVector4 &A, const uniform FVector4 &B) {
+    varying float S0, S1, Result;
+    *((uniform FVector4 * uniform) & S0) = *((uniform FVector4 * uniform) & A);
+    *((uniform FVector4 * uniform) & S1) = *((uniform FVector4 * uniform) & B);
+
+    Result = S0 * S1;
+
+    return *((uniform FVector4 * uniform) & Result);
+}
+
+inline uniform FVector4 SetVector4(const uniform float X, const uniform float Y, const uniform float Z,
+                                   const uniform float W) {
+    const uniform FVector4 Result = {{X, Y, Z, W}};
+    return Result;
+}
+
+inline uniform FVector4 VectorMultiplyAdd(const uniform FVector4 &A, const uniform FVector4 &B, const uniform FVector4 &C) {
+    return SetVector4(
+        A.V[0] * B.V[0] + C.V[0],
+        A.V[1] * B.V[1] + C.V[1],
+        A.V[2] * B.V[2] + C.V[2],
+        A.V[3] * B.V[3] + C.V[3]
+    );
+}
+
+uniform FVector4 VectorTransformVector(const uniform FVector4 &Vec, const uniform FMatrix &M) {
+    uniform FVector4 VTempX, VTempY, VTempZ, VTempW;
+
+    // Splat x,y,z and w
+    VTempX = SetVector4(Vec.V[0], Vec.V[0], Vec.V[0], Vec.V[0]);
+    VTempY = SetVector4(Vec.V[1], Vec.V[1], Vec.V[1], Vec.V[1]);
+    VTempZ = SetVector4(Vec.V[2], Vec.V[2], Vec.V[2], Vec.V[2]);
+    VTempW = SetVector4(Vec.V[3], Vec.V[3], Vec.V[3], Vec.V[3]);
+
+    // Mul by the matrix
+    VTempX = VTempX * SetVector4(M.M[0], M.M[1], M.M[2], M.M[3]);
+    VTempX = VectorMultiplyAdd(VTempY, SetVector4(M.M[4], M.M[5], M.M[6], M.M[7]), VTempX);
+    VTempX = VectorMultiplyAdd(VTempZ, SetVector4(M.M[8], M.M[9], M.M[10], M.M[11]), VTempX);
+    VTempX = VectorMultiplyAdd(VTempW, SetVector4(M.M[12], M.M[13], M.M[14], M.M[15]), VTempX);
+
+    return VTempX;
+}

--- a/tests/lit-tests/2052-2.ispc
+++ b/tests/lit-tests/2052-2.ispc
@@ -1,0 +1,29 @@
+// The tests checks that no extra load/store instructions is generated.
+// RUN: %{ispc} %s --arch=aarch64 --target=neon-i32x4 --emit-asm  -o - | FileCheck %s
+// REQUIRES: ARM_ENABLED
+
+// CHECK-LABEL: VectorMatrixMultiply
+// CHECK-COUNT-2: ldp
+// CHECK-NOT: ld1r
+// CHECK-NOT: add
+// CHECK: {{LBB0_[0-9]}}:
+struct FMatrix {
+    float<16> M;
+};
+FMatrix VectorMatrixMultiply(const FMatrix &A, const uniform FMatrix &B) {
+    FMatrix Result;
+
+    for (uniform unsigned int m = 0; m < 4; m++) {
+        varying float Sum;
+        for (uniform unsigned int k = 0; k < 4; k++) {
+            Sum = 0.0f;
+            for (uniform unsigned int n = 0; n < 4; n++) {
+                Sum += A.M[m * 4 + n] * B.M[n * 4 + k];
+            }
+
+            Result.M[m * 4 + k] = Sum;
+        }
+    }
+
+    return Result;
+}

--- a/tests/lit-tests/2052-3.ispc
+++ b/tests/lit-tests/2052-3.ispc
@@ -1,0 +1,31 @@
+// The tests checks that no extra load/store instructions is generated.
+// RUN: %{ispc} %s --arch=aarch64 --target=neon-i32x4 --emit-asm  -o - | FileCheck %s
+// REQUIRES: ARM_ENABLED
+
+// CHECK-COUNT-2: mov
+// CHECK-NOT: add
+// CHECK-LABEL: This Inner Loop Header
+// CHECK-COUNT-2: ldr
+// CHECK: fcm
+// CHECK-NOT: ldp
+typedef struct {
+    uniform float<4> v;
+} FVector4;
+
+unmasked void mm_cmpgt_ss(uniform float Result[], const uniform float Source1[], const uniform float Source2[],
+                        const uniform int Iterations) {
+    for (uniform int k = 0; k < Iterations; k++) {
+        uniform FVector4 S1;
+        S1.v[0] = Source1[k];
+
+        uniform FVector4 S2;
+        S2.v[0] = Source2[k];
+
+        uniform FVector4 R;
+        R = S1;
+        R.v[0] = S1.v[0] > S2.v[0] ? floatbits(0xFFFFFFFF) : 0.0f;
+
+        // Inline _mm_store_ss(&Result[k], R);
+        Result[k] = R.v[0];
+    }
+}

--- a/tests/lit-tests/2720.ispc
+++ b/tests/lit-tests/2720.ispc
@@ -1,0 +1,16 @@
+// The tests checks that no extra load/store instructions is generated.
+// RUN: %{ispc} %s --arch=aarch64 --target=neon-i32x4 --emit-asm  -o - | FileCheck %s
+// REQUIRES: ARM_ENABLED
+
+// CHECK-COUNT: 1 mov
+// CHECK-COUNT: 1 str
+// CHECK-COUNT: 3 ldr
+// CHECK-COUNT: 3 ldr
+// CHECK-NOT: add
+uniform int foo(uniform float v1[], uniform float v2[], uniform float v3[], uniform float result[]) {
+    uniform float invArea = 1.f / ((v3[0] - v1[0]) * (v2[1] - v1[1]) - ((v3[1] - v1[1]) * (v2[0] - v1[0])));
+    result[0] = invArea;
+    result[1] = invArea;
+    result[2] = invArea;
+    result[3] = invArea;
+}


### PR DESCRIPTION
This PR introduces usage of LoadStoreVectorizerPass and SLPVectorizerPass for ARM. As a result generated code becomes much more cleaner without extra load/stores described in issue #2052. For example:
**Before the changes:**
```
VectorTransformVector___REFs_5B__c_unFVector4_5D_REFs_5B__c_unFMatrix_5D_: // @VectorTransformVector___REFs_5B__c_unFVector4_5D_REFs_5B__c_unFMatrix_5D_
// %bb.0:
	ldr	s0, [x1]
	add	x8, x1, #4
	ld1	{ v0.s }[1], [x8]
	add	x8, x1, #8
	ld1	{ v0.s }[2], [x8]
	add	x8, x1, #12
	ld1	{ v0.s }[3], [x8]
	ldp	s1, s2, [x0]
	fmul	v0.4s, v0.4s, v1.s[0]
	mov	s1, v0.s[1]
	ldp	s3, s4, [x1, #16]
	fmadd	s3, s2, s3, s0
	mov	s5, v0.s[2]
	fmadd	s1, s2, s4, s1
	ldp	s4, s7, [x1, #24]
	ldp	s6, s17, [x0, #8]
	fmadd	s4, s2, s4, s5
	ldp	s5, s16, [x1, #32]
	mov	s0, v0.s[3]
	fmadd	s3, s6, s5, s3
	fmadd	s1, s6, s16, s1
	fmadd	s2, s2, s7, s0
	ldp	s0, s5, [x1, #40]
	ldp	s7, s16, [x1, #48]
	fmadd	s4, s6, s0, s4
	fmadd	s0, s17, s7, s3
	fmadd	s1, s17, s16, s1
	fmadd	s2, s6, s5, s2
	ldp	s3, s5, [x1, #56]
	fmadd	s3, s17, s3, s4
	mov	v0.s[1], v1.s[0]
	fmadd	s1, s17, s5, s2
	mov	v0.s[2], v3.s[0]
	mov	v0.s[3], v1.s[0]
	ret
```
**After the changes:**
```
VectorTransformVector___REFs_5B__c_unFVector4_5D_REFs_5B__c_unFMatrix_5D_: // @VectorTransformVector___REFs_5B__c_unFVector4_5D_REFs_5B__c_unFMatrix_5D_
// %bb.0:
	ldr	q1, [x0]
	ldp	q0, q2, [x1]
	fmul	v0.4s, v0.4s, v1.s[0]
	fmla	v0.4s, v2.4s, v1.s[1]
	ldp	q2, q3, [x1, #32]
	fmla	v0.4s, v2.4s, v1.s[2]
	fmla	v0.4s, v3.4s, v1.s[3]
	ret
```
Or another example is vectorized loads:
**Before the change**
```
	ldp	d0, d1, [x11, #-256]
	ldp	d2, d3, [x11, #-224]
	ldp	d4, d5, [x11, #-192]
	ldp	d6, d7, [x11, #-160]
	ldp	d16, d17, [x11, #-240]
	ldp	d18, d19, [x11, #-208]
	ldp	d20, d21, [x11, #-176]
	ldp	d22, d23, [x11, #-144]
```
**After the change**
```
	ld4	{ v0.2d, v1.2d, v2.2d, v3.2d }, [x13]
	ld4	{ v4.2d, v5.2d, v6.2d, v7.2d }, [x13]
```

So this change improves performance up to 75% on target benchmarks.
Enabling it on other targets may be beneficial but require extensive testing.