### PR TITLE
Use PointerType::get with LLVMContext over Type

### DIFF
--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -77,9 +77,7 @@ static void lCheckModuleIntrinsics(llvm::Module *module) {
                 error_message += funcName;
                 FATAL(error_message.c_str());
             }
-            llvm::Type *intrinsicType = llvm::Intrinsic::getType(*g->ctx, id);
-            intrinsicType = llvm::PointerType::get(intrinsicType, 0);
-            Assert(func->getType() == intrinsicType);
+            Assert(func->getType() == LLVMTypes::VoidPointerType);
         }
     }
 }

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -3693,11 +3693,9 @@ llvm::Value *FunctionEmitContext::CallInst(llvm::Value *func, const FunctionType
                 SetInternalMask(callMask);
             }
 
-            // bitcast the i32/64 function pointer to the actual function
+            // bitcast the i32/64 function pointer to the function
             // pointer type.
-            llvm::Type *llvmFuncType = funcType->LLVMFunctionType(g->ctx);
-            llvm::Type *llvmFPtrType = llvm::PointerType::get(llvmFuncType, 0);
-            llvm::Value *fptrCast = IntToPtrInst(fptr, llvmFPtrType);
+            llvm::Value *fptrCast = IntToPtrInst(fptr, LLVMTypes::VoidPointerType);
 
             // Call the function: callResult = call ftpr(args, args, call mask)
             llvm::Value *callResult = CallInst(fptrCast, funcType, args, name);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -234,40 +234,10 @@ static const Type *lLLVMTypeToISPCType(const llvm::Type *t, bool intAsUnsigned) 
         return AtomicType::VaryingInt1;
     }
 
-    // pointers to uniform
-    else if (t == LLVMTypes::Int8PointerType) {
-        return PointerType::GetUniform(intAsUnsigned ? AtomicType::UniformUInt8 : AtomicType::UniformInt8);
-    } else if (t == LLVMTypes::Int16PointerType) {
-        return PointerType::GetUniform(intAsUnsigned ? AtomicType::UniformUInt16 : AtomicType::UniformInt16);
-    } else if (t == LLVMTypes::Int32PointerType) {
-        return PointerType::GetUniform(intAsUnsigned ? AtomicType::UniformUInt32 : AtomicType::UniformInt32);
-    } else if (t == LLVMTypes::Int64PointerType) {
-        return PointerType::GetUniform(intAsUnsigned ? AtomicType::UniformUInt64 : AtomicType::UniformInt64);
-    } else if (t == LLVMTypes::Float16PointerType) {
-        return PointerType::GetUniform(AtomicType::UniformFloat16);
-    } else if (t == LLVMTypes::FloatPointerType) {
-        return PointerType::GetUniform(AtomicType::UniformFloat);
-    } else if (t == LLVMTypes::DoublePointerType) {
-        return PointerType::GetUniform(AtomicType::UniformDouble);
+    // pointer
+    else if (t == LLVMTypes::PtrType) {
+        return PointerType::GetUniform(AtomicType::UniformInt8);
     }
-
-    // pointers to varying
-    else if (t == LLVMTypes::Int8VectorPointerType) {
-        return PointerType::GetUniform(intAsUnsigned ? AtomicType::VaryingUInt8 : AtomicType::VaryingInt8);
-    } else if (t == LLVMTypes::Int16VectorPointerType) {
-        return PointerType::GetUniform(intAsUnsigned ? AtomicType::VaryingUInt16 : AtomicType::VaryingInt16);
-    } else if (t == LLVMTypes::Int32VectorPointerType) {
-        return PointerType::GetUniform(intAsUnsigned ? AtomicType::VaryingUInt32 : AtomicType::VaryingInt32);
-    } else if (t == LLVMTypes::Int64VectorPointerType) {
-        return PointerType::GetUniform(intAsUnsigned ? AtomicType::VaryingUInt64 : AtomicType::VaryingInt64);
-    } else if (t == LLVMTypes::Float16VectorPointerType) {
-        return PointerType::GetUniform(AtomicType::VaryingFloat16);
-    } else if (t == LLVMTypes::FloatVectorPointerType) {
-        return PointerType::GetUniform(AtomicType::VaryingFloat);
-    } else if (t == LLVMTypes::DoubleVectorPointerType) {
-        return PointerType::GetUniform(AtomicType::VaryingDouble);
-    }
-
     // vector of pointers
     else if (t == LLVMTypes::PtrVectorType) {
         return AtomicType::VaryingUInt64;

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -42,14 +42,6 @@ llvm::Type *LLVMTypes::FloatType = nullptr;
 llvm::Type *LLVMTypes::DoubleType = nullptr;
 llvm::Type *LLVMTypes::PtrType = nullptr;
 
-llvm::Type *LLVMTypes::Int8PointerType = nullptr;
-llvm::Type *LLVMTypes::Int16PointerType = nullptr;
-llvm::Type *LLVMTypes::Int32PointerType = nullptr;
-llvm::Type *LLVMTypes::Int64PointerType = nullptr;
-llvm::Type *LLVMTypes::Float16PointerType = nullptr;
-llvm::Type *LLVMTypes::FloatPointerType = nullptr;
-llvm::Type *LLVMTypes::DoublePointerType = nullptr;
-
 llvm::VectorType *LLVMTypes::MaskType = nullptr;
 llvm::VectorType *LLVMTypes::BoolVectorType = nullptr;
 llvm::VectorType *LLVMTypes::BoolVectorStorageType = nullptr;
@@ -64,14 +56,6 @@ llvm::VectorType *LLVMTypes::FloatVectorType = nullptr;
 llvm::VectorType *LLVMTypes::DoubleVectorType = nullptr;
 llvm::VectorType *LLVMTypes::PtrVectorType = nullptr;
 
-llvm::Type *LLVMTypes::Int8VectorPointerType = nullptr;
-llvm::Type *LLVMTypes::Int16VectorPointerType = nullptr;
-llvm::Type *LLVMTypes::Int32VectorPointerType = nullptr;
-llvm::Type *LLVMTypes::Int64VectorPointerType = nullptr;
-llvm::Type *LLVMTypes::Float16VectorPointerType = nullptr;
-llvm::Type *LLVMTypes::FloatVectorPointerType = nullptr;
-llvm::Type *LLVMTypes::DoubleVectorPointerType = nullptr;
-
 llvm::VectorType *LLVMTypes::VoidPointerVectorType = nullptr;
 
 llvm::Constant *LLVMTrue = nullptr;
@@ -83,7 +67,7 @@ llvm::Constant *LLVMMaskAllOff = nullptr;
 
 void InitLLVMUtil(llvm::LLVMContext *ctx, Target &target) {
     LLVMTypes::VoidType = llvm::Type::getVoidTy(*ctx);
-    LLVMTypes::VoidPointerType = llvm::PointerType::get(llvm::Type::getInt8Ty(*ctx), 0);
+    LLVMTypes::VoidPointerType = llvm::PointerType::get(*ctx, 0);
     LLVMTypes::PointerIntType = target.is32Bit() ? llvm::Type::getInt32Ty(*ctx) : llvm::Type::getInt64Ty(*ctx);
 
     LLVMTypes::BoolType = llvm::Type::getInt1Ty(*ctx);
@@ -96,14 +80,6 @@ void InitLLVMUtil(llvm::LLVMContext *ctx, Target &target) {
     LLVMTypes::FloatType = llvm::Type::getFloatTy(*ctx);
     LLVMTypes::DoubleType = llvm::Type::getDoubleTy(*ctx);
     LLVMTypes::PtrType = llvm::PointerType::get(*ctx, 0);
-
-    LLVMTypes::Int8PointerType = llvm::PointerType::get(LLVMTypes::Int8Type, 0);
-    LLVMTypes::Int16PointerType = llvm::PointerType::get(LLVMTypes::Int16Type, 0);
-    LLVMTypes::Int32PointerType = llvm::PointerType::get(LLVMTypes::Int32Type, 0);
-    LLVMTypes::Int64PointerType = llvm::PointerType::get(LLVMTypes::Int64Type, 0);
-    LLVMTypes::Float16PointerType = llvm::PointerType::get(LLVMTypes::Float16Type, 0);
-    LLVMTypes::FloatPointerType = llvm::PointerType::get(LLVMTypes::FloatType, 0);
-    LLVMTypes::DoublePointerType = llvm::PointerType::get(LLVMTypes::DoubleType, 0);
 
     switch (target.getMaskBitCount()) {
     case 1:
@@ -140,15 +116,6 @@ void InitLLVMUtil(llvm::LLVMContext *ctx, Target &target) {
     LLVMTypes::FloatVectorType = LLVMVECTOR::get(LLVMTypes::FloatType, target.getVectorWidth());
     LLVMTypes::DoubleVectorType = LLVMVECTOR::get(LLVMTypes::DoubleType, target.getVectorWidth());
     LLVMTypes::PtrVectorType = LLVMVECTOR::get(LLVMTypes::PtrType, target.getVectorWidth());
-
-    LLVMTypes::Int8VectorPointerType = llvm::PointerType::get(LLVMTypes::Int8VectorType, 0);
-    LLVMTypes::Int16VectorPointerType = llvm::PointerType::get(LLVMTypes::Int16VectorType, 0);
-    LLVMTypes::Int32VectorPointerType = llvm::PointerType::get(LLVMTypes::Int32VectorType, 0);
-    LLVMTypes::Int64VectorPointerType = llvm::PointerType::get(LLVMTypes::Int64VectorType, 0);
-    LLVMTypes::Float16VectorPointerType = llvm::PointerType::get(LLVMTypes::Float16VectorType, 0);
-    LLVMTypes::FloatVectorPointerType = llvm::PointerType::get(LLVMTypes::FloatVectorType, 0);
-    LLVMTypes::DoubleVectorPointerType = llvm::PointerType::get(LLVMTypes::DoubleVectorType, 0);
-
     LLVMTypes::VoidPointerVectorType = g->target->is32Bit() ? LLVMTypes::Int32VectorType : LLVMTypes::Int64VectorType;
 
     LLVMTrue = llvm::ConstantInt::getTrue(*ctx);

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -52,14 +52,6 @@ struct LLVMTypes {
     static llvm::Type *DoubleType;
     static llvm::Type *PtrType;
 
-    static llvm::Type *Int8PointerType;
-    static llvm::Type *Int16PointerType;
-    static llvm::Type *Int32PointerType;
-    static llvm::Type *Int64PointerType;
-    static llvm::Type *Float16PointerType;
-    static llvm::Type *FloatPointerType;
-    static llvm::Type *DoublePointerType;
-
     static llvm::VectorType *MaskType;
 
     static llvm::VectorType *BoolVectorType;
@@ -73,14 +65,6 @@ struct LLVMTypes {
     static llvm::VectorType *FloatVectorType;
     static llvm::VectorType *DoubleVectorType;
     static llvm::VectorType *PtrVectorType;
-
-    static llvm::Type *Int8VectorPointerType;
-    static llvm::Type *Int16VectorPointerType;
-    static llvm::Type *Int32VectorPointerType;
-    static llvm::Type *Int64VectorPointerType;
-    static llvm::Type *Float16VectorPointerType;
-    static llvm::Type *FloatVectorPointerType;
-    static llvm::Type *DoubleVectorPointerType;
 
     static llvm::VectorType *VoidPointerVectorType;
 };

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3481,7 +3481,7 @@ static llvm::FunctionType *lGetVaryingDispatchType(FunctionTargetVariants &funcs
                     // For each varying type pointed to, swap the LLVM pointer type
                     // with i8 * (as close as we can get to void *)
                     if (baseType->IsVaryingType()) {
-                        ftype[j] = LLVMTypes::Int8PointerType;
+                        ftype[j] = LLVMTypes::VoidPointerType;
                         foundVarying = true;
                     }
                 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3373,7 +3373,11 @@ int Module::execPreprocessor(const char *infilename, llvm::raw_string_ostream *o
 
     // Finally, create an preprocessor object
     clang::TrivialModuleLoader modLoader;
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_21_0
+    clang::Preprocessor prep(*preProcOpts, diagEng, langOpts, srcMgr, hdrSearch, modLoader);
+#else
     clang::Preprocessor prep(preProcOpts, diagEng, langOpts, srcMgr, hdrSearch, modLoader);
+#endif
 
     // Initialize preprocessor
     prep.Initialize(*tgtInfo);

--- a/src/opt/GatherCoalescePass.cpp
+++ b/src/opt/GatherCoalescePass.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2022-2024, Intel Corporation
+  Copyright (c) 2022-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -264,8 +264,6 @@ static void lCoalescePerfInfo(const std::vector<llvm::CallInst *> &coalesceGroup
 static llvm::Value *lGEPAndLoad(llvm::Value *basePtr, llvm::Type *baseType, int64_t offset, int align,
                                 llvm::Instruction *insertBefore, llvm::Type *type) {
     llvm::Value *ptr = LLVMGEPInst(basePtr, baseType, LLVMInt64(offset), "new_base", insertBefore);
-    ptr = new llvm::BitCastInst(ptr, llvm::PointerType::get(type, 0), "ptr_cast",
-                                ISPC_INSERTION_POINT_INSTRUCTION(insertBefore));
     Assert(llvm::isa<llvm::PointerType>(ptr->getType()));
     return new llvm::LoadInst(type, ptr, "gather_load", false /* not volatile */, llvm::MaybeAlign(align).valueOrOne(),
                               ISPC_INSERTION_POINT_INSTRUCTION(insertBefore));

--- a/src/opt/IntrinsicsOptPass.cpp
+++ b/src/opt/IntrinsicsOptPass.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2022-2024, Intel Corporation
+  Copyright (c) 2022-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -134,7 +134,7 @@ bool IntrinsicsOpt::optimizeIntrinsics(llvm::BasicBlock &bb) {
                 Assert(llvm::isa<llvm::VectorType>(returnType));
                 // cast the i8 * to the appropriate type
                 llvm::Value *castPtr =
-                    new llvm::BitCastInst(callInst->getArgOperand(0), llvm::PointerType::get(returnType, 0),
+                    new llvm::BitCastInst(callInst->getArgOperand(0), LLVMTypes::PtrType,
                                           llvm::Twine(callInst->getArgOperand(0)->getName()) + "_cast",
                                           ISPC_INSERTION_POINT_INSTRUCTION(callInst));
                 LLVMCopyMetadata(castPtr, callInst);
@@ -165,9 +165,8 @@ bool IntrinsicsOpt::optimizeIntrinsics(llvm::BasicBlock &bb) {
             } else if (maskStatus == MaskStatus::all_on) {
                 // all lanes storing, so replace with a regular store
                 llvm::Value *rvalue = callInst->getArgOperand(2);
-                llvm::Type *storeType = rvalue->getType();
                 llvm::Value *castPtr =
-                    new llvm::BitCastInst(callInst->getArgOperand(0), llvm::PointerType::get(storeType, 0),
+                    new llvm::BitCastInst(callInst->getArgOperand(0), LLVMTypes::PtrType,
                                           llvm::Twine(callInst->getArgOperand(0)->getName()) + "_ptrcast",
                                           ISPC_INSERTION_POINT_INSTRUCTION(callInst));
                 LLVMCopyMetadata(castPtr, callInst);

--- a/src/opt/ReplaceMaskedMemOps.cpp
+++ b/src/opt/ReplaceMaskedMemOps.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2024, Intel Corporation
+  Copyright (c) 2024-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -163,10 +163,9 @@ llvm::Value *lMaskedMergeVectors(llvm::IRBuilder<> &B, llvm::Value *firstVector,
 }
 
 llvm::Value *lBitcastPointerType(llvm::IRBuilder<> &B, llvm::Value *ptr, llvm::Value *value) {
-    auto *vecType = llvm::dyn_cast<llvm::VectorType>(value->getType());
     llvm::PointerType *ptrType = llvm::dyn_cast<llvm::PointerType>(ptr->getType());
-    Assert(vecType && ptrType);
-    auto *newPtrType = llvm::PointerType::get(vecType, ptrType->getAddressSpace());
+    Assert(ptrType);
+    auto *newPtrType = llvm::PointerType::get(*g->ctx, ptrType->getAddressSpace());
     // If ptr is opaque pointer then no-op is generated here.
     return B.CreateBitCast(ptr, newPtrType);
 }
@@ -210,7 +209,7 @@ void lReplaceMaskedLoad(llvm::IRBuilder<> &B, llvm::CallInst *CI, unsigned SubVe
     Assert(vecType);
     auto *subVecType = llvm::VectorType::get(vecType->getElementType(), SubVectorLength, false);
     llvm::PointerType *ptrType = llvm::dyn_cast<llvm::PointerType>(ptr->getType());
-    ptr = B.CreateBitCast(ptr, llvm::PointerType::get(subVecType, ptrType->getAddressSpace()));
+    ptr = B.CreateBitCast(ptr, llvm::PointerType::get(*g->ctx, ptrType->getAddressSpace()));
 
     llvm::LoadInst *subVec = B.CreateLoad(subVecType, ptr, llvm::Twine(origName) + ".part");
     // It is important to preserve the alignment of the original masked load.

--- a/src/opt/XeGatherCoalescePass.cpp
+++ b/src/opt/XeGatherCoalescePass.cpp
@@ -540,7 +540,7 @@ void XeGatherCoalescing::optimizePtr(llvm::Value *Ptr, PtrData &PD, llvm::Instru
         llvm::Instruction *Addr = llvm::BinaryOperator::CreateAdd(PtrToInt, Offset, "vectorized_address", InsertPoint);
         llvm::Type *RetType = llvm::FixedVectorType::get(LargestType, ReqSize / LargestTypeSize);
         llvm::IntToPtrInst *PtrForLd =
-            new llvm::IntToPtrInst(Addr, llvm::PointerType::get(RetType, 0), "vectorized_address_ptr", InsertPoint);
+            new llvm::IntToPtrInst(Addr, LLVMTypes::PtrType, "vectorized_address_ptr", InsertPoint);
         llvm::LoadInst *LD = new llvm::LoadInst(RetType, PtrForLd, "vectorized_ld_exp", InsertPoint);
 
         //  If the Offset is zero, we generate a LD with default alignment for the target.

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -3976,9 +3976,9 @@ static PrintArgsBuilder getPrintArgsBuilder(Expr *values, FunctionEmitContext *c
 
 // This name should be also properly mangled. It happens later.
 static llvm::FunctionCallee getSPIRVOCLPrintfDecl() {
-    auto *PrintfTy = llvm::FunctionType::get(LLVMTypes::Int32Type,
-                                             llvm::PointerType::get(LLVMTypes::Int8Type, /* const addrspace */ 2),
-                                             /* isVarArg */ true);
+    auto *PrintfTy =
+        llvm::FunctionType::get(LLVMTypes::Int32Type, llvm::PointerType::get(*g->ctx, /* const addrspace */ 2),
+                                /* isVarArg */ true);
     return m->module->getOrInsertFunction("__spirv_ocl_printf", PrintfTy);
 }
 
@@ -4016,8 +4016,7 @@ static AddressInfo *lEmitPrintArgCode(Expr *expr, FunctionEmitContext *ctx) {
     }
     ctx->StoreInst(val, ptrInfo);
 
-    llvm::Value *ptr = ctx->BitCastInst(ptrInfo->getPointer(), LLVMTypes::VoidPointerType);
-    return new AddressInfo(ptr, LLVMTypes::VoidPointerType);
+    return new AddressInfo(ptrInfo->getPointer(), LLVMTypes::VoidPointerType);
 }
 
 static bool lProcessPrintArg(Expr *expr, FunctionEmitContext *ctx, AddressInfo *argPtrArray, int offset,
@@ -4049,8 +4048,7 @@ std::vector<llvm::Value *> PrintStmt::getDoPrintArgs(FunctionEmitContext *ctx) c
     if (values == nullptr) {
         // Check requested format
         checkFormatString(format, 0, pos);
-        llvm::Type *ptrPtrType = llvm::PointerType::get(LLVMTypes::VoidPointerType, 0);
-        doPrintArgs[ARGS_IDX] = llvm::Constant::getNullValue(ptrPtrType);
+        doPrintArgs[ARGS_IDX] = llvm::Constant::getNullValue(LLVMTypes::VoidPointerType);
     } else {
         // Get the values passed to the print() statement evaluated and
         // stored in memory so that we set up the array of pointers to them
@@ -4064,8 +4062,7 @@ std::vector<llvm::Value *> PrintStmt::getDoPrintArgs(FunctionEmitContext *ctx) c
         AddressInfo *argPtrArrayInfo = ctx->AllocaInst(argPtrArrayType, "print_arg_ptrs");
         // Store the array pointer as a void **, which is what __do_print()
         // expects
-        doPrintArgs[ARGS_IDX] =
-            ctx->BitCastInst(argPtrArrayInfo->getPointer(), llvm::PointerType::get(LLVMTypes::VoidPointerType, 0));
+        doPrintArgs[ARGS_IDX] = argPtrArrayInfo->getPointer();
 
         // Now, for each of the arguments, emit code to evaluate its value
         // and store the value into alloca's storage.  Then store the

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1265,17 +1265,7 @@ llvm::Type *PointerType::LLVMType(llvm::LLVMContext *ctx) const {
 
     switch (variability.type) {
     case Variability::Uniform: {
-        llvm::Type *ptype = nullptr;
-        const FunctionType *ftype = CastType<FunctionType>(baseType);
-        if (ftype != nullptr) {
-            ptype = llvm::PointerType::get(ftype->LLVMFunctionType(ctx), (unsigned)addrSpace);
-        } else {
-            if (baseType->IsVoidType()) {
-                ptype = llvm::PointerType::get(llvm::Type::getInt8Ty(*ctx), (unsigned)addrSpace);
-            } else {
-                ptype = llvm::PointerType::get(baseType->LLVMStorageType(ctx), (unsigned)addrSpace);
-            }
-        }
+        llvm::Type *ptype = llvm::PointerType::get(*ctx, (unsigned)addrSpace);
         return ptype;
     }
     case Variability::Varying:
@@ -2615,14 +2605,7 @@ llvm::Type *ReferenceType::LLVMType(llvm::LLVMContext *ctx) const {
         Assert(m->errorCount > 0);
         return nullptr;
     }
-
-    llvm::Type *t = targetType->LLVMStorageType(ctx);
-    if (t == nullptr) {
-        Assert(m->errorCount > 0);
-        return nullptr;
-    }
-
-    return llvm::PointerType::get(t, (unsigned)addrSpace);
+    return llvm::PointerType::get(*ctx, (unsigned)addrSpace);
 }
 
 llvm::DIType *ReferenceType::GetDIType(llvm::DIScope *scope) const {
@@ -3067,8 +3050,7 @@ llvm::FunctionType *FunctionType::LLVMFunctionType(llvm::LLVMContext *ctx, bool 
         // threads the tasks system has running.  (Task arguments are
         // marshalled in a struct so that it's easy to allocate space to
         // hold them until the task actually runs.)
-        llvm::Type *st = llvm::StructType::get(*ctx, llvmArgTypes);
-        callTypes.push_back(llvm::PointerType::getUnqual(st));
+        callTypes.push_back(llvm::PointerType::getUnqual(*ctx));
         callTypes.push_back(LLVMTypes::Int32Type); // threadIndex
         callTypes.push_back(LLVMTypes::Int32Type); // threadCount
         callTypes.push_back(LLVMTypes::Int32Type); // taskIndex


### PR DESCRIPTION
This PR switches from typed pointers to more generic pointer types. This corresponds to the latest changes in LLVM trunk.