### PR TITLE
Remove cygwin installation

### DIFF
--- a/.github/workflows/scripts/install-build-deps.ps1
+++ b/.github/workflows/scripts/install-build-deps.ps1
@@ -2,13 +2,8 @@
 Install-ChocoPackage winflexbison3
 Install-ChocoPackage wget
 Install-ChocoPackage 7zip
-Install-ChocoPackage cygwin
-Install-ChocoPackage cyg-get
+Install-ChocoPackage gnuwin32-m4
 Install-ChocoPackage ninja
-
-# Install M4 exec and put it into PATH
-cyg-get m4
-echo "C:\tools\cygwin\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
 # Download and unpack llvm
 if ( !(Test-Path ${env:LLVM_HOME}) ) { mkdir ${env:LLVM_HOME} }


### PR DESCRIPTION
There is no need to install Cygwin just to install `m4`. Install `m4` from Chocolatey straight away.