### PR TITLE
dispatcher: remove dependency on C abort

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -693,6 +693,13 @@ deprecated. It leads to a warning when the function is called.
 
 The target ``avx512knl-x16`` was removed.
 
+The release introduces a breaking change by altering the behavior of user
+programs when no supported ISA is detected in the auto-dispatch code. It
+replaces the previous ``SIGABRT`` signal with ``SIGILL``. This affects users
+who rely on ``SIGABRT`` in their signal handlers for error handling or
+recovery. Such users must update their code to handle ``SIGILL`` instead. The
+change improves predictability and eliminates reliance of the dispatcher on the
+C standard library.
 
 Getting Started with ISPC
 =========================

--- a/src/builtins-decl.cpp
+++ b/src/builtins-decl.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2024, Intel Corporation
+  Copyright (c) 2024-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -349,6 +349,7 @@ DECL_BUILTIN_NAME(__task_index);
 DECL_BUILTIN_NAME(__task_index0);
 DECL_BUILTIN_NAME(__task_index1);
 DECL_BUILTIN_NAME(__task_index2);
+DECL_BUILTIN_NAME(__terminate_now);
 DECL_BUILTIN_NAME(__wasm_cmp_msk_eq);
 
 std::unordered_map<PersistentGroup, std::vector<const char *>> persistentGroups = {

--- a/src/builtins-decl.h
+++ b/src/builtins-decl.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2024, Intel Corporation
+  Copyright (c) 2024-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -397,6 +397,7 @@ extern const char *const __task_index;
 extern const char *const __task_index0;
 extern const char *const __task_index1;
 extern const char *const __task_index2;
+extern const char *const __terminate_now;
 extern const char *const __wasm_cmp_msk_eq;
 
 } // namespace builtin

--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -356,7 +356,7 @@ void ispc::LinkDispatcher(llvm::Module *module) {
     llvm::Module *dispatchBCModule = dispatch->getLLVMModule();
     lAddDeclarationsToModule(dispatchBCModule, module);
     lAddBitcodeToModule(dispatchBCModule, module);
-    llvm::StringSet<> dispatchFunctions = {builtin::__set_system_isa};
+    llvm::StringSet<> dispatchFunctions = {builtin::__set_system_isa, builtin::__terminate_now};
     lSetAsInternal(module, dispatchFunctions);
 }
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3469,12 +3469,13 @@ static void lCreateDispatchFunction(llvm::Module *module, llvm::Function *setISA
         bblock = nextBBlock;
     }
 
-    // We couldn't find a match that the current system was capable of
-    // running.  We'll call abort(); this is a bit of a blunt hammer--it
-    // might be preferable to call a user-supplied callback--ISPCError(...)
+    // We couldn't find a match that the current system was capable of running.
+    // We used to call abort() here but replaced it with call to our own
+    // implementation __terminate_now from builtins/dispatch.c
+    // It might be preferable to call a user-supplied callback--ISPCError(...)
     // or some such, but we don't want to start imposing too much of a
     // runtime library requirement either...
-    llvm::Function *abortFunc = module->getFunction("abort");
+    llvm::Function *abortFunc = module->getFunction(builtin::__terminate_now);
     Assert(abortFunc);
     llvm::CallInst::Create(abortFunc, "", bblock);
 


### PR DESCRIPTION
Replace the dependency on the C abort function with a custom implementation (`__terminate_now`), which directly invokes the `ud2` instruction.

This change introduces a breaking change for compiled user programs. Specifically, when no ISA is detected, the behavior changes from triggering an abort to executing an illegal instruction, meaning a different signal is raised (`SIGABRT` → `SIGILL`). User code that installs signal handlers for `SIGABRT` and processes them in any way will break and require modifications.

ISPC does not appear to guarantee any specific behavior for this case, so this change is likely acceptable. However, it is beneficial to document this behavior explicitly.

This fixes #3163 (at least the most important its part).