### PR TITLE
Fix generic-i1x64 target

### DIFF
--- a/builtins/generic.ispc
+++ b/builtins/generic.ispc
@@ -1381,7 +1381,7 @@ EXT uniform uint64 __cast_mask_to_i64(UIntMaskType mask) { return @llvm.ispc.pac
 // mask operations
 EXT uniform int64 __movmsk(UIntMaskType mask) { return __cast_mask_to_i64(mask); }
 EXT uniform bool __any(UIntMaskType mask) { return __cast_mask_to_i64(mask) != 0; }
-EXT uniform bool __all(UIntMaskType mask) { return __cast_mask_to_i64(mask) == (1ULL << TARGET_WIDTH) - 1; }
+EXT uniform bool __all(UIntMaskType mask) { return __cast_mask_to_i64(mask) == ~0ULL >> (64 - TARGET_WIDTH); }
 EXT uniform bool __none(UIntMaskType mask) { return __cast_mask_to_i64(mask) == 0; }
 
 // general gather functions

--- a/cmake/GenericTargets.cmake
+++ b/cmake/GenericTargets.cmake
@@ -40,12 +40,12 @@ function (generate_generic_builtins ispc_name)
         list(APPEND os_list "unix")
     endif()
 
-    # "generic-i1x64" is not supported due to #3123
     list(APPEND TARGET_LIST
         "i1x4"
         "i1x8"
         "i1x16"
         "i1x32"
+        "i1x64"
         "i8x16"
         "i8x32"
         "i16x8"

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1302,6 +1302,9 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_vectorWidth = 64;
         this->m_maskingIsFree = true;
         this->m_maskBitCount = 1;
+        // TODO: this is a workaround for the bug in GatherCoalescePass for x32 targets.
+        // see issue #3153
+        this->m_hasGather = true;
         break;
     case ISPCTarget::sse2_i32x4:
         this->m_isa = Target::SSE2;

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1703,9 +1703,13 @@ declarator
 
 int_constant
     : TOKEN_INT8_CONSTANT { $$ = yylval.intVal; }
+    | TOKEN_UINT8_CONSTANT { $$ = yylval.intVal; }
     | TOKEN_INT16_CONSTANT { $$ = yylval.intVal; }
+    | TOKEN_UINT16_CONSTANT { $$ = yylval.intVal; }
     | TOKEN_INT32_CONSTANT { $$ = yylval.intVal; }
+    | TOKEN_UINT32_CONSTANT { $$ = yylval.intVal; }
     | TOKEN_INT64_CONSTANT { $$ = yylval.intVal; }
+    | TOKEN_UINT64_CONSTANT { $$ = yylval.intVal; }
     ;
 
 direct_declarator

--- a/tests/lit-tests/3123.ispc
+++ b/tests/lit-tests/3123.ispc
@@ -1,0 +1,6 @@
+// RUN: %{ispc} --target=generic-i1x64 --nostdlib %s --nowrap -o %t.o 2>&1 | FileCheck %s --allow-empty
+// CHECK-NOT: Error: syntax error
+
+// REQUIRES: X86_ENABLED && !MACOS_HOST
+
+uniform int<128> data;

--- a/tests/lit-tests/err-soa-1.ispc
+++ b/tests/lit-tests/err-soa-1.ispc
@@ -8,7 +8,7 @@ struct F { float a, b, c; };
 // CHECK: Error: soa<3> width illegal. Value must be positive power of two
 soa<3> F farray1[10];
 
-// CHECK: Error: syntax error, unexpected '-', expecting int
+// CHECK: Error: syntax error, unexpected '-'.
 soa<-4> F farray2[10];
 
 // CHECK: Error: "uniform" qualifier and "soa<4>" qualifier can't both be used

--- a/tests/lit-tests/generic-target-aarch64.ispc
+++ b/tests/lit-tests/generic-target-aarch64.ispc
@@ -2,7 +2,7 @@
 // RUN: %{ispc} --target=generic-i1x8 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X8
 // RUN: %{ispc} --target=generic-i1x16 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X16
 // RUN: %{ispc} --target=generic-i1x32 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X32
-// TODO!: %{ispc} --target=generic-i1x64 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X64
+// RUN: %{ispc} --target=generic-i1x64 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X64
 // RUN: %{ispc} --target=generic-i8x16 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X16
 // RUN: %{ispc} --target=generic-i8x32 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X32
 // RUN: %{ispc} --target=generic-i16x8 --arch=aarch64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I16X8

--- a/tests/lit-tests/generic-target-arm.ispc
+++ b/tests/lit-tests/generic-target-arm.ispc
@@ -2,7 +2,7 @@
 // RUN: %{ispc} --target=generic-i1x8 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X8
 // RUN: %{ispc} --target=generic-i1x16 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X16
 // RUN: %{ispc} --target=generic-i1x32 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X32
-// TODO!: %{ispc} --target=generic-i1x64 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X64
+// RUN: %{ispc} --target=generic-i1x64 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X64
 // RUN: %{ispc} --target=generic-i8x16 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X16
 // RUN: %{ispc} --target=generic-i8x32 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X32
 // RUN: %{ispc} --target=generic-i16x8 --arch=arm --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I16X8

--- a/tests/lit-tests/generic-target-x86.ispc
+++ b/tests/lit-tests/generic-target-x86.ispc
@@ -2,7 +2,7 @@
 // RUN: %{ispc} --target=generic-i1x8 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X8
 // RUN: %{ispc} --target=generic-i1x16 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X16
 // RUN: %{ispc} --target=generic-i1x32 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X32
-// TODO!: %{ispc} --target=generic-i1x64 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X64
+// RUN: %{ispc} --target=generic-i1x64 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X64
 // RUN: %{ispc} --target=generic-i8x16 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X16
 // RUN: %{ispc} --target=generic-i8x32 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X32
 // RUN: %{ispc} --target=generic-i16x8 --arch=x86 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I16X8

--- a/tests/lit-tests/generic-target-x86_64.ispc
+++ b/tests/lit-tests/generic-target-x86_64.ispc
@@ -2,7 +2,7 @@
 // RUN: %{ispc} --target=generic-i1x8 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X8
 // RUN: %{ispc} --target=generic-i1x16 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X16
 // RUN: %{ispc} --target=generic-i1x32 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X32
-// TODO!: %{ispc} --target=generic-i1x64 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X64
+// RUN: %{ispc} --target=generic-i1x64 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I1X64
 // RUN: %{ispc} --target=generic-i8x16 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X16
 // RUN: %{ispc} --target=generic-i8x32 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I8X32
 // RUN: %{ispc} --target=generic-i16x8 --arch=x86_64 --nostdlib %s --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK-I16X8


### PR DESCRIPTION
This PR fixes generic_i1x64 target so it can be used in targets' hierarchy.
Fixes #3123 