### PR TITLE
Add missing types for packed_load/packed_store

### DIFF
--- a/benchmarks/01_trivial/05_packed_load_store.cpp
+++ b/benchmarks/01_trivial/05_packed_load_store.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, Intel Corporation
+// Copyright (c) 2021-2025, Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <benchmark/benchmark.h>
@@ -162,6 +162,42 @@ static void check_packed_store_active2_neq(T *src, T *dst, const unsigned int in
 // 3 is 1/4, 3/4
 // 7 is 1/8, 7/8
 // 15 is 1/16, 15/16
+
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_load_active, 0)
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_load_active, 1)
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_load_active, 3)
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_load_active, 7)
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_load_active, 15)
+
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_store_active, 0)
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_store_active, 1)
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_store_active, 3)
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_store_active, 7)
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_store_active, 15)
+
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_store_active2, 0)
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_store_active2, 1)
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_store_active2, 3)
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_store_active2, 7)
+PACKED_LOAD_STORE_COND(int8_t, int8, packed_store_active2, 15)
+
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_load_active, 0)
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_load_active, 1)
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_load_active, 3)
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_load_active, 7)
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_load_active, 15)
+
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_store_active, 0)
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_store_active, 1)
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_store_active, 3)
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_store_active, 7)
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_store_active, 15)
+
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_store_active2, 0)
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_store_active2, 1)
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_store_active2, 3)
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_store_active2, 7)
+PACKED_LOAD_STORE_COND(int16_t, int16, packed_store_active2, 15)
 
 PACKED_LOAD_STORE_COND(int32_t, int32, packed_load_active, 0)
 PACKED_LOAD_STORE_COND(int32_t, int32, packed_load_active, 1)

--- a/benchmarks/01_trivial/05_packed_load_store.ispc
+++ b/benchmarks/01_trivial/05_packed_load_store.ispc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, Intel Corporation
+// Copyright (c) 2021-2025, Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 export uniform int width() { return programCount; }
@@ -54,6 +54,14 @@ export uniform int width() { return programCount; }
         }                                                                                                              \
         return num;                                                                                                    \
     }
+
+PACKEDLOAD(int8)
+PACKEDSTORE(int8, packed_store_active)
+PACKEDSTORE(int8, packed_store_active2)
+
+PACKEDLOAD(int16)
+PACKEDSTORE(int16, packed_store_active)
+PACKEDSTORE(int16, packed_store_active2)
 
 PACKEDLOAD(int32)
 PACKEDSTORE(int32, packed_store_active)

--- a/builtins/generic.ispc
+++ b/builtins/generic.ispc
@@ -1847,11 +1847,39 @@ EXT void __scatter_factored_base_offsets64_double(uniform int8 *uniform base, va
 }
 
 // packed active stores
+EXT PackedStoreResultType __packed_store_activei8(uniform int8 *uniform ptr, varying int8 val, UIntMaskType mask) {
+    @llvm.masked.compressstore(val, ptr, mask);
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT PackedStoreResultType __packed_store_activei16(uniform int8 *uniform ptr, varying int16 val, UIntMaskType mask) {
+    @llvm.masked.compressstore(val, ptr, mask);
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
 EXT PackedStoreResultType __packed_store_activei32(uniform int8 *uniform ptr, varying int32 val, UIntMaskType mask) {
     @llvm.masked.compressstore(val, ptr, mask);
     return __popcnt_int64(__cast_mask_to_i64(mask));
 }
 EXT PackedStoreResultType __packed_store_activei64(uniform int8 *uniform ptr, varying int64 val, UIntMaskType mask) {
+    @llvm.masked.compressstore(val, ptr, mask);
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT PackedStoreResultType __packed_store_activef16(uniform int8 *uniform ptr, varying float16 val, UIntMaskType mask) {
+    @llvm.masked.compressstore(val, ptr, mask);
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT PackedStoreResultType __packed_store_activef32(uniform int8 *uniform ptr, varying float val, UIntMaskType mask) {
+    @llvm.masked.compressstore(val, ptr, mask);
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT PackedStoreResultType __packed_store_activef64(uniform int8 *uniform ptr, varying double val, UIntMaskType mask) {
+    @llvm.masked.compressstore(val, ptr, mask);
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT PackedStoreResultType __packed_store_active2i8(uniform int8 *uniform ptr, varying int8 val, UIntMaskType mask) {
+    @llvm.masked.compressstore(val, ptr, mask);
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT PackedStoreResultType __packed_store_active2i16(uniform int8 *uniform ptr, varying int16 val, UIntMaskType mask) {
     @llvm.masked.compressstore(val, ptr, mask);
     return __popcnt_int64(__cast_mask_to_i64(mask));
 }
@@ -1863,8 +1891,33 @@ EXT PackedStoreResultType __packed_store_active2i64(uniform int8 *uniform ptr, v
     @llvm.masked.compressstore(val, ptr, mask);
     return __popcnt_int64(__cast_mask_to_i64(mask));
 }
-
+EXT PackedStoreResultType __packed_store_active2f16(uniform int8 *uniform ptr, varying float16 val, UIntMaskType mask) {
+    @llvm.masked.compressstore(val, ptr, mask);
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT PackedStoreResultType __packed_store_active2f32(uniform int8 *uniform ptr, varying float val, UIntMaskType mask) {
+    @llvm.masked.compressstore(val, ptr, mask);
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT PackedStoreResultType __packed_store_active2f64(uniform int8 *uniform ptr, varying double val, UIntMaskType mask) {
+    @llvm.masked.compressstore(val, ptr, mask);
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
 // packed active loads
+EXT uniform int32 __packed_load_activei8(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
+    varying int8 *uniform ptr = (varying int8 * uniform) to;
+    varying int8 passthru = *ptr;
+    varying int8 vec = @llvm.masked.expandload(from, mask, passthru);
+    *ptr = vec;
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT uniform int32 __packed_load_activei16(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
+    varying int16 *uniform ptr = (varying int16 * uniform) to;
+    varying int16 passthru = *ptr;
+    varying int16 vec = @llvm.masked.expandload(from, mask, passthru);
+    *ptr = vec;
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
 EXT uniform int32 __packed_load_activei32(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
     varying int32 *uniform ptr = (varying int32 * uniform) to;
     varying int32 passthru = *ptr;
@@ -1876,6 +1929,27 @@ EXT uniform int32 __packed_load_activei64(uniform int8 *uniform from, uniform in
     varying int64 *uniform ptr = (varying int64 * uniform) to;
     varying int64 passthru = *ptr;
     varying int64 vec = @llvm.masked.expandload(from, mask, passthru);
+    *ptr = vec;
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT uniform int32 __packed_load_activef16(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
+    varying float16 *uniform ptr = (varying float16 * uniform) to;
+    varying float16 passthru = *ptr;
+    varying float16 vec = @llvm.masked.expandload(from, mask, passthru);
+    *ptr = vec;
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT uniform int32 __packed_load_activef32(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
+    varying float *uniform ptr = (varying float *uniform)to;
+    varying float passthru = *ptr;
+    varying float vec = @llvm.masked.expandload(from, mask, passthru);
+    *ptr = vec;
+    return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT uniform int32 __packed_load_activef64(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
+    varying double *uniform ptr = (varying double *uniform)to;
+    varying double passthru = *ptr;
+    varying double vec = @llvm.masked.expandload(from, mask, passthru);
     *ptr = vec;
     return __popcnt_int64(__cast_mask_to_i64(mask));
 }

--- a/builtins/generic.ispc
+++ b/builtins/generic.ispc
@@ -107,6 +107,29 @@ unmasked uniform float16<DOUBLE_WIDTH> __concat(float16 v0, float16 v1) { return
 unmasked uniform float<DOUBLE_WIDTH> __concat(float v0, float v1) { return @llvm.ispc.concat(v0, v1); }
 unmasked uniform double<DOUBLE_WIDTH> __concat(double v0, double v1) { return @llvm.ispc.concat(v0, v1); }
 
+// overloaded __masked_expandload functions
+unmasked varying int8 __masked_expandload(uniform int8 *uniform from, UIntMaskType mask, varying int8 passthru) {
+    return @llvm.masked.expandload(from, mask, passthru);
+}
+unmasked varying int16 __masked_expandload(uniform int8 *uniform from, UIntMaskType mask, varying int16 passthru) {
+    return @llvm.masked.expandload(from, mask, passthru);
+}
+unmasked varying int32 __masked_expandload(uniform int8 *uniform from, UIntMaskType mask, varying int32 passthru) {
+    return @llvm.masked.expandload(from, mask, passthru);
+}
+unmasked varying int64 __masked_expandload(uniform int8 *uniform from, UIntMaskType mask, varying int64 passthru) {
+    return @llvm.masked.expandload(from, mask, passthru);
+}
+unmasked varying float16 __masked_expandload(uniform int8 *uniform from, UIntMaskType mask, varying float16 passthru) {
+    return @llvm.masked.expandload(from, mask, passthru);
+}
+unmasked varying float __masked_expandload(uniform int8 *uniform from, UIntMaskType mask, varying float passthru) {
+    return @llvm.masked.expandload(from, mask, passthru);
+}
+unmasked varying double __masked_expandload(uniform int8 *uniform from, UIntMaskType mask, varying double passthru) {
+    return @llvm.masked.expandload(from, mask, passthru);
+}
+
 // bitcast
 template <typename L, typename R> unmasked L __bitcast(R x) {
     // This function should never be called, instead specialized versions should be used.
@@ -1904,54 +1927,34 @@ EXT PackedStoreResultType __packed_store_active2f64(uniform int8 *uniform ptr, v
     return __popcnt_int64(__cast_mask_to_i64(mask));
 }
 // packed active loads
-EXT uniform int32 __packed_load_activei8(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
-    varying int8 *uniform ptr = (varying int8 * uniform) to;
-    varying int8 passthru = *ptr;
-    varying int8 vec = @llvm.masked.expandload(from, mask, passthru);
+template <typename T>
+uniform int32 __packed_load_active(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
+    varying T *uniform ptr = (varying T * uniform) to;
+    varying T passthru = *ptr;
+    varying T vec = __masked_expandload(from, mask, passthru);
     *ptr = vec;
     return __popcnt_int64(__cast_mask_to_i64(mask));
+}
+EXT uniform int32 __packed_load_activei8(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
+    return __packed_load_active<int8>(from, to, mask);
 }
 EXT uniform int32 __packed_load_activei16(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
-    varying int16 *uniform ptr = (varying int16 * uniform) to;
-    varying int16 passthru = *ptr;
-    varying int16 vec = @llvm.masked.expandload(from, mask, passthru);
-    *ptr = vec;
-    return __popcnt_int64(__cast_mask_to_i64(mask));
+    return __packed_load_active<int16>(from, to, mask);
 }
 EXT uniform int32 __packed_load_activei32(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
-    varying int32 *uniform ptr = (varying int32 * uniform) to;
-    varying int32 passthru = *ptr;
-    varying int32 vec = @llvm.masked.expandload(from, mask, passthru);
-    *ptr = vec;
-    return __popcnt_int64(__cast_mask_to_i64(mask));
+    return __packed_load_active<int32>(from, to, mask);
 }
 EXT uniform int32 __packed_load_activei64(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
-    varying int64 *uniform ptr = (varying int64 * uniform) to;
-    varying int64 passthru = *ptr;
-    varying int64 vec = @llvm.masked.expandload(from, mask, passthru);
-    *ptr = vec;
-    return __popcnt_int64(__cast_mask_to_i64(mask));
+    return __packed_load_active<int64>(from, to, mask);
 }
 EXT uniform int32 __packed_load_activef16(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
-    varying float16 *uniform ptr = (varying float16 * uniform) to;
-    varying float16 passthru = *ptr;
-    varying float16 vec = @llvm.masked.expandload(from, mask, passthru);
-    *ptr = vec;
-    return __popcnt_int64(__cast_mask_to_i64(mask));
+    return __packed_load_active<float16>(from, to, mask);
 }
 EXT uniform int32 __packed_load_activef32(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
-    varying float *uniform ptr = (varying float *uniform)to;
-    varying float passthru = *ptr;
-    varying float vec = @llvm.masked.expandload(from, mask, passthru);
-    *ptr = vec;
-    return __popcnt_int64(__cast_mask_to_i64(mask));
+    return __packed_load_active<float>(from, to, mask);
 }
 EXT uniform int32 __packed_load_activef64(uniform int8 *uniform from, uniform int8 *uniform to, UIntMaskType mask) {
-    varying double *uniform ptr = (varying double *uniform)to;
-    varying double passthru = *ptr;
-    varying double vec = @llvm.masked.expandload(from, mask, passthru);
-    *ptr = vec;
-    return __popcnt_int64(__cast_mask_to_i64(mask));
+    return __packed_load_active<double>(from, to, mask);
 }
 
 template <typename T>

--- a/builtins/target-wasm-i32x4.ll
+++ b/builtins/target-wasm-i32x4.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2024, Intel Corporation
+;;  Copyright (c) 2020-2025, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -491,7 +491,7 @@ gen_scatter(float)
 gen_scatter(i64)
 gen_scatter(double)
 
-packed_load_and_store(4)
+packed_load_and_store(FALSE)
 define_prefetches()
 popcnt()
 

--- a/builtins/util-xe.m4
+++ b/builtins/util-xe.m4
@@ -4974,13 +4974,14 @@ define void @__masked_store_blend_i16(<16 x i16>* nocapture, <16 x i16>,
 ;;
 ;; Implement valid version of 'packed_store_active2' based on 'type' specified.
 ;;
-;; $1: Integer type for which function is to be created.
+;; $1: LLVM type for which function is to be created (i32, float...).
 ;; $2: Alignment for store.
+;; $3: LLVM overloaded type for which function is to be created (i32, f32...).
 ;;
 ;; FIXME: use the per_lane macro, defined below, to implement these!
 define(`packed_load_and_store_type', `
 
-define i32 @__packed_load_active$1(i8 * %startptr, i8 * %val_ptr,
+define i32 @__packed_load_active$3(i8 * %startptr, i8 * %val_ptr,
                                  <WIDTH x MASK> %full_mask) nounwind alwaysinline {
 entry:
   %startptr_typed = bitcast i8* %startptr to $1*
@@ -5036,7 +5037,7 @@ done:
   ret i32 %nextoffset
 }
 
-define i32 @__packed_store_active$1(i8 * %startptr, <WIDTH x $1> %vals,
+define i32 @__packed_store_active$3(i8 * %startptr, <WIDTH x $1> %vals,
                                    <WIDTH x MASK> %full_mask) nounwind alwaysinline {
 entry:
   %startptr_typed = bitcast i8* %startptr to $1*
@@ -5086,9 +5087,9 @@ done:
   ret i32 %nextoffset
 }
 
-define i32 @__packed_store_active2$1(i8 * %startptr, <WIDTH x $1> %vals,
+define i32 @__packed_store_active2$3(i8 * %startptr, <WIDTH x $1> %vals,
                                    <WIDTH x MASK> %full_mask) nounwind alwaysinline {
-  %res = call i32 @__packed_store_active$1(i8 * %startptr, <WIDTH x $1> %vals,
+  %res = call i32 @__packed_store_active$3(i8 * %startptr, <WIDTH x $1> %vals,
                                    <WIDTH x MASK> %full_mask)
   ret i32 %res
 }
@@ -5105,8 +5106,13 @@ define i32 @__packed_store_active2$1(i8 * %startptr, <WIDTH x $1> %vals,
 ;; loads a sequential value from the array.
 
 define(`packed_load_and_store', `
-  packed_load_and_store_type(i32, 4)
-  packed_load_and_store_type(i64, 8)
+  packed_load_and_store_type(i8, 1, i8)
+  packed_load_and_store_type(i16, 2, i16)
+  packed_load_and_store_type(i32, 4, i32)
+  packed_load_and_store_type(i64, 8, i64)
+  packed_load_and_store_type(half, 2, f16)
+  packed_load_and_store_type(float, 4, f32)
+  packed_load_and_store_type(double, 8, f64)
 ')
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -5487,10 +5487,28 @@ variable.  They return the total number of values loaded.
 
 ::
 
+    uniform int packed_load_active(uniform int8 * uniform base,
+                                   varying int8 * uniform val)
+    uniform int packed_load_active(uniform unsigned int8 * uniform base,
+                                   varying unsigned int8 * uniform val)
+    uniform int packed_load_active(uniform int16 * uniform base,
+                                   varying int16 * uniform val)
+    uniform int packed_load_active(uniform unsigned int16 * uniform base,
+                                   varying unsigned int16 * uniform val)
     uniform int packed_load_active(uniform int * uniform base,
                                    varying int * uniform val)
     uniform int packed_load_active(uniform unsigned int * uniform base,
                                    varying unsigned int * uniform val)
+    uniform int packed_load_active(uniform int64 * uniform base,
+                                   varying int64 * uniform val)
+    uniform int packed_load_active(uniform unsigned int64 * uniform base,
+                                   varying unsigned int64 * uniform val)
+    uniform int packed_load_active(uniform float16 * uniform base,
+                                   varying float16 * uniform val)
+    uniform int packed_load_active(uniform float * uniform base,
+                                   varying float * uniform val)
+    uniform int packed_load_active(uniform double * uniform base,
+                                   varying double * uniform val)
 
 Similarly, the ``packed_store_active()`` functions store the ``val`` values
 for each program instances that executed the ``packed_store_active()``
@@ -5499,11 +5517,28 @@ They return the total number of values stored.
 
 ::
 
+    uniform int packed_store_active(uniform int8 * uniform base,
+                                    int8 val)
+    uniform int packed_store_active(uniform unsigned int8* uniform base,
+                                    unsigned int8 val)
+    uniform int packed_store_active(uniform int16 * uniform base,
+                                    int16 val)
+    uniform int packed_store_active(uniform unsigned int16 * uniform base,
+                                    unsigned int16 val)
     uniform int packed_store_active(uniform int * uniform base,
                                     int val)
     uniform int packed_store_active(uniform unsigned int * uniform base,
                                     unsigned int val)
-
+    uniform int packed_store_active(uniform int64 * uniform base,
+                                    int64 val)
+    uniform int packed_store_active(uniform unsigned int64 * uniform base,
+                                    unsigned int64 val)
+    uniform int packed_store_active(uniform float16 * uniform base,
+                                    float16 val)
+    uniform int packed_store_active(uniform float * uniform base,
+                                    float val)
+    uniform int packed_store_active(uniform double * uniform base,
+                                    double val)
 
 There are also ``packed_store_active2()`` functions with exactly the same
 signatures and the same semantic except that they may write one extra

--- a/stdlib/include/builtins.isph
+++ b/stdlib/include/builtins.isph
@@ -1,5 +1,5 @@
 // -*- mode: c++ -*-
-// Copyright (c) 2024, Intel Corporation
+// Copyright (c) 2024-2025, Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // @file builtins.isph
@@ -472,12 +472,29 @@ EXT uniform bool __rdrand_i64(uniform int8 *uniform);
 #else
 #define PackedStoreResultType UniformMaskType
 #endif
+EXT inline uniform int32 __packed_load_activei8(uniform int8 *uniform, uniform int8 *uniform, UIntMaskType);
+EXT inline uniform int32 __packed_load_activei16(uniform int8 *uniform, uniform int8 *uniform, UIntMaskType);
 EXT inline uniform int32 __packed_load_activei32(uniform int8 *uniform, uniform int8 *uniform, UIntMaskType);
 EXT inline uniform int32 __packed_load_activei64(uniform int8 *uniform, uniform int8 *uniform, UIntMaskType);
+EXT inline uniform int32 __packed_load_activef16(uniform int8 *uniform, uniform int8 *uniform, UIntMaskType);
+EXT inline uniform int32 __packed_load_activef32(uniform int8 *uniform, uniform int8 *uniform, UIntMaskType);
+EXT inline uniform int32 __packed_load_activef64(uniform int8 *uniform, uniform int8 *uniform, UIntMaskType);
+
+EXT inline PackedStoreResultType __packed_store_active2i8(uniform int8 *uniform, varying int8, UIntMaskType);
+EXT inline PackedStoreResultType __packed_store_active2i16(uniform int8 *uniform, varying int16, UIntMaskType);
 EXT inline PackedStoreResultType __packed_store_active2i32(uniform int8 *uniform, varying int32, UIntMaskType);
 EXT inline PackedStoreResultType __packed_store_active2i64(uniform int8 *uniform, varying int64, UIntMaskType);
+EXT inline PackedStoreResultType __packed_store_active2f16(uniform int8 *uniform, varying float16, UIntMaskType);
+EXT inline PackedStoreResultType __packed_store_active2f32(uniform int8 *uniform, varying float, UIntMaskType);
+EXT inline PackedStoreResultType __packed_store_active2f64(uniform int8 *uniform, varying double, UIntMaskType);
+
+EXT inline PackedStoreResultType __packed_store_activei8(uniform int8 *uniform, varying int8, UIntMaskType);
+EXT inline PackedStoreResultType __packed_store_activei16(uniform int8 *uniform, varying int16, UIntMaskType);
 EXT inline PackedStoreResultType __packed_store_activei32(uniform int8 *uniform, varying int32, UIntMaskType);
 EXT inline PackedStoreResultType __packed_store_activei64(uniform int8 *uniform, varying int64, UIntMaskType);
+EXT inline PackedStoreResultType __packed_store_activef16(uniform int8 *uniform, varying float16, UIntMaskType);
+EXT inline PackedStoreResultType __packed_store_activef32(uniform int8 *uniform, varying float, UIntMaskType);
+EXT inline PackedStoreResultType __packed_store_activef64(uniform int8 *uniform, varying double, UIntMaskType);
 
 // TODO: rewrite in stdlib.ispc
 EXT void __prefetch_read_sized_uniform_1(uniform int8 *uniform, uniform int8);

--- a/stdlib/include/stdlib.isph
+++ b/stdlib/include/stdlib.isph
@@ -329,6 +329,36 @@ inline uniform int packed_store_active(uniform unsigned int a[], unsigned int va
 // unsigned int32 store2.
 inline uniform int packed_store_active2(uniform unsigned int a[], unsigned int vals);
 
+/* unsigned int16 implementations. */
+// unsigned int16 load.
+inline uniform int packed_load_active(uniform unsigned int16 a[], varying unsigned int16 *uniform vals);
+
+// unsigned int16 store.
+inline uniform int packed_store_active(uniform unsigned int16 a[], unsigned int16 vals);
+
+// unsigned int16 store2.
+inline uniform int packed_store_active2(uniform unsigned int16 a[], unsigned int16 vals);
+
+/* unsigned int8 implementations. */
+// unsigned int8 load.
+inline uniform int packed_load_active(uniform unsigned int8 a[], varying unsigned int8 *uniform vals);
+
+// unsigned int8 store.
+inline uniform int packed_store_active(uniform unsigned int8 a[], unsigned int8 vals);
+
+// unsigned int8 store2.
+inline uniform int packed_store_active2(uniform unsigned int8 a[], unsigned int8 vals);
+
+/* unsigned int64 implementations. */
+// unsigned int64 load.
+inline uniform int packed_load_active(uniform unsigned int64 a[], varying unsigned int64 *uniform vals);
+
+// unsigned int64 store.
+inline uniform int packed_store_active(uniform unsigned int64 a[], unsigned int64 vals);
+
+// unsigned int64 store2.
+inline uniform int packed_store_active2(uniform unsigned int64 a[], unsigned int64 vals);
+
 /* int32 implementations. */
 // int32 load.
 inline uniform int packed_load_active(uniform int a[], varying int *uniform vals);
@@ -342,15 +372,25 @@ inline uniform int packed_store_active2(uniform int a[], int vals);
 // int32 store with lanes.
 inline uniform int packed_store_active(bool active, uniform int a[], int vals);
 
-/* unsigned int64 implementations. */
-// unsigned int64 load.
-inline uniform int packed_load_active(uniform unsigned int64 a[], varying unsigned int64 *uniform vals);
+/* int16 implementations. */
+// int16 load.
+inline uniform int packed_load_active(uniform int16 a[], varying int16 *uniform vals);
 
-// unsigned int64 store.
-inline uniform int packed_store_active(uniform unsigned int64 a[], unsigned int64 vals);
+// int16 store.
+inline uniform int packed_store_active(uniform int16 a[], int16 vals);
 
-// unsigned int64 store2.
-inline uniform int packed_store_active2(uniform unsigned int64 a[], unsigned int64 vals);
+// int16 store2.
+inline uniform int packed_store_active2(uniform int16 a[], int16 vals);
+
+/* int8 implementations. */
+// int8 load.
+inline uniform int packed_load_active(uniform int8 a[], varying int8 *uniform vals);
+
+// int8 store.
+inline uniform int packed_store_active(uniform int8 a[], int8 vals);
+
+// int8 store2.
+inline uniform int packed_store_active2(uniform int8 a[], int8 vals);
 
 /* int64 implementations. */
 // int64 load.
@@ -364,6 +404,36 @@ inline uniform int packed_store_active2(uniform int64 a[], int64 vals);
 
 // int64 store with lanes.
 inline uniform int packed_store_active(bool active, uniform int64 a[], int64 vals);
+
+/* float16 implementations. */
+// float16 load.
+inline uniform int packed_load_active(uniform float16 a[], varying float16 *uniform vals);
+
+// float16 store.
+inline uniform int packed_store_active(uniform float16 a[], float16 vals);
+
+// float16 store2.
+inline uniform int packed_store_active2(uniform float16 a[], float16 vals);
+
+/* float implementations. */
+// float load.
+inline uniform int packed_load_active(uniform float a[], varying float *uniform vals);
+
+// float store.
+inline uniform int packed_store_active(uniform float a[], float vals);
+
+// float store2.
+inline uniform int packed_store_active2(uniform float a[], float vals);
+
+/* double implementations. */
+// double load.
+inline uniform int packed_load_active(uniform double a[], varying double *uniform vals);
+
+// double store.
+inline uniform int packed_store_active(uniform double a[], double vals);
+
+// double store2.
+inline uniform int packed_store_active2(uniform double a[], double vals);
 
 ///////////////////////////////////////////////////////////////////////////
 // streaming store

--- a/stdlib/stdlib.ispc
+++ b/stdlib/stdlib.ispc
@@ -1281,6 +1281,54 @@ static inline uniform int packed_store_active2(uniform unsigned int a[], unsigne
     return __packed_store_active2i32((opaque_ptr_t)a, vals, (UIntMaskType)__mask);
 }
 
+/* unsigned int16 implementations. */
+// unsigned int16 load.
+static inline uniform int packed_load_active(uniform unsigned int16 a[], varying unsigned int16 *uniform vals) {
+    return __packed_load_activei16((opaque_ptr_t)a, (opaque_ptr_t)vals, (UIntMaskType)__mask);
+}
+
+// unsigned int16 store.
+static inline uniform int packed_store_active(uniform unsigned int16 a[], unsigned int16 vals) {
+    return __packed_store_activei16((opaque_ptr_t)a, vals, (UIntMaskType)__mask);
+}
+
+// unsigned int16 store2.
+static inline uniform int packed_store_active2(uniform unsigned int16 a[], unsigned int16 vals) {
+    return __packed_store_active2i16((opaque_ptr_t)a, vals, (UIntMaskType)__mask);
+}
+
+/* unsigned int8 implementations. */
+// unsigned int8 load.
+static inline uniform int packed_load_active(uniform unsigned int8 a[], varying unsigned int8 *uniform vals) {
+    return __packed_load_activei8((opaque_ptr_t)a, (opaque_ptr_t)vals, (UIntMaskType)__mask);
+}
+
+// unsigned int8 store.
+static inline uniform int packed_store_active(uniform unsigned int8 a[], unsigned int8 vals) {
+    return __packed_store_activei8((opaque_ptr_t)a, vals, (UIntMaskType)__mask);
+}
+
+// unsigned int8 store2.
+static inline uniform int packed_store_active2(uniform unsigned int8 a[], unsigned int8 vals) {
+    return __packed_store_active2i8((opaque_ptr_t)a, vals, (UIntMaskType)__mask);
+}
+
+/* unsigned int64 implementations. */
+// unsigned int64 load.
+static inline uniform int packed_load_active(uniform unsigned int64 a[], varying unsigned int64 *uniform vals) {
+    return __packed_load_activei64((opaque_ptr_t)a, (opaque_ptr_t)vals, (UIntMaskType)__mask);
+}
+
+// unsigned int64 store.
+static inline uniform int packed_store_active(uniform unsigned int64 a[], unsigned int64 vals) {
+    return __packed_store_activei64((opaque_ptr_t)a, vals, (UIntMaskType)__mask);
+}
+
+// unsigned int64 store2.
+static inline uniform int packed_store_active2(uniform unsigned int64 a[], unsigned int64 vals) {
+    return __packed_store_active2i64((opaque_ptr_t)a, vals, (UIntMaskType)__mask);
+}
+
 /* int32 implementations. */
 // int32 load.
 static inline uniform int packed_load_active(uniform int a[], varying int *uniform vals) {
@@ -1302,20 +1350,36 @@ static inline uniform int packed_store_active(bool active, uniform int a[], int 
     return __packed_store_activei32((opaque_ptr_t)a, vals, (IntMaskType)(-(int)active));
 }
 
-/* unsigned int64 implementations. */
-// unsigned int64 load.
-static inline uniform int packed_load_active(uniform unsigned int64 a[], varying unsigned int64 *uniform vals) {
-    return __packed_load_activei64((opaque_ptr_t)a, (opaque_ptr_t)vals, (UIntMaskType)__mask);
+/* int16 implementations. */
+// int16 load.
+static inline uniform int packed_load_active(uniform int16 a[], varying int16 *uniform vals) {
+    return __packed_load_activei16((opaque_ptr_t)a, (opaque_ptr_t)vals, (IntMaskType)__mask);
 }
 
-// unsigned int64 store.
-static inline uniform int packed_store_active(uniform unsigned int64 a[], unsigned int64 vals) {
-    return __packed_store_activei64((opaque_ptr_t)a, vals, (UIntMaskType)__mask);
+// int16 store.
+static inline uniform int packed_store_active(uniform int16 a[], int16 vals) {
+    return __packed_store_activei16((opaque_ptr_t)a, vals, (IntMaskType)__mask);
 }
 
-// unsigned int64 store2.
-static inline uniform int packed_store_active2(uniform unsigned int64 a[], unsigned int64 vals) {
-    return __packed_store_active2i64((opaque_ptr_t)a, vals, (UIntMaskType)__mask);
+// int16 store2.
+static inline uniform int packed_store_active2(uniform int16 a[], int16 vals) {
+    return __packed_store_active2i16((opaque_ptr_t)a, vals, (IntMaskType)__mask);
+}
+
+/* int8 implementations. */
+// int8 load.
+static inline uniform int packed_load_active(uniform int8 a[], varying int8 *uniform vals) {
+    return __packed_load_activei8((opaque_ptr_t)a, (opaque_ptr_t)vals, (IntMaskType)__mask);
+}
+
+// int8 store.
+static inline uniform int packed_store_active(uniform int8 a[], int8 vals) {
+    return __packed_store_activei8((opaque_ptr_t)a, vals, (IntMaskType)__mask);
+}
+
+// int8 store2.
+static inline uniform int packed_store_active2(uniform int8 a[], int8 vals) {
+    return __packed_store_active2i8((opaque_ptr_t)a, vals, (IntMaskType)__mask);
 }
 
 /* int64 implementations. */
@@ -1339,6 +1403,53 @@ static inline uniform int packed_store_active(bool active, uniform int64 a[], in
     return __packed_store_activei64((opaque_ptr_t)a, vals, (IntMaskType)(-(int)active));
 }
 
+/* float16 implementations. */
+// float16 load.
+static inline uniform int packed_load_active(uniform float16 a[], varying float16 *uniform vals) {
+    return __packed_load_activef16((opaque_ptr_t)a, (opaque_ptr_t)vals, (IntMaskType)__mask);
+}
+
+// float16 store.
+static inline uniform int packed_store_active(uniform float16 a[], float16 vals) {
+    return __packed_store_activef16((opaque_ptr_t)a, vals, (IntMaskType)__mask);
+}
+
+// float16 store2.
+static inline uniform int packed_store_active2(uniform float16 a[], float16 vals) {
+    return __packed_store_active2f16((opaque_ptr_t)a, vals, (IntMaskType)__mask);
+}
+
+/* float implementations. */
+// float load.
+static inline uniform int packed_load_active(uniform float a[], varying float *uniform vals) {
+    return __packed_load_activef32((opaque_ptr_t)a, (opaque_ptr_t)vals, (IntMaskType)__mask);
+}
+
+// float store.
+static inline uniform int packed_store_active(uniform float a[], float vals) {
+    return __packed_store_activef32((opaque_ptr_t)a, vals, (IntMaskType)__mask);
+}
+
+// float store2.
+static inline uniform int packed_store_active2(uniform float a[], float vals) {
+    return __packed_store_active2f32((opaque_ptr_t)a, vals, (IntMaskType)__mask);
+}
+
+/* double implementations. */
+// double load.
+static inline uniform int packed_load_active(uniform double a[], varying double *uniform vals) {
+    return __packed_load_activef64((opaque_ptr_t)a, (opaque_ptr_t)vals, (IntMaskType)__mask);
+}
+
+// double store.
+static inline uniform int packed_store_active(uniform double a[], double vals) {
+    return __packed_store_activef64((opaque_ptr_t)a, vals, (IntMaskType)__mask);
+}
+
+// double store2.
+static inline uniform int packed_store_active2(uniform double a[], double vals) {
+    return __packed_store_active2f64((opaque_ptr_t)a, vals, (IntMaskType)__mask);
+}
 ///////////////////////////////////////////////////////////////////////////
 // streaming store
 

--- a/tests/func-tests/packed-load-16-1.ispc
+++ b/tests/func-tests/packed-load-16-1.ispc
@@ -1,0 +1,14 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform unsigned int16 a[programCount];
+    #pragma ignore warning(perf)
+    a[programIndex] = aFOO[programIndex];
+    unsigned int16 aa;
+    packed_load_active(a, &aa);
+    #pragma ignore warning(perf)
+    RET[programIndex] = aa;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1+programIndex;
+}

--- a/tests/func-tests/packed-load-16-2.ispc
+++ b/tests/func-tests/packed-load-16-2.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform int16 a[programCount];
+    a[programIndex] = aFOO[programIndex];
+    int16 aa = 15;
+    if (programIndex < 2)
+        packed_load_active(a, &aa);
+    RET[programIndex] = aa;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 15;
+    RET[0] = 1;
+    RET[1] = 2;
+}

--- a/tests/func-tests/packed-load-16-3.ispc
+++ b/tests/func-tests/packed-load-16-3.ispc
@@ -1,0 +1,14 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform int16 a[programCount];
+    a[programIndex] = aFOO[programIndex];
+    int16 aa;
+    uniform int count = 0;
+    if (programIndex < 2)
+        count += packed_load_active(a, &aa);
+    RET[programIndex] = count;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = (programCount == 1) ? 1 : 2;
+}

--- a/tests/func-tests/packed-load-16-4.ispc
+++ b/tests/func-tests/packed-load-16-4.ispc
@@ -1,0 +1,17 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform int16 a[100];
+    for (uniform int i = 0; i < 100; ++i)
+        a[i] = i;
+    int16 aa = 32;
+    uniform int count = 0;
+    if (programIndex < 2)
+        count += packed_load_active(&a[5], &aa);
+    RET[programIndex] = aa;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 32;
+    RET[0] = 5;
+    RET[1] = 6;
+}

--- a/tests/func-tests/packed-load-16-5.ispc
+++ b/tests/func-tests/packed-load-16-5.ispc
@@ -1,0 +1,24 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform int16 a[100];
+    for (uniform int i = 0; i < 100; ++i)
+        a[i] = i;
+    int16 aa = 32;
+    uniform int count = 0;
+    if (programIndex & 1)
+        count += packed_load_active(&a[10], &aa);
+    if (!(programIndex & 1))
+        count += packed_load_active(&a[10+count], &aa);
+    RET[programIndex] = aa;
+}
+
+task void result(uniform float RET[]) {
+    if (programCount == 1)
+        RET[0] = 10;
+    else {
+        for (uniform int i = 0; i < programCount/2; ++i) {
+            RET[2*i+1] = 10+i;
+            RET[2*i] = 10+programCount/2+i;
+        }
+    }
+}

--- a/tests/func-tests/packed-load-8-1.ispc
+++ b/tests/func-tests/packed-load-8-1.ispc
@@ -1,0 +1,14 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform unsigned int8 a[programCount];
+    #pragma ignore warning(perf)
+    a[programIndex] = aFOO[programIndex];
+    unsigned int8 aa;
+    packed_load_active(a, &aa);
+    #pragma ignore warning(perf)
+    RET[programIndex] = aa;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1+programIndex;
+}

--- a/tests/func-tests/packed-load-8-2.ispc
+++ b/tests/func-tests/packed-load-8-2.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform int8 a[programCount];
+    a[programIndex] = aFOO[programIndex];
+    int8 aa = 15;
+    if (programIndex < 2)
+        packed_load_active(a, &aa);
+    RET[programIndex] = aa;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 15;
+    RET[0] = 1;
+    RET[1] = 2;
+}

--- a/tests/func-tests/packed-load-8-3.ispc
+++ b/tests/func-tests/packed-load-8-3.ispc
@@ -1,0 +1,14 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform int8 a[programCount];
+    a[programIndex] = aFOO[programIndex];
+    int8 aa;
+    uniform int count = 0;
+    if (programIndex < 2)
+        count += packed_load_active(a, &aa);
+    RET[programIndex] = count;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = (programCount == 1) ? 1 : 2;
+}

--- a/tests/func-tests/packed-load-8-4.ispc
+++ b/tests/func-tests/packed-load-8-4.ispc
@@ -1,0 +1,17 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform int8 a[100];
+    for (uniform int i = 0; i < 100; ++i)
+        a[i] = i;
+    int8 aa = 32;
+    uniform int count = 0;
+    if (programIndex < 2)
+        count += packed_load_active(&a[5], &aa);
+    RET[programIndex] = aa;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 32;
+    RET[0] = 5;
+    RET[1] = 6;
+}

--- a/tests/func-tests/packed-load-8-5.ispc
+++ b/tests/func-tests/packed-load-8-5.ispc
@@ -1,0 +1,24 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform int8 a[100];
+    for (uniform int i = 0; i < 100; ++i)
+        a[i] = i;
+    int8 aa = 32;
+    uniform int count = 0;
+    if (programIndex & 1)
+        count += packed_load_active(&a[10], &aa);
+    if (!(programIndex & 1))
+        count += packed_load_active(&a[10+count], &aa);
+    RET[programIndex] = aa;
+}
+
+task void result(uniform float RET[]) {
+    if (programCount == 1)
+        RET[0] = 10;
+    else {
+        for (uniform int i = 0; i < programCount/2; ++i) {
+            RET[2*i+1] = 10+i;
+            RET[2*i] = 10+programCount/2+i;
+        }
+    }
+}

--- a/tests/func-tests/packed-load-double.ispc
+++ b/tests/func-tests/packed-load-double.ispc
@@ -1,0 +1,16 @@
+#include "test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform double a[programCount];
+    #pragma ignore warning(perf)
+    a[programIndex] = aFOO[programIndex];
+    double aa;
+    packed_load_active(a, &aa);
+    #pragma ignore warning(perf)
+    RET[programIndex] = aa;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1+programIndex;
+}

--- a/tests/func-tests/packed-load-float.ispc
+++ b/tests/func-tests/packed-load-float.ispc
@@ -1,0 +1,14 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform float a[programCount];
+    #pragma ignore warning(perf)
+    a[programIndex] = aFOO[programIndex];
+    float aa;
+    packed_load_active(a, &aa);
+    #pragma ignore warning(perf)
+    RET[programIndex] = aa;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1+programIndex;
+}

--- a/tests/func-tests/packed-load-float16.ispc
+++ b/tests/func-tests/packed-load-float16.ispc
@@ -1,0 +1,16 @@
+#include "test_static.isph"
+// rule: skip on arch=x86
+// rule: skip on arch=x86-64
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    uniform float16 a[programCount];
+    #pragma ignore warning(perf)
+    a[programIndex] = aFOO[programIndex];
+    float16 aa;
+    packed_load_active(a, &aa);
+    #pragma ignore warning(perf)
+    RET[programIndex] = aa;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1+programIndex;
+}

--- a/tests/func-tests/packed-store-16-1.ispc
+++ b/tests/func-tests/packed-store-16-1.ispc
@@ -1,0 +1,14 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex];
+    uniform int16 pack[2+programCount];
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    packed_store_active(&pack[2], (int16)a);
+    RET[programIndex] = pack[programIndex];
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = programIndex-1;
+    RET[0] = RET[1] = 0;
+}

--- a/tests/func-tests/packed-store-16-2.ispc
+++ b/tests/func-tests/packed-store-16-2.ispc
@@ -1,0 +1,17 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex];
+    uniform int16 pack[2+programCount];
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    if ((int)a & 1)
+        packed_store_active(&pack[2], (int16)a);
+    RET[programIndex] = pack[programIndex];
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 0;
+    uniform int val = 1;
+    for (uniform int i = 2; i < 2+programCount/2; ++i, val += 2)
+        RET[i] = val;
+}

--- a/tests/func-tests/packed-store-16-3.ispc
+++ b/tests/func-tests/packed-store-16-3.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex];
+    uniform int16 pack[2+programCount];
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    uniform int count = 0;
+    if ((int)a & 1)
+        count += packed_store_active(&pack[2], (int16)a);
+    RET[programIndex] = count;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = (programCount == 1) ? 1 : programCount/2;
+}

--- a/tests/func-tests/packed-store-16.ispc
+++ b/tests/func-tests/packed-store-16.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform unsigned int16 pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    #pragma ignore warning(perf)
+    packed_store_active(pack, (unsigned int16)a);
+    #pragma ignore warning(perf)
+    RET[programIndex] = pack[programIndex]; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}

--- a/tests/func-tests/packed-store-64.ispc
+++ b/tests/func-tests/packed-store-64.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform unsigned int64 pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    #pragma ignore warning(perf)
+    packed_store_active(pack, (unsigned int64)a);
+    #pragma ignore warning(perf)
+    RET[programIndex] = pack[programIndex]; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}

--- a/tests/func-tests/packed-store-8-1.ispc
+++ b/tests/func-tests/packed-store-8-1.ispc
@@ -1,0 +1,14 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex];
+    uniform int8 pack[2+programCount];
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    packed_store_active(&pack[2], (int8)a);
+    RET[programIndex] = pack[programIndex];
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = programIndex-1;
+    RET[0] = RET[1] = 0;
+}

--- a/tests/func-tests/packed-store-8-2.ispc
+++ b/tests/func-tests/packed-store-8-2.ispc
@@ -1,0 +1,17 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex];
+    uniform int8 pack[2+programCount];
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    if ((int)a & 1)
+        packed_store_active(&pack[2], (int8)a);
+    RET[programIndex] = pack[programIndex];
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 0;
+    uniform int val = 1;
+    for (uniform int i = 2; i < 2+programCount/2; ++i, val += 2)
+        RET[i] = val;
+}

--- a/tests/func-tests/packed-store-8-3.ispc
+++ b/tests/func-tests/packed-store-8-3.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex];
+    uniform int8 pack[2+programCount];
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    uniform int count = 0;
+    if ((int)a & 1)
+        count += packed_store_active(&pack[2], (int8)a);
+    RET[programIndex] = count;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = (programCount == 1) ? 1 : programCount/2;
+}

--- a/tests/func-tests/packed-store-8.ispc
+++ b/tests/func-tests/packed-store-8.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform unsigned int8 pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    #pragma ignore warning(perf)
+    packed_store_active(pack, (unsigned int8)a);
+    #pragma ignore warning(perf)
+    RET[programIndex] = pack[programIndex]; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}

--- a/tests/func-tests/packed-store-double.ispc
+++ b/tests/func-tests/packed-store-double.ispc
@@ -1,0 +1,17 @@
+#include "test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform double pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    #pragma ignore warning(perf)
+    packed_store_active(pack, (double)a);
+    #pragma ignore warning(perf)
+    RET[programIndex] = pack[programIndex]; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}

--- a/tests/func-tests/packed-store-float.ispc
+++ b/tests/func-tests/packed-store-float.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform float pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    #pragma ignore warning(perf)
+    packed_store_active(pack, a);
+    #pragma ignore warning(perf)
+    RET[programIndex] = pack[programIndex]; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}

--- a/tests/func-tests/packed-store-float16.ispc
+++ b/tests/func-tests/packed-store-float16.ispc
@@ -1,0 +1,17 @@
+#include "test_static.isph"
+// rule: skip on arch=x86
+// rule: skip on arch=x86-64
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform float16 pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    #pragma ignore warning(perf)
+    packed_store_active(pack, (float16)a);
+    #pragma ignore warning(perf)
+    RET[programIndex] = pack[programIndex]; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}

--- a/tests/func-tests/packed-store2-16-1.ispc
+++ b/tests/func-tests/packed-store2-16-1.ispc
@@ -1,0 +1,14 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex];
+    uniform int16 pack[2+programCount];
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    packed_store_active2(&pack[2], (int16)a);
+    RET[programIndex] = pack[programIndex];
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = programIndex-1;
+    RET[0] = RET[1] = 0;
+}

--- a/tests/func-tests/packed-store2-16-2.ispc
+++ b/tests/func-tests/packed-store2-16-2.ispc
@@ -1,0 +1,19 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex];
+    uniform int16 pack[2+programCount];
+    uniform int number;
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    if ((int)a & 1)
+        number = packed_store_active2(&pack[2], (int16)a);
+    pack[2+number] = 0;
+    RET[programIndex] = pack[programIndex];
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 0;
+    uniform int val = 1;
+    for (uniform int i = 2; i < 2+programCount/2; ++i, val += 2)
+        RET[i] = val;
+}

--- a/tests/func-tests/packed-store2-16-3.ispc
+++ b/tests/func-tests/packed-store2-16-3.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex];
+    uniform int16 pack[2+programCount];
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    uniform int count = 0;
+    if ((int)a & 1)
+        count += packed_store_active2(&pack[2], (int16)a);
+    RET[programIndex] = count;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = (programCount == 1) ? 1 : programCount/2;
+}

--- a/tests/func-tests/packed-store2-16.ispc
+++ b/tests/func-tests/packed-store2-16.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform unsigned int16 pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    #pragma ignore warning(perf)
+    packed_store_active2(pack, (unsigned int16)a);
+    #pragma ignore warning(perf)
+    RET[programIndex] = pack[programIndex]; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}

--- a/tests/func-tests/packed-store2-64.ispc
+++ b/tests/func-tests/packed-store2-64.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform unsigned int64 pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    #pragma ignore warning(perf)
+    packed_store_active2(pack, (unsigned int64)a);
+    #pragma ignore warning(perf)
+    RET[programIndex] = pack[programIndex]; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}

--- a/tests/func-tests/packed-store2-8-1.ispc
+++ b/tests/func-tests/packed-store2-8-1.ispc
@@ -1,0 +1,14 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex];
+    uniform int8 pack[2+programCount];
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    packed_store_active2(&pack[2], (int8)a);
+    RET[programIndex] = pack[programIndex];
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = programIndex-1;
+    RET[0] = RET[1] = 0;
+}

--- a/tests/func-tests/packed-store2-8-2.ispc
+++ b/tests/func-tests/packed-store2-8-2.ispc
@@ -1,0 +1,19 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex];
+    uniform int8 pack[2+programCount];
+    uniform int number;
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    if ((int)a & 1)
+        number = packed_store_active2(&pack[2], (int8)a);
+    pack[2+number] = 0;
+    RET[programIndex] = pack[programIndex];
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 0;
+    uniform int val = 1;
+    for (uniform int i = 2; i < 2+programCount/2; ++i, val += 2)
+        RET[i] = val;
+}

--- a/tests/func-tests/packed-store2-8-3.ispc
+++ b/tests/func-tests/packed-store2-8-3.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex];
+    uniform int8 pack[2+programCount];
+    for (uniform int i = 0; i < 2+programCount; ++i)
+        pack[i] = 0;
+    uniform int count = 0;
+    if ((int)a & 1)
+        count += packed_store_active2(&pack[2], (int8)a);
+    RET[programIndex] = count;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = (programCount == 1) ? 1 : programCount/2;
+}

--- a/tests/func-tests/packed-store2-8.ispc
+++ b/tests/func-tests/packed-store2-8.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform unsigned int8 pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    #pragma ignore warning(perf)
+    packed_store_active2(pack, (unsigned int8)a);
+    #pragma ignore warning(perf)
+    RET[programIndex] = pack[programIndex]; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}

--- a/tests/func-tests/packed-store2-double.ispc
+++ b/tests/func-tests/packed-store2-double.ispc
@@ -1,0 +1,17 @@
+#include "test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform double pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    #pragma ignore warning(perf)
+    packed_store_active2(pack, (double)a);
+    #pragma ignore warning(perf)
+    RET[programIndex] = pack[programIndex]; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}

--- a/tests/func-tests/packed-store2-float.ispc
+++ b/tests/func-tests/packed-store2-float.ispc
@@ -1,0 +1,15 @@
+#include "test_static.isph"
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform float pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    #pragma ignore warning(perf)
+    packed_store_active2(pack, (float)a);
+    #pragma ignore warning(perf)
+    RET[programIndex] = pack[programIndex]; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}

--- a/tests/func-tests/packed-store2-float16.ispc
+++ b/tests/func-tests/packed-store2-float16.ispc
@@ -1,0 +1,17 @@
+#include "test_static.isph"
+// rule: skip on arch=x86
+// rule: skip on arch=x86-64
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    float a = aFOO[programIndex]; 
+    uniform float16 pack[programCount];
+    for (uniform int i = 0; i < programCount; ++i)
+        pack[i] = 0;
+    #pragma ignore warning(perf)
+    packed_store_active2(pack, (float16)a);
+    #pragma ignore warning(perf)
+    RET[programIndex] = pack[programIndex]; 
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 1 + programIndex;
+}


### PR DESCRIPTION
This PR adds support for signed/unsigned int8, int16, float16, float and double into `packed_load`/`packed_store`.
Fixes https://github.com/ispc/ispc/issues/3095.