### PR TITLE
Add missing functions for unsigned types for cross-lane operations

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -709,6 +709,12 @@ their signal handlers for error handling or recovery.  Such users must update
 their code to handle ``SIGILL`` instead. This change improves predictability and
 removes the dispatcher's reliance on the C standard library.
 
+Updating ISPC Programs For Changes In ISPC 1.27.0
+-------------------------------------------------
+
+Added cross lane operations for unsigned types: ``broadcast``, ``rotate``, ``shift``,
+and ``shuffle``.
+
 Getting Started with ISPC
 =========================
 
@@ -5113,9 +5119,13 @@ the running program instances.
 ::
 
     int8 broadcast(int8 value, uniform int index)
+    unsigned int8 broadcast(unsigned int8 value, uniform int index)
     int16 broadcast(int16 value, uniform int index)
+    unsigned int16 broadcast(unsigned int16 value, uniform int index)
     int32 broadcast(int32 value, uniform int index)
+    unsigned int32 broadcast(unsigned int32 value, uniform int index)
     int64 broadcast(int64 value, uniform int index)
+    unsigned int64 broadcast(unsigned int64 value, uniform int index)
     float16 broadcast(float16 value, uniform int index)
     float broadcast(float value, uniform int index)
     double broadcast(double value, uniform int index)
@@ -5131,9 +5141,13 @@ the size of the gang (it is masked to ensure valid offsets).
 
 ::
 
+    unsigned int8 rotate(unsigned int8 value, uniform int offset)
     int8 rotate(int8 value, uniform int offset)
+    unsigned int16 rotate(unsigned int16 value, uniform int offset)
     int16 rotate(int16 value, uniform int offset)
+    unsigned int32 rotate(unsigned int32 value, uniform int offset)
     int32 rotate(int32 value, uniform int offset)
+    unsigned int64 rotate(unsigned int64 value, uniform int offset)
     int64 rotate(int64 value, uniform int offset)
     float16 rotate(float16 value, uniform int offset)
     float rotate(float value, uniform int offset)
@@ -5149,9 +5163,13 @@ Instead, zeroes are shifted in where appropriate.
 ::
 
     int8 shift(int8 value, uniform int offset)
+    unsigned int8 shift(unsigned int8 value, uniform int offset)
     int16 shift(int16 value, uniform int offset)
+    unsigned int16 shift(unsigned int16 value, uniform int offset)
     int32 shift(int32 value, uniform int offset)
+    unsigned int32 shift(unsigned int32 value, uniform int offset)
     int64 shift(int64 value, uniform int offset)
+    unsigned int64 shift(unsigned int64 value, uniform int offset)
     float16 shift(float16 value, uniform int offset)
     float shift(float value, uniform int offset)
     double shift(double value, uniform int offset)
@@ -5166,9 +5184,13 @@ from which to get the value of ``value``.  The provided values for
 ::
 
     int8 shuffle(int8 value, int permutation)
+    unsigned int8 shuffle(unsigned int8 value, int permutation)
     int16 shuffle(int16 value, int permutation)
+    unsigned int16 shuffle(unsigned int16 value, int permutation)
     int32 shuffle(int32 value, int permutation)
+    unsigned int32 shuffle(unsigned int32 value, int permutation)
     int64 shuffle(int64 value, int permutation)
+    unsigned int64 shuffle(unsigned int64 value, int permutation)
     float16 shuffle(float16 value, int permutation)
     float shuffle(float value, int permutation)
     double shuffle(double value, int permutation)
@@ -5183,9 +5205,13 @@ the last element of ``value1``, etc.)
 ::
 
     int8 shuffle(int8 value0, int8 value1, int permutation)
+    unsigned int8 shuffle(unsigned int8 value0, unsigned int8 value1, int permutation)
     int16 shuffle(int16 value0, int16 value1, int permutation)
+    unsigned int16 shuffle(unsigned int16 value0, unsigned int16 value1, int permutation)
     int32 shuffle(int32 value0, int32 value1, int permutation)
+    unsigned int32 shuffle(unsigned int32 value0, unsigned int32 value1, int permutation)
     int64 shuffle(int64 value0, int64 value1, int permutation)
+    unsigned int64 shuffle(unsigned int64 value0, unsigned int64 value1, int permutation)
     float16 shuffle(float16 value0, float16 value1, int permutation)
     float shuffle(float value0, float value1, int permutation)
     double shuffle(double value0, double value1, int permutation)
@@ -5202,9 +5228,13 @@ element of it as a single ``uniform`` value.  .
 
     uniform bool extract(bool x, uniform int i)
     uniform int8 extract(int8 x, uniform int i)
+    uniform unsigned int8 extract(unsigned int8 x, uniform int i)
     uniform int16 extract(int16 x, uniform int i)
+    uniform unsigned int16 extract(unsigned int16 x, uniform int i)
     uniform int32 extract(int32 x, uniform int i)
+    uniform unsigned int32 extract(unsigned int32 x, uniform int i)
     uniform int64 extract(int64 x, uniform int i)
+    uniform unsigned int64 extract(unsigned int64 x, uniform int i)
     uniform float16 extract(float16 x, uniform int i)
     uniform float extract(float x, uniform int i)
     uniform double extract(double x, uniform int i)
@@ -5216,9 +5246,13 @@ where the ``i`` th element of ``x`` has been replaced with the value ``v``
 
     bool insert(bool x, uniform int i, uniform bool v)
     int8 insert(int8 x, uniform int i, uniform int8 v)
+    unsigned int8 insert(unsigned int8 x, uniform int i, uniform unsigned int8 v)
     int16 insert(int16 x, uniform int i, uniform int16 v)
+    unsigned int16 insert(unsigned int16 x, uniform int i, uniform unsigned int16 v)
     int32 insert(int32 x, uniform int i, uniform int32 v)
+    unsigned int32 insert(unsigned int32 x, uniform int i, uniform unsigned int32 v)
     int64 insert(int64 x, uniform int i, uniform int64 v)
+    unsigned int64 insert(unsigned int64 x, uniform int i, uniform unsigned int64 v)
     float16 insert(float16 x, uniform int i, uniform float16 v)
     float insert(float x, uniform int i, uniform float v)
     double insert(double x, uniform int i, uniform double v)

--- a/stdlib/include/stdlib.isph
+++ b/stdlib/include/stdlib.isph
@@ -57,26 +57,38 @@ __declspec(safe) inline unsigned int64 rotate(unsigned int64 v, uniform int i);
 
 __declspec(safe) inline float shift(float v, uniform int i);
 __declspec(safe) inline int8 shift(int8 v, uniform int i);
+__declspec(safe) inline unsigned int8 shift(unsigned int8 v, uniform int i);
 __declspec(safe) inline int16 shift(int16 v, uniform int i);
+__declspec(safe) inline unsigned int16 shift(unsigned int16 v, uniform int i);
 __declspec(safe) inline float16 shift(float16 v, uniform int i);
 __declspec(safe) inline int32 shift(int32 v, uniform int i);
+__declspec(safe) inline unsigned int32 shift(unsigned int32 v, uniform int i);
 __declspec(safe) inline double shift(double v, uniform int i);
 __declspec(safe) inline int64 shift(int64 v, uniform int i);
+__declspec(safe) inline unsigned int64 shift(unsigned int64 v, uniform int i);
 
 __declspec(safe) inline float shuffle(float v, int i);
 __declspec(safe) inline int8 shuffle(int8 v, int i);
+__declspec(safe) inline unsigned int8 shuffle(unsigned int8 v, int i);
 __declspec(safe) inline int16 shuffle(int16 v, int i);
+__declspec(safe) inline unsigned int16 shuffle(unsigned int16 v, int i);
 __declspec(safe) inline float16 shuffle(float16 v, int i);
 __declspec(safe) inline int32 shuffle(int32 v, int i);
+__declspec(safe) inline unsigned int32 shuffle(unsigned int32 v, int i);
 __declspec(safe) inline double shuffle(double v, int i);
 __declspec(safe) inline int64 shuffle(int64 v, int i);
+__declspec(safe) inline unsigned int64 shuffle(unsigned int64 v, int i);
 __declspec(safe) inline float shuffle(float v0, float v1, int i);
 __declspec(safe) inline int8 shuffle(int8 v0, int8 v1, int i);
+__declspec(safe) inline unsigned int8 shuffle(unsigned int8 v0, unsigned int8 v1, int i);
 __declspec(safe) inline int16 shuffle(int16 v0, int16 v1, int i);
+__declspec(safe) inline unsigned int16 shuffle(unsigned int16 v0, unsigned int16 v1, int i);
 __declspec(safe) inline float16 shuffle(float16 v0, float16 v1, int i);
 __declspec(safe) inline int32 shuffle(int32 v0, int32 v1, int i);
+__declspec(safe) inline unsigned int32 shuffle(unsigned int32 v0, unsigned int32 v1, int i);
 __declspec(safe) inline double shuffle(double v0, double v1, int i);
 __declspec(safe) inline int64 shuffle(int64 v0, int64 v1, int i);
+__declspec(safe) inline unsigned int64 shuffle(unsigned int64 v0, unsigned int64 v1, int i);
 
 // x[i]
 __declspec(safe, cost1) inline uniform float extract(float x, uniform int i);

--- a/stdlib/include/stdlib.isph
+++ b/stdlib/include/stdlib.isph
@@ -1,5 +1,5 @@
 // -*- mode: c++ -*-
-// Copyright (c) 2024, Intel Corporation
+// Copyright (c) 2024-2025, Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 // @file stdlib.isph
@@ -33,19 +33,27 @@ __declspec(safe, cost0) inline uniform unsigned int64 intbits(uniform double d);
 
 __declspec(safe) inline float broadcast(float v, uniform int i);
 __declspec(safe) inline int8 broadcast(int8 v, uniform int i);
+__declspec(safe) inline unsigned int8 broadcast(unsigned int8 v, uniform int i);
 __declspec(safe) inline int16 broadcast(int16 v, uniform int i);
+__declspec(safe) inline unsigned int16 broadcast(unsigned int16 v, uniform int i);
 __declspec(safe) inline float16 broadcast(float16 v, uniform int i);
 __declspec(safe) inline int32 broadcast(int32 v, uniform int i);
+__declspec(safe) inline unsigned int32 broadcast(unsigned int32 v, uniform int i);
 __declspec(safe) inline double broadcast(double v, uniform int i);
 __declspec(safe) inline int64 broadcast(int64 v, uniform int i);
+__declspec(safe) inline unsigned int64 broadcast(unsigned int64 v, uniform int i);
 
 __declspec(safe) inline float rotate(float v, uniform int i);
 __declspec(safe) inline int8 rotate(int8 v, uniform int i);
+__declspec(safe) inline unsigned int8 rotate(unsigned int8 v, uniform int i);
 __declspec(safe) inline int16 rotate(int16 v, uniform int i);
+__declspec(safe) inline unsigned int16 rotate(unsigned int16 v, uniform int i);
 __declspec(safe) inline float16 rotate(float16 v, uniform int i);
 __declspec(safe) inline int32 rotate(int32 v, uniform int i);
+__declspec(safe) inline unsigned int32 rotate(unsigned int32 v, uniform int i);
 __declspec(safe) inline double rotate(double v, uniform int i);
 __declspec(safe) inline int64 rotate(int64 v, uniform int i);
+__declspec(safe) inline unsigned int64 rotate(unsigned int64 v, uniform int i);
 
 __declspec(safe) inline float shift(float v, uniform int i);
 __declspec(safe) inline int8 shift(int8 v, uniform int i);

--- a/stdlib/stdlib.ispc
+++ b/stdlib/stdlib.ispc
@@ -131,8 +131,20 @@ __declspec(safe) static inline int8 shift(int8 v, uniform int i) {
     return result;
 }
 
+__declspec(safe) static inline unsigned int8 shift(unsigned int8 v, uniform int i) {
+    varying unsigned int8 result;
+    unmasked { result = __shift_i8(v, i); }
+    return result;
+}
+
 __declspec(safe) static inline int16 shift(int16 v, uniform int i) {
     varying int16 result;
+    unmasked { result = __shift_i16(v, i); }
+    return result;
+}
+
+__declspec(safe) static inline unsigned int16 shift(unsigned int16 v, uniform int i) {
+    varying unsigned int16 result;
     unmasked { result = __shift_i16(v, i); }
     return result;
 }
@@ -149,6 +161,12 @@ __declspec(safe) static inline int32 shift(int32 v, uniform int i) {
     return result;
 }
 
+__declspec(safe) static inline unsigned int32 shift(unsigned int32 v, uniform int i) {
+    varying unsigned int32 result;
+    unmasked { result = __shift_i32(v, i); }
+    return result;
+}
+
 __declspec(safe) static inline double shift(double v, uniform int i) {
     varying double result;
     unmasked { result = __shift_double(v, i); }
@@ -161,33 +179,63 @@ __declspec(safe) static inline int64 shift(int64 v, uniform int i) {
     return result;
 }
 
+__declspec(safe) static inline unsigned int64 shift(unsigned int64 v, uniform int i) {
+    varying unsigned int64 result;
+    unmasked { result = __shift_i64(v, i); }
+    return result;
+}
+
 __declspec(safe) static inline float shuffle(float v, int i) { return __shuffle_float(v, i); }
 
 __declspec(safe) static inline int8 shuffle(int8 v, int i) { return __shuffle_i8(v, i); }
 
+__declspec(safe) static inline unsigned int8 shuffle(unsigned int8 v, int i) { return __shuffle_i8(v, i); }
+
 __declspec(safe) static inline int16 shuffle(int16 v, int i) { return __shuffle_i16(v, i); }
+
+__declspec(safe) static inline unsigned int16 shuffle(unsigned int16 v, int i) { return __shuffle_i16(v, i); }
 
 __declspec(safe) static inline float16 shuffle(float16 v, int i) { return __shuffle_half(v, i); }
 
 __declspec(safe) static inline int32 shuffle(int32 v, int i) { return __shuffle_i32(v, i); }
 
+__declspec(safe) static inline unsigned int32 shuffle(unsigned int32 v, int i) { return __shuffle_i32(v, i); }
+
 __declspec(safe) static inline double shuffle(double v, int i) { return __shuffle_double(v, i); }
 
 __declspec(safe) static inline int64 shuffle(int64 v, int i) { return __shuffle_i64(v, i); }
+
+__declspec(safe) static inline unsigned int64 shuffle(unsigned int64 v, int i) { return __shuffle_i64(v, i); }
 
 __declspec(safe) static inline float shuffle(float v0, float v1, int i) { return __shuffle2_float(v0, v1, i); }
 
 __declspec(safe) static inline int8 shuffle(int8 v0, int8 v1, int i) { return __shuffle2_i8(v0, v1, i); }
 
+__declspec(safe) static inline unsigned int8 shuffle(unsigned int8 v0, unsigned int8 v1, int i) {
+    return __shuffle2_i8(v0, v1, i);
+}
+
 __declspec(safe) static inline int16 shuffle(int16 v0, int16 v1, int i) { return __shuffle2_i16(v0, v1, i); }
+
+__declspec(safe) static inline unsigned int16 shuffle(unsigned int16 v0, unsigned int16 v1, int i) {
+    return __shuffle2_i16(v0, v1, i);
+}
 
 __declspec(safe) static inline float16 shuffle(float16 v0, float16 v1, int i) { return __shuffle2_half(v0, v1, i); }
 
 __declspec(safe) static inline int32 shuffle(int32 v0, int32 v1, int i) { return __shuffle2_i32(v0, v1, i); }
 
+__declspec(safe) static inline unsigned int32 shuffle(unsigned int32 v0, unsigned int32 v1, int i) {
+    return __shuffle2_i32(v0, v1, i);
+}
+
 __declspec(safe) static inline double shuffle(double v0, double v1, int i) { return __shuffle2_double(v0, v1, i); }
 
 __declspec(safe) static inline int64 shuffle(int64 v0, int64 v1, int i) { return __shuffle2_i64(v0, v1, i); }
+
+__declspec(safe) static inline unsigned int64 shuffle(unsigned int64 v0, unsigned int64 v1, int i) {
+    return __shuffle2_i64(v0, v1, i);
+}
 
 // x[i]
 __declspec(safe, cost1) static inline uniform float extract(float x, uniform int i) {

--- a/stdlib/stdlib.ispc
+++ b/stdlib/stdlib.ispc
@@ -73,29 +73,51 @@ __declspec(safe) static inline float broadcast(float v, uniform int i) { return 
 
 __declspec(safe) static inline int8 broadcast(int8 v, uniform int i) { return __broadcast_i8(v, i); }
 
+__declspec(safe) static inline unsigned int8 broadcast(unsigned int8 v, uniform int i) { return __broadcast_i8(v, i); }
+
 __declspec(safe) static inline int16 broadcast(int16 v, uniform int i) { return __broadcast_i16(v, i); }
+
+__declspec(safe) static inline unsigned int16 broadcast(unsigned int16 v, uniform int i) {
+    return __broadcast_i16(v, i);
+}
 
 __declspec(safe) static inline float16 broadcast(float16 v, uniform int i) { return __broadcast_half(v, i); }
 
 __declspec(safe) static inline int32 broadcast(int32 v, uniform int i) { return __broadcast_i32(v, i); }
 
+__declspec(safe) static inline unsigned int32 broadcast(unsigned int32 v, uniform int i) {
+    return __broadcast_i32(v, i);
+}
+
 __declspec(safe) static inline double broadcast(double v, uniform int i) { return __broadcast_double(v, i); }
 
 __declspec(safe) static inline int64 broadcast(int64 v, uniform int i) { return __broadcast_i64(v, i); }
+
+__declspec(safe) static inline unsigned int64 broadcast(unsigned int64 v, uniform int i) {
+    return __broadcast_i64(v, i);
+}
 
 __declspec(safe) static inline float rotate(float v, uniform int i) { return __rotate_float(v, i); }
 
 __declspec(safe) static inline int8 rotate(int8 v, uniform int i) { return __rotate_i8(v, i); }
 
+__declspec(safe) static inline unsigned int8 rotate(unsigned int8 v, uniform int i) { return __rotate_i8(v, i); }
+
 __declspec(safe) static inline int16 rotate(int16 v, uniform int i) { return __rotate_i16(v, i); }
+
+__declspec(safe) static inline unsigned int16 rotate(unsigned int16 v, uniform int i) { return __rotate_i16(v, i); }
 
 __declspec(safe) static inline float16 rotate(float16 v, uniform int i) { return __rotate_half(v, i); }
 
 __declspec(safe) static inline int32 rotate(int32 v, uniform int i) { return __rotate_i32(v, i); }
 
+__declspec(safe) static inline unsigned int32 rotate(unsigned int32 v, uniform int i) { return __rotate_i32(v, i); }
+
 __declspec(safe) static inline double rotate(double v, uniform int i) { return __rotate_double(v, i); }
 
 __declspec(safe) static inline int64 rotate(int64 v, uniform int i) { return __rotate_i64(v, i); }
+
+__declspec(safe) static inline unsigned int64 rotate(unsigned int64 v, uniform int i) { return __rotate_i64(v, i); }
 
 __declspec(safe) static inline float shift(float v, uniform int i) {
     varying float result;

--- a/tests/func-tests/broadcast-6.ispc
+++ b/tests/func-tests/broadcast-6.ispc
@@ -1,0 +1,10 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint32 a = aFOO[programIndex]; 
+    uint32 br = (programCount == 1) ? 4 : broadcast(a, (uniform int)b-2);
+    RET[programIndex] = br;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 4;
+}

--- a/tests/func-tests/broadcast-7.ispc
+++ b/tests/func-tests/broadcast-7.ispc
@@ -1,0 +1,10 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint8 a = aFOO[programIndex]; 
+    uint8 br = (programCount == 1) ? 4 : broadcast(a, (uniform int)b-2);
+    RET[programIndex] = br;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 4;
+}

--- a/tests/func-tests/broadcast-8.ispc
+++ b/tests/func-tests/broadcast-8.ispc
@@ -1,0 +1,10 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uint16 a = aFOO[programIndex]; 
+    uint16 b = (programCount == 1) ? 3 : broadcast(a, 2);
+    RET[programIndex] = b;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 3;
+}

--- a/tests/func-tests/broadcast-9.ispc
+++ b/tests/func-tests/broadcast-9.ispc
@@ -1,0 +1,10 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint64 a = aFOO[programIndex]; 
+    uint64 br = (programCount == 1) ? 4 : broadcast(a, (uniform int)b-2);
+    RET[programIndex] = br;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 4;
+}

--- a/tests/func-tests/extract-2.ispc
+++ b/tests/func-tests/extract-2.ispc
@@ -1,0 +1,9 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uint8 a = programIndex;
+    RET[programIndex] = extract(a, min(programCount-1, 3)); 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = (programCount == 1) ? 0 : 3;
+}

--- a/tests/func-tests/extract-3.ispc
+++ b/tests/func-tests/extract-3.ispc
@@ -1,0 +1,9 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uint16 a = programIndex;
+    RET[programIndex] = extract(a, min(programCount-1, 3)); 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = (programCount == 1) ? 0 : 3;
+}

--- a/tests/func-tests/extract-4.ispc
+++ b/tests/func-tests/extract-4.ispc
@@ -1,0 +1,9 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uint32 a = programIndex;
+    RET[programIndex] = extract(a, min(programCount-1, 3)); 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = (programCount == 1) ? 0 : 3;
+}

--- a/tests/func-tests/extract-5.ispc
+++ b/tests/func-tests/extract-5.ispc
@@ -1,0 +1,9 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uint64 a = programIndex;
+    RET[programIndex] = extract(a, min(programCount-1, 3)); 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = (programCount == 1) ? 0 : 3;
+}

--- a/tests/func-tests/insert-3.ispc
+++ b/tests/func-tests/insert-3.ispc
@@ -1,0 +1,11 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uint16 a;
+    for (uniform int i = 0; i < programCount; ++i)
+        a = insert(a, i, (uint16)i);
+    RET[programIndex] = a; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = programIndex;
+}

--- a/tests/func-tests/insert-4.ispc
+++ b/tests/func-tests/insert-4.ispc
@@ -1,0 +1,11 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uint32 a;
+    for (uniform int i = 0; i < programCount; ++i)
+        a = insert(a, i, (uint32)i);
+    RET[programIndex] = a; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = programIndex;
+}

--- a/tests/func-tests/insert-5.ispc
+++ b/tests/func-tests/insert-5.ispc
@@ -1,0 +1,11 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uint64 a;
+    for (uniform int i = 0; i < programCount; ++i)
+        a = insert(a, i, (uint64)i);
+    RET[programIndex] = a; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = programIndex;
+}

--- a/tests/func-tests/insert-6.ispc
+++ b/tests/func-tests/insert-6.ispc
@@ -1,0 +1,11 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uint8 a;
+    for (uniform int i = 0; i < programCount; ++i)
+        a = insert(a, i, (uint8)i);
+    RET[programIndex] = a; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = programIndex;
+}

--- a/tests/func-tests/rotate-10.ispc
+++ b/tests/func-tests/rotate-10.ispc
@@ -1,0 +1,10 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint8 a = aFOO[programIndex]; 
+    uint8 rot = rotate(a, 2);
+    RET[programIndex] = rot;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + (programIndex + 2) % programCount;
+}

--- a/tests/func-tests/rotate-11.ispc
+++ b/tests/func-tests/rotate-11.ispc
@@ -1,0 +1,10 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint16 a = aFOO[programIndex]; 
+    uint16 rot = rotate(a, -1);
+    RET[programIndex] = rot;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + (programIndex + programCount - 1) % programCount;
+}

--- a/tests/func-tests/rotate-8.ispc
+++ b/tests/func-tests/rotate-8.ispc
@@ -1,0 +1,10 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint32 a = aFOO[programIndex]; 
+    uint32 rot = rotate(a, 2);
+    RET[programIndex] = rot;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + (programIndex + 2) % programCount;
+}

--- a/tests/func-tests/rotate-9.ispc
+++ b/tests/func-tests/rotate-9.ispc
@@ -1,0 +1,10 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint64 a = aFOO[programIndex]; 
+    uint64 rot = rotate(a, -1);
+    RET[programIndex] = rot;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + (programIndex + programCount - 1) % programCount;
+}

--- a/tests/func-tests/shift-5.ispc
+++ b/tests/func-tests/shift-5.ispc
@@ -1,0 +1,12 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint8 a = aFOO[programIndex]; 
+    uint8 rot = shift(a, 1);
+    RET[programIndex] = rot;
+}
+
+task void result(uniform float RET[]) {
+    varying int val = 2 + programIndex;
+    if (val > programCount) val = 0;	 
+    RET[programIndex] = val;	 
+}   

--- a/tests/func-tests/shift-6.ispc
+++ b/tests/func-tests/shift-6.ispc
@@ -1,0 +1,12 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint16 a = aFOO[programIndex]; 
+    uint16 rot = shift(a, 1);
+    RET[programIndex] = rot;
+}
+
+task void result(uniform float RET[]) {
+    varying int val = 2 + programIndex;
+    if (val > programCount) val = 0;	 
+    RET[programIndex] = val;	 
+}   

--- a/tests/func-tests/shift-7.ispc
+++ b/tests/func-tests/shift-7.ispc
@@ -1,0 +1,12 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint32 a = aFOO[programIndex]; 
+    uint32 rot = shift(a, 1);
+    RET[programIndex] = rot;
+}
+
+task void result(uniform float RET[]) {
+    varying int val = 2 + programIndex;
+    if (val > programCount) val = 0;	 
+    RET[programIndex] = val;	 
+}   

--- a/tests/func-tests/shift-8.ispc
+++ b/tests/func-tests/shift-8.ispc
@@ -1,0 +1,12 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint64 a = aFOO[programIndex]; 
+    uint64 rot = shift(a, 1);
+    RET[programIndex] = rot;
+}
+
+task void result(uniform float RET[]) {
+    varying int val = 2 + programIndex;
+    if (val > programCount) val = 0;	 
+    RET[programIndex] = val;	 
+}   

--- a/tests/func-tests/shuffle-10.ispc
+++ b/tests/func-tests/shuffle-10.ispc
@@ -1,0 +1,11 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint64 a = aFOO[programIndex]; 
+    int reverse = programCount - 1 - programIndex + (int)b - 5;
+    uint64 shuf = shuffle(a, reverse);
+    RET[programIndex] = shuf;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = programCount - programIndex;
+}

--- a/tests/func-tests/shuffle-7.ispc
+++ b/tests/func-tests/shuffle-7.ispc
@@ -1,0 +1,11 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint16 a = aFOO[programIndex]; 
+    int reverse = programCount - 1 - programIndex;
+    uint16 shuf = shuffle(a, reverse);
+    RET[programIndex] = shuf;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = programCount - programIndex;
+}

--- a/tests/func-tests/shuffle-8.ispc
+++ b/tests/func-tests/shuffle-8.ispc
@@ -1,0 +1,11 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint8 a = aFOO[programIndex]; 
+    int reverse = programCount - 1 - programIndex + (int)b - 5;
+    uint8 shuf = shuffle(a, reverse);
+    RET[programIndex] = shuf;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = programCount - programIndex;
+}

--- a/tests/func-tests/shuffle-9.ispc
+++ b/tests/func-tests/shuffle-9.ispc
@@ -1,0 +1,11 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint32 a = aFOO[programIndex]; 
+    int reverse = programCount - 1 - programIndex + (int)b - 5;
+    uint32 shuf = shuffle(a, reverse);
+    RET[programIndex] = shuf;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = programCount - programIndex;
+}

--- a/tests/func-tests/shuffle2-13.ispc
+++ b/tests/func-tests/shuffle2-13.ispc
@@ -1,0 +1,11 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint8 aa = aFOO[programIndex]; 
+    uint8 bb = aa + programCount;
+    uint8 shuf = shuffle(aa, bb, 1);
+    RET[programIndex] = shuf;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 2;
+}

--- a/tests/func-tests/shuffle2-14.ispc
+++ b/tests/func-tests/shuffle2-14.ispc
@@ -1,0 +1,11 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint16 aa = aFOO[programIndex]; 
+    uint16 bb = aa + programCount;
+    uint16 shuf = shuffle(aa, bb, 2*programIndex);
+    RET[programIndex] = shuf;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + 2*programIndex;
+}

--- a/tests/func-tests/shuffle2-15.ispc
+++ b/tests/func-tests/shuffle2-15.ispc
@@ -1,0 +1,11 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint32 aa = aFOO[programIndex]; 
+    uint32 bb = aa + programCount;
+    uint32 shuf = shuffle(aa, bb, 2*programIndex);
+    RET[programIndex] = shuf;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + 2*programIndex;
+}

--- a/tests/func-tests/shuffle2-16.ispc
+++ b/tests/func-tests/shuffle2-16.ispc
@@ -1,0 +1,11 @@
+#include "test_static.isph"
+task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
+    uint64 aa = aFOO[programIndex]; 
+    uint64 bb = aa + programCount;
+    uint64 shuf = shuffle(aa, bb, 2*programIndex);
+    RET[programIndex] = shuf;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + 2*programIndex;
+}


### PR DESCRIPTION
This is the first part of adding missing stdlib functions for unsigned types. Fixes https://github.com/ispc/ispc/issues/3139