### PR TITLE
Set CPU for generic targets

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2116,6 +2116,15 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
 
     if (CPUID == CPU_None) {
         cpu = a.GetDefaultNameFromType(CPUfromISA).c_str();
+        std::string cpu_string = cpu;
+        if ((arch == Arch::x86_64 || arch == Arch::x86) && ISPCTargetIsGeneric(m_ispc_target) && cpu_string.empty()) {
+            // If CPU is not specified and target is generic, use x86_64 as
+            // default CPU for generic targets.
+            // Note: It is actually possible to use older target CPUs for
+            // generic targets that we don't have at the moment in CPU_ enum.
+            CPUID = CPU_x86_64;
+            cpu = a.GetDefaultNameFromType(CPUID).c_str();
+        }
     } else {
         if ((CPUfromISA != CPU_None) && !a.BackwardCompatible(CPUID, CPUfromISA)) {
             std::string target_string = ISPCTargetToString(m_ispc_target);

--- a/tests/func-tests/fmod-double-varying.ispc
+++ b/tests/func-tests/fmod-double-varying.ispc
@@ -1,6 +1,8 @@
 #include "test_static.isph"
 // rule: skip on cpu=tgllp
 // rule: skip on cpu=dg2
+// rule: skip on target=generic.*
+// rule: run on OS=!windows
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {
     RET[programIndex] = 0;

--- a/tests/func-tests/fmod-float-varying.ispc
+++ b/tests/func-tests/fmod-float-varying.ispc
@@ -1,4 +1,6 @@
 #include "test_static.isph"
+// rule: skip on target=generic.*
+// rule: run on OS=!windows
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {
     RET[programIndex] = 0;


### PR DESCRIPTION
This PR should repair full tests run for generic targets.

The job result is here: https://github.com/nurmukhametov/ispc/actions/runs/12949417763

This PR sets CPU in CPU_x86_64 for generic targets when `--cpu` is not explicitly specified on command line. Otherwise, the oldest CPU model supported by LLVM is picked in backend that results in very old CPUs in case of `i686-*` triple (when ISPC compiles with `--arch=x86`).