### PR TITLE
Report an error when casting to unsized array

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -457,6 +457,11 @@ static bool lDoTypeConv(const Type *fromType, const Type *toType, Expr **expr, b
             // the case of different element counts should have returned
             // successfully earlier, yes??
             AssertPos(pos, toArrayType->GetElementCount() != fromArrayType->GetElementCount());
+            if (toArrayType->IsUnsized() && !failureOk) {
+                Error(pos, "Array type \"%s\" can't be converted to unsized array \"%s\" for %s.",
+                      fromType->GetString().c_str(), toType->GetString().c_str(), errorMsgBase);
+                return false;
+            }
             return lTypeCastOk(expr, toType, pos);
         } else if (Type::Equal(toArrayType->GetElementType(), fromArrayType->GetElementType()->GetAsConstType())) {
             // T[x] -> const T[x]
@@ -8796,7 +8801,7 @@ llvm::Value *SymbolExpr::GetValue(FunctionEmitContext *ctx) const {
 }
 
 llvm::Value *SymbolExpr::GetLValue(FunctionEmitContext *ctx) const {
-    if (symbol == nullptr) {
+    if (symbol == nullptr || symbol->storageInfo == nullptr) {
         return nullptr;
     }
     ctx->SetDebugPos(pos);

--- a/tests/lit-tests/1234.ispc
+++ b/tests/lit-tests/1234.ispc
@@ -1,0 +1,16 @@
+// This test checks that the ISPC compiler can handle the following constructs without crashing.
+// The test is not expected to produce any output.
+// RUN: not %{ispc} --target=host --nostdlib --nowrap -o - %s 2>&1 | FileCheck %s
+
+// CHECK-NOT: FATAL ERROR
+// CHECK: 15:15: Error: Array type "varying float[4]" can't be converted to unsized array "varying float[]" for type cast expression.
+// CHECK: 10:5: Error: Illegal to declare an unsized array variable without providing an initializer expression to set its size.
+
+void test1(float RET[]) {
+    float values[];
+    RET = values;
+}
+void test2() {
+    float values[4];
+    (float [])values;
+}

--- a/tests/lit-tests/3258.ispc
+++ b/tests/lit-tests/3258.ispc
@@ -1,0 +1,11 @@
+// This test checks that the ISPC compiler can handle the following constructs without crashing.
+// The test is not expected to produce any output.
+// RUN: not %{ispc} --target=host --nostdlib --nowrap -o - %s 2>&1 | FileCheck %s
+
+// CHECK-NOT: FATAL ERROR
+// CHECK: 9:30: Error: Array initializer must be an initializer list
+
+export uniform float test(const uniform float values[][3]) {
+    uniform float value[3] = values[programIndex];
+    return value[0];
+}


### PR DESCRIPTION
This PR fixes a crash on malformed code.
Fixes #1234 and #3258.