### PR TITLE
Fix generic targets with `-O0`

### DIFF
--- a/builtins/generic.ispc
+++ b/builtins/generic.ispc
@@ -1331,32 +1331,26 @@ EXT void __masked_store_double(NOESCAPE varying double *uniform ptr, varying dou
     @llvm.masked.store(val, (uniform int8 * uniform) ptr, 1l, mask);
 }
 
-template <typename T>
-unmasked void __masked_store_blend(NOESCAPE varying T *uniform ptr, varying T new_val, UIntMaskType mask) {
-    varying T old_val = *ptr;
-    varying T blend = __select((bool)mask, new_val, old_val);
-    *ptr = blend;
-}
 EXT void __masked_store_blend_i8(NOESCAPE varying int8 *uniform ptr, varying int8 val, UIntMaskType mask) {
-    __masked_store_blend<int8>(ptr, val, mask);
+    @llvm.ispc.blend_store(val, (uniform int8 * uniform) ptr, mask);
 }
 EXT void __masked_store_blend_i16(NOESCAPE varying int16 *uniform ptr, varying int16 val, UIntMaskType mask) {
-    __masked_store_blend<int16>(ptr, val, mask);
+    @llvm.ispc.blend_store(val, (uniform int8 * uniform) ptr, mask);
 }
 EXT void __masked_store_blend_i32(NOESCAPE varying int32 *uniform ptr, varying int32 val, UIntMaskType mask) {
-    __masked_store_blend<int32>(ptr, val, mask);
+    @llvm.ispc.blend_store(val, (uniform int8 * uniform) ptr, mask);
 }
 EXT void __masked_store_blend_i64(NOESCAPE varying int64 *uniform ptr, varying int64 val, UIntMaskType mask) {
-    __masked_store_blend<int64>(ptr, val, mask);
+    @llvm.ispc.blend_store(val, (uniform int8 * uniform) ptr, mask);
 }
 EXT void __masked_store_blend_half(NOESCAPE varying float16 *uniform ptr, varying float16 val, UIntMaskType mask) {
-    __masked_store_blend<float16>(ptr, val, mask);
+    @llvm.ispc.blend_store(val, (uniform int8 * uniform) ptr, mask);
 }
 EXT void __masked_store_blend_float(NOESCAPE varying float *uniform ptr, varying float val, UIntMaskType mask) {
-    __masked_store_blend<float>(ptr, val, mask);
+    @llvm.ispc.blend_store(val, (uniform int8 * uniform) ptr, mask);
 }
 EXT void __masked_store_blend_double(NOESCAPE varying double *uniform ptr, varying double val, UIntMaskType mask) {
-    __masked_store_blend<double>(ptr, val, mask);
+    @llvm.ispc.blend_store(val, (uniform int8 * uniform) ptr, mask);
 }
 
 EXT uniform uint64 __cast_mask_to_i64(UIntMaskType mask) { return @llvm.ispc.packmask(mask); }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2024, Intel Corporation
+  Copyright (c) 2024-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -30,6 +30,7 @@ enum class ISPCIntrinsics : unsigned {
     not_intrinsic = 0,
     atomicrmw,
     bitcast,
+    blend_store,
     concat,
     cmpxchg,
     extract,
@@ -56,6 +57,8 @@ static ISPCIntrinsics lLookupISPCInstrinsic(const std::string &name) {
     // These intrinsics are not overloaded.
     else if (name == "llvm.ispc.bitcast") {
         return ISPCIntrinsics::bitcast;
+    } else if (name == "llvm.ispc.blend_store") {
+        return ISPCIntrinsics::blend_store;
     } else if (name == "llvm.ispc.concat") {
         return ISPCIntrinsics::concat;
     } else if (name == "llvm.ispc.extract") {
@@ -368,6 +371,12 @@ static llvm::Function *lGetISPCIntrinsicsFuncDecl(llvm::Module *M, std::string o
         Assert(TYs.size() == 2 && TYs[0]->getPrimitiveSizeInBits() == TYs[1]->getPrimitiveSizeInBits());
         retType = TYs[1];
         name += "." + lGetMangledTypeStr(TYs[0], hasUnnamedType) + "." + lGetMangledTypeStr(TYs[1], hasUnnamedType);
+        break;
+    }
+    case ISPCIntrinsics::blend_store: {
+        Assert(TYs.size() == 3);
+        retType = llvm::Type::getVoidTy(*g->ctx);
+        name += "." + lGetMangledTypeStr(TYs[0], hasUnnamedType);
         break;
     }
     case ISPCIntrinsics::concat: {

--- a/tests/lit-tests/ispc-intrinsics.ispc
+++ b/tests/lit-tests/ispc-intrinsics.ispc
@@ -76,6 +76,12 @@ ATTRS uniform float16 bitcast(uniform int16 x) {
     return @llvm.ispc.bitcast(x, (uniform float16)0);
 }
 
+// CHECK-LABEL: @blend_store
+// CHECK-DAG:   call void @llvm.ispc.blend_store.v[[WIDTH]]f64(<[[WIDTH]] x double> {{.*}}, [[PTR]] {{%ptr.*}}, <[[WIDTH]] x [[MASK]]> {{%__mask.*}})
+ATTRS void blend_store(uniform int8 *uniform ptr, varying double val) {
+    @llvm.ispc.blend_store(val, ptr, __mask);
+}
+
 // CHECK-LABEL: @concat
 // CHECK-DAG: %calltmp = call <[[DOUBLE_WIDTH]] x i8> @llvm.ispc.concat.v[[DOUBLE_WIDTH]]i8.v[[WIDTH]]i8(<[[WIDTH]] x i8> {{%v0.*}}, <[[WIDTH]] x i8> {{%v1.*}})
 ATTRS uniform int8<DOUBLE_WIDTH> concat(int8 v0, int8 v1) { return @llvm.ispc.concat(v0, v1); }

--- a/tests/lit-tests/ispc-intrinsics.ll
+++ b/tests/lit-tests/ispc-intrinsics.ll
@@ -18,6 +18,17 @@ define half @bitcast(i16 %x) {
   ret half %calltmp
 }
 
+; CHECK-LABEL: @blend_store
+; CHECK-DAG: [[OLD_VAL:%.*]] = load <4 x double>, ptr %ptr
+; CHECK-DAG-NEXT: [[BLENDED:%.*]] = select <4 x i1> %mask, <4 x double> %val, <4 x double> [[OLD_VAL]]
+; CHECK-DAG-NEXT: store <4 x double> [[BLENDED]], ptr %ptr
+declare void @llvm.ispc.blend_store.v4f64(<4 x double>, ptr, <4 x i1>)
+define void @blend_store(<4 x double> %val, ptr %ptr, <4 x i1> %mask) {
+  call void @llvm.ispc.blend_store.v4f64(<4 x double> %val, ptr %ptr, <4 x i1> %mask)
+  ret void
+}
+
+
 ; CHECK-LABEL: @concat
 ; CHECK-DAG: [[RES:%.*]] = shufflevector <2 x i32> %x, <2 x i32> %y, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ; CHECK-DAG: ret <4 x i32> [[RES]]


### PR DESCRIPTION
This PR fixes the tests (https://github.com/ispc/ispc/actions/runs/13108110736). Nightly runs revealed that for generic/neon targets, the `__masked_blend_store` implementation from https://github.com/ispc/ispc/commit/1f1a117743cf5110e7b109b4cd475f1ef83a6bac is effectively recursive for `-O0`. This happens because ISPC generates masked stores even inside blocks where the mask is certainly `all_on` (this occurs when the first IR is generated). Later on, ISPC relies on optimizations to replace such masked stores with usual ones.

To fix that, introduce `llvm.ispc.blend_store` and use it for `__masked_store_blend` implementation.