### PR TITLE
Improve performance of packed_load_store2 on AVX2 i32x8

### DIFF
--- a/builtins/target-avx-common-8.ll
+++ b/builtins/target-avx-common-8.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2024, Intel Corporation
+;;  Copyright (c) 2010-2025, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -10,7 +10,6 @@ define(`MASK',`i32')
 include(`util.m4')
 
 stdlib_core()
-packed_load_and_store(FALSE)
 scans()
 int64minmax()
 

--- a/builtins/target-avx1-i32x8.ll
+++ b/builtins/target-avx1-i32x8.ll
@@ -1,10 +1,11 @@
-;;  Copyright (c) 2010-2024, Intel Corporation
+;;  Copyright (c) 2010-2025, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
 define(`ISA',`AVX1')
 
 include(`target-avx-common-8.ll')
+packed_load_and_store(FALSE)
 saturation_arithmetic()
 define_shuffles()
 


### PR DESCRIPTION
For issue: #2295

This PR removes util.m4 macros from [target-avx2-common-i32x8.ll](https://github.com/ispc/ispc/compare/main...daviddjh-intel:dheadric/packed_load_store?expand=1#diff-88e339f0a363a65c810f81dc37eb94252fe598d26570270ae223eee3ffce0956) and replaces them with faster custom implementations. Implementations are largely based off of an algorithm described in this [StackOverflow article](https://stackoverflow.com/questions/36932240/avx2-what-is-the-most-efficient-way-to-pack-left-based-on-a-mask).

At the time of opening the (draft) PR, the only custom implementations are:
@__packed_store_active2i32
@__packed_store_active2i64

Below is a performance comparison, using 05_packed_load_store.exe benchmark and avx2-i32x8 target:
|                                        | MAIN + LLVM 19 |                                      |             | dheadric/packed_load_store + LLVM 19 | | |
| -------------------------------------- | -------------- | ------------------------------------ | ----------- | ---------- | ------------ |  ---------- |
|                                        | iterations     | real_time ns                         | cpu_time ns | iterations | real_time ns | cpu_time ns |
| packed_store_active2_int32_0_eq/8192   | 373333         | 1908.79                              | 1925.22 | 1000000 | 539.676 | 546.875 |
| packed_store_active2_int32_0_neq/8192  | 2.04E+08       | 3.32954                              | 3.37612 | 2.64E+08 | 2.66578 | 2.66811 |
| packed_store_active2_int32_1_eq/8192   | 298667         | 2149.21                              | 2144.95 | 1000000 | 509.737 | 515.625 |
| packed_store_active2_int32_1_neq/8192  | 320000         | 2183.75                              | 2148.44 | 1120000 | 522.136 | 516.183 |
| packed_store_active2_int32_3_eq/8192   | 344615         | 1947.84                              | 1949.64 | 896000 | 630.824 | 627.79 |
| packed_store_active2_int32_3_neq/8192  | 298667         | 2260.97                              | 2249.58 | 1120000 | 564.395 | 558.036 |
| packed_store_active2_int32_7_eq/8192   | 373333         | 1826.91                              | 1799.67 | 1120000 | 576.367 | 571.987 |
| packed_store_active2_int32_7_neq/8192  | 280000         | 2372.67                              | 2343.75 | 1120000 | 605.716 | 599.888 |
| packed_store_active2_int32_15_eq/8192  | 344615         | 1856                                 | 1813.62 | 1120000 | 578.527 | 571.987 |
| packed_store_active2_int32_15_neq/8192 | 280000         | 2359.65                              | 2343.75 | 1120000 | 597.569 | 599.888 |
| packed_store_active2_int64_0_eq/8192   | 320000         | 2129.8                               | 2148.44 | 640000 | 1032.65 | 1025.39 |
| packed_store_active2_int64_0_neq/8192  | 2.13E+08       | 3.32921                              | 3.36914 | 2.49E+08 | 2.77255 | 2.76228 |
| packed_store_active2_int64_1_eq/8192   | 298667         | 2345.71                              | 2354.21 | 640000 | 967.293 | 952.148 |
| packed_store_active2_int64_1_neq/8192  | 320000         | 2241.34                              | 2246.09 | 896000 | 964.927 | 976.562 |
| packed_store_active2_int64_3_eq/8192   | 320000         | 2243.18                              | 2246.09 | 448000 | 1319.53 | 1325.33 |
| packed_store_active2_int64_3_neq/8192  | 320000         | 2137.4                               | 2148.44 | 640000 | 1093.13 | 1098.63 |
| packed_store_active2_int64_7_eq/8192   | 320000         | 2083.39                              | 2099.61 | 640000 | 1065.12 | 1074.22 |
| packed_store_active2_int64_7_neq/8192  | 298667         | 2184.92                              | 2197.26 | 640000 | 1146.83 | 1147.46 |
| packed_store_active2_int64_15_eq/8192  | 320000         | 2089.63                              | 2099.61 | 560000 | 1038.76 | 1032.37 |
| packed_store_active2_int64_15_neq/8192 | 320000         | 2177.66                              | 2197.27 | 560000 | 1138.73 | 1116.07 |


Remaining data types to optimize:
 - [ ] i8
 - [ ] i16
 - [ ] f16
 - [ ] f32
 - [ ] f64