### PR TITLE
Add a flag to set min os version on darwin platforms

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -701,6 +701,10 @@ recovery. Such users must update their code to handle ``SIGILL`` instead. The
 change improves predictability and eliminates reliance of the dispatcher on the
 C standard library.
 
+The ``--darwin-version-min`` option was added to specify the minimum deployment
+target version for macOS and iOS applications addressing the new linker
+introduced in Xcode 15.0 that issues a warning when no version is provided.
+
 Getting Started with ISPC
 =========================
 
@@ -915,6 +919,12 @@ that removes unused sections: ``--gc-sections`` for ``GNU ld`` and ``/OPT:REF``
 for ``MSVC link.exe``. On macOS, this flag does not have any effect (as in
 clang) because dead stripping ``-dead_strip`` for ``ld64`` works differently.
 The ``-fno-function-sections`` disables this behavior.
+
+The ``--darwin-version-min`` option was added to specify the minimum deployment
+target version for macOS and iOS applications addressing the new linker
+introduced in Xcode 15.0 that issues a warning when no version is provided.
+The version should be specified in the format ``[major.minor]``. When an empty
+string ("") is passed, no minimum version will be specified in the output binary.
 
 Selecting The Compilation Target
 --------------------------------

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -34,6 +34,7 @@
 
 #include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/StringRef.h>
+#include <llvm/Support/VersionTuple.h>
 
 /** @def ISPC_MAX_NVEC maximum vector size of any of the compliation
     targets.
@@ -901,7 +902,15 @@ struct Globals {
 
     /* When compile time tracing is enabled, set time granularity. */
     int timeTraceGranularity;
+
+    /* Set macOS/iOS deployment target. The version will be propagated to the triple.
+       This address the new linker introduced in Xcode 15 that issues a warning if version when no version is provided.
+       https://github.com/ispc/ispc/issues/3143  */
+    llvm::VersionTuple darwinVersionMin;
 };
+
+// This is used when empty string is used for "--darwin-version-min"
+constexpr llvm::VersionTuple darwinUnspecifiedVersion(INT_MAX);
 
 enum {
     COST_ASSIGN = 1,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,6 +67,10 @@ static void lPrintVersion() {
 #endif
     printf("    [--cpu=<type>]\t\t\tAn alias for [--device=<type>] switch\n");
     printf("    [-D<foo>]\t\t\t\t#define given value when running preprocessor\n");
+#if defined(ISPC_MACOS_TARGET_ON) || defined(ISPC_IOS_TARGET_ON)
+    printf("    [--darwin-version-min=<major.minor>]Set the minimum macOS/iOS version required for the "
+           "deployment.\n");
+#endif
     printf("    [--dev-stub <filename>]\t\tEmit device-side offload stub functions to file\n");
     printf("    ");
     char cpuHelp[2048];
@@ -790,6 +794,21 @@ int main(int Argc, char *Argv[]) {
                                       "only 2, 3, 4 and 5 are allowed.",
                                       argv[i] + 16);
             }
+#if defined(ISPC_MACOS_TARGET_ON) || defined(ISPC_IOS_TARGET_ON)
+        } else if (!strncmp(argv[i], "--darwin-version-min=", 21)) {
+            const char *version = argv[i] + 21;
+            // Validate the version format
+            std::string versionStr(version);
+            llvm::VersionTuple versionTuple;
+            if (!versionStr.empty()) {
+                if (versionTuple.tryParse(versionStr)) {
+                    errorHandler.AddError("Invalid version format: \"%s\". Use <major_ver.minor_ver>.", version);
+                }
+            } else {
+                versionTuple = darwinUnspecifiedVersion;
+            }
+            g->darwinVersionMin = versionTuple;
+#endif
         } else if (!strcmp(argv[i], "--print-target")) {
             g->printTarget = true;
         } else if (!strcmp(argv[i], "--no-omit-frame-pointer")) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND LIT_ARGS "-Dwindows_enabled=$<IF:$<BOOL:${ISPC_WINDOWS_TARGET}>,ON,O
 list(APPEND LIT_ARGS "-Dlinux_enabled=$<IF:$<BOOL:${ISPC_LINUX_TARGET}>,ON,OFF>")
 list(APPEND LIT_ARGS "-Dps_enabled=$<IF:$<BOOL:${ISPC_PS_TARGET}>,ON,OFF>")
 list(APPEND LIT_ARGS "-Dmacos_arm_enabled=$<IF:$<BOOL:${ISPC_MACOS_ARM_TARGET}>,ON,OFF>")
+list(APPEND LIT_ARGS "-Dmacos_ios_enabled=$<IF:$<BOOL:${ISPC_IOS_ARM_TARGET}>,ON,OFF>")
 # TODO! generic target bc?
 add_custom_target(check-all DEPENDS ispc ispc-opt stdlibs-bc stdlib-headers
     COMMAND ${LIT_COMMAND} ${LIT_ARGS} "--verbose"

--- a/tests/lit-tests/darwin-minos-ver-1.ispc
+++ b/tests/lit-tests/darwin-minos-ver-1.ispc
@@ -1,0 +1,36 @@
+// The test checks that the triple contain minimum OS version if provided.
+
+// RUN: %{ispc} %s --nostdlib --target-os=macos --target=avx2 --arch=x86-64 --emit-llvm-text --nowrap -o - | FileCheck %s --check-prefix=CHECK-MACOS-DEFAULT
+// RUN: %{ispc} %s --nostdlib --target-os=macos --target=avx2 --arch=x86-64 --emit-llvm-text --nowrap --darwin-version-min=15.0 -o - | FileCheck %s --check-prefix=CHECK-MACOS-VER
+// RUN: %{ispc} %s --nostdlib --target-os=macos --target=avx2 --arch=x86-64 --emit-llvm-text --nowrap --darwin-version-min="" -o - | FileCheck %s --check-prefix=CHECK-MACOS-VER-UNSET
+// RUN: not %{ispc} %s --nostdlib --target-os=macos --arch=x86-64 --nowrap --target=avx2 --darwin-version-min=a.b -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR-VER
+
+// RUN: %{ispc} %s --nostdlib --target-os=macos --target=host -h %t.h -o %t.o
+// RUN: %{cc} -x c -c %s --include %t.h -o %t.cpp.o
+// RUN: %{cxx} %t.o %t.cpp.o -o %t.bin -mmacosx-version-min=13.0 2>&1 | FileCheck %s --check-prefix=CHECK-WARNING --allow-empty
+// RUN: otool -l %t.bin | FileCheck %s --check-prefix=CHECK-MINOS
+
+// REQUIRES: MACOS_HOST && X86_ENABLED
+
+// CHECK-MACOS-DEFAULT: target triple = "x86_64-apple-macosx10.12"
+// CHECK-MACOS-VER: target triple = "x86_64-apple-macosx15.0"
+// CHECK-MACOS-VER-UNSET: target triple = "x86_64-apple-macosx"
+
+// CHECK-ERROR-VER: Error: Invalid version format: "a.b". Use <major_ver.minor_ver>.
+
+// CHECK-WARNING-NOT: no platform load command found
+
+// CHECK-MINOS: minos 13.0
+
+#ifdef ISPC
+export void set(uniform int &result) {
+    result = programCount;
+}
+
+#else
+int main(int argc, char **argv) {
+    int r = 0;
+    set(&r);
+    return 0;
+}
+#endif

--- a/tests/lit-tests/darwin-minos-ver-2.ispc
+++ b/tests/lit-tests/darwin-minos-ver-2.ispc
@@ -1,0 +1,15 @@
+// The test checks that the triple contain minimum OS version if provided.
+
+// RUN: %{ispc} %s --nostdlib --target-os=macos --arch=aarch64 --emit-llvm-text --nowrap --target=neon-i32x4 -o - | FileCheck %s --check-prefix=CHECK-MACOS-DEFAULT
+// RUN: %{ispc} %s --nostdlib --target-os=macos --arch=aarch64 --emit-llvm-text --nowrap --target=neon-i32x4 --darwin-version-min=15.0 -o - | FileCheck %s --check-prefix=CHECK-MACOS-VER
+// RUN: %{ispc} %s --nostdlib --target-os=macos --arch=aarch64 --emit-llvm-text --nowrap --target=neon-i32x4 --darwin-version-min="" -o - | FileCheck %s --check-prefix=CHECK-MACOS-VER-UNSET
+
+// RUN: not %{ispc} %s --nostdlib --target-os=macos --arch=aarch64 --nowrap --target=neon-i32x4 --darwin-version-min=a.b -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR-VER
+
+// REQUIRES: MACOS_HOST && MACOS_ARM_ENABLED && ARM_ENABLED
+
+// CHECK-MACOS-DEFAULT: target triple = "arm64-apple-macosx11.0"
+// CHECK-MACOS-VER: target triple = "arm64-apple-macosx15.0"
+// CHECK-MACOS-VER-UNSET: target triple = "arm64-apple-macosx"
+
+// CHECK-ERROR-VER: Error: Invalid version format: "a.b". Use <major_ver.minor_ver>.

--- a/tests/lit-tests/darwin-minos-ver-3.ispc
+++ b/tests/lit-tests/darwin-minos-ver-3.ispc
@@ -1,0 +1,16 @@
+// The test checks that the triple contain minimum OS version if provided.
+// Note: iOS target is enabled one ARM platforms only.
+
+// RUN: %{ispc} %s --nostdlib --target-os=ios --arch=aarch64 --emit-llvm-text --nowrap --target=neon-i32x4 -o - | FileCheck %s --check-prefix=CHECK-IOS-DEFAULT
+// RUN: %{ispc} %s --nostdlib --target-os=ios --arch=aarch64 --emit-llvm-text --nowrap --target=neon-i32x4 --darwin-version-min=15.0 -o - | FileCheck %s --check-prefix=CHECK-IOS-VER
+// RUN: %{ispc} %s --nostdlib --target-os=ios --arch=aarch64 --emit-llvm-text --nowrap --target=neon-i32x4 --darwin-version-min="" -o - | FileCheck %s --check-prefix=CHECK-IOS-VER-UNSET
+
+// REQUIRES: MACOS_HOST && MACOS_ARM_ENABLED && MACOS_IOS_ENABLED
+
+// CHECK-IOS-DEFAULT: target triple = "arm64-apple-ios11.0"
+// CHECK-IOS-VER: target triple = "arm64-apple-ios15.0"
+// CHECK-IOS-VER-UNSET: target triple = "arm64-apple-ios"
+
+uniform int j;
+
+int foo(int i) { return i + 1; }

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -127,6 +127,16 @@ elif wasm_enabled == "OFF":
 else:
     sys.exit("Cannot parse wasm_enabled: " + wasm_enabled)
 
+# iOS target
+macos_ios_enabled = lit_config.params.get('macos_ios_enabled')
+if macos_ios_enabled == "ON":
+    print("MACOS_IOS_ENABLED: YES")
+    config.available_features.add("MACOS_IOS_ENABLED")
+elif macos_ios_enabled == "OFF":
+    print("MACOS_IOS_ENABLED: NO")
+else:
+    sys.exit("Cannot parse macos_ios_enabled: " + macos_ios_enabled)
+
 # Xe backend
 xe_enabled = lit_config.params.get('xe_enabled', '0')
 if xe_enabled == "ON":


### PR DESCRIPTION
This PR introduces option to set min OS version for Darwin platforms.
Fixes: https://github.com/ispc/ispc/issues/3143