### PR TITLE
Add -dD and -dM compile flags for ispc ( Closes #3205 )

### DIFF
--- a/src/ispc.h
+++ b/src/ispc.h
@@ -891,6 +891,11 @@ struct Globals {
 
     enum pragmaUnrollType { none, nounroll, unroll, count };
 
+    /** Preprocessor Output Types, process with -E/-dD/-dM options */
+    enum class PreprocessorOutputType { Cpp, WithMacros, MacrosOnly };
+
+    PreprocessorOutputType preprocessorOutputType = PreprocessorOutputType::Cpp;
+
     /* If true, we are compiling for more than one target. */
     bool isMultiTargetCompilation;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,7 @@ static void lPrintVersion() {
     printf("    [--darwin-version-min=<major.minor>]Set the minimum macOS/iOS version required for the "
            "deployment.\n");
 #endif
+    printf("    [-dD]\t\t\t\tPrint macro definitions in addition to the preprocessor result\n");
     printf("    [--dev-stub <filename>]\t\tEmit device-side offload stub functions to file\n");
     printf("    ");
     char cpuHelp[2048];
@@ -78,6 +79,7 @@ static void lPrintVersion() {
              Target::SupportedCPUs().c_str());
     PrintWithWordBreaks(cpuHelp, 16, TerminalWidth(), stdout);
     printf("    [--dllexport]\t\t\tMake non-static functions DLL exported.  Windows target only\n");
+    printf("    [-dM]\t\t\t\tPrint macro definitions for the preprocessor result\n");
     printf("    [--dwarf-version={2,3,4,5}]\t\tGenerate source-level debug information with given DWARF version "
            "(triggers -g).  It forces the usage of DWARF debug info on Windows target\n");
     printf("    [-E]\t\t\t\tRun only the preprocessor\n");
@@ -821,6 +823,15 @@ int main(int Argc, char *Argv[]) {
         } else if (!strcmp(argv[i], "-E")) {
             g->onlyCPP = true;
             ot = Module::CPPStub;
+            // g->preprocessorOutputType is initialized as "Cpp" automatically
+        } else if (!strcmp(argv[i], "-dM")) {
+            g->onlyCPP = true;
+            ot = Module::CPPStub;
+            g->preprocessorOutputType = Globals::PreprocessorOutputType::MacrosOnly;
+        } else if (!strcmp(argv[i], "-dD")) {
+            g->onlyCPP = true;
+            ot = Module::CPPStub;
+            g->preprocessorOutputType = Globals::PreprocessorOutputType::WithMacros;
         } else if (!strcmp(argv[i], "--emit-asm")) {
             ot = Module::Asm;
         } else if (!strcmp(argv[i], "--emit-llvm")) {

--- a/src/module.h
+++ b/src/module.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -127,7 +127,7 @@ class Module {
         Deps,        /** generate dependencies */
         DevStub,     /** generate device-side offload stubs */
         HostStub,    /** generate host-side offload stubs */
-        CPPStub,     /** generate preprocessed stubs (-E mode) */
+        CPPStub,     /** generate preprocessed stubs (-E/-dD/-dM mode) */
 #ifdef ISPC_XE_ENABLED
         ZEBIN, /** generate L0 binary file */
         SPIRV, /** generate spir-v file */
@@ -299,7 +299,8 @@ class Module {
 
     /** Run the preprocessor on the given file, writing to the output stream.
         Returns the number of diagnostic errors encountered. */
-    int execPreprocessor(const char *filename, llvm::raw_string_ostream *ostream) const;
+    int execPreprocessor(const char *filename, llvm::raw_string_ostream *ostream,
+                         Globals::PreprocessorOutputType type = Globals::PreprocessorOutputType::Cpp) const;
 
     /** Helper function to initialize the internal CPP buffer. **/
     void initCPPBuffer();

--- a/tests/lit-tests/3205.ispc
+++ b/tests/lit-tests/3205.ispc
@@ -1,0 +1,37 @@
+// Ensure that output(-dM) can output the embedded predefined ISPC macros with empty input
+// RUN: %{ispc} -dM --outfile=emptydm.dM.cpp -
+// RUN: FileCheck %s --input-file=emptydm.dM.cpp --check-prefix=EMPTYDM
+// EMPTYDM: ISPC
+
+// Ensure that the output(-dM) includes macros but doesn't include functions
+// -dm itself doesn't enable "ShowComments" so only need to check for 1 count.
+// RUN: %{ispc} %s -dM --outfile=%t.dM.cpp
+// RUN: FileCheck %s --input-file=%t.dM.cpp --check-prefix=DM
+// DM: MyDescriptor
+// DM: MyType
+// DM: MyValue
+// DM-NOT: my_func
+
+// Ensure that output(-E) has functions but doesn't include macros
+// -E has "ShowComments", so need to count lit comments
+// RUN: %{ispc} %s -E --outfile=%t.E.cpp
+// RUN: FileCheck %s --input-file=%t.E.cpp --check-prefix=E
+// E: CHECK-COUNT-3: MyDescriptor
+// E: CHECK-COUNT-3: MyType
+// E: CHECK-COUNT-3: MyValue
+// E: CHECK-COUNT-4: my_func
+
+// Ensure that output(-dD) has both functions and macros.
+// -dD has "ShowComments", so need to count lit comments
+// RUN: %{ispc} %s -dD --outfile=%t.dD.cpp
+// RUN: FileCheck %s --input-file=%t.dD.cpp --check-prefix=DD
+// DD: CHECK-COUNT-4: MyDescriptor
+// DD: CHECK-COUNT-4: MyType
+// DD: CHECK-COUNT-4: MyValue
+// DD: CHECK-COUNT-4: my_func
+
+#define MyType float
+#define MyDescriptor const
+#define MyValue 100
+
+MyType my_func(MyDescriptor MyType _value) { return _value + MyValue; }


### PR DESCRIPTION
Added -dD and -dM options for ispc and tests. 
(Commit clean, no squash merge needed)

Implementation:
Flags macthing clang pre-process options refer to https://clang.llvm.org/doxygen/classclang_1_1PreprocessorOutputOptions.html:
-dM: ShowMacros only - Find customized macros, and no functions
-E: ShowCPP and ShowComments - Find function but no macros definition
-dD: ShowCPP, ShowMacros, and ShowComments - Find both macros definition and function.
Functionality difference: Unlike clang -dD or -dM must be used in addition with -E flag, both flags for ispc in this implementation makes the "-E" implicit. This is an easier implementation and I didn't find the benefit to follow clang. Please leave your thoughts if you prefer the clang way.

Test:
Covered by functions and macros search in results.
In discussion https://github.com/ispc/ispc/issues/2167#issuecomment-2631786461, ideally, the test should make sure "all the expected macros are added and nothing else is defined". This is not doable because ispc can add macros during runtime, by using g->addMacroDef(<DEF>). Thus, it is not easy to design a golden result to cover the exact necessary ispc macros.
Thus, the detection of macros only covers "finding all the user's macros" instead.
