### PR TITLE
Support deprecated attribute

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -676,6 +676,10 @@ refer to `The Preprocessor`_ for more details.
 
 ``--nocpp`` command line flag is deprecated and will be removed in future.
 
+``__attribute__((deprecated))`` can be applied to a function to mark it as
+deprecated. It leads to a warning when the function is called.
+
+
 Getting Started with ISPC
 =========================
 
@@ -3009,6 +3013,19 @@ from C/C++ in case when the user wants to reduce the size of the generated
 code. Same effect can be achieved by using ``-ffunction-sections`` compiler
 option but not in all cases (e.g., shared libraries with ISPC code), so this
 attribute is provided as a more fine-grained control.
+
+deprecated
+----------
+
+``__attribute__((deprecated))`` can be applied to a function to mark it as
+deprecated. The compiler will issue a warning when the function is called.
+There are two ways to use this attribute in ISPC with or without a message:
+
+::
+
+    __attribute__((deprecated)) void foo();
+    __attribute__((deprecated("Use bar() instead."))) void foo();
+
 
 Expressions
 -----------

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -213,8 +213,8 @@ Attribute::Attribute(const Attribute &a) : name(a.name), arg(a.arg) {}
 
 bool Attribute::IsKnownAttribute() const {
     // Known/supported attributes.
-    static std::unordered_set<std::string> lKnownParamAttrs = {"noescape", "address_space", "unmangled",
-                                                               "memory",   "cdecl",         "external_only"};
+    static std::unordered_set<std::string> lKnownParamAttrs = {"noescape", "address_space", "unmangled", "memory",
+                                                               "cdecl",    "external_only", "deprecated"};
 
     if (lKnownParamAttrs.find(name) != lKnownParamAttrs.end()) {
         return true;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -1227,7 +1227,8 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
 
     // Finally, we know all is good and we can add the function to the
     // symbol table
-    Symbol *funSym = new Symbol(name, pos, Symbol::SymbolKind::Function, functionType, storageClass);
+    Symbol *funSym =
+        new Symbol(name, pos, Symbol::SymbolKind::Function, functionType, storageClass, decl->attributeList);
     funSym->function = function;
     bool ok = symbolTable->AddFunction(funSym);
     Assert(ok);

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -24,9 +24,16 @@ using namespace ispc;
 ///////////////////////////////////////////////////////////////////////////
 // Symbol
 
-Symbol::Symbol(const std::string &n, SourcePos p, SymbolKind st, const Type *t, StorageClass sc)
+Symbol::Symbol(const std::string &n, SourcePos p, SymbolKind st, const Type *t, StorageClass sc, AttributeList *a)
     : pos(p), name(n), storageInfo(nullptr), function(nullptr), exportedFunction(nullptr), type(t), constValue(nullptr),
-      storageClass(sc), varyingCFDepth(0), parentFunction(nullptr), kind(st) {}
+      storageClass(sc), varyingCFDepth(0), parentFunction(nullptr),
+      attrs(a != nullptr ? new AttributeList(*a) : nullptr), kind(st) {}
+
+Symbol::~Symbol() {
+    if (attrs != nullptr) {
+        delete attrs;
+    }
+}
 
 ///////////////////////////////////////////////////////////////////////////
 // TemplateSymbol

--- a/src/sym.h
+++ b/src/sym.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -53,7 +53,8 @@ class Symbol : public Traceable {
     /** The Symbol constructor takes the name of the symbol, its
         position in a source file, and its type (if known). */
     Symbol(const std::string &name, SourcePos pos, SymbolKind st = SymbolKind::Default, const Type *t = nullptr,
-           StorageClass sc = SC_NONE);
+           StorageClass sc = SC_NONE, AttributeList *a = nullptr);
+    ~Symbol();
 
     SourcePos pos;            /*!< Source file position where the symbol was defined */
     std::string name;         /*!< Symbol's name */
@@ -93,6 +94,10 @@ class Symbol : public Traceable {
     /*!< For symbols that are parameters to functions or are
          variables declared inside functions, this gives the
          function they're in. */
+
+    /** Attributes associated with the symbol. */
+    AttributeList *attrs;
+
     /* */
     SymbolKind GetSymbolKind() const { return kind; }
 

--- a/tests/lit-tests/deprecated-attr-1.ispc
+++ b/tests/lit-tests/deprecated-attr-1.ispc
@@ -1,0 +1,17 @@
+// RUN: %{ispc} --target=host --nowrap %s -o t.o 2>&1 | FileCheck %s
+
+// Check that the deprecated attribute is working correctly for overloaded functions.
+
+__attribute__((deprecated)) void foo(int x);
+void foo(float x);
+// CHECK: Warning: Function "foo(varying int32)" is deprecated.
+void use_foo(int x) {
+    foo(x);
+}
+
+__attribute__((deprecated)) void bar(int x);
+void bar(float x);
+// CHECK-NOT: Warning: Function "bar(varying float)" is deprecated.
+void use_bar(float x) {
+    bar(x);
+}

--- a/tests/lit-tests/deprecated-attr.ispc
+++ b/tests/lit-tests/deprecated-attr.ispc
@@ -1,0 +1,20 @@
+// RUN: %{ispc} --target=host --nowrap %s -o t.o 2>&1 | FileCheck %s
+
+// Functions below are called, so warnings should be generated.
+__attribute__((deprecated)) void foo();
+__attribute__((deprecated("reason"))) void foo1();
+// CHECK: Warning: Function "foo()" is deprecated.
+// CHECK: Warning: Function "foo1()" is deprecated: reason.
+void bar() {
+    foo();
+    foo1();
+}
+
+// Functions below are not called, so no warnings should be generated.
+
+// CHECK-NOT: Warning: Function "func()" is deprecated.
+__attribute__((deprecated)) void func() { }
+
+// CHECK-NOT: Warning: Function "func1()" is deprecated: reason.
+__attribute__((deprecated("reason"))) void func1() { }
+


### PR DESCRIPTION
Two variants are supported:
`__attribute__((deprecated))`
`__attribute__((deprecated("reason")))`

This fixes #2941 