### PR TITLE
Fix leak of file handle in DispatchHeaderInfo

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2737,8 +2737,15 @@ struct ispc::DispatchHeaderInfo {
     bool Emit4;
     bool Emit8;
     bool Emit16;
-    FILE *file;
-    const char *fn;
+    FILE *file = nullptr;
+    const char *fn = nullptr;
+
+    ~DispatchHeaderInfo() {
+        if (file != nullptr) {
+            fclose(file);
+            file = nullptr;
+        }
+    }
 };
 
 bool Module::writeDispatchHeader(DispatchHeaderInfo *DHI) {
@@ -3840,9 +3847,6 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
                 }
                 if (!m->writeOutput(Module::Header, outputFlags, targetHeaderFileName.c_str())) {
                     return 1;
-                }
-                if (i == targets.size() - 1) {
-                    fclose(DHI.file);
                 }
             }
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2740,12 +2740,14 @@ struct ispc::DispatchHeaderInfo {
     FILE *file = nullptr;
     const char *fn = nullptr;
 
-    ~DispatchHeaderInfo() {
+    void closeFile() {
         if (file != nullptr) {
             fclose(file);
             file = nullptr;
         }
     }
+
+    ~DispatchHeaderInfo() { closeFile(); }
 };
 
 bool Module::writeDispatchHeader(DispatchHeaderInfo *DHI) {
@@ -3847,6 +3849,9 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
                 }
                 if (!m->writeOutput(Module::Header, outputFlags, targetHeaderFileName.c_str())) {
                     return 1;
+                }
+                if (i == targets.size() - 1) {
+                    DHI.closeFile();
                 }
             }
 


### PR DESCRIPTION
This fixes the issue of leaking a file handle (DHI->file) if the file was opened but the compilation was terminated earlier for some reason, e.g., at https://github.com/ispc/ispc/blob/c9ee084affb75700d495a600f52b5ae7c2ff2173/src/module.cpp#L3776