### PR TITLE
Check for incompatible attributes before setting optsize

### DIFF
--- a/src/func.cpp
+++ b/src/func.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2024, Intel Corporation
+  Copyright (c) 2011-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -299,6 +299,18 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
         function->addFnAttr("target-features", "+simd128");
     }
 
+    // This attribute is required for LoopUnroll passes when -O1
+    if (g->opt.level == 1) {
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_18_1
+        if ((!function->hasFnAttribute(llvm::Attribute::OptimizeNone)) &&
+            (!function->hasFnAttribute(llvm::Attribute::OptimizeForDebugging)))
+#else
+        if (!function->hasFnAttribute(llvm::Attribute::OptimizeNone))
+#endif
+        {
+            function->addFnAttr(llvm::Attribute::OptimizeForSize);
+        }
+    }
     g->target->markFuncWithTargetAttr(function);
     const FunctionType *type = CastType<FunctionType>(sym->type);
     Assert(type != nullptr);

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2290,10 +2290,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         for (auto const &f_attr : m_funcAttributes) {
             fattrBuilder->addAttribute(f_attr.first, f_attr.second);
         }
-        // This attribute is required for LoopUnroll passes
-        if (g->opt.level == 1) {
-            fattrBuilder->addAttribute(llvm::Attribute::OptimizeForSize);
-        }
+
         this->m_tf_attributes = fattrBuilder;
 
         Assert(this->m_vectorWidth <= ISPC_MAX_NVEC);


### PR DESCRIPTION
Fix setting of `optsize` attribute. Currently failing on print tests https://github.com/ispc/ispc/actions/runs/12824288745/job/35760635474 due to incompatible `optnone` and `optsize` attributes.