### PR TITLE
Improve the performance of masked_load and masked_store for AVX-512 targets (32- and 64-wide).

### DIFF
--- a/builtins/target-avx512skx-x32.ll
+++ b/builtins/target-avx512skx-x32.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2024, Intel Corporation
+;;  Copyright (c) 2020-2025, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -680,55 +680,10 @@ define i64 @__reduce_max_uint64(<32 x i64>) nounwind readnone alwaysinline {
   reduce32(i64, @__max_varying_uint64, @__max_uniform_uint64)
 }
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; unaligned loads/loads+broadcasts
-
-masked_load(i8,  1)
-masked_load(i16, 2)
-masked_load(half, 2)
-masked_load(i32, 4)
-masked_load(float, 4)
-masked_load(i64, 8)
-masked_load(double, 8)
-
-gen_masked_store(i8)
-gen_masked_store(i16)
-gen_masked_store(i32)
-gen_masked_store(i64)
-
-masked_store_float_double()
-
-define void @__masked_store_blend_i8(<WIDTH x i8>* nocapture, <WIDTH x i8>,
-                                     <WIDTH x i1>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<WIDTH x i8> ')  %0
-  %v1 = select <WIDTH x i1> %2, <WIDTH x i8> %1, <WIDTH x i8> %v
-  store <WIDTH x i8> %v1, <WIDTH x i8> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i16(<WIDTH x i16>* nocapture, <WIDTH x i16>,
-                                      <WIDTH x i1>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<WIDTH x i16> ')  %0
-  %v1 = select <WIDTH x i1> %2, <WIDTH x i16> %1, <WIDTH x i16> %v
-  store <WIDTH x i16> %v1, <WIDTH x i16> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i32(<WIDTH x i32>* nocapture, <WIDTH x i32>,
-                                      <WIDTH x i1>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<WIDTH x i32> ')  %0
-  %v1 = select <WIDTH x i1> %2, <WIDTH x i32> %1, <WIDTH x i32> %v
-  store <WIDTH x i32> %v1, <WIDTH x i32> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i64(<WIDTH x i64>* nocapture,
-                            <WIDTH x i64>, <WIDTH x i1>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<WIDTH x i64> ')  %0
-  %v1 = select <WIDTH x i1> %2, <WIDTH x i64> %1, <WIDTH x i64> %v
-  store <WIDTH x i64> %v1, <WIDTH x i64> * %0
-  ret void
-}
+declare void @__masked_store_blend_i8(<WIDTH x i8>* nocapture, <WIDTH x i8>, <WIDTH x i1>) nounwind alwaysinline
+declare void @__masked_store_blend_i16(<WIDTH x i16>* nocapture, <WIDTH x i16>, <WIDTH x i1>) nounwind alwaysinline
+declare void @__masked_store_blend_i32(<WIDTH x i32>* nocapture, <WIDTH x i32>, <WIDTH x i1>) nounwind alwaysinline
+declare void @__masked_store_blend_i64(<WIDTH x i64>* nocapture, <WIDTH x i64>, <WIDTH x i1>) nounwind alwaysinline
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; gather/scatter

--- a/builtins/target-avx512skx-x64.ll
+++ b/builtins/target-avx512skx-x64.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2024, Intel Corporation
+;;  Copyright (c) 2020-2025, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -719,55 +719,10 @@ define i64 @__reduce_max_uint64(<64 x i64>) nounwind readnone alwaysinline {
   reduce64(i64, @__max_varying_uint64, @__max_uniform_uint64)
 }
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; unaligned loads/loads+broadcasts
-
-masked_load(i8,  1)
-masked_load(i16, 2)
-masked_load(half, 2)
-masked_load(i32, 4)
-masked_load(float, 4)
-masked_load(i64, 8)
-masked_load(double, 8)
-
-gen_masked_store(i8)
-gen_masked_store(i16)
-gen_masked_store(i32)
-gen_masked_store(i64)
-
-masked_store_float_double()
-
-define void @__masked_store_blend_i8(<WIDTH x i8>* nocapture, <WIDTH x i8>,
-                                     <WIDTH x i1>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<WIDTH x i8> ')  %0
-  %v1 = select <WIDTH x i1> %2, <WIDTH x i8> %1, <WIDTH x i8> %v
-  store <WIDTH x i8> %v1, <WIDTH x i8> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i16(<WIDTH x i16>* nocapture, <WIDTH x i16>,
-                                      <WIDTH x i1>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<WIDTH x i16> ')  %0
-  %v1 = select <WIDTH x i1> %2, <WIDTH x i16> %1, <WIDTH x i16> %v
-  store <WIDTH x i16> %v1, <WIDTH x i16> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i32(<WIDTH x i32>* nocapture, <WIDTH x i32>,
-                                      <WIDTH x i1>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<WIDTH x i32> ')  %0
-  %v1 = select <WIDTH x i1> %2, <WIDTH x i32> %1, <WIDTH x i32> %v
-  store <WIDTH x i32> %v1, <WIDTH x i32> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i64(<WIDTH x i64>* nocapture,
-                            <WIDTH x i64>, <WIDTH x i1>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<WIDTH x i64> ')  %0
-  %v1 = select <WIDTH x i1> %2, <WIDTH x i64> %1, <WIDTH x i64> %v
-  store <WIDTH x i64> %v1, <WIDTH x i64> * %0
-  ret void
-}
+declare void @__masked_store_blend_i8(<WIDTH x i8>* nocapture, <WIDTH x i8>, <WIDTH x i1>) nounwind alwaysinline
+declare void @__masked_store_blend_i16(<WIDTH x i16>* nocapture, <WIDTH x i16>, <WIDTH x i1>) nounwind alwaysinline
+declare void @__masked_store_blend_i32(<WIDTH x i32>* nocapture, <WIDTH x i32>, <WIDTH x i1>) nounwind alwaysinline
+declare void @__masked_store_blend_i64(<WIDTH x i64>* nocapture, <WIDTH x i64>, <WIDTH x i1>) nounwind alwaysinline
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; gather/scatter

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -1148,7 +1148,7 @@ preprocessor runs:
   * - ISPC
     - 1
     - Enables detecting that the ``ispc`` compiler is processing the file
-  * - ISPC_TARGET_{NEON, SSE2, SSE4, AVX, AVX2, AVX512KNL, AVX512SKX, AVX512SPR}
+  * - ISPC_TARGET_{NEON, SSE2, SSE4, AVX, AVX2, AVX512SKX, AVX512ICL, AVX512SPR}
     - 1
     - One of these will be set, depending on the compilation target
   * - ISPC_POINTER_SIZE

--- a/tests/lit-tests/2611-3.ispc
+++ b/tests/lit-tests/2611-3.ispc
@@ -2,7 +2,6 @@
 // RUN: %{ispc} --target=avx512skx-x64 --nowrap --x86-asm-syntax=intel --emit-asm -o - %s 2>&1 | FileCheck %s
 
 // REQUIRES: X86_ENABLED
-// XFAIL: *
 
 struct vec4 {
     float V[4];


### PR DESCRIPTION
This PR drops the implementation of maked stores and loads from `util.m4` (LLVM IR generic ones) in favor of generic ones from based on LLVM intrinsics from `generic.ispc` for targets `avx512*-x32` and `avx512*-x64`.

It improves performance of `08_masked_load_store` on order of magnitude, i.e., around ~10x times.

This PR changesthe implementation of masked stores and loads from `util.m4` (the generic LLVM IR versions) in favor of the generic versions based on LLVM intrinsics from `generic.ispc` for the targets avx512*-x32 and avx512*-x64.

This change improves the performance of `08_masked_load_store` by an order of magnitude (approximately ~10x).