### PR TITLE
#3098 fix the warnings in examples/cpu and update CI workflow to enforce -Werror flag for examples build

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -1404,7 +1404,7 @@ jobs:
     - name: Build examples
       run: |
         mkdir examples-build
-        cmake examples-package\examples\cpu -B examples-build -Thost=x64 -G "Visual Studio 16"
+        cmake -DCMAKE_C_FLAGS="/WX" -DCMAKE_CXX_FLAGS="/WX" examples-package\examples\cpu -B examples-build -Thost=x64 -G "Visual Studio 16"
         cmake --build examples-build --target ALL_BUILD --config Release
       shell: cmd
 
@@ -1441,7 +1441,7 @@ jobs:
     - name: Build examples
       run: |
         mkdir examples-build
-        cmake examples-package/examples/cpu -B examples-build
+        cmake -DCMAKE_C_FLAGS="-Wall -Werror" -DCMAKE_CXX_FLAGS="-Wall -Werror" examples-package/examples/cpu -B examples-build
         cmake --build examples-build
 
   macos-build-examples:
@@ -1476,7 +1476,7 @@ jobs:
     - name: Build examples
       run: |
         mkdir examples-build
-        cmake examples-package/examples/cpu -B examples-build
+        cmake -DCMAKE_C_FLAGS="-Wall -Werror" -DCMAKE_CXX_FLAGS="-Wall -Werror" examples-package/examples/cpu -B examples-build
         cmake --build examples-build
 
   linux-wasm:

--- a/examples/common/tasksys.cpp
+++ b/examples/common/tasksys.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2023, Intel Corporation
+  Copyright (c) 2011-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -326,7 +326,7 @@ static int32_t lAtomicCompareAndSwap32(volatile int32_t *v, int32_t newValue, in
 #endif // ISPC_IS_WINDOWS
 }
 
-static inline int32_t lAtomicAdd(volatile int32_t *v, int32_t delta) {
+[[maybe_unused]] static inline int32_t lAtomicAdd(volatile int32_t *v, int32_t delta) {
 #ifdef ISPC_IS_WINDOWS
     return InterlockedExchangeAdd((volatile LONG *)v, delta) + delta;
 #else

--- a/examples/cpu/CMakeLists.txt
+++ b/examples/cpu/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2023, Intel Corporation
+#  Copyright (c) 2018-2025, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -10,6 +10,11 @@ cmake_minimum_required(VERSION 3.12)
 
 set (PROJECT_NAME ispc_examples)
 project(${PROJECT_NAME} C CXX)
+
+# Set the C++ standard to C++17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(CMAKE_BUILD_TYPE)
     # Validate build type

--- a/examples/cpu/cmake/AddISPCExampleLegacy.cmake
+++ b/examples/cpu/cmake/AddISPCExampleLegacy.cmake
@@ -71,10 +71,6 @@ function(add_ispc_example)
     target_sources(${example_NAME} PRIVATE ${example_TARGET_SOURCES})
     target_include_directories(${example_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-     # Set C++ standard to C++11.
-     set_target_properties(${example_NAME} PROPERTIES
-         CXX_STANDARD 11
-         CXX_STANDARD_REQUIRED YES)
 
     # Compile options
     set_property(TARGET ${example_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/examples/cpu/cmake/AddISPCExampleModern.cmake
+++ b/examples/cpu/cmake/AddISPCExampleModern.cmake
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018-2024, Intel Corporation
+#  Copyright (c) 2018-2025, Intel Corporation
 #
 #  SPDX-License-Identifier: BSD-3-Clause
 
@@ -27,10 +27,6 @@ function(add_ispc_example)
             ${example_TARGET_SOURCES}
         )
 
-    # Set C++ standard to C++11.
-    set_target_properties(${example_NAME} PROPERTIES
-        CXX_STANDARD 11
-        CXX_STANDARD_REQUIRED YES)
 
     set_property(TARGET ${example_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
     set_property(TARGET ${example_NAME} PROPERTY ISPC_INSTRUCTION_SETS "${ISPC_TARGETS}")

--- a/examples/cpu/deferred/dynamic_c.cpp
+++ b/examples/cpu/deferred/dynamic_c.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2023, Intel Corporation
+  Copyright (c) 2011-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -331,8 +331,14 @@ static inline float half_to_float_fast(uint16_t h) {
     uint32_t xm = ((uint32_t)hm) << 13;
 
     uint32_t bits = (xs | xe | xm);
-    float *fp = reinterpret_cast<float *>(&bits);
-    return *fp;
+
+    // Use a union for safe type punning.
+    union {
+        uint32_t u;
+        float f;
+    } conv;
+    conv.u = bits;
+    return conv.f;
 }
 
 static void ShadeTileC(int32_t tileStartX, int32_t tileEndX, int32_t tileStartY, int32_t tileEndY, int32_t gBufferWidth,

--- a/examples/cpu/gmres/debug.h
+++ b/examples/cpu/gmres/debug.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2023, Intel Corporation
+  Copyright (c) 2012-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -8,11 +8,21 @@
 #define __DEBUG_H__
 
 #include <cassert>
+#include <cstdio>
 
 /**************************************************************\
 | Macros
 \**************************************************************/
 #define DEBUG
+
+// Define the correct format specifier for size_t
+#ifdef _MSC_VER
+  // MSVC: use '%zu'
+  #define SIZE_T_FORMAT "%zu"
+#else
+  // Linux/macOS: use '%lu'
+  #define SIZE_T_FORMAT "%lu"
+#endif
 
 #ifdef DEBUG
 #define ASSERT(expr) assert(expr)

--- a/examples/cpu/gmres/main.cpp
+++ b/examples/cpu/gmres/main.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2023, Intel Corporation
+  Copyright (c) 2012-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
     Matrix *A = CRSMatrix::matrix_from_mtf(argv[1]);
     if (A == nullptr)
         return -1;
-    DEBUG_PRINT("... size: %lu\n", A->cols());
+    DEBUG_PRINT("... size: " SIZE_T_FORMAT "\n", A->cols());
 
     DEBUG_PRINT("Loading b...\n");
     Vector *b = Vector::vector_from_mtf(argv[2]);

--- a/examples/cpu/gmres/matrix.h
+++ b/examples/cpu/gmres/matrix.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2023, Intel Corporation
+  Copyright (c) 2012-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -159,11 +159,11 @@ class DenseMatrix : public Matrix {
     friend class Vector;
 
   public:
-    DenseMatrix(size_t size_r, size_t size_c) : Matrix(size_r, size_c), shared_ptr(false) {
+    DenseMatrix(size_t size_r, size_t size_c) : Matrix(size_r, size_c) {
         entries = (double *)malloc(size_r * size_c * sizeof(double));
     }
 
-    DenseMatrix(size_t size_r, size_t size_c, const double *content) : Matrix(size_r, size_c), shared_ptr(false) {
+    DenseMatrix(size_t size_r, size_t size_c, const double *content) : Matrix(size_r, size_c) {
         entries = (double *)malloc(size_r * size_c * sizeof(double));
         memcpy(entries, content, size_r * size_c * sizeof(double));
     }
@@ -192,7 +192,6 @@ class DenseMatrix : public Matrix {
 
   private:
     double *entries;
-    bool shared_ptr;
 };
 
 /**************************************************************\

--- a/examples/cpu/gmres/mmio.c
+++ b/examples/cpu/gmres/mmio.c
@@ -357,13 +357,12 @@ char *mm_typecode_to_str(MM_typecode matcode) {
     char buffer[MM_MAX_LINE_LENGTH];
     char *types[4];
     char *mm_strdup(const char *);
-    int error = 0;
 
     /* check for MTX type */
     if (mm_is_matrix(matcode))
         types[0] = MM_MTX_STR;
     else
-        error = 1;
+        return NULL;
 
     /* check for CRD or ARR matrix */
     if (mm_is_sparse(matcode))


### PR DESCRIPTION
fix the warnings in examples/cpu and update CI workflow to enforce -Werror flag for examples build
there are two warnings detected for the examples/cpu
1. in examples/cpu/deferred, the compiler warning arises from the use of a reinterpret_cast to convert the address of a local variable into a float pointer. A common and safe solution is to avoid the reinterpret_cast altogether and use a union for type punning.
2. in examples/cpu/gmres: the warning appears because the variable 'error' is set (in the else branch of the first check) but is never actually used in any decision-making or output. It was fixed by removing the unused 'error' variable

Finally, The ispc-ci.yml workflow was updated to enforce -Werror flag for examples build