### PR TITLE
Fix predefined macro values

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -86,6 +86,7 @@ Contents:
   + `Selecting The Compilation Target`_
   + `Selecting 32 or 64 Bit Addressing`_
   + `The Preprocessor`_
+  + `Pragma Directives`_
   + `Debugging`_
   + `Optimization Settings`_
   + `Other ways of passing arguments to ISPC`_
@@ -1175,6 +1176,51 @@ preprocessor runs:
   * - FLT16_MAX, FLT_MAX, DBL_MAX
     -
     - Largest normal number of the corresponding floating-point type
+
+Others Standard Predefined Macros:
+
+``__FILE__`` expands to the name of the current input file, in the form of a C
+string constant.
+
+``__LINE__`` expands to the current line number in the input file, in the form
+of a decimal integer constant.
+
+``__DATE__`` expands to a string constant containing the date the preprocessor
+was run, e.g., ``"Feb  3 2025"``.
+
+``__TIME__`` expands to a string constant containing the time the preprocessor
+was run, e.g., ``"13:14:33"``.
+
+Variadic Macros:
+
+Variadic macros are supported in ``ispc``. The ``__VA_ARGS__`` and
+``__VA_OPT__`` macros are defined inside a variadic macro definition.
+
+``__VA_ARGS__`` is a variable argument list macro that represents the arguments
+after the last named argument.
+
+``__VA_OPT__(...)`` is a function macro that expands to its argument if the
+variable argument has any tokens, but if the variable argument does not have
+any tokens, the ``__VA_OPT__`` expands to nothing.
+
+To illustrate, consider the following example:
+
+::
+
+    #define PRINT(fmt, ...) print(fmt, __VA_ARGS__)
+    #define EPRINT(fmt, ...) print(fmt __VA_OPT__(,) __VA_ARGS__)
+
+    void test_va_args() {
+        PRINT("% % %\n", 0, 1, 2);
+        // PRINT("Hello, World!\n"); is compilation error
+        // you can't call PRINT with just string because of trailing comma in
+        // macro expansion, call EPRINT with __VA_OPT__(,) instead
+        EPRINT("Hello, World!\n");
+    }
+
+
+Pragma Directives
+-----------------
 
 ``ispc`` supports the following ``#pragma`` directives.
 

--- a/stdlib/include/core.isph
+++ b/stdlib/include/core.isph
@@ -17,15 +17,15 @@
 
 #pragma once
 
-#define ISPC
+#define ISPC 1
 
 #define PI 3.1415926535
 
 // This lets the user know uint* is part of language.
-#define ISPC_UINT_IS_DEFINED
+#define ISPC_UINT_IS_DEFINED 1
 
 // This lets the user know __attribute__ is part of language.
-#define ISPC_ATTRIBUTE_SUPPORTED
+#define ISPC_ATTRIBUTE_SUPPORTED 1
 
 #if defined(ISPC_TARGET_GEN9) || defined(ISPC_TARGET_XELP) || defined(ISPC_TARGET_XEHPG) ||                            \
     defined(ISPC_TARGET_XEHPC) || defined(ISPC_TARGET_XELPG) || defined(ISPC_TARGET_XE2HPG) ||                         \

--- a/tests/lit-tests/macro_values.ispc
+++ b/tests/lit-tests/macro_values.ispc
@@ -1,0 +1,15 @@
+// RUN: %{ispc} --target=host --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+
+// CHECK: @ispc = {{.*}} constant i32 1
+// CHECK: @ispc_uint_is_defined = {{.*}} constant i32 1
+// CHECK: @ispc_attribute_supported = {{.*}} constant i32 1
+const uniform int32 ispc = ISPC;
+const uniform int32 ispc_uint_is_defined = ISPC_UINT_IS_DEFINED;
+const uniform int32 ispc_attribute_supported = ISPC_ATTRIBUTE_SUPPORTED;
+
+// CHECK-NOT: Error: syntax error, unexpected ')'.
+void foo() {
+    print("%", ISPC);
+    print("%", ISPC_UINT_IS_DEFINED);
+    print("%", ISPC_ATTRIBUTE_SUPPORTED);
+}


### PR DESCRIPTION
This PR fixes #2167 by updating the documentation about predefined macros and fixing the values for some of them.