### PR TITLE
Report error when pointer types are used with unsupported binary operators

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -2316,7 +2316,12 @@ const Type *BinaryExpr::GetType() const {
         }
 
         // otherwise fall through for these...
-        AssertPos(pos, op == Lt || op == Gt || op == Le || op == Ge || op == Equal || op == NotEqual);
+        bool supportedOps = op == Lt || op == Gt || op == Le || op == Ge || op == Equal || op == NotEqual;
+        if (!supportedOps) {
+            Error(pos, "Unsupported binary operator \"%s\" for pointer type: \"%s\"", lOpString(op),
+                  type0->GetString().c_str());
+            return nullptr;
+        }
     }
 
     const Type *exprType = Type::MoreGeneralType(type0, type1, pos, lOpString(op));

--- a/tests/lit-tests/3295.ispc
+++ b/tests/lit-tests/3295.ispc
@@ -1,0 +1,10 @@
+// This test checks that the compiler reports an error when a pointer type is
+// used with unsupported binary operators.
+
+// RUN: not %{ispc} --target=host --nowrap %s -o - 2>&1 | FileCheck %s
+
+// CHECK-NOT: Error: Assertion failed
+// CHECK: Error: Unsupported binary operator "%" for pointer type: "uniform int32 * uniform"
+// CHECK: Error: First operand to binary operator "%" is of invalid type "uniform int32 * uniform".
+
+export uniform int gather_ints_buffer(uniform int values[]) { assume(&values[0] % programCount == 0); }


### PR DESCRIPTION
This fixes #3295 