### PR TITLE
Tune -O1 pipeline for code size

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2240,11 +2240,16 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
             // Set Optimization level for llvm codegen based on Optimization level
             // requested by user via ISPC Optimization Flag. Mapping is :
             // ISPC O0 -> Codegen O0
-            // ISPC O1,O2,O3,default -> Codegen O3
+            // ISPC O1 -> Codegen Default (-Os)
+            // ISPC O2,O3,default -> Codegen O3
             CodegenOptLevel cOptLevel = CodegenOptLevel::Aggressive;
             switch (g->codegenOptLevel) {
             case Globals::CodegenOptLevel::None:
                 cOptLevel = CodegenOptLevel::None;
+                break;
+
+            case Globals::CodegenOptLevel::Default:
+                cOptLevel = CodegenOptLevel::Default;
                 break;
 
             case Globals::CodegenOptLevel::Aggressive:
@@ -2291,6 +2296,10 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
 #endif
         for (auto const &f_attr : m_funcAttributes) {
             fattrBuilder->addAttribute(f_attr.first, f_attr.second);
+        }
+        // This attribute is required for LoopUnroll passes
+        if (g->opt.level == 1) {
+            fattrBuilder->addAttribute(llvm::Attribute::OptimizeForSize);
         }
         this->m_tf_attributes = fattrBuilder;
 
@@ -2814,7 +2823,7 @@ bool Target::hasXePrefetch() const {
 // Opt
 
 Opt::Opt() {
-    level = 1;
+    level = 2;
     fastMath = false;
     fastMaskedVload = false;
     force32BitAddressing = true;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -535,8 +535,8 @@ struct Opt {
     Opt();
 
     /** Optimization level.  Currently, the only valid values are 0,
-        indicating essentially no optimization, and 1, indicating as much
-        optimization as possible. */
+        indicating essentially no optimization, 1, indicating optimization for size,
+        and 2, indicating as much optimization as possible. */
     int level;
 
     /** Indicates whether "fast and loose" numerically unsafe optimizations
@@ -717,7 +717,7 @@ struct Globals {
     MathLib mathLib;
 
     /** Optimization level to be specified while creating TargetMachine. */
-    enum class CodegenOptLevel { None, Aggressive };
+    enum class CodegenOptLevel { None, Default, Aggressive };
     CodegenOptLevel codegenOptLevel;
 
     /** Records whether the ispc standard library should be made available

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -991,13 +991,13 @@ int main(int Argc, char *Argv[]) {
         } else if (!strcmp(argv[i], "-O0")) {
             g->opt.level = 0;
             g->codegenOptLevel = Globals::CodegenOptLevel::None;
-        } else if (!strcmp(argv[i], "-O") || !strcmp(argv[i], "-O1") || !strcmp(argv[i], "-O2") ||
-                   !strcmp(argv[i], "-O3")) {
+        } else if (!strcmp(argv[i], "-O1")) {
             g->opt.level = 1;
+            g->codegenOptLevel = Globals::CodegenOptLevel::Default;
+            g->opt.disableCoherentControlFlow = true;
+        } else if (!strcmp(argv[i], "-O") || !strcmp(argv[i], "-O2") || !strcmp(argv[i], "-O3")) {
+            g->opt.level = 2;
             g->codegenOptLevel = Globals::CodegenOptLevel::Aggressive;
-            if (!strcmp(argv[i], "-O1")) {
-                g->opt.disableCoherentControlFlow = true;
-            }
         } else if (!strcmp(argv[i], "-")) {
             file = argv[i];
         } else if (!strcmp(argv[i], "--nostdlib")) {

--- a/tests/lit-tests/loop_nounroll.ispc
+++ b/tests/lit-tests/loop_nounroll.ispc
@@ -1,6 +1,7 @@
 // Test to check '#pragma nounroll' functionality for different loop statemnts.
 
 // RUN: %{ispc} %s --target=host --nowrap -O0 --emit-llvm-text --no-discard-value-names --nostdlib -o - | FileCheck %s -check-prefix=CHECKO0
+// RUN: %{ispc} %s --target=host --nowrap -O1 --emit-llvm-text --no-discard-value-names --nostdlib -o - | FileCheck %s -check-prefix=CHECKO2
 // RUN: %{ispc} %s --target=host --nowrap -O2 --emit-llvm-text --no-discard-value-names --nostdlib -o - | FileCheck %s -check-prefix=CHECKO2
 
 // CHECKO0: define void @foo_for___

--- a/tests/lit-tests/loop_unroll-1.ispc
+++ b/tests/lit-tests/loop_unroll-1.ispc
@@ -1,0 +1,14 @@
+// Checks that loop unrolling is not happening with O1 and when --opt-desable-loop-unrolling is used
+// RUN: %{ispc} %s --target=host --nowrap -O1 --emit-llvm-text --no-discard-value-names --nostdlib -o - | FileCheck %s -check-prefix=CHECKO1
+// RUN: %{ispc} %s --target=host --nowrap -O2 --emit-llvm-text --no-discard-value-names --nostdlib --opt=disable-loop-unroll -o - | FileCheck %s -check-prefix=CHECKO1
+// RUN: %{ispc} %s --target=host --nowrap -O2 --emit-llvm-text --no-discard-value-names --nostdlib -o - | FileCheck %s -check-prefix=CHECKO2
+
+// CHECK-LABEL: @compute
+// CHECKO1-COUNT-1: @bar
+// CHECKO2-COUNT-2: @bar
+extern float bar(float);
+void compute(uniform float input[], uniform float output[]) {
+    foreach (i = 0 ... 16) {
+        output[i] = bar(input[i]) + (input[i]);
+    }
+}

--- a/tests/lit-tests/loop_unroll.ispc
+++ b/tests/lit-tests/loop_unroll.ispc
@@ -1,6 +1,8 @@
 // Test to check '#pragma unroll' functionality for different loop statemnts.
+// Pragma has higher priority that -O1.
 
 // RUN: %{ispc} %s --target=host --nowrap -O0 --emit-llvm-text --no-discard-value-names --nostdlib -o - | FileCheck %s -check-prefix=CHECKO0
+// RUN: %{ispc} %s --target=host --nowrap -O1 --emit-llvm-text --no-discard-value-names --nostdlib -o - | FileCheck %s -check-prefix=CHECKO2
 // RUN: %{ispc} %s --target=host --nowrap -O2 --emit-llvm-text --no-discard-value-names --nostdlib -o - | FileCheck %s -check-prefix=CHECKO2
 
 // CHECKO0: define void @foo_for___

--- a/tests/lit-tests/loop_unroll_varying.ispc
+++ b/tests/lit-tests/loop_unroll_varying.ispc
@@ -1,7 +1,9 @@
 // Test to check '#pragma unroll' functionality for different loop statements
 //   with varying type induction variables.
+// Pragma has higher priority that -O1.
 
 // RUN: %{ispc} %s --target=host --nowrap -O0 --emit-llvm-text --no-discard-value-names --nostdlib -o - | FileCheck %s -check-prefixes=CHECK_ALL,CHECKO0
+// RUN: %{ispc} %s --target=host --nowrap -O1 --emit-llvm-text --no-discard-value-names --nostdlib -o - | FileCheck %s -check-prefixes=CHECK_ALL,CHECKO2
 // RUN: %{ispc} %s --target=host --nowrap -O2 --emit-llvm-text --no-discard-value-names --nostdlib -o - | FileCheck %s -check-prefixes=CHECK_ALL,CHECKO2
 
 

--- a/tests/lit-tests/optsize.ispc
+++ b/tests/lit-tests/optsize.ispc
@@ -1,0 +1,19 @@
+// Checks that function inlining is not happening with O1 and the function has optsize attribute
+// RUN: %{ispc} %s --target=host --nowrap -O1 --emit-llvm-text --no-discard-value-names -o - | FileCheck %s -check-prefix=CHECKO1
+// RUN: %{ispc} %s --target=host --nowrap -O2 --emit-llvm-text --no-discard-value-names -o - | FileCheck %s -check-prefix=CHECKO2
+
+
+void compute(uniform float input[], uniform float output[], uniform int count) {
+    foreach (i = 0 ... count) {
+        output[i] = sin(input[i]) + (input[i]);
+    }
+}
+
+// CHECKO1: Function Attrs: {{.*}} optsize
+// CHECKO1-LABEL: @foo
+// CHECKO1: @compute
+
+// CHECKO2-NOT: Function Attrs: {{.*}} optsize
+// CHECKO2-LABEL: @foo
+// CHECKO2-NOT: @compute
+unmasked void foo(uniform float input[], uniform float output[], uniform int count) { compute(input, output, count); }


### PR DESCRIPTION
Fixes #3164.
Surprisingly ISPC was using optLevel 1 by default. It didn't matter because we didn't pass optlevel to optimization passes but it matters now with the changes in this PR.

1. Change default optLevel to 2
2. Pass `CodegenOptLevel::Default` to codegen when -O1 is selected (it corresponds to LLVM -Os)
3. Pass optLevel to Loop unrolling passes preventing them from aggressing unrolling
4. Get InlineParams from optLevel and sizeOptlevel and pass to Inliner pass
5. Add `optSize` function attribute when -O1 is passed. It's needed for loop unrolling passes.

Note: pragma has priority over optimization level. This behavior is aligned with LLVM. 