### PR TITLE
Skip 2954.ispc

### DIFF
--- a/tests/lit-tests/2954.ispc
+++ b/tests/lit-tests/2954.ispc
@@ -1,6 +1,11 @@
 // RUN: %{ispc} -O2 --target=avx2-i32x8 --emit-asm --x86-asm-syntax=intel %s -o - 2>&1 | FileCheck %s
 
-// XFAIL: !LLVM_20_0+
+// This test passes when built with LLVM 20.0 or with LLVM 18/19 built with the
+// backport patch llvm_patches/18_1_19_1_InstCombine-foldVecExtTruncToExtElt-extend.patch
+// It is better to skip it as UNSUPPORTED for the release because many package
+// maintainers will not have older LLVMs patched.
+
+// UNSUPPORTED: !LLVM_20_0+
 
 // REQUIRES: X86_ENABLED
 


### PR DESCRIPTION
This test passes when built with LLVM 20.0 or with LLVM 18/19 built with the backport patch llvm_patches/18_1_19_1_InstCombine-foldVecExtTruncToExtElt-extend.patch It is better to skip it as UNSUPPORTED for the release because many package maintainers will not have older LLVMs patched.

We also need to update LLVM 18/19 prebuilt archives to enable this test in future.