### PR TITLE
[WIP] Prototype of tensor support in ISPC (tensor add)

### DIFF
--- a/benchmarks/04_tensor/01_tensor_add.cpp
+++ b/benchmarks/04_tensor/01_tensor_add.cpp
@@ -1,0 +1,249 @@
+#include "../common.h"
+#include "01_tensor_add_ispc.h"
+#include "dlpack.h"
+#include <benchmark/benchmark.h>
+#include <cmath>
+#include <cstdint>
+#include <stdio.h>
+
+static Docs docs("Tensor addition benchmark\n"
+                 "Expectations:\n"
+                 " - Tests different tensor shapes and data types\n"
+                 " - Validates correctness of the tensor addition operation");
+
+WARM_UP_RUN();
+
+// Initialize tensors with random data
+template <typename T> void init(T *a_data, T *b_data, T *c_data, int count) {
+    for (int i = 0; i < count; ++i) {
+        a_data[i] = static_cast<T>(i % 100);        // Fill A with sample values
+        b_data[i] = static_cast<T>((i + 50) % 100); // Fill B with different values
+        c_data[i] = static_cast<T>(0);              // Zero-initialize the result tensor
+    }
+}
+
+// Validate results of tensor addition
+template <typename T>
+bool validate_results(const T *a_data, const T *b_data, const T *c_data, DLTensor &A, DLTensor &B, DLTensor &C) {
+    // Get tensor dimensions and properties
+    const int ndim = A.ndim;
+    int total_size = 1;
+    for (int i = 0; i < ndim; i++) {
+        total_size *= A.shape[i];
+    }
+
+    // For each logical element in the tensor
+    for (int i = 0; i < total_size; i++) {
+        // Calculate the physical indices using the same logic as the tensor operation
+        int physical_idx_A = 0;
+        int physical_idx_B = 0;
+        int physical_idx_C = 0;
+
+        // Decompose linear index to coordinates
+        int temp_idx = i;
+        for (int d = ndim - 1; d >= 0; d--) {
+            int coord = temp_idx % A.shape[d];
+            temp_idx /= A.shape[d];
+
+            // Apply strides to get physical index
+            physical_idx_A += coord * A.strides[d];
+            physical_idx_B += coord * B.strides[d];
+            physical_idx_C += coord * C.strides[d];
+        }
+
+        // Get values at the correct physical locations
+        T a_val = a_data[physical_idx_A];
+        T b_val = b_data[physical_idx_B];
+        T c_val = c_data[physical_idx_C];
+        T expected = a_val + b_val;
+
+        // For floating point, use epsilon-based comparison
+        if (std::is_floating_point<T>::value) {
+            T epsilon = static_cast<T>(1e-5);
+            if (std::abs(c_val - expected) > epsilon) {
+                printf("Validation failed at logical index %d (physical index %d): Expected %f, Got %f\n", i,
+                       physical_idx_C, static_cast<double>(expected), static_cast<double>(c_val));
+                printf("A[%d]=%f, B[%d]=%f\n", physical_idx_A, static_cast<double>(a_val), physical_idx_B,
+                       static_cast<double>(b_val));
+                return false;
+            }
+        } else {
+            // For integer types, use exact comparison
+            if (c_val != expected) {
+                printf("Validation failed at logical index %d (physical index %d): Expected %d, Got %d\n", i,
+                       physical_idx_C, static_cast<int>(expected), static_cast<int>(c_val));
+                printf("A[%d]=%d, B[%d]=%d\n", physical_idx_A, static_cast<int>(a_val), physical_idx_B,
+                       static_cast<int>(b_val));
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+// Generic function to initialize a DLTensor with proper strides
+template <typename T>
+void CreateDLTensor(DLTensor &tensor, T *data, const std::vector<int64_t> &shape, DLDataType dtype,
+                    bool non_contiguous = false, int64_t padding = 1) {
+    tensor.data = data;
+    tensor.ndim = shape.size();
+    tensor.shape = new int64_t[tensor.ndim];
+    tensor.strides = new int64_t[tensor.ndim];
+
+    // Copy shape values
+    for (int i = 0; i < tensor.ndim; i++) {
+        tensor.shape[i] = shape[i];
+    }
+
+    // Compute strides (row-major layout by default)
+    if (!non_contiguous) {
+        // Contiguous layout (C-order)
+        tensor.strides[tensor.ndim - 1] = 1;
+        for (int i = tensor.ndim - 2; i >= 0; --i) {
+            tensor.strides[i] = tensor.strides[i + 1] * tensor.shape[i + 1];
+        }
+    } else {
+        // Non-contiguous layout with uniform padding
+        // For the innermost dimension (last one according to tensor terminology), use padding+1 as the stride
+        tensor.strides[tensor.ndim - 1] = padding + 1;
+
+        // For other dimensions, add padding to the normal stride computation
+        for (int i = tensor.ndim - 2; i >= 0; --i) {
+            tensor.strides[i] = (tensor.strides[i + 1] * tensor.shape[i + 1]) + padding;
+        }
+    }
+
+    tensor.byte_offset = 0;
+    tensor.dtype = dtype;
+
+    // Set device to CPU
+    tensor.device.device_type = kDLCPU;
+    tensor.device.device_id = 0;
+}
+
+// Clean up resources for a DLTensor
+void CleanupDLTensor(DLTensor &tensor) {
+    delete[] tensor.shape;
+    delete[] tensor.strides;
+}
+
+// Helper function to determine which ISPC function to call based on type
+template <typename T> void call_ispc_tensor_add(const DLTensor *A, const DLTensor *B, DLTensor *C) {
+    // This will be specialized for each type
+    // Default implementation might throw an error or use a generic version
+    std::cerr << "Unsupported type for ISPC tensor addition" << std::endl;
+    throw std::runtime_error("Unsupported type");
+}
+
+// Specializations for different types
+template <> void call_ispc_tensor_add<float>(const DLTensor *A, const DLTensor *B, DLTensor *C) {
+    ispc::tensor_add_ISPC_float((void *)A, (void *)B, (void *)C);
+}
+
+template <> void call_ispc_tensor_add<double>(const DLTensor *A, const DLTensor *B, DLTensor *C) {
+    ispc::tensor_add_ISPC_double((void *)A, (void *)B, (void *)C);
+}
+
+template <> void call_ispc_tensor_add<int32_t>(const DLTensor *A, const DLTensor *B, DLTensor *C) {
+    ispc::tensor_add_ISPC_int32((void *)A, (void *)B, (void *)C);
+}
+
+// Benchmarking function for ISPC tensor addition with validation
+template <typename T> static void tensor_add(benchmark::State &state, DLDataTypeCode code, int bits) {
+    const int count = static_cast<int>(state.range(0));
+    const int ndim = static_cast<int>(state.range(1));
+
+    // Create tensor shapes based on ndim
+    std::vector<int64_t> shape;
+    if (ndim == 1) {
+        shape = {count}; // 1D tensor
+    } else if (ndim == 2) {
+        int side = static_cast<int>(std::sqrt(count));
+        shape = {side, side}; // 2D square tensor
+    } else if (ndim == 3) {
+        int side = static_cast<int>(std::cbrt(count));
+        shape = {side, side, side}; // 3D cube tensor
+    } else {
+        // Fallback to 1D
+        shape = {count};
+    }
+
+    // Calculate total elements
+    int total_elements = 1;
+    for (int i = 0; i < ndim; i++) {
+        total_elements *= shape[i];
+    }
+
+    bool non_contiguous = (state.range(2) == 1);
+    // Determine padding factor based on dimensions for non-contiguous case
+    int padding_factor = 2; // Default for 1D
+    if (non_contiguous) {
+        // For higher dimensions, we need more memory
+        if (ndim == 2)
+            padding_factor = 3; // For 2D
+        else if (ndim >= 3)
+            padding_factor = 4; // For 3D and higher
+    }
+
+    // Allocate memory with padding for non-contiguous test
+    T *a_data = static_cast<T *>(aligned_alloc_helper(sizeof(T) * total_elements * padding_factor));
+    T *b_data = static_cast<T *>(aligned_alloc_helper(sizeof(T) * total_elements * padding_factor));
+    T *c_data = static_cast<T *>(aligned_alloc_helper(sizeof(T) * total_elements * padding_factor));
+
+    init(a_data, b_data, c_data, total_elements * padding_factor);
+
+    // Create DLTensors with proper data type
+    DLTensor A, B, C;
+    // We will not use DLDataType but keep it for now for reference
+    DLDataType dtype;
+    dtype.code = code;
+    dtype.bits = static_cast<uint8_t>(bits);
+    dtype.lanes = 1;
+
+    CreateDLTensor(A, a_data, shape, dtype, non_contiguous);
+    CreateDLTensor(B, b_data, shape, dtype, non_contiguous);
+    CreateDLTensor(C, c_data, shape, dtype, non_contiguous);
+
+    // Run the benchmark
+    for (auto _ : state) {
+        call_ispc_tensor_add<T>(&A, &B, &C);
+    }
+
+    // Validate results
+    bool valid = validate_results(a_data, b_data, c_data, A, B, C);
+    if (!valid) {
+        state.SkipWithError("Result validation failed!");
+    }
+
+    // Cleanup
+    aligned_free_helper(a_data);
+    aligned_free_helper(b_data);
+    aligned_free_helper(c_data);
+    CleanupDLTensor(A);
+    CleanupDLTensor(B);
+    CleanupDLTensor(C);
+}
+
+// Define benchmarks for different types and configurations
+static void tensor_add_float(benchmark::State &state) { tensor_add<float>(state, kDLFloat, 32); }
+
+static void tensor_add_int(benchmark::State &state) { tensor_add<int32_t>(state, kDLInt, 32); }
+
+static void tensor_add_double(benchmark::State &state) { tensor_add<double>(state, kDLFloat, 64); }
+
+// Register benchmarks: args are (elements, dimensions, non_contiguous?)
+// 1D contiguous
+BENCHMARK(tensor_add_float)->Args({1024, 1, 0})->Args({4096, 1, 0});
+BENCHMARK(tensor_add_int)->Args({1024, 1, 0})->Args({4096, 1, 0});
+
+// 2D contiguous
+BENCHMARK(tensor_add_float)->Args({1024, 2, 0})->Args({4096, 2, 0});
+
+// 3D contiguous
+BENCHMARK(tensor_add_float)->Args({1000, 3, 0})->Args({8000, 3, 0});
+
+// Non-contiguous tests
+BENCHMARK(tensor_add_float)->Args({1024, 1, 1})->Args({4096, 2, 1});
+BENCHMARK(tensor_add_double)->Args({1024, 2, 0})->Args({1024, 2, 1});
+
+BENCHMARK_MAIN();

--- a/benchmarks/04_tensor/01_tensor_add.ispc
+++ b/benchmarks/04_tensor/01_tensor_add.ispc
@@ -1,0 +1,6 @@
+// Copyright (c) 2025, Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+#include "tensor.isph"
+export void tensor_add_ISPC_int32(void *uniform A, void *uniform B, void *uniform C) { tensor_add<int>(A, B, C); }
+export void tensor_add_ISPC_float(void *uniform A, void *uniform B, void *uniform C) { tensor_add<float>(A, B, C); }
+export void tensor_add_ISPC_double(void *uniform A, void *uniform B, void *uniform C) { tensor_add<double>(A, B, C); }

--- a/benchmarks/04_tensor/02_tensor_mul.cpp
+++ b/benchmarks/04_tensor/02_tensor_mul.cpp
@@ -1,0 +1,287 @@
+#include "../common.h"
+#include "02_tensor_mul_ispc.h"
+#include "dlpack.h"
+#include <benchmark/benchmark.h>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <stdio.h>
+
+static Docs docs("Tensor multiplication benchmark\n"
+                 "Expectations:\n"
+                 " - Tests different tensor shapes and data types\n"
+                 " - Validates correctness of the tensor multiplication operation\n"
+                 " - Special handling for matrix multiplication in 2D and batched matrix multiplication in 3D cases");
+
+WARM_UP_RUN();
+
+// Initialize tensors with random data
+template <typename T> void init(T *a_data, T *b_data, T *c_data, int count) {
+    for (int i = 0; i < count; ++i) {
+        a_data[i] = static_cast<T>((i % 10) + 1);       // Fill A with sample values (avoid zeros)
+        b_data[i] = static_cast<T>(((i + 3) % 10) + 1); // Fill B with different values
+        c_data[i] = static_cast<T>(0);                  // Zero-initialize the result tensor
+    }
+}
+
+// Helper function to calculate the expected result for element-wise multiplication (general case)
+template <typename T>
+void calculate_expected(const T *a_data, const T *b_data, T *expected_data, const DLTensor &A, const DLTensor &B,
+                        const DLTensor &C) {
+    // Get tensor dimensions
+    const int ndim = A.ndim;
+    int total_size = 1;
+    for (int i = 0; i < ndim; i++) {
+        total_size *= A.shape[i];
+    }
+
+    // For each logical element in the tensor
+    for (int i = 0; i < total_size; i++) {
+        // Calculate the physical indices using the same logic as in the tensor operation
+        int physical_idx_A = 0;
+        int physical_idx_B = 0;
+        int physical_idx_C = 0;
+
+        // Decompose linear index to coordinates
+        int temp_idx = i;
+        for (int d = ndim - 1; d >= 0; d--) {
+            int coord = temp_idx % A.shape[d];
+            temp_idx /= A.shape[d];
+
+            // Apply strides to get physical index
+            physical_idx_A += coord * A.strides[d];
+            physical_idx_B += coord * B.strides[d];
+            physical_idx_C += coord * C.strides[d];
+        }
+
+        // Element-wise multiplication
+        expected_data[physical_idx_C] = a_data[physical_idx_A] * b_data[physical_idx_B];
+    }
+}
+
+// Validate results of tensor multiplication
+template <typename T>
+bool validate_results(const T *a_data, const T *b_data, const T *c_data, DLTensor &A, DLTensor &B, DLTensor &C) {
+    const int ndim = A.ndim;
+
+    // Create expected results array
+    int total_size = 1;
+    for (int i = 0; i < ndim; i++) {
+        total_size *= A.shape[i];
+    }
+
+    T *expected_data = new T[total_size * 2]; // Extra space for padding if needed
+    memset(expected_data, 0, sizeof(T) * total_size * 2);
+
+    // Calculate expected results based on tensor dimensions
+    calculate_expected(a_data, b_data, expected_data, A, B, C);
+
+    // Compare with actual results
+    bool valid = true;
+    for (int i = 0; i < total_size; i++) {
+        // Calculate physical index
+        int physical_idx_C = 0;
+        int temp_idx = i;
+        for (int d = ndim - 1; d >= 0; d--) {
+            int coord = temp_idx % C.shape[d];
+            temp_idx /= C.shape[d];
+            physical_idx_C += coord * C.strides[d];
+        }
+
+        T c_val = c_data[physical_idx_C];
+        T expected = expected_data[physical_idx_C];
+
+        // For floating point, use epsilon-based comparison
+        if (std::is_floating_point<T>::value) {
+            T epsilon = static_cast<T>(1e-3); // Larger epsilon for matrix multiplication
+            if (std::abs(c_val - expected) > epsilon * (1 + std::abs(expected))) {
+                printf("Validation failed at logical index %d (physical index %d): Expected %f, Got %f\n", i,
+                       physical_idx_C, static_cast<double>(expected), static_cast<double>(c_val));
+                valid = false;
+                break;
+            }
+        } else {
+            // For integer types, use exact comparison
+            if (c_val != expected) {
+                printf("Validation failed at logical index %d (physical index %d): Expected %d, Got %d\n", i,
+                       physical_idx_C, static_cast<int>(expected), static_cast<int>(c_val));
+                valid = false;
+                break;
+            }
+        }
+    }
+
+    delete[] expected_data;
+    return valid;
+}
+
+// Generic function to initialize a DLTensor with proper strides
+template <typename T>
+void CreateDLTensor(DLTensor &tensor, T *data, const std::vector<int64_t> &shape, DLDataType dtype,
+                    bool non_contiguous = false, int64_t padding = 1) {
+    tensor.data = data;
+    tensor.ndim = shape.size();
+    tensor.shape = new int64_t[tensor.ndim];
+    tensor.strides = new int64_t[tensor.ndim];
+
+    // Copy shape values
+    for (int i = 0; i < tensor.ndim; i++) {
+        tensor.shape[i] = shape[i];
+    }
+
+    // Compute strides (row-major layout by default)
+    if (!non_contiguous) {
+        // Contiguous layout (C-order)
+        tensor.strides[tensor.ndim - 1] = 1;
+        for (int i = tensor.ndim - 2; i >= 0; --i) {
+            tensor.strides[i] = tensor.strides[i + 1] * tensor.shape[i + 1];
+        }
+    } else {
+        // Non-contiguous layout with uniform padding
+        // For the innermost dimension (last one according to tensor terminology), use padding+1 as the stride
+        tensor.strides[tensor.ndim - 1] = padding + 1;
+
+        // For other dimensions, add padding to the normal stride computation
+        for (int i = tensor.ndim - 2; i >= 0; --i) {
+            tensor.strides[i] = (tensor.strides[i + 1] * tensor.shape[i + 1]) + padding;
+        }
+    }
+
+    tensor.byte_offset = 0;
+    tensor.dtype = dtype;
+
+    // Set device to CPU
+    tensor.device.device_type = kDLCPU;
+    tensor.device.device_id = 0;
+}
+
+// Clean up resources for a DLTensor
+void CleanupDLTensor(DLTensor &tensor) {
+    delete[] tensor.shape;
+    delete[] tensor.strides;
+}
+
+// Helper function to determine which ISPC function to call based on type
+template <typename T> void call_ispc_tensor_mul(const DLTensor *A, const DLTensor *B, DLTensor *C) {
+    // This will be specialized for each type
+    // Default implementation might throw an error or use a generic version
+    std::cerr << "Unsupported type for ISPC tensor multiplication" << std::endl;
+    throw std::runtime_error("Unsupported type");
+}
+
+// Specializations for different types
+template <> void call_ispc_tensor_mul<float>(const DLTensor *A, const DLTensor *B, DLTensor *C) {
+    ispc::tensor_mul_ISPC_float((void *)A, (void *)B, (void *)C);
+}
+
+template <> void call_ispc_tensor_mul<double>(const DLTensor *A, const DLTensor *B, DLTensor *C) {
+    ispc::tensor_mul_ISPC_double((void *)A, (void *)B, (void *)C);
+}
+
+template <> void call_ispc_tensor_mul<int32_t>(const DLTensor *A, const DLTensor *B, DLTensor *C) {
+    ispc::tensor_mul_ISPC_int32((void *)A, (void *)B, (void *)C);
+}
+
+// Benchmarking function for element-wise multiplication (1D, 3D, 4D, etc.)
+template <typename T> static void tensor_mul(benchmark::State &state, DLDataTypeCode code, int bits) {
+    const int total_elements = static_cast<int>(state.range(0));
+    const int ndim = static_cast<int>(state.range(1));
+    bool non_contiguous = (state.range(2) == 1);
+
+    // Create shape based on ndim
+    std::vector<int64_t> shape;
+    if (ndim == 1) {
+        shape = {total_elements}; // 1D tensor
+    } else if (ndim == 3) {
+        int side = static_cast<int>(std::cbrt(total_elements));
+        shape = {side, side, side}; // 3D cube tensor
+    } else if (ndim == 4) {
+        int side = static_cast<int>(std::sqrt(std::sqrt(total_elements)));
+        shape = {side, side, side, side}; // 4D hypercube tensor
+    } else {
+        // Fallback to 1D
+        shape = {total_elements};
+    }
+
+    // Calculate total elements with padding
+    int padding_factor = non_contiguous ? 4 : 1;
+    size_t padded_elements = static_cast<size_t>(total_elements) * padding_factor;
+
+    // Check for potential overflow
+    if (padded_elements == 0 || padded_elements > 100000000) {
+        state.SkipWithError("Invalid or excessive tensor size");
+        return;
+    }
+
+    // Allocate memory
+    T *a_data = static_cast<T *>(aligned_alloc_helper(sizeof(T) * padded_elements));
+    T *b_data = static_cast<T *>(aligned_alloc_helper(sizeof(T) * padded_elements));
+    T *c_data = static_cast<T *>(aligned_alloc_helper(sizeof(T) * padded_elements));
+
+    // Initialize with test data
+    init(a_data, b_data, c_data, padded_elements);
+
+    // Create DLTensors
+    DLTensor A, B, C;
+    DLDataType dtype;
+    dtype.code = code;
+    dtype.bits = static_cast<uint8_t>(bits);
+    dtype.lanes = 1;
+
+    CreateDLTensor(A, a_data, shape, dtype, non_contiguous);
+    CreateDLTensor(B, b_data, shape, dtype, non_contiguous);
+    CreateDLTensor(C, c_data, shape, dtype, non_contiguous);
+
+    // Run the benchmark
+    for (auto _ : state) {
+        call_ispc_tensor_mul<T>(&A, &B, &C);
+    }
+
+    // Validate results
+    bool valid = validate_results(a_data, b_data, c_data, A, B, C);
+    if (!valid) {
+        state.SkipWithError("Element-wise multiplication result validation failed!");
+    }
+
+    // Cleanup
+    aligned_free_helper(a_data);
+    aligned_free_helper(b_data);
+    aligned_free_helper(c_data);
+    CleanupDLTensor(A);
+    CleanupDLTensor(B);
+    CleanupDLTensor(C);
+}
+
+// Define benchmarks for different types and configurations
+static void tensor_mul_float(benchmark::State &state) { tensor_mul<float>(state, kDLFloat, 32); }
+
+static void tensor_mul_int(benchmark::State &state) { tensor_mul<int32_t>(state, kDLInt, 32); }
+
+static void tensor_mul_double(benchmark::State &state) { tensor_mul<double>(state, kDLFloat, 64); }
+
+// Matrix multiplication benchmarks - varying sizes
+BENCHMARK(tensor_mul_float)->Args({32, 32, 32, 0})->Args({64, 64, 64, 0})->Args({128, 128, 128, 0});
+BENCHMARK(tensor_mul_int)->Args({32, 32, 32, 0})->Args({64, 64, 64, 0});
+BENCHMARK(tensor_mul_double)->Args({32, 32, 32, 0})->Args({64, 64, 64, 0});
+
+// Non-square matrices - ensure valid matrix dimensions where A is [M×N] and B is [N×K]
+// BENCHMARK(tensor_mul_float)->Args({64, 32, 16, 0})->Args({32, 64, 32, 0});
+
+// Non-contiguous matrices
+// BENCHMARK(tensor_mul_float)->Args({64, 64, 64, 1});
+
+// Register benchmarks for element-wise multiplication: args are (elements, dimensions, non_contiguous?)
+// 1D element-wise
+BENCHMARK(tensor_mul_float)->Args({1024, 1, 0})->Args({4096, 1, 0});
+BENCHMARK(tensor_mul_int)->Args({1024, 1, 0});
+
+// 3D element-wise
+BENCHMARK(tensor_mul_float)->Args({2048, 3, 0})->Args({8096, 3, 0});
+
+// 4D element-wise
+BENCHMARK(tensor_mul_float)->Args({1024, 4, 0});
+
+// Non-contiguous element-wise
+// BENCHMARK(tensor_matmul_float)->Args({1024, 3, 1});
+
+BENCHMARK_MAIN();

--- a/benchmarks/04_tensor/02_tensor_mul.ispc
+++ b/benchmarks/04_tensor/02_tensor_mul.ispc
@@ -1,0 +1,6 @@
+// Copyright (c) 2025, Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+#include "tensor.isph"
+export void tensor_mul_ISPC_int32(void *uniform A, void *uniform B, void *uniform C) { tensor_mul<int>(A, B, C); }
+export void tensor_mul_ISPC_float(void *uniform A, void *uniform B, void *uniform C) { tensor_mul<float>(A, B, C); }
+export void tensor_mul_ISPC_double(void *uniform A, void *uniform B, void *uniform C) { tensor_mul<double>(A, B, C); }

--- a/benchmarks/04_tensor/CMakeLists.txt
+++ b/benchmarks/04_tensor/CMakeLists.txt
@@ -5,3 +5,4 @@
 
 # List the benchmarks
 compile_benchmark_test(01_tensor_add)
+compile_benchmark_test(02_tensor_mul)

--- a/benchmarks/04_tensor/CMakeLists.txt
+++ b/benchmarks/04_tensor/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+#  Copyright (c) 2025, Intel Corporation
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+
+# List the benchmarks
+compile_benchmark_test(01_tensor_add)

--- a/benchmarks/04_tensor/dlpack.h
+++ b/benchmarks/04_tensor/dlpack.h
@@ -1,0 +1,347 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ *  Copyright (c) 2025, Intel Corporation
+ * \file dlpack.h
+ * \brief The common header of DLPack.
+ */
+
+// clang-format off
+
+ #ifndef DLPACK_DLPACK_H_
+ #define DLPACK_DLPACK_H_
+
+ /**
+  * \brief Compatibility with C++
+  */
+ #ifdef __cplusplus
+ #define DLPACK_EXTERN_C extern "C"
+ #else
+ #define DLPACK_EXTERN_C
+ #endif
+
+ /*! \brief The current major version of dlpack */
+ #define DLPACK_MAJOR_VERSION 1
+
+ /*! \brief The current minor version of dlpack */
+ #define DLPACK_MINOR_VERSION 0
+
+ /*! \brief DLPACK_DLL prefix for windows */
+ #ifdef _WIN32
+ #ifdef DLPACK_EXPORTS
+ #define DLPACK_DLL __declspec(dllexport)
+ #else
+ #define DLPACK_DLL __declspec(dllimport)
+ #endif
+ #else
+ #define DLPACK_DLL
+ #endif
+
+ #ifndef ISPC
+ #include <stdint.h>
+ #include <stddef.h>
+ #endif
+
+ #ifdef ISPC
+ typedef int32 int32_t;
+ typedef uint8 uint8_t;
+ typedef uint16 uint16_t;
+ typedef uint32 uint32_t;
+ typedef uint64 uint64_t;
+ typedef int64 int64_t;
+ #endif
+
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+
+ /*!
+  * \brief The DLPack version.
+  *
+  * A change in major version indicates that we have changed the
+  * data layout of the ABI - DLManagedTensorVersioned.
+  *
+  * A change in minor version indicates that we have added new
+  * code, such as a new device type, but the ABI is kept the same.
+  *
+  * If an obtained DLPack tensor has a major version that disagrees
+  * with the version number specified in this header file
+  * (i.e. major != DLPACK_MAJOR_VERSION), the consumer must call the deleter
+  * (and it is safe to do so). It is not safe to access any other fields
+  * as the memory layout will have changed.
+  *
+  * In the case of a minor version mismatch, the tensor can be safely used as
+  * long as the consumer knows how to interpret all fields. Minor version
+  * updates indicate the addition of enumeration values.
+  */
+ typedef struct {
+   /*! \brief DLPack major version. */
+   uint32_t major;
+   /*! \brief DLPack minor version. */
+   uint32_t minor;
+ } DLPackVersion;
+
+ /*!
+  * \brief The device type in DLDevice.
+  */
+ #ifdef __cplusplus
+ typedef enum : int32_t {
+ #else
+ typedef enum {
+ #endif
+   /*! \brief CPU device */
+   kDLCPU = 1,
+   /*! \brief CUDA GPU device */
+   kDLCUDA = 2,
+   /*!
+    * \brief Pinned CUDA CPU memory by cudaMallocHost
+    */
+   kDLCUDAHost = 3,
+   /*! \brief OpenCL devices. */
+   kDLOpenCL = 4,
+   /*! \brief Vulkan buffer for next generation graphics. */
+   kDLVulkan = 7,
+   /*! \brief Metal for Apple GPU. */
+   kDLMetal = 8,
+   /*! \brief Verilog simulator buffer */
+   kDLVPI = 9,
+   /*! \brief ROCm GPUs for AMD GPUs */
+   kDLROCM = 10,
+   /*!
+    * \brief Pinned ROCm CPU memory allocated by hipMallocHost
+    */
+   kDLROCMHost = 11,
+   /*!
+    * \brief Reserved extension device type,
+    * used for quickly test extension device
+    * The semantics can differ depending on the implementation.
+    */
+   kDLExtDev = 12,
+   /*!
+    * \brief CUDA managed/unified memory allocated by cudaMallocManaged
+    */
+   kDLCUDAManaged = 13,
+   /*!
+    * \brief Unified shared memory allocated on a oneAPI non-partititioned
+    * device. Call to oneAPI runtime is required to determine the device
+    * type, the USM allocation type and the sycl context it is bound to.
+    *
+    */
+   kDLOneAPI = 14,
+   /*! \brief GPU support for next generation WebGPU standard. */
+   kDLWebGPU = 15,
+   /*! \brief Qualcomm Hexagon DSP */
+   kDLHexagon = 16,
+   /*! \brief Microsoft MAIA devices */
+   kDLMAIA = 17,
+ } DLDeviceType;
+
+ /*!
+  * \brief A Device for Tensor and operator.
+  */
+ typedef struct {
+   /*! \brief The device type used in the device. */
+   DLDeviceType device_type;
+   /*!
+    * \brief The device index.
+    * For vanilla CPU memory, pinned memory, or managed memory, this is set to 0.
+    */
+   int32_t device_id;
+ } DLDevice;
+
+ /*!
+  * \brief The type code options DLDataType.
+  */
+ typedef enum {
+   /*! \brief signed integer */
+   kDLInt = 0U,
+   /*! \brief unsigned integer */
+   kDLUInt = 1U,
+   /*! \brief IEEE floating point */
+   kDLFloat = 2U,
+   /*!
+    * \brief Opaque handle type, reserved for testing purposes.
+    * Frameworks need to agree on the handle data type for the exchange to be well-defined.
+    */
+   kDLOpaqueHandle = 3U,
+   /*! \brief bfloat16 */
+   kDLBfloat = 4U,
+   /*!
+    * \brief complex number
+    * (C/C++/Python layout: compact struct per complex number)
+    */
+   kDLComplex = 5U,
+   /*! \brief boolean */
+   kDLBool = 6U,
+ } DLDataTypeCode;
+
+ /*!
+  * \brief The data type the tensor can hold. The data type is assumed to follow the
+  * native endian-ness. An explicit error message should be raised when attempting to
+  * export an array with non-native endianness
+  *
+  *  Examples
+  *   - float: type_code = 2, bits = 32, lanes = 1
+  *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes = 4
+  *   - int8: type_code = 0, bits = 8, lanes = 1
+  *   - std::complex<float>: type_code = 5, bits = 64, lanes = 1
+  *   - bool: type_code = 6, bits = 8, lanes = 1 (as per common array library convention, the underlying storage size of bool is 8 bits)
+  */
+ typedef struct {
+   /*!
+    * \brief Type code of base types.
+    * We keep it uint8_t instead of DLDataTypeCode for minimal memory
+    * footprint, but the value should be one of DLDataTypeCode enum values.
+    * */
+   uint8_t code;
+   /*!
+    * \brief Number of bits, common choices are 8, 16, 32.
+    */
+   uint8_t bits;
+   /*! \brief Number of lanes in the type, used for vector types. */
+   uint16_t lanes;
+ } DLDataType;
+
+ /*!
+  * \brief Plain C Tensor object, does not manage memory.
+  */
+ typedef struct {
+   /*!
+    * \brief The data pointer points to the allocated data. This will be CUDA
+    * device pointer or cl_mem handle in OpenCL. It may be opaque on some device
+    * types. This pointer is always aligned to 256 bytes as in CUDA. The
+    * `byte_offset` field should be used to point to the beginning of the data.
+    *
+    * Note that as of Nov 2021, multiply libraries (CuPy, PyTorch, TensorFlow,
+    * TVM, perhaps others) do not adhere to this 256 byte aligment requirement
+    * on CPU/CUDA/ROCm, and always use `byte_offset=0`.  This must be fixed
+    * (after which this note will be updated); at the moment it is recommended
+    * to not rely on the data pointer being correctly aligned.
+    *
+    * For given DLTensor, the size of memory required to store the contents of
+    * data is calculated as follows:
+    *
+    * \code{.c}
+    * static inline size_t GetDataSize(const DLTensor* t) {
+    *   size_t size = 1;
+    *   for (tvm_index_t i = 0; i < t->ndim; ++i) {
+    *     size *= t->shape[i];
+    *   }
+    *   size *= (t->dtype.bits * t->dtype.lanes + 7) / 8;
+    *   return size;
+    * }
+    * \endcode
+    *
+    * Note that if the tensor is of size zero, then the data pointer should be
+    * set to `NULL`.
+    */
+   void* data;
+   /*! \brief The device of the tensor */
+   DLDevice device;
+   /*! \brief Number of dimensions */
+   int32_t ndim;
+   /*! \brief The data type of the pointer*/
+   DLDataType dtype;
+   /*! \brief The shape of the tensor */
+   int64_t* shape;
+   /*!
+    * \brief strides of the tensor (in number of elements, not bytes)
+    *  can be NULL, indicating tensor is compact and row-majored.
+    */
+   int64_t* strides;
+   /*! \brief The offset in bytes to the beginning pointer to data */
+   uint64_t byte_offset;
+ } DLTensor;
+
+ /*!
+  * \brief C Tensor object, manage memory of DLTensor. This data structure is
+  *  intended to facilitate the borrowing of DLTensor by another framework. It is
+  *  not meant to transfer the tensor. When the borrowing framework doesn't need
+  *  the tensor, it should call the deleter to notify the host that the resource
+  *  is no longer needed.
+  *
+  * \note This data structure is used as Legacy DLManagedTensor
+  *       in DLPack exchange and is deprecated after DLPack v0.8
+  *       Use DLManagedTensorVersioned instead.
+  *       This data structure may get renamed or deleted in future versions.
+  *
+  * \sa DLManagedTensorVersioned
+  */
+ typedef struct DLManagedTensor {
+   /*! \brief DLTensor which is being memory managed */
+   DLTensor dl_tensor;
+   /*! \brief the context of the original host framework of DLManagedTensor in
+    *   which DLManagedTensor is used in the framework. It can also be NULL.
+    */
+   void * manager_ctx;
+   /*!
+    * \brief Destructor - this should be called
+    * to destruct the manager_ctx  which backs the DLManagedTensor. It can be
+    * NULL if there is no way for the caller to provide a reasonable destructor.
+    * The destructor deletes the argument self as well.
+    */
+   void (*deleter)(struct DLManagedTensor * self);
+ } DLManagedTensor;
+
+ // bit masks used in in the DLManagedTensorVersioned
+
+ /*! \brief bit mask to indicate that the tensor is read only. */
+ #define DLPACK_FLAG_BITMASK_READ_ONLY (1UL << 0UL)
+
+ /*!
+  * \brief bit mask to indicate that the tensor is a copy made by the producer.
+  *
+  * If set, the tensor is considered solely owned throughout its lifetime by the
+  * consumer, until the producer-provided deleter is invoked.
+  */
+ #define DLPACK_FLAG_BITMASK_IS_COPIED (1UL << 1UL)
+
+ /*!
+  * \brief A versioned and managed C Tensor object, manage memory of DLTensor.
+  *
+  * This data structure is intended to facilitate the borrowing of DLTensor by
+  * another framework. It is not meant to transfer the tensor. When the borrowing
+  * framework doesn't need the tensor, it should call the deleter to notify the
+  * host that the resource is no longer needed.
+  *
+  * \note This is the current standard DLPack exchange data structure.
+  */
+ struct DLManagedTensorVersioned {
+   /*!
+    * \brief The API and ABI version of the current managed Tensor
+    */
+   DLPackVersion version;
+   /*!
+    * \brief the context of the original host framework.
+    *
+    * Stores DLManagedTensorVersioned is used in the
+    * framework. It can also be NULL.
+    */
+   void *manager_ctx;
+   /*!
+    * \brief Destructor.
+    *
+    * This should be called to destruct manager_ctx which holds the DLManagedTensorVersioned.
+    * It can be NULL if there is no way for the caller to provide a reasonable
+    * destructor. The destructor deletes the argument self as well.
+    */
+   void (*deleter)(struct DLManagedTensorVersioned *self);
+   /*!
+    * \brief Additional bitmask flags information about the tensor.
+    *
+    * By default the flags should be set to 0.
+    *
+    * \note Future ABI changes should keep everything until this field
+    *       stable, to ensure that deleter can be correctly called.
+    *
+    * \sa DLPACK_FLAG_BITMASK_READ_ONLY
+    * \sa DLPACK_FLAG_BITMASK_IS_COPIED
+    */
+   uint64_t flags;
+   /*! \brief DLTensor which is being memory managed */
+   DLTensor dl_tensor;
+ };
+
+ #ifdef __cplusplus
+ }  // DLPACK_EXTERN_C
+ #endif
+ #endif  // DLPACK_DLPACK_H_

--- a/benchmarks/04_tensor/tensor.isph
+++ b/benchmarks/04_tensor/tensor.isph
@@ -1,0 +1,147 @@
+// Copyright (c) 2025, Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "dlpack.h"
+
+extern "C" void __not_supported();
+
+// Vectorized linear index computation with direct stride access
+static inline int tensor_compute_index(uniform int64 *uniform shape, uniform int64 *uniform strides, uniform int ndim,
+                                       int64 index) {
+    int linear_idx = 0;
+    int64 offset = index;
+
+    // Unroll common case for 1D, 2D, 3D, 4D tensors for better performance
+    if (ndim == 1) {
+        return offset * strides[0];
+    } else if (ndim == 2) {
+        uniform int shape1 = shape[1];
+#pragma ignore warning(perf)
+        int d1 = offset % shape1;
+#pragma ignore warning(perf)
+        int d0 = offset / shape1;
+        return d0 * strides[0] + d1 * strides[1];
+    } else if (ndim == 3) {
+        uniform int shape2 = shape[2];
+        uniform int shape1 = shape[1];
+#pragma ignore warning(perf)
+        int d2 = offset % shape2;
+#pragma ignore warning(perf)
+        offset /= shape2;
+#pragma ignore warning(perf)
+        int d1 = offset % shape1;
+#pragma ignore warning(perf)
+        int d0 = offset / shape1;
+        return d0 * strides[0] + d1 * strides[1] + d2 * strides[2];
+    } else if (ndim == 4) {
+        uniform int shape3 = shape[3];
+        uniform int shape2 = shape[2];
+        uniform int shape1 = shape[1];
+#pragma ignore warning(perf)
+        int d3 = offset % shape3;
+#pragma ignore warning(perf)
+        offset /= shape3;
+#pragma ignore warning(perf)
+        int d2 = offset % shape2;
+#pragma ignore warning(perf)
+        offset /= shape2;
+#pragma ignore warning(perf)
+        int d1 = offset % shape1;
+#pragma ignore warning(perf)
+        int d0 = offset / shape1;
+        return d0 * strides[0] + d1 * strides[1] + d2 * strides[2] + d3 * strides[3];
+    } else {
+        // General case for arbitrary dimensions
+        for (uniform int d = ndim - 1; d >= 0; --d) {
+            uniform int current_shape = shape[d];
+#pragma ignore warning(perf)
+            int coord = offset % current_shape;
+#pragma ignore warning(perf)
+            offset /= current_shape;
+            linear_idx += coord * strides[d];
+        }
+        return linear_idx;
+    }
+}
+
+// Helper function to calculate total size of a tensor
+static inline uniform int64 calculate_total_size(uniform DLTensor *uniform tensor) {
+    uniform int64 total_size = 1;
+    uniform int ndim = tensor->ndim;
+    for (uniform int i = 0; i < ndim; i++) {
+        total_size *= tensor->shape[i];
+    }
+    return total_size;
+}
+
+// Helper function to check if a tensor is contiguous in memory
+static inline bool is_tensor_contiguous(uniform DLTensor *uniform tensor) {
+    uniform int ndim = tensor->ndim;
+    if (ndim == 0)
+        return true;
+
+    uniform int expected_stride = 1;
+    for (uniform int d = ndim - 1; d >= 0; --d) {
+        if (tensor->strides[d] != expected_stride) {
+            return false;
+        }
+        expected_stride *= tensor->shape[d];
+    }
+    return true;
+}
+
+// Complete implementation of tensor addition for any data type
+template <typename T>
+static inline void tensor_add_impl(void *uniform _A, void *uniform _B, void *uniform _C) {
+    uniform DLTensor *uniform A = (uniform DLTensor * uniform) _A;
+    uniform DLTensor *uniform B = (uniform DLTensor * uniform) _B;
+    uniform DLTensor *uniform C = (uniform DLTensor * uniform) _C;
+
+    // Direct pointers to data
+    uniform T *uniform A_data = (uniform T * uniform)(A->data);
+    uniform T *uniform B_data = (uniform T * uniform)(B->data);
+    uniform T *uniform C_data = (uniform T * uniform)(C->data);
+
+    uniform int64 total_size = calculate_total_size(A);
+    bool is_contiguous = is_tensor_contiguous(A);
+
+    if (is_contiguous) {
+        foreach (i = 0 ... total_size) {
+            C_data[i] = A_data[i] + B_data[i];
+        }
+    } else {
+        // Non-contiguous case: calculate indices
+        uniform int ndim = A->ndim;
+        foreach (i = 0 ... total_size) {
+            int idx = tensor_compute_index(A->shape, A->strides, ndim, i);
+            C_data[idx] = A_data[idx] + B_data[idx];
+        }
+    }
+}
+
+// Generic template for tensor operations
+template <typename T> void tensor_add(void *uniform _A, void *uniform _B, void *uniform _C) {
+    __not_supported();
+}
+
+// Specialized implementations for common types
+template <> void tensor_add<int8>(void *uniform _A, void *uniform _B, void *uniform _C) {
+    tensor_add_impl<int8>(_A, _B, _C);
+}
+template <> void tensor_add<int16>(void *uniform _A, void *uniform _B, void *uniform _C) {
+    tensor_add_impl<int16>(_A, _B, _C);
+}
+
+template <> void tensor_add<int>(void *uniform _A, void *uniform _B, void *uniform _C) {
+    tensor_add_impl<int>(_A, _B, _C);
+}
+
+template <> void tensor_add<float>(void *uniform _A, void *uniform _B, void *uniform _C) {
+    tensor_add_impl<float>(_A, _B, _C);
+}
+
+template <> void tensor_add<double>(void *uniform _A, void *uniform _B, void *uniform _C) {
+    tensor_add_impl<double>(_A, _B, _C);
+}

--- a/benchmarks/04_tensor/tensor.isph
+++ b/benchmarks/04_tensor/tensor.isph
@@ -77,7 +77,7 @@ static inline uniform int64 calculate_total_size(uniform DLTensor *uniform tenso
 }
 
 // Helper function to check if a tensor is contiguous in memory
-static inline bool is_tensor_contiguous(uniform DLTensor *uniform tensor) {
+static inline uniform bool is_tensor_contiguous(uniform DLTensor *uniform tensor) {
     uniform int ndim = tensor->ndim;
     if (ndim == 0)
         return true;
@@ -93,8 +93,7 @@ static inline bool is_tensor_contiguous(uniform DLTensor *uniform tensor) {
 }
 
 // Complete implementation of tensor addition for any data type
-template <typename T>
-static inline void tensor_add_impl(void *uniform _A, void *uniform _B, void *uniform _C) {
+template <typename T> static inline void tensor_add_impl(void *uniform _A, void *uniform _B, void *uniform _C) {
     uniform DLTensor *uniform A = (uniform DLTensor * uniform) _A;
     uniform DLTensor *uniform B = (uniform DLTensor * uniform) _B;
     uniform DLTensor *uniform C = (uniform DLTensor * uniform) _C;
@@ -105,7 +104,7 @@ static inline void tensor_add_impl(void *uniform _A, void *uniform _B, void *uni
     uniform T *uniform C_data = (uniform T * uniform)(C->data);
 
     uniform int64 total_size = calculate_total_size(A);
-    bool is_contiguous = is_tensor_contiguous(A);
+    uniform bool is_contiguous = is_tensor_contiguous(A);
 
     if (is_contiguous) {
         foreach (i = 0 ... total_size) {
@@ -122,9 +121,7 @@ static inline void tensor_add_impl(void *uniform _A, void *uniform _B, void *uni
 }
 
 // Generic template for tensor operations
-template <typename T> void tensor_add(void *uniform _A, void *uniform _B, void *uniform _C) {
-    __not_supported();
-}
+template <typename T> void tensor_add(void *uniform _A, void *uniform _B, void *uniform _C) { __not_supported(); }
 
 // Specialized implementations for common types
 template <> void tensor_add<int8>(void *uniform _A, void *uniform _B, void *uniform _C) {
@@ -144,4 +141,122 @@ template <> void tensor_add<float>(void *uniform _A, void *uniform _B, void *uni
 
 template <> void tensor_add<double>(void *uniform _A, void *uniform _B, void *uniform _C) {
     tensor_add_impl<double>(_A, _B, _C);
+}
+
+#define TILE_HEIGHT 2
+#define TILE_WIDTH 32
+
+// Implementation for matrix multiplication with tiling
+template <typename T>
+static inline void tensor_mul_2d_impl(uniform T *uniform A_data, uniform T *uniform B_data, uniform T *uniform C_data,
+                                      uniform int M, uniform int N, uniform int K) {
+    // Tile for accumulating sums
+    uniform T sumTile[TILE_HEIGHT][TILE_WIDTH];
+    // Array to store one value from A for each row in the tile
+    uniform T oneAVal[TILE_HEIGHT];
+
+    for (uniform unsigned int m = 0; m < M; m += TILE_HEIGHT) {
+        for (uniform unsigned int k0 = 0; k0 < K; k0 += TILE_WIDTH) {
+            // Initialize the sum tile to zeros
+            foreach (ki = 0 ... TILE_WIDTH) {
+                for (uniform unsigned int i = 0; i < TILE_HEIGHT; i++) {
+                    sumTile[i][ki] = 0;
+                }
+            }
+
+            // Loop through N dimension
+            for (uniform unsigned int n = 0; n < N; n++) {
+                // Load values from A for current tile rows
+                for (uniform unsigned int i = 0; i < TILE_HEIGHT; i++) {
+                    oneAVal[i] = A_data[(m + i) * N + n];
+                }
+
+                // SPMD iterate over tile width
+                foreach (kt = 0 ... TILE_WIDTH) {
+                    // Load B value once and reuse for all rows in the tile
+                    varying T matB1 = B_data[n * K + k0 + kt];
+                    for (uniform unsigned int i = 0; i < TILE_HEIGHT; i++) {
+                        // Accumulate product
+                        sumTile[i][kt] += oneAVal[i] * matB1;
+                    }
+                }
+            }
+
+            // Write results back to C
+            foreach (ki = 0 ... TILE_WIDTH) {
+                for (uniform unsigned int i = 0; i < TILE_HEIGHT; i++) {
+                    C_data[(m + i) * K + k0 + ki] = sumTile[i][ki];
+                }
+            }
+        }
+    }
+}
+
+// Generic tensor multiplication for different dimension handling
+template <typename T> static inline void tensor_mul_impl(void *uniform _A, void *uniform _B, void *uniform _C) {
+    uniform DLTensor *uniform A = (uniform DLTensor * uniform) _A;
+    uniform DLTensor *uniform B = (uniform DLTensor * uniform) _B;
+    uniform DLTensor *uniform C = (uniform DLTensor * uniform) _C;
+
+    // Direct pointers to data
+    uniform T *uniform A_data = (uniform T * uniform)(A->data);
+    uniform T *uniform B_data = (uniform T * uniform)(B->data);
+    uniform T *uniform C_data = (uniform T * uniform)(C->data);
+
+    uniform int ndim = A->ndim;
+    uniform int64 total_size = calculate_total_size(A);
+    uniform bool is_contiguous = is_tensor_contiguous(A);
+
+    // Handle different tensor dimensions
+    if (is_contiguous) {
+        if (ndim == 2) {
+            // 2D case: Standard matrix multiplication
+            uniform int M = A->shape[0];
+            uniform int N = A->shape[1];
+            uniform int K = B->shape[1];
+
+            // Use tiled matrix multiplication algorithm from sgemm.ispc
+            tensor_mul_2d_impl<T>(A_data, B_data, C_data, M, N, K);
+        } else if (ndim == 3) {
+            // 3D case: TODO: implement optimized version
+            foreach (i = 0 ... total_size) {
+                C_data[i] = A_data[i] * B_data[i];
+            }
+        } else {
+            // Element-wise multiplication for other dimensions when contiguous
+            foreach (i = 0 ... total_size) {
+                C_data[i] = A_data[i] * B_data[i];
+            }
+        }
+    } else {
+        // Non-contiguous case: calculate indices for each element
+        foreach (i = 0 ... total_size) {
+            int idx = tensor_compute_index(A->shape, A->strides, ndim, i);
+            C_data[idx] = A_data[idx] * B_data[idx];
+        }
+    }
+}
+
+// Generic template for tensor multiplication operations
+template <typename T> void tensor_mul(void *uniform _A, void *uniform _B, void *uniform _C) { __not_supported(); }
+
+// Specialized implementations for common types
+template <> void tensor_mul<int8>(void *uniform _A, void *uniform _B, void *uniform _C) {
+    tensor_mul_impl<int8>(_A, _B, _C);
+}
+
+template <> void tensor_mul<int16>(void *uniform _A, void *uniform _B, void *uniform _C) {
+    tensor_mul_impl<int16>(_A, _B, _C);
+}
+
+template <> void tensor_mul<int>(void *uniform _A, void *uniform _B, void *uniform _C) {
+    tensor_mul_impl<int>(_A, _B, _C);
+}
+
+template <> void tensor_mul<float>(void *uniform _A, void *uniform _B, void *uniform _C) {
+    tensor_mul_impl<float>(_A, _B, _C);
+}
+
+template <> void tensor_mul<double>(void *uniform _A, void *uniform _B, void *uniform _C) {
+    tensor_mul_impl<double>(_A, _B, _C);
 }

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2020-2023, Intel Corporation
+#  Copyright (c) 2020-2025, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -64,3 +64,4 @@ include(cmake/AddBenchmark.cmake)
 add_subdirectory(01_trivial)
 add_subdirectory(02_medium)
 add_subdirectory(03_complex)
+add_subdirectory(04_tensor)


### PR DESCRIPTION
The example code demonstrates a generic implementation of tensor operations in ISPC using the [DLPack](https://github.com/dmlc/dlpack/tree/main) standard. DLPack (`dlpack.h`) provides a common tensor structure (`DLTensor`) that enables interoperability between different deep learning frameworks, making it an industry standard used by frameworks like PyTorch, TensorFlow, MXNet, and others.
By having DLPack compatible tensor in ISPC we enable interoperability with all these frameworks.

`dlpack.isph` is a copy of original `dlpack.h` with several typedefs (look for `#ifdef ISPC`)

The implementation uses DLPack format as is without any optimizations.
There is a big inefficiency in index calculation right now. Both division and modulo operators are performed on varying values.

There are several **optimization strategies**:

1. Instead of runtime dispatch
```
// Before optimization: Runtime dispatch
if (code == kDLFloat && bits == 32 && lanes == 1) {
    tensor_add_typed<float>(A, B, C);
}
```
have a specialized function:
```
void tensor_add_float32(uniform DLTensor* uniform A, 
                              uniform DLTensor* uniform B,
                              uniform DLTensor* uniform C) {
    // Direct float implementation without template or dispatch
}
```

2. Create specialized versions for common tensor dimensions

```
void tensor_add_float32_2D(uniform float* uniform A_data,
                                 uniform float* uniform B_data,
                                 uniform float* uniform C_data,
                                 uniform int64 height,
                                 uniform int64 width) {
    foreach (h = 0 ... height) {
        for (uniform int w = 0; w < width; w++) {
            C_data[h*width + w] = A_data[h*width + w] + B_data[h*width + w];
        }
    }
}
```
3. Require tensor shape optimized for ISPC (shape[1] and shape[2] = `programCount`, see OIDN example below)

**OIDN** uses ISPC for tensor operations with specialized optimizations:

- Compile-time Shape Dimensions: OIDN maps certain tensor dimensions to `programCount`, allowing compile-time optimization
- Fixed-size Kernels: They implement specialized kernels for common tensor shapes (3×3 ...)

Example from OIDN:
```
#define B programCount // channel block size
// Tensor in ChwBc/chw layout
struct TensorAccessor3D
{
  uniform uint8* uniform ptr;
  uniform size_t hByteStride;
  uniform size_t CByteStride;
  uniform int C, H, W;
};
inline size_t Tensor_getIndex(const uniform TensorAccessor3D& acc, uniform int c, uniform int h, int w)
{
#if defined(OIDN_BNNS)
  // chw layout
  return ((uniform size_t)acc.H * c + h) * (uniform size_t)acc.W + w;
#else
  // ChwBc layout (blocked)
  return ((uniform size_t)acc.H * (c/B) + h) * ((uniform size_t)acc.W*B) + (size_t)w*B + (c%B);
#endif
}
```