### PR TITLE
Check for StructType before accessing GetElementType in gather()

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -2688,13 +2688,13 @@ llvm::Value *FunctionEmitContext::gather(llvm::Value *ptr, const PointerType *pt
 
             eltPtr = addVaryingOffsetsIfNeeded(eltPtr, eltPtrType);
             const Type *eltType = nullptr;
-            if (returnCollectionType) {
+            if (returnCollectionType && CastType<StructType>(ptrType->GetBaseType())) {
                 eltType = returnCollectionType->GetElementType(i);
             }
 
             // It is a kludge. When we dereference varying pointer to uniform struct
             // with "bound uniform" member, we should return first unmasked member.
-            int need_one_elem = CastType<StructType>(ptrType->GetBaseType()) && eltType && eltType->IsUniformType();
+            int need_one_elem = eltType && eltType->IsUniformType();
             // This in turn will be another gather
             llvm::Value *eltValues = LoadInst(eltPtr, mask, eltPtrType, name, need_one_elem);
             if (eltType && eltType->IsBoolType()) {

--- a/tests/lit-tests/3321.ispc
+++ b/tests/lit-tests/3321.ispc
@@ -1,0 +1,25 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s --allow-empty
+
+// CHECK-NOT: Error: Assertion failed
+struct FloatVec3 {
+    float coords[3];
+};
+
+struct Triangle {
+    FloatVec3 point[3];
+};
+
+struct MeshObject {
+    unsigned int numTris;
+    Triangle *triangles;
+};
+
+bool intersects_triangle_ispc(Triangle triangle);
+
+export void intersects_mesh(uniform MeshObject const &MO, uniform float tOut[]) {
+    foreach (i = 0...MO.numTris) {
+        if (!intersects_triangle_ispc(MO.triangles[i])) {
+            tOut[i] = -1;
+        }
+    }
+}


### PR DESCRIPTION
This fixes #3321.
The issue is a regression after https://github.com/ispc/ispc/commit/64d511b58fd0a78576d88cadcf9eee67ae2be7a9. I'm adding check that `ptrType->GetBaseType()` is `StructType` before accessing `GetElementType(i)`.