### PR TITLE
Use target specific intrinsics for masked load/store operations for int8/int16 types

### DIFF
--- a/builtins/target-avx512-common-16.ll
+++ b/builtins/target-avx512-common-16.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2015-2024, Intel Corporation
+;;  Copyright (c) 2015-2025, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -571,9 +571,21 @@ define i64 @__reduce_max_uint64(<16 x i64>) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; unaligned loads/loads+broadcasts
 
-masked_load(i8,  1)
-masked_load(i16, 2)
 masked_load(half, 2)
+
+declare <16 x i8> @llvm.x86.avx512.mask.loadu.b.128(ptr, <16 x i8>, i16)
+define <16 x i8> @__masked_load_i8(i8 * %ptr, <WIDTH x MASK> %mask) nounwind alwaysinline {
+  %mask_i16 = call i16 @__cast_mask_to_i16 (<WIDTH x MASK> %mask)
+  %res = call <16 x i8> @llvm.x86.avx512.mask.loadu.b.128(i8* %ptr, <16 x i8> zeroinitializer, i16 %mask_i16)
+  ret <16 x i8> %res
+}
+
+declare <16 x i16> @llvm.x86.avx512.mask.loadu.w.256(ptr, <16 x i16>, i16)
+define <16 x i16> @__masked_load_i16(i8 * %ptr, <WIDTH x MASK> %mask) nounwind alwaysinline {
+  %mask_i16 = call i16 @__cast_mask_to_i16 (<WIDTH x MASK> %mask)
+  %res = call <16 x i16> @llvm.x86.avx512.mask.loadu.w.256(i8* %ptr, <16 x i16> zeroinitializer, i16 %mask_i16)
+  ret <16 x i16> %res
+}
 
 declare <16 x i32> @llvm.x86.avx512.mask.loadu.d.512(i8*, <16 x i32>, i16)
 define <16 x i32> @__masked_load_i32(i8 * %ptr, <WIDTH x MASK> %mask) nounwind alwaysinline {
@@ -627,9 +639,23 @@ define <16 x double> @__masked_load_double(i8 * %ptr, <WIDTH x MASK> %mask) read
 }
 
 
-gen_masked_store(i8) ; llvm.x86.sse2.storeu.dq
-gen_masked_store(i16)
 gen_masked_store(half)
+
+declare void @llvm.x86.avx512.mask.storeu.b.128(i8*, <16 x i8>, i16)
+define void @__masked_store_i8(<16 x i8>* nocapture, <16 x i8> %v, <WIDTH x MASK> %mask) nounwind alwaysinline {
+  %mask_i16 = call i16 @__cast_mask_to_i16 (<WIDTH x MASK> %mask)
+  %ptr_i8 = bitcast <16 x i8>* %0 to i8*
+  call void @llvm.x86.avx512.mask.storeu.b.128(i8* %ptr_i8, <16 x i8> %v, i16 %mask_i16)
+  ret void
+}
+
+declare void @llvm.x86.avx512.mask.storeu.w.256(i8*, <16 x i16>, i16)
+define void @__masked_store_i16(<16 x i16>* nocapture, <16 x i16> %v, <WIDTH x MASK> %mask) nounwind alwaysinline {
+  %mask_i16 = call i16 @__cast_mask_to_i16 (<WIDTH x MASK> %mask)
+  %ptr_i8 = bitcast <16 x i16>* %0 to i8*
+  call void @llvm.x86.avx512.mask.storeu.w.256(i8* %ptr_i8, <16 x i16> %v, i16 %mask_i16)
+  ret void
+}
 
 declare void @llvm.x86.avx512.mask.storeu.d.512(i8*, <16 x i32>, i16)
 define void @__masked_store_i32(<16 x i32>* nocapture, <16 x i32> %v, <WIDTH x MASK> %mask) nounwind alwaysinline {

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -3556,6 +3556,32 @@ loop would be preferable, as ``foreach`` naturally handles the case where
 processed, while the loop above assumes that case implicitly.
 
 
+Remember that ``foreach`` begins each loop iteration with an "all on"
+execution mask, meaning all program instances are active at the start.
+In contrast, a ``for`` loop using ``programIndex`` and ``programCount``
+respects the current execution mask, which may disable some instances.
+To match the behavior of ``foreach`` in regards of masking, you should
+use an ``unmasked`` region. For example:
+
+::
+
+    foreach (index = 0 ... 16) {
+        values[index] = select(upd, newVal, values[index]);
+    }
+
+
+will be equivalent to the following code:
+
+::
+
+  unmasked {
+      for (uniform int i = 0; i < 16; i+=programCount) {
+          int index = i + programIndex;
+          values[index] = select(upd, newVal, values[index]);
+      }
+  }
+
+
 Unstructured Control Flow: "goto"
 ---------------------------------
 

--- a/tests/lit-tests/3181.ispc
+++ b/tests/lit-tests/3181.ispc
@@ -1,0 +1,23 @@
+// Check that target-specific instructions are used for int8/int16 masked store on avx512
+// RUN: %{ispc} --target=avx512skx-x8 --nowrap -O2 --emit-asm --x86-asm-syntax=intel %s -o - | FileCheck %s --check-prefix=CHECK_X8 
+// RUN: %{ispc} --target=avx512skx-x16 --nowrap -O2 --emit-asm --x86-asm-syntax=intel %s -o - | FileCheck %s --check-prefix=CHECK_X16
+
+// REQUIRES: X86_ENABLED && !MACOS_HOST
+
+// CHECK-LABEL: update_int8
+// CHECK_X16-COUNT-2: vmovdqu8
+void update_int8(uniform int8 values[16], bool upd, uniform int8 newVal) {
+    for (uniform int i = 0; i < 16; i += programCount) {
+        int index = i + programIndex;
+        values[index] = select(upd, newVal, values[index]);
+    }
+}
+// CHECK-LABEL: update_int16
+// CHECK_X8-COUNT-4: vmovdqu16
+// CHECK_X16-COUNT-2: vmovdqu16
+void update_int16(uniform int16 values[16], bool upd, uniform int16 newVal) {
+    for (uniform int i = 0; i < 16; i += programCount) {
+        int index = i + programIndex;
+        values[index] = select(upd, newVal, values[index]);
+    }
+}


### PR DESCRIPTION
This PR introduces using of target-specific instructions for masked load/store operations for int8/int16 types on avx512 where is directly maps to HW instructions. These instructions are covered by `avx512_bw` and `avx512_vl` features which are available starting skx (but were not available in knl)

These implementations still performs better then corresponding generic targets. However eventually we should replace remaining masked load/store functions coming from utils to generic implementation which produces much better code.

Fixes #3181.
