### PR TITLE
Fix the quick-start-build.py script when it is rerun on Windows

### DIFF
--- a/scripts/quick-start-build.py
+++ b/scripts/quick-start-build.py
@@ -487,11 +487,11 @@ Examples:
     else:
         print(f"{llvm_dir} already exists")
 
+    build_type = "RelWithDebInfo" if is_windows else "Debug"
     if not build_dir.exists():
         env = os.environ.copy()
         env["PATH"] = f"{llvm_dir / 'bin'}{os.pathsep}{env['PATH']}"
 
-        build_type = "RelWithDebInfo" if is_windows else "Debug"
         configure_cmd = [
             "cmake",
             "-B", str(build_dir),


### PR DESCRIPTION
This PR fixes the issue that one reruns the `quick-start-build.py` script on Windows, e.g., for rebuilding ISPC after some changes or for running tests.