### PR TITLE
Minor docs and CI update 

### DIFF
--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  zip_url: https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.zip?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202019%2C%20LLVM_VERSION%3Dlatest
-  tar_url: https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-linux.tar.gz?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DUbuntu2204%2C%20LLVM_VERSION%3Dlatest
+  zip_url: https://github.com/ispc/ispc/releases/download/trunk-artifacts/ispc-trunk-windows.zip
+  tar_url: https://github.com/ispc/ispc/releases/download/trunk-artifacts/ispc-trunk-linux.tar.gz
 
 jobs:
   scan:

--- a/.github/workflows/cve-bin.yml
+++ b/.github/workflows/cve-bin.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  zip_url: https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.zip?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202019%2C%20LLVM_VERSION%3Dlatest
-  tar_url: https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-linux.tar.gz?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DUbuntu2204%2C%20LLVM_VERSION%3Dlatest
+  zip_url: https://github.com/ispc/ispc/releases/download/trunk-artifacts/ispc-trunk-windows.zip
+  tar_url: https://github.com/ispc/ispc/releases/download/trunk-artifacts/ispc-trunk-linux.tar.gz
 
 jobs:
   scan:

--- a/.github/workflows/dll-inject.yml
+++ b/.github/workflows/dll-inject.yml
@@ -1,7 +1,7 @@
 # Copyright 2024-2025, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
-name: Check against DLL injection (trunc)
+name: Check against DLL injection (trunk)
 
 permissions: read-all
 
@@ -32,9 +32,9 @@ jobs:
         pip install defusedxml
       shell: powershell
 
-    - name: Download ISPC trunc archives
+    - name: Download ISPC trunk archives
       env:
-        ZIP_URL: https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.zip?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202019%2C%20LLVM_VERSION%3Dlatest
+        ZIP_URL: https://github.com/ispc/ispc/releases/download/trunk-artifacts/ispc-trunk-windows.zip
       run: |
         ZIP="ispc-trunk-windows.zip"
         echo "Download artifact $ZIP_URL" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/hardening-check.yml
+++ b/.github/workflows/hardening-check.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ZIP_URL: https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.zip?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202019%2C%20LLVM_VERSION%3Dlatest
-  TAR_URL: https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-linux.tar.gz?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DUbuntu2204%2C%20LLVM_VERSION%3Dlatest
+  ZIP_URL: https://github.com/ispc/ispc/releases/download/trunk-artifacts/ispc-trunk-windows.zip
+  TAR_URL: https://github.com/ispc/ispc/releases/download/trunk-artifacts/ispc-trunk-linux.tar.gz
 
 jobs:
   hardening_check:

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -4347,7 +4347,12 @@ The ISPC Standard Library
 
 ``ispc`` has a standard library that is automatically available when
 compiling ``ispc`` programs.  (To disable the standard library, pass the
-``--nostdlib`` command-line flag to the compiler.)
+``--nostdlib`` command-line flag to the compiler.).
+For a complete list of functions available in the standard library, consult the
+`stdlib.isph`_ header file. This file serves as the definitive reference for all
+the function declarations provided by the standard library.
+
+.. _stdlib.isph: https://github.com/ispc/ispc/tree/main/stdlib/include/stdlib.isph
 
 Basic Operations On Data
 ------------------------


### PR DESCRIPTION
1. Mention `stdlib.isph` as a reference for standard library functions, fixes https://github.com/ispc/ispc/issues/2349
2. Replace appveyor with trunk-releases in CI workflows.