### PR TITLE
Add release pipeline

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1,0 +1,75 @@
+# Copyright 2025, Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Release Pipeline
+
+permissions: read-all
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'ISPC Version'
+        required: true
+        type: string
+        default: 'v1.26.0'
+
+jobs:
+  aarch64:
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          ref: ${{ github.event.inputs.version }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+
+      - name: Build Docker image
+        working-directory: docker/${{ github.event.inputs.version }}/ubuntu18.04
+        run: |
+          docker build --no-cache \
+            --build-arg XE_DEPS=OFF \
+            --build-arg LTO=ON \
+            -t ispc-release .
+
+      - name: Extract tarball from container
+        run: |
+          CONTAINER_ID=$(docker create ispc-release)
+          docker cp "$CONTAINER_ID":/usr/local/src/ ./
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: ispc_aarch64
+          path: src/ispc-*.tar.gz
+
+  x86_64:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          ref: ${{ github.event.inputs.version }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+
+      - name: Build Docker image
+        working-directory: docker/${{ github.event.inputs.version }}/ubuntu18.04
+        run: |
+          docker build --no-cache \
+            --build-arg LTO=ON \
+            -t ispc-release .
+
+      - name: Extract tarball from container
+        run: |
+          CONTAINER_ID=$(docker create ispc-release)
+          docker cp "$CONTAINER_ID":/usr/local/src/ ./
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: ispc_x86_64
+          path: src/ispc-*.tar.gz


### PR DESCRIPTION
It can build release archives for both Linux aarch64 and x86_64. This fixes #3216 