### PR TITLE
Dump semantic values under --yydebug in parser

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2024, Intel Corporation
+  Copyright (c) 2011-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -174,6 +174,9 @@ class ASTNode : public Traceable {
 
     /** A function for interactive debugging */
     void Dump() const;
+
+    /** Return a short string that represents the node. */
+    virtual std::string GetString() const = 0;
 
     /** A function that should be used for hierarchical AST dump. */
     virtual void Print(Indent &indent) const = 0;

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -389,7 +389,7 @@ FunctionEmitContext::FunctionEmitContext(const Function *func, Symbol *funSym, l
             mangledName = "";
         }
 
-        bool isStatic = (funSym->storageClass == SC_STATIC);
+        bool isStatic = (funSym->storageClass == StorageClass::STATIC);
         bool isOptimized = (g->opt.level > 0);
         int firstLine = funcStartPos.first_line;
 

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -389,7 +389,7 @@ FunctionEmitContext::FunctionEmitContext(const Function *func, Symbol *funSym, l
             mangledName = "";
         }
 
-        bool isStatic = (funSym->storageClass == StorageClass::STATIC);
+        bool isStatic = funSym->storageClass.IsStatic();
         bool isOptimized = (g->opt.level > 0);
         int firstLine = funcStartPos.first_line;
 

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -805,7 +805,7 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
                 decl->type = decl->type->ResolveUnboundVariability(Variability::Varying);
             }
 
-            if (d->declSpecs->storageClass != StorageClass::NONE) {
+            if (!d->declSpecs->storageClass.IsNone()) {
                 Error(decl->pos,
                       "Storage class \"%s\" is illegal in "
                       "function parameter declaration for parameter \"%s\".",
@@ -893,8 +893,8 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
             returnType = returnType->ResolveUnboundVariability(Variability::Varying);
         }
 
-        bool isExternC = ds && (ds->storageClass == StorageClass::EXTERN_C);
-        bool isExternSYCL = ds && (ds->storageClass == StorageClass::EXTERN_SYCL);
+        bool isExternC = ds && ds->storageClass.IsExternC();
+        bool isExternSYCL = ds && ds->storageClass.IsExternSYCL();
         bool isExported = ds && ((ds->typeQualifiers & TYPEQUAL_EXPORT) != 0);
         bool isExternalOnly = ds && ds->attributeList && ds->attributeList->HasAttribute("external_only");
         bool isTask = ds && ((ds->typeQualifiers & TYPEQUAL_TASK) != 0);
@@ -1015,7 +1015,7 @@ Declaration::Declaration(DeclSpecs *ds, Declarator *d) {
 }
 
 std::vector<VariableDeclaration> Declaration::GetVariableDeclarations() const {
-    Assert(declSpecs->storageClass != StorageClass::TYPEDEF);
+    Assert(!declSpecs->storageClass.IsTypedef());
     std::vector<VariableDeclaration> vars;
 
     for (unsigned int i = 0; i < declarators.size(); ++i) {
@@ -1056,7 +1056,7 @@ std::vector<VariableDeclaration> Declaration::GetVariableDeclarations() const {
 }
 
 void Declaration::DeclareFunctions() {
-    Assert(declSpecs->storageClass != StorageClass::TYPEDEF);
+    Assert(!declSpecs->storageClass.IsTypedef());
 
     for (unsigned int i = 0; i < declarators.size(); ++i) {
         Declarator *decl = declarators[i];

--- a/src/decl.h
+++ b/src/decl.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -69,6 +69,7 @@ class AttrArgument {
     AttrArgument(int64_t i);
     AttrArgument(const std::string &s);
 
+    std::string GetString() const;
     void Print() const;
 
     AttrArgKind kind;
@@ -91,6 +92,7 @@ class Attribute {
     /** Returns true if the attribute is known/supported false otherwise. */
     bool IsKnownAttribute() const;
 
+    std::string GetString() const;
     void Print() const;
 
     std::string name;
@@ -129,6 +131,7 @@ class AttributeList {
         issue a warning. */
     void CheckForUnknownAttributes(SourcePos pos) const;
 
+    std::string GetString() const;
     void Print() const;
 
   private:
@@ -145,7 +148,10 @@ class DeclSpecs : public Traceable {
     DeclSpecs(const Type *t = nullptr, StorageClass sc = SC_NONE, int tq = TYPEQUAL_NONE);
     ~DeclSpecs();
 
+    std::string GetString() const;
     void Print() const;
+
+    static std::string GetTypeQualifiersString(int typeQualifiers);
 
     StorageClass storageClass;
 
@@ -199,6 +205,7 @@ class Declarator : public Traceable {
 
     void InitFromType(const Type *base, DeclSpecs *ds);
 
+    std::string GetString() const;
     void Print() const;
     void Print(Indent &indent) const;
 
@@ -251,6 +258,7 @@ class Declaration : public Traceable {
     Declaration(DeclSpecs *ds, std::vector<Declarator *> *dlist = nullptr);
     Declaration(DeclSpecs *ds, Declarator *d);
 
+    std::string GetString() const;
     void Print() const;
     void Print(Indent &indent) const;
 
@@ -274,6 +282,8 @@ class Declaration : public Traceable {
 struct StructDeclaration : public Traceable {
     StructDeclaration(const Type *t, std::vector<Declarator *> *d) : type(t), declarators(d) {}
     ~StructDeclaration() { delete declarators; }
+
+    std::string GetString() const;
 
     // We don't copy these objects at the moment. If we will then proper
     // implementations are needed considering the ownership of declarators.

--- a/src/decl.h
+++ b/src/decl.h
@@ -145,7 +145,7 @@ class AttributeList {
  */
 class DeclSpecs : public Traceable {
   public:
-    DeclSpecs(const Type *t = nullptr, StorageClass sc = SC_NONE, int tq = TYPEQUAL_NONE);
+    DeclSpecs(const Type *t = nullptr, StorageClass sc = StorageClass::NONE, int tq = TYPEQUAL_NONE);
     ~DeclSpecs();
 
     std::string GetString() const;

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1050,7 +1050,7 @@ static llvm::Value *lMaskForSymbol(Symbol *baseSym, FunctionEmitContext *ctx) {
         return ctx->GetFullMask();
     }
 
-    llvm::Value *mask = (baseSym->parentFunction == ctx->GetFunction() && baseSym->storageClass != SC_STATIC)
+    llvm::Value *mask = (baseSym->parentFunction == ctx->GetFunction() && baseSym->storageClass != StorageClass::STATIC)
                             ? ctx->GetInternalMask()
                             : ctx->GetFullMask();
     return mask;
@@ -1062,7 +1062,7 @@ static void lStoreAssignResult(llvm::Value *value, llvm::Value *ptr, const Type 
                                FunctionEmitContext *ctx, Symbol *baseSym) {
     Assert(baseSym == nullptr || baseSym->varyingCFDepth <= ctx->VaryingCFDepth());
     if (!g->opt.disableMaskedStoreToStore && !g->opt.disableMaskAllOnOptimizations && baseSym != nullptr &&
-        baseSym->varyingCFDepth == ctx->VaryingCFDepth() && baseSym->storageClass != SC_STATIC &&
+        baseSym->varyingCFDepth == ctx->VaryingCFDepth() && baseSym->storageClass != StorageClass::STATIC &&
         CastType<ReferenceType>(baseSym->type) == nullptr && CastType<PointerType>(baseSym->type) == nullptr) {
         // If the variable is declared at the same varying control flow
         // depth as where it's being assigned, then we don't need to do any

--- a/src/expr.h
+++ b/src/expr.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -105,6 +105,7 @@ class UnaryExpr : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
     Expr *Optimize();
     Expr *TypeCheck();
@@ -151,6 +152,7 @@ class BinaryExpr : public Expr {
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
     const Type *GetLValueType() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Expr *Optimize();
@@ -189,6 +191,7 @@ class AssignExpr : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Expr *Optimize();
@@ -214,6 +217,7 @@ class SelectExpr : public Expr {
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
     const Type *GetLValueType() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Expr *Optimize();
@@ -241,6 +245,7 @@ class ExprList : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
     std::pair<llvm::Constant *, bool> GetStorageConstant(const Type *type) const;
     std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
@@ -288,6 +293,7 @@ class FunctionCallExpr : public Expr {
     llvm::Value *GetLValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
     const Type *GetLValueType() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Expr *Optimize();
@@ -319,6 +325,7 @@ class IndexExpr : public Expr {
     const Type *GetType() const;
     const Type *GetLValueType() const;
     Symbol *GetBaseSymbol() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Expr *Optimize();
@@ -352,6 +359,7 @@ class MemberExpr : public Expr {
     llvm::Value *GetLValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
     Symbol *GetBaseSymbol() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
     Expr *Optimize();
     Expr *TypeCheck();
@@ -492,6 +500,7 @@ class ConstExpr : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
     std::pair<llvm::Constant *, bool> GetStorageConstant(const Type *type) const;
     std::pair<llvm::Constant *, bool> GetConstant(const Type *constType) const;
@@ -560,6 +569,7 @@ class TypeCastExpr : public Expr {
     llvm::Value *GetLValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
     const Type *GetLValueType() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
     Expr *TypeCheck();
     Expr *Optimize();
@@ -587,6 +597,7 @@ class ReferenceExpr : public Expr {
     const Type *GetType() const;
     const Type *GetLValueType() const;
     Symbol *GetBaseSymbol() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
     Expr *TypeCheck();
     Expr *Optimize();
@@ -627,6 +638,7 @@ class PtrDerefExpr : public DerefExpr {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == PtrDerefExprID; }
 
     const Type *GetType() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
     Expr *TypeCheck();
     int EstimateCost() const;
@@ -643,6 +655,7 @@ class RefDerefExpr : public DerefExpr {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == RefDerefExprID; }
 
     const Type *GetType() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
     Expr *TypeCheck();
     int EstimateCost() const;
@@ -661,6 +674,7 @@ class AddressOfExpr : public Expr {
     const Type *GetType() const;
     const Type *GetLValueType() const;
     Symbol *GetBaseSymbol() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
     Expr *TypeCheck();
     Expr *Optimize();
@@ -683,6 +697,7 @@ class SizeOfExpr : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
     Expr *TypeCheck();
     Expr *Optimize();
@@ -707,6 +722,7 @@ class AllocaExpr : public Expr {
 
     llvm::Value *GetValue(FunctionEmitContext *ctx) const;
     const Type *GetType() const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
     Expr *TypeCheck();
     Expr *Optimize();
@@ -733,6 +749,7 @@ class SymbolExpr : public Expr {
     Symbol *GetBaseSymbol() const;
     Expr *TypeCheck();
     Expr *Optimize();
+    std::string GetString() const;
     void Print(Indent &indent) const;
     int EstimateCost() const;
     SymbolExpr *Instantiate(TemplateInstantiation &templInst) const;
@@ -758,6 +775,7 @@ class FunctionSymbolExpr : public Expr {
     Symbol *GetBaseSymbol() const;
     Expr *TypeCheck();
     Expr *Optimize();
+    std::string GetString() const;
     void Print(Indent &indent) const;
     int EstimateCost() const;
     FunctionSymbolExpr *Instantiate(TemplateInstantiation &templInst) const;
@@ -838,6 +856,7 @@ class SyncExpr : public Expr {
     const Type *GetType() const;
     Expr *TypeCheck();
     Expr *Optimize();
+    std::string GetString() const;
     void Print(Indent &indent) const;
     int EstimateCost() const;
     SyncExpr *Instantiate(TemplateInstantiation &templInst) const;
@@ -856,6 +875,7 @@ class NullPointerExpr : public Expr {
     Expr *TypeCheck();
     Expr *Optimize();
     std::pair<llvm::Constant *, bool> GetConstant(const Type *type) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
     int EstimateCost() const;
     NullPointerExpr *Instantiate(TemplateInstantiation &templInst) const;
@@ -875,6 +895,7 @@ class NewExpr : public Expr {
     const Type *GetType() const;
     Expr *TypeCheck();
     Expr *Optimize();
+    std::string GetString() const;
     void Print(Indent &indent) const;
     int EstimateCost() const;
     NewExpr *Instantiate(TemplateInstantiation &templInst) const;

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -55,7 +55,7 @@ bool Function::IsInternal() const {
     if (function != nullptr) {
         isInline = (function->getAttributes().getFnAttrs().hasAttribute(llvm::Attribute::AlwaysInline));
     }
-    return sc == SC_STATIC || isInline;
+    return sc == StorageClass::STATIC || isInline;
 }
 
 void Function::UpdateLinkage(llvm::GlobalValue::LinkageTypes linkage) const {

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -3330,6 +3330,7 @@ bool StorageClass::IsStatic() const { return m_kind == Kind::STATIC; }
 bool StorageClass::IsTypedef() const { return m_kind == Kind::TYPEDEF; }
 bool StorageClass::IsExternC() const { return m_kind == Kind::EXTERN_C; }
 bool StorageClass::IsExternSYCL() const { return m_kind == Kind::EXTERN_SYCL; }
+bool StorageClass::IsAnyExtern() const { return IsExtern() || IsExternC() || IsExternSYCL(); }
 
 ///////////////////////////////////////////////////////////////////////////
 // SourcePos

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -3324,6 +3324,13 @@ std::string StorageClass::GetString() const {
     }
 }
 
+bool StorageClass::IsNone() const { return m_kind == Kind::NONE; }
+bool StorageClass::IsExtern() const { return m_kind == Kind::EXTERN; }
+bool StorageClass::IsStatic() const { return m_kind == Kind::STATIC; }
+bool StorageClass::IsTypedef() const { return m_kind == Kind::TYPEDEF; }
+bool StorageClass::IsExternC() const { return m_kind == Kind::EXTERN_C; }
+bool StorageClass::IsExternSYCL() const { return m_kind == Kind::EXTERN_SYCL; }
+
 ///////////////////////////////////////////////////////////////////////////
 // SourcePos
 

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -3308,15 +3308,15 @@ std::string StorageClass::GetString() const {
     switch (m_kind) {
     case Kind::NONE:
         return "";
-    case Kind::EXTERN:
+    case Kind::EXT:
         return "extern";
     case Kind::STATIC:
         return "static";
     case Kind::TYPEDEF:
         return "typedef";
-    case Kind::EXTERN_C:
+    case Kind::EXT_C:
         return "extern \"C\"";
-    case Kind::EXTERN_SYCL:
+    case Kind::EXT_SYCL:
         return "extern \"SYCL\"";
     default:
         FATAL("Unhandled storage class in lGetStorageClassName");
@@ -3325,11 +3325,11 @@ std::string StorageClass::GetString() const {
 }
 
 bool StorageClass::IsNone() const { return m_kind == Kind::NONE; }
-bool StorageClass::IsExtern() const { return m_kind == Kind::EXTERN; }
+bool StorageClass::IsExtern() const { return m_kind == Kind::EXT; }
 bool StorageClass::IsStatic() const { return m_kind == Kind::STATIC; }
 bool StorageClass::IsTypedef() const { return m_kind == Kind::TYPEDEF; }
-bool StorageClass::IsExternC() const { return m_kind == Kind::EXTERN_C; }
-bool StorageClass::IsExternSYCL() const { return m_kind == Kind::EXTERN_SYCL; }
+bool StorageClass::IsExternC() const { return m_kind == Kind::EXT_C; }
+bool StorageClass::IsExternSYCL() const { return m_kind == Kind::EXT_SYCL; }
 bool StorageClass::IsAnyExtern() const { return IsExtern() || IsExternC() || IsExternSYCL(); }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -3299,6 +3299,32 @@ Globals::Globals() {
 }
 
 ///////////////////////////////////////////////////////////////////////////
+// StorageClass
+
+StorageClass::StorageClass(Kind kind) : m_kind(kind) {}
+StorageClass::operator StorageClass::Kind() const { return m_kind; }
+
+std::string StorageClass::GetString() const {
+    switch (m_kind) {
+    case Kind::NONE:
+        return "";
+    case Kind::EXTERN:
+        return "extern";
+    case Kind::STATIC:
+        return "static";
+    case Kind::TYPEDEF:
+        return "typedef";
+    case Kind::EXTERN_C:
+        return "extern \"C\"";
+    case Kind::EXTERN_SYCL:
+        return "extern \"SYCL\"";
+    default:
+        FATAL("Unhandled storage class in lGetStorageClassName");
+        return "";
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
 // SourcePos
 
 SourcePos::SourcePos(const char *n, int fl, int fc, int ll, int lc) {

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -125,6 +125,12 @@ class StorageClass {
     static constexpr Kind EXTERN_SYCL{Kind::EXTERN_SYCL};
 
     std::string GetString() const;
+    bool IsNone() const;
+    bool IsExtern() const;
+    bool IsStatic() const;
+    bool IsTypedef() const;
+    bool IsExternC() const;
+    bool IsExternSYCL() const;
 
   private:
     Kind m_kind = Kind::NONE;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -105,11 +105,11 @@ class StorageClass {
   public:
     enum class Kind {
         NONE,
-        EXTERN,
-        STATIC,
-        TYPEDEF,
-        EXTERN_C,
-        EXTERN_SYCL,
+        EXT,      // extern
+        STATIC,   // static
+        TYPEDEF,  // typedef
+        EXT_C,    // extern "C"
+        EXT_SYCL, // extern "SYCL"
     };
 
     // The constructor, operators, and constants are required to use
@@ -118,11 +118,11 @@ class StorageClass {
     StorageClass(Kind kind);
     operator Kind() const;
     static constexpr Kind NONE{Kind::NONE};
-    static constexpr Kind EXTERN{Kind::EXTERN};
+    static constexpr Kind EXT{Kind::EXT};
     static constexpr Kind STATIC{Kind::STATIC};
     static constexpr Kind TYPEDEF{Kind::TYPEDEF};
-    static constexpr Kind EXTERN_C{Kind::EXTERN_C};
-    static constexpr Kind EXTERN_SYCL{Kind::EXTERN_SYCL};
+    static constexpr Kind EXT_C{Kind::EXT_C};
+    static constexpr Kind EXT_SYCL{Kind::EXT_SYCL};
 
     std::string GetString() const;
     bool IsNone() const;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -101,7 +101,34 @@ class Type;
 struct VariableDeclaration;
 typedef std::vector<TemplateArg> TemplateArgs;
 
-enum StorageClass { SC_NONE, SC_EXTERN, SC_STATIC, SC_TYPEDEF, SC_EXTERN_C, SC_EXTERN_SYCL };
+class StorageClass {
+  public:
+    enum class Kind {
+        NONE,
+        EXTERN,
+        STATIC,
+        TYPEDEF,
+        EXTERN_C,
+        EXTERN_SYCL,
+    };
+
+    // The constructor, operators, and constants are required to use
+    // StorageClass in the same way as an enum class (which StorageClass was
+    // previously) in switch statements, comparisons, and so on.
+    StorageClass(Kind kind);
+    operator Kind() const;
+    static constexpr Kind NONE{Kind::NONE};
+    static constexpr Kind EXTERN{Kind::EXTERN};
+    static constexpr Kind STATIC{Kind::STATIC};
+    static constexpr Kind TYPEDEF{Kind::TYPEDEF};
+    static constexpr Kind EXTERN_C{Kind::EXTERN_C};
+    static constexpr Kind EXTERN_SYCL{Kind::EXTERN_SYCL};
+
+    std::string GetString() const;
+
+  private:
+    Kind m_kind = Kind::NONE;
+};
 
 // Enumerant for address spaces.
 enum class AddressSpace {

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -131,6 +131,7 @@ class StorageClass {
     bool IsTypedef() const;
     bool IsExternC() const;
     bool IsExternSYCL() const;
+    bool IsAnyExtern() const;
 
   private:
     Kind m_kind = Kind::NONE;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -754,8 +754,7 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
         // global.
 
         // If the type doesn't match with the previous one, issue an error.
-        if (!Type::Equal(sym->type, type) || (!sym->storageClass.IsExtern() && !sym->storageClass.IsExternC() &&
-                                              !sym->storageClass.IsExternSYCL() && sym->storageClass != storageClass)) {
+        if (!Type::Equal(sym->type, type) || (!sym->storageClass.IsAnyExtern() && sym->storageClass != storageClass)) {
             Error(pos, "Definition of variable \"%s\" conflicts with definition at %s:%d.", name.c_str(), sym->pos.name,
                   sym->pos.first_line);
             return;
@@ -765,8 +764,7 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
         Assert(gv != nullptr);
 
         // And issue an error if this is a redefinition of a variable
-        if (gv->hasInitializer() && !sym->storageClass.IsExtern() && !sym->storageClass.IsExternC() &&
-            !sym->storageClass.IsExternSYCL()) {
+        if (gv->hasInitializer() && !sym->storageClass.IsAnyExtern()) {
             Error(pos, "Redefinition of variable \"%s\" is illegal. (Previous definition at %s:%d.)", sym->name.c_str(),
                   sym->pos.name, sym->pos.first_line);
             return;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -636,12 +636,12 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
         return;
     }
 
-    if (storageClass == StorageClass::EXTERN_C) {
+    if (storageClass.IsExternC()) {
         Error(pos, "extern \"C\" qualifier can only be used for functions.");
         return;
     }
 
-    if (storageClass == StorageClass::EXTERN_SYCL) {
+    if (storageClass.IsExternSYCL()) {
         Error(pos, "extern \"SYCL\" qualifier can only be used for functions.");
         return;
     }
@@ -673,7 +673,7 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
     // make sure it's a compile-time constant!
     llvm::Constant *llvmInitializer = nullptr;
     ConstExpr *constValue = nullptr;
-    if (storageClass == StorageClass::EXTERN) {
+    if (storageClass.IsExtern()) {
         if (initExpr != nullptr) {
             Error(pos, "Initializer can't be provided with \"extern\" global variable \"%s\".", name.c_str());
         }
@@ -709,7 +709,7 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
                     // If compiling for multitarget, skip initialization for
                     // indentified scenarios unless it's static
                     if (llvmInitializer != nullptr) {
-                        if ((storageClass != StorageClass::STATIC) && (initPair.second == true)) {
+                        if (!storageClass.IsStatic() && initPair.second) {
                             if (g->isMultiTargetCompilation == true) {
                                 Error(initExpr->pos,
                                       "Initializer for global variable \"%s\" is not a constant for multi-target "
@@ -754,9 +754,8 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
         // global.
 
         // If the type doesn't match with the previous one, issue an error.
-        if (!Type::Equal(sym->type, type) ||
-            (sym->storageClass != StorageClass::EXTERN && sym->storageClass != StorageClass::EXTERN_C &&
-             sym->storageClass != StorageClass::EXTERN_SYCL && sym->storageClass != storageClass)) {
+        if (!Type::Equal(sym->type, type) || (!sym->storageClass.IsExtern() && !sym->storageClass.IsExternC() &&
+                                              !sym->storageClass.IsExternSYCL() && sym->storageClass != storageClass)) {
             Error(pos, "Definition of variable \"%s\" conflicts with definition at %s:%d.", name.c_str(), sym->pos.name,
                   sym->pos.first_line);
             return;
@@ -766,8 +765,8 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
         Assert(gv != nullptr);
 
         // And issue an error if this is a redefinition of a variable
-        if (gv->hasInitializer() && sym->storageClass != StorageClass::EXTERN && sym->storageClass != StorageClass::EXTERN_C &&
-            sym->storageClass != StorageClass::EXTERN_SYCL) {
+        if (gv->hasInitializer() && !sym->storageClass.IsExtern() && !sym->storageClass.IsExternC() &&
+            !sym->storageClass.IsExternSYCL()) {
             Error(pos, "Redefinition of variable \"%s\" is illegal. (Previous definition at %s:%d.)", sym->name.c_str(),
                   sym->pos.name, sym->pos.first_line);
             return;
@@ -784,7 +783,7 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
     sym->constValue = constValue;
 
     llvm::GlobalValue::LinkageTypes linkage =
-        (sym->storageClass == StorageClass::STATIC) ? llvm::GlobalValue::InternalLinkage : llvm::GlobalValue::ExternalLinkage;
+        sym->storageClass.IsStatic() ? llvm::GlobalValue::InternalLinkage : llvm::GlobalValue::ExternalLinkage;
 
     // Note that the nullptr llvmInitializer is what leads to "extern"
     // declarations coming up extern and not defining storage (a bit
@@ -807,7 +806,7 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
         llvm::GlobalVariable *sym_GV_storagePtr = llvm::dyn_cast<llvm::GlobalVariable>(sym->storageInfo->getPointer());
         Assert(sym_GV_storagePtr);
         llvm::DIGlobalVariableExpression *var = diBuilder->createGlobalVariableExpression(
-            diSpace, name, name, file, pos.first_line, sym->type->GetDIType(diSpace), (sym->storageClass == StorageClass::STATIC));
+            diSpace, name, name, file, pos.first_line, sym->type->GetDIType(diSpace), sym->storageClass.IsStatic());
         sym_GV_storagePtr->addDebugInfo(var);
         /*#if ISPC_LLVM_VERSION <= ISPC_LLVM_3_6
                 Assert(var.Verify());
@@ -1017,7 +1016,7 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
         }
     }
 
-    if (storageClass == StorageClass::EXTERN_C || storageClass == StorageClass::EXTERN_SYCL) {
+    if (storageClass.IsExternC() || storageClass.IsExternSYCL()) {
         // Make sure the user hasn't supplied both an 'extern "C"' and a
         // 'task' qualifier with the function
         if (functionType->isTask) {
@@ -1051,7 +1050,7 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
     }
 
     // Get the LLVM FunctionType
-    bool disableMask = (storageClass == StorageClass::EXTERN_C || storageClass == StorageClass::EXTERN_SYCL);
+    bool disableMask = (storageClass.IsExternC() || storageClass.IsExternSYCL());
 
     auto [name_pref, name_suf] = functionType->GetFunctionMangledName(false);
     std::string functionName = name_pref + name + name_suf;
@@ -1060,7 +1059,7 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
 
     if (g->target_os == TargetOS::windows) {
         // Make export functions callable from DLLs.
-        if ((g->dllExport) && (storageClass != StorageClass::STATIC)) {
+        if ((g->dllExport) && !storageClass.IsStatic()) {
             function->setDLLStorageClass(llvm::GlobalValue::DLLExportStorageClass);
         }
     }
@@ -1071,12 +1070,12 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
     }
     // Set function attributes: we never throw exceptions
     function->setDoesNotThrow();
-    if ((storageClass != StorageClass::EXTERN_C) && (storageClass != StorageClass::EXTERN_SYCL) && isInline) {
+    if (!storageClass.IsExternC() && !storageClass.IsExternSYCL() && isInline) {
         function->addFnAttr(llvm::Attribute::AlwaysInline);
     }
 
     if (isVectorCall) {
-        if ((storageClass != StorageClass::EXTERN_C)) {
+        if (!storageClass.IsExternC()) {
             Error(pos, "Illegal to use \"__vectorcall\" qualifier on non-extern function \"%s\".", name.c_str());
             return;
         }
@@ -1088,7 +1087,7 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
     }
 
     if (isRegCall) {
-        if ((storageClass != StorageClass::EXTERN_C) && (storageClass != StorageClass::EXTERN_SYCL)) {
+        if (!storageClass.IsExternC() && !storageClass.IsExternSYCL()) {
             Error(pos, "Illegal to use \"__regcall\" qualifier on non-extern function \"%s\".", name.c_str());
             return;
         }
@@ -1411,14 +1410,14 @@ void Module::AddFunctionTemplateInstantiation(const std::string &name, const Tem
     if (templ) {
         // If primary template has default storage class, but explicit instantiation has non-default storage class,
         // report an error
-        if (templ->GetStorageClass() == StorageClass::NONE && sc != StorageClass::NONE) {
+        if (templ->GetStorageClass().IsNone() && !sc.IsNone()) {
             Error(pos, "Template instantiation has inconsistent storage class. Consider assigning it to the primary "
                        "template to inherit it's signature.");
             return;
         }
         // If primary template has non-default storage class, but explicit instantiation has different non-default
         // storage class, report an error
-        if (templ->GetStorageClass() != StorageClass::NONE && sc != StorageClass::NONE && sc != templ->GetStorageClass()) {
+        if (!templ->GetStorageClass().IsNone() && !sc.IsNone() && sc != templ->GetStorageClass()) {
             Error(pos, "Template instantiation has inconsistent storage class.");
             return;
         }
@@ -1469,14 +1468,14 @@ void Module::AddFunctionTemplateSpecializationDeclaration(const std::string &nam
     }
     // If primary template has default storage class, but specialization has non-default storage class,
     // report an error
-    if (templ->GetStorageClass() == StorageClass::NONE && sc != StorageClass::NONE) {
+    if (templ->GetStorageClass().IsNone() && !sc.IsNone()) {
         Error(pos, "Template specialization has inconsistent storage class. Consider assigning it to the primary "
                    "template to inherit it's signature.");
         return;
     }
     // If primary template has non-default storage class, but specialization has different non-default storage class,
     // report an error
-    if (templ->GetStorageClass() != StorageClass::NONE && sc != StorageClass::NONE && sc != templ->GetStorageClass()) {
+    if (!templ->GetStorageClass().IsNone() && !sc.IsNone() && sc != templ->GetStorageClass()) {
         Error(pos, "Template specialization has inconsistent storage class.");
         return;
     }

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1337,9 +1337,9 @@ init_declarator
 
 storage_class_specifier
     : TOKEN_TYPEDEF { $$ = new StorageClass(StorageClass::TYPEDEF); }
-    | TOKEN_EXTERN { $$ = new StorageClass(StorageClass::EXTERN); }
-    | TOKEN_EXTERN TOKEN_STRING_C_LITERAL  { $$ = new StorageClass(StorageClass::EXTERN_C); }
-    | TOKEN_EXTERN TOKEN_STRING_SYCL_LITERAL  { $$ = new StorageClass(StorageClass::EXTERN_SYCL); }
+    | TOKEN_EXTERN { $$ = new StorageClass(StorageClass::EXT); }
+    | TOKEN_EXTERN TOKEN_STRING_C_LITERAL  { $$ = new StorageClass(StorageClass::EXT_C); }
+    | TOKEN_EXTERN TOKEN_STRING_SYCL_LITERAL  { $$ = new StorageClass(StorageClass::EXT_SYCL); }
     | TOKEN_STATIC { $$ = new StorageClass(StorageClass::STATIC); }
     ;
 
@@ -3327,11 +3327,11 @@ lCheckTemplateDeclSpecs(DeclSpecs *ds, SourcePos pos, TemplateType type, const c
     }
     // We can't support extern "C"/extern "SYCL" for templates because
     // we need mangling information.
-    if (ds->storageClass == StorageClass::EXTERN_C || ds->storageClass == StorageClass::EXTERN_SYCL) {
+    if (ds->storageClass.IsExternC() || ds->storageClass.IsExternSYCL()) {
         Error(pos, "Illegal linkage provided with %s.", templateTypeStr.c_str());
         return;
     }
-    Assert(ds->storageClass == StorageClass::NONE || ds->storageClass == StorageClass::STATIC || ds->storageClass == StorageClass::EXTERN);
+    Assert(ds->storageClass.IsNone() || ds->storageClass.IsStatic() || ds->storageClass.IsExtern());
     bool isVectorCall = (ds->typeQualifiers & TYPEQUAL_VECTORCALL);
     if (isVectorCall) {
         Error(pos, "Illegal to use \"__vectorcall\" qualifier on non-extern function \"%s\".", name);

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -905,7 +905,7 @@ declaration_statement
             AssertPos(@1, m->errorCount > 0);
             $$ = nullptr;
         }
-        else if ($1->declSpecs->storageClass == StorageClass::TYPEDEF) {
+        else if ($1->declSpecs->storageClass.IsTypedef()) {
             for (unsigned int i = 0; i < $1->declarators.size(); ++i) {
                 if ($1->declarators[i] == nullptr)
                     AssertPos(@1, m->errorCount > 0);
@@ -991,7 +991,7 @@ declaration_specifiers
       {
           DeclSpecs *ds = (DeclSpecs *)$2;
           if (ds != nullptr) {
-              if (ds->storageClass != StorageClass::NONE)
+              if (!ds->storageClass.IsNone())
                   Error(@1, "Multiple storage class specifiers in a declaration are illegal. "
                         "(Have provided both \"%s\" and \"%s\".)",
                         ds->storageClass.GetString().c_str(),
@@ -2570,7 +2570,7 @@ function_definition
             const FunctionType *funcType = CastType<FunctionType>($2->type);
             if (funcType == nullptr)
                 AssertPos(@1, m->errorCount > 0);
-            else if ($1->storageClass == StorageClass::TYPEDEF)
+            else if ($1->storageClass.IsTypedef())
                 Error(@1, "Illegal \"typedef\" provided with function definition.");
             else {
                 Stmt *code = $4;
@@ -3119,7 +3119,7 @@ lAddDeclaration(DeclSpecs *ds, Declarator *decl) {
         return;
 
     decl->InitFromDeclSpecs(ds);
-    if (ds->storageClass == StorageClass::TYPEDEF) {
+    if (ds->storageClass.IsTypedef()) {
         const StructType *st = CastType<StructType>(decl->type);
         if (st && st->IsAnonymousType()) {
             st = st->GetAsNamed(decl->name);

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -181,7 +181,7 @@ void DeclStmt::EmitCode(FunctionEmitContext *ctx) const {
             return;
         }
 
-        if (sym->storageClass == StorageClass::STATIC) {
+        if (sym->storageClass.IsStatic()) {
             // For static variables, we need a compile-time constant value
             // for its initializer; if there's no initializer, we use a
             // zero value.

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -181,7 +181,7 @@ void DeclStmt::EmitCode(FunctionEmitContext *ctx) const {
             return;
         }
 
-        if (sym->storageClass == SC_STATIC) {
+        if (sym->storageClass == StorageClass::STATIC) {
             // For static variables, we need a compile-time constant value
             // for its initializer; if there's no initializer, we use a
             // zero value.

--- a/src/stmt.h
+++ b/src/stmt.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2023, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -52,6 +52,7 @@ class ExprStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ExprStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -80,6 +81,7 @@ class DeclStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == DeclStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *Optimize();
@@ -100,6 +102,7 @@ class IfStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == IfStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -140,6 +143,7 @@ class DoStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == DoStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -167,6 +171,7 @@ class ForStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ForStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -200,6 +205,7 @@ class BreakStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == BreakStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -217,6 +223,7 @@ class ContinueStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ContinueStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -238,6 +245,7 @@ class ForeachStmt : public Stmt {
     void EmitCodeForXe(FunctionEmitContext *ctx) const;
 #endif
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -264,6 +272,7 @@ class ForeachActiveStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ForeachActiveStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -289,6 +298,7 @@ class ForeachUniqueStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ForeachUniqueStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -313,6 +323,7 @@ class UnmaskedStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == UnmaskedStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -332,6 +343,7 @@ class ReturnStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == ReturnStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -352,6 +364,7 @@ class CaseStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == CaseStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -373,6 +386,7 @@ class DefaultStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == DefaultStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -391,6 +405,7 @@ class SwitchStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == SwitchStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -412,6 +427,7 @@ class GotoStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == GotoStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *Optimize();
@@ -434,6 +450,7 @@ class LabeledStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == LabeledStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *Optimize();
@@ -457,6 +474,7 @@ class StmtList : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == StmtListID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -488,6 +506,7 @@ class PrintStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == PrintStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -537,6 +556,7 @@ class AssertStmt : public Stmt {
     void EmitAssertCode(FunctionEmitContext *ctx, const Type *type) const;
     void EmitAssumeCode(FunctionEmitContext *ctx, const Type *type) const;
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();
@@ -559,6 +579,7 @@ class DeleteStmt : public Stmt {
     static inline bool classof(ASTNode const *N) { return N->getValueID() == DeleteStmtID; }
 
     void EmitCode(FunctionEmitContext *ctx) const;
+    std::string GetString() const;
     void Print(Indent &indent) const;
 
     Stmt *TypeCheck();

--- a/src/sym.h
+++ b/src/sym.h
@@ -53,7 +53,7 @@ class Symbol : public Traceable {
     /** The Symbol constructor takes the name of the symbol, its
         position in a source file, and its type (if known). */
     Symbol(const std::string &name, SourcePos pos, SymbolKind st = SymbolKind::Default, const Type *t = nullptr,
-           StorageClass sc = SC_NONE, AttributeList *a = nullptr);
+           StorageClass sc = StorageClass::NONE, AttributeList *a = nullptr);
     ~Symbol();
 
     SourcePos pos;            /*!< Source file position where the symbol was defined */


### PR DESCRIPTION
This implements #2974 

Now, the `--yydebug` is annotated like the following:

```bash
Reducing stack by rule 167 (line 1330):
   $1 = nterm declarator (: programIndex)
   $2 = token '=' (: )
   $3 = nterm initializer (: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
-> $$ = nterm init_declarator (: programIndex)

Reading a token: Next token is token TOKEN_IDENTIFIER (: y)
Shifting token TOKEN_IDENTIFIER (: y)
Entering state 536
Reducing stack by rule 43 (line 651):
   $1 = nterm postfix_expression (: b)
   $2 = token '.' (: )
   $3 = token TOKEN_IDENTIFIER (: y)
-> $$ = nterm postfix_expression (: b.y)

Reducing stack by rule 385 (line 2683):
   $1 = nterm declaration_specifiers (: uniform  /*unbound*/ float:)
   $2 = nterm declarator (: dotProduct)
   $3 = nterm $@5 (: )
   $4 = nterm compound_statement (: {return a.x*b.x+a.y*b.y+a.z*b.z; ...})

Reducing stack by rule 174 (line 1348):
   $1 = token TOKEN_TYPE_NAME (: Particle)
-> $$ = nterm type_specifier (: /*unbound*/ struct Particle)

Reading a token: Next token is token TOKEN_IDENTIFIER (: numParticles)
Shifting token TOKEN_IDENTIFIER (: numParticles)
```