### PR TITLE
Report compilation errors about incomplete types

### DIFF
--- a/src/func.cpp
+++ b/src/func.cpp
@@ -206,6 +206,21 @@ Function::Function(Symbol *s, Stmt *c, Symbol *ms, std::vector<Symbol *> &a)
 }
 
 void Function::typeCheckAndOptimize() {
+    const FunctionType *funcType = GetType();
+    const Type *retType = GetType()->GetReturnType();
+    if (!retType->IsCompleteType()) {
+        Error(funcType->GetSourcePos(), "return type is an incomplete type: %s", retType->GetString().c_str());
+    }
+
+    for (int i = 0; i < funcType->GetNumParameters(); i++) {
+        const Type *paramType = funcType->GetParameterType(i);
+        if (!paramType->IsCompleteType()) {
+            const SourcePos &pos = funcType->GetParameterSourcePos(i);
+            const std::string &paramName = funcType->GetParameterName(i);
+            Error(pos, "parameter '%s' is an incomplete type: %s", paramName.c_str(), paramType->GetString().c_str());
+        }
+    }
+
     if (code != nullptr) {
         debugPrintHelper(DebugPrintPoint::Initial);
 

--- a/src/type.h
+++ b/src/type.h
@@ -123,6 +123,12 @@ class Type : public Traceable {
     /** Returns true if this type is 'const'-qualified. */
     virtual bool IsConstType() const = 0;
 
+    /** Returns true if this type is complete. This is used to check for
+        incomplete types (e.g. forward-declared structs) that are not
+        allowed in certain contexts, e.g., when we need to allocate memory for
+        them. */
+    virtual bool IsCompleteType() const = 0;
+
     /** Returns true if the underlying type is a float or integer type. */
     bool IsNumericType() const { return IsFloatType() || IsIntType(); }
 
@@ -309,6 +315,7 @@ class AtomicType : public Type {
     bool IsUnsignedType() const;
     bool IsSignedType() const;
     bool IsConstType() const;
+    bool IsCompleteType() const;
 
     /** For AtomicTypes, the base type is just the same as the AtomicType
         itself. */
@@ -404,6 +411,7 @@ class TemplateTypeParmType : public Type {
     bool IsUnsignedType() const;
     bool IsSignedType() const;
     bool IsConstType() const;
+    bool IsCompleteType() const;
 
     const Type *GetBaseType() const;
     const Type *GetAsVaryingType() const;
@@ -453,6 +461,7 @@ class EnumType : public Type {
     bool IsUnsignedType() const;
     bool IsSignedType() const;
     bool IsConstType() const;
+    bool IsCompleteType() const;
 
     const EnumType *GetBaseType() const;
     const EnumType *GetAsVaryingType() const;
@@ -534,6 +543,7 @@ class PointerType : public Type {
     bool IsUnsignedType() const;
     bool IsSignedType() const;
     bool IsConstType() const;
+    bool IsCompleteType() const;
 
     bool IsSlice() const { return isSlice; }
     bool IsFrozenSlice() const { return isFrozen; }
@@ -676,6 +686,7 @@ class ArrayType : public SequentialType {
     bool IsUnsignedType() const;
     bool IsSignedType() const;
     bool IsConstType() const;
+    bool IsCompleteType() const;
     /* Returns true if the number of elements in the array is dependent on a template parameter. */
     virtual bool IsCountDependent() const { return elementCount.symbolCount != nullptr; }
 
@@ -757,6 +768,7 @@ class VectorType : public SequentialType {
     bool IsUnsignedType() const;
     bool IsSignedType() const;
     bool IsConstType() const;
+    bool IsCompleteType() const;
     /* Returns true if the number of elements in the vector is dependent on a template parameter. */
     virtual bool IsCountDependent() const { return elementCount.symbolCount != nullptr; }
 
@@ -818,6 +830,7 @@ class StructType : public CollectionType {
     bool IsUnsignedType() const;
     bool IsSignedType() const;
     bool IsConstType() const;
+    bool IsCompleteType() const;
     bool IsDefined() const;
     bool IsAnonymousType() const;
 
@@ -915,6 +928,7 @@ class UndefinedStructType : public Type {
     bool IsUnsignedType() const;
     bool IsSignedType() const;
     bool IsConstType() const;
+    bool IsCompleteType() const;
 
     const Type *GetBaseType() const;
     const UndefinedStructType *GetAsVaryingType() const;
@@ -959,6 +973,7 @@ class ReferenceType : public Type {
     bool IsUnsignedType() const;
     bool IsSignedType() const;
     bool IsConstType() const;
+    bool IsCompleteType() const;
     AddressSpace GetAddressSpace() const { return addrSpace; }
 
     const Type *GetBaseType() const;
@@ -1020,6 +1035,7 @@ class FunctionType : public Type {
     bool IsUnsignedType() const;
     bool IsSignedType() const;
     bool IsConstType() const;
+    bool IsCompleteType() const;
 
     bool IsISPCKernel() const;
     bool IsISPCExternal() const;

--- a/src/type.h
+++ b/src/type.h
@@ -951,6 +951,7 @@ class UndefinedStructType : public Type {
 
     /** Returns the name of the structure type.  (e.g. struct Foo -> "Foo".) */
     const std::string &GetStructName() const { return name; }
+    const SourcePos &GetSourcePos() const { return pos; };
 
   private:
     const std::string name;

--- a/tests/lit-tests/2844-1.ispc
+++ b/tests/lit-tests/2844-1.ispc
@@ -1,0 +1,11 @@
+// Check that we catch the case where a function returns an incomplete struct type
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s
+
+// CHECK: Error: return type is an incomplete type: varying struct Sx
+struct Sx bar() {}
+
+// CHECK-NOT: Error: return type is an incomplete type: varying struct Sy
+struct Sy foo();
+
+// CHECK-NOT: FATAL ERROR:

--- a/tests/lit-tests/2844-2.ispc
+++ b/tests/lit-tests/2844-2.ispc
@@ -1,0 +1,18 @@
+// Check that we catch incomplete struct types in function parameters
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s
+
+// CHECK: Error: parameter 'a' is an incomplete type: varying struct Sy
+int bar(struct Sy a) {}
+
+// CHECK-NOT: Error: parameter 'b' is an incomplete type: varying struct Sx
+int foo(struct Sx b);
+
+// CHECK-NOT: Error: parameter 'n' is an incomplete
+int func1(struct Sn *n) {}
+// CHECK-NOT: Error: parameter 'm' is an incomplete
+int func2(struct Sm &m) {}
+// CHECK-NOT: Error: parameter 'q' is an incomplete
+int boo(struct Cs q[10]) {}
+
+// CHECK-NOT: FATAL ERROR:

--- a/tests/lit-tests/2844-3.ispc
+++ b/tests/lit-tests/2844-3.ispc
@@ -1,0 +1,15 @@
+// Check that we catch incomplete struct types in variable definitions
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s
+
+// CHECK: Error: variable 'x' has initializer but incomplete struct type
+int foo() { struct Sx x = { 0 }; }
+// CHECK: Error: variable 'y' has incomplete struct type 'varying struct Sy' and cannot be defined
+int bar() { struct Sy y; }
+
+// CHECK: Error: Attempt to allocate memory for incomplete type "varying struct Sz[10]".
+int func() { struct Sz z[10]; }
+// CHECK-NOT: Error: Attempt to allocate memory for incomplete type "varying struct St[10]".
+int func2() { struct St* p[10]; }
+
+// CHECK-NOT: FATAL ERROR:

--- a/tests/lit-tests/2844-4.ispc
+++ b/tests/lit-tests/2844-4.ispc
@@ -1,0 +1,25 @@
+// Test that incomplete struct types are properly diagnosed in initializers and
+// variable declarations with recursive struct types with incomplete struct
+// types.
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s
+
+// CHECK: Error: incomplete type 'S1'.
+// CHECK-NEXT: - field 'a' has incomplete type '/*unbound*/ struct S2'.
+struct S1 { struct S2 a; };
+struct S1 func() {
+// CHECK: Error: variable 'x' has initializer but incomplete struct type
+    struct S1 x = { 0 };
+    return x;
+}
+
+struct S3 { struct S4 a; };
+struct S3 foo() {
+// CHECK: Error: variable 'y' has incomplete struct type 'varying struct S3' and cannot be defined
+    struct S3 y;
+// CHECK: Error: Attempt to allocate memory for incomplete type "varying struct S3".
+// CHECK: Error: Malformed return value in function with non-void return type.
+    return y;
+}
+
+// CHECK-NOT: FATAL ERROR

--- a/tests/lit-tests/2844-5.ispc
+++ b/tests/lit-tests/2844-5.ispc
@@ -1,0 +1,11 @@
+// Test that we catch incomplete struct types.
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s
+
+// CHECK: Error: incomplete type 'S1'.
+// CHECK-NEXT: - field 'a' has incomplete type '/*unbound*/ struct S2'.
+struct S1 { struct S2 a; };
+
+// CHECK-NOT: Error: incomplete type 'C1'. 
+// CHECK-NOT: - field 'c' has incomplete type
+struct C1 { struct I1 *c; };

--- a/tests/lit-tests/2844-6.ispc
+++ b/tests/lit-tests/2844-6.ispc
@@ -1,0 +1,16 @@
+// Test for incomplete types regarding unsized arrays.
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s
+
+// CHECK: Error: incomplete type 'S1'
+struct S1 { int a[]; };
+
+// CHECK-NOT: Error: incomplete type 'S2'
+struct S2 { int y; int x[]; };
+
+// CHECK-NOT: Error: parameter 'b' has incomplete type
+int foo(int b[]);
+// CHECK-NOT: Error: parameter 'c' has incomplete type
+int boo(int c[]) { return c[0]; }
+
+// CHECK-NOT: FATAL ERROR:

--- a/tests/lit-tests/2844-7.ispc
+++ b/tests/lit-tests/2844-7.ispc
@@ -1,0 +1,16 @@
+// Check incomplete struct type handling in template functions parameters and return types
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s
+
+// CHECK: Error: variable 'x' has incomplete struct type 'varying struct Si' and cannot be defined
+// CHECK: Error: return type is an incomplete type: varying struct Si
+// CHECK: Error: parameter 'a' is an incomplete type: varying struct Si
+// CHECK: Error: Attempt to allocate memory for incomplete type "varying struct Si".
+// CHECK: Error: Malformed return value in function with non-void return type.
+template <typename T> T bar(T a) { return a; }
+
+int foo() {
+    struct Si x;
+    bar(x);
+    return 0;
+}

--- a/tests/lit-tests/478.ispc
+++ b/tests/lit-tests/478.ispc
@@ -1,0 +1,7 @@
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s
+
+// CHECK: Error: variable 't' has incomplete struct type 'varying struct Test' and cannot be defined
+extern "C" struct Test;
+export void simple() { Test t; }
+
+// CHECK-NOT: FATAL ERROR:


### PR DESCRIPTION
This fixes #2844 and #478.

This change adds error reports for incomplete types in various situations:
- return values of functions
- parameters of functions
- variable declaration and initialization