### PR TITLE
Fix dependencies for subprojects (examples/benchmarks)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -904,6 +904,8 @@ if (ISPC_SLIM_BINARY)
     install(DIRECTORY ${BITCODE_FOLDER} DESTINATION share)
 endif()
 
+set(ISPC_DEPS generic-target-bc stdlibs-bc stdlib-headers)
+
 
 if (ISPC_INCLUDE_TESTS)
     add_subdirectory(tests)
@@ -927,7 +929,7 @@ if (ISPC_INCLUDE_EXAMPLES AND NOT ISPC_PREPARE_PACKAGE)
     include(ExternalProject)
     ExternalProject_Add(ispc_cpu_examples
         PREFIX cpu_examples
-        DEPENDS ispc stdlibs-bc stdlib-headers
+        DEPENDS ispc ${ISPC_DEPS}
         SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/examples/cpu"
         CMAKE_CACHE_ARGS
             -DISPC_BUILD:BOOL=TRUE
@@ -953,7 +955,7 @@ if (ISPC_INCLUDE_XE_EXAMPLES AND ISPC_INCLUDE_RT AND NOT ISPC_PREPARE_PACKAGE)
         # using cmake generator conditional expressions were unsuccessful.
         ExternalProject_Add(ispc_xpu_examples
             PREFIX xpu_examples
-            DEPENDS ispc stdlibs-bc stdlib-headers ispcrt benchmark
+            DEPENDS ispc ${ISPC_DEPS} ispcrt benchmark
             SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/examples/xpu"
             CMAKE_CACHE_ARGS
                 -DISPC_BUILD:BOOL=TRUE
@@ -973,7 +975,7 @@ if (ISPC_INCLUDE_XE_EXAMPLES AND ISPC_INCLUDE_RT AND NOT ISPC_PREPARE_PACKAGE)
     else()
         ExternalProject_Add(ispc_xpu_examples
             PREFIX xpu_examples
-            DEPENDS ispc stdlibs-bc stdlib-headers ispcrt
+            DEPENDS ispc ${ISPC_DEPS} ispcrt
             SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/examples/xpu"
             CMAKE_CACHE_ARGS
                 -DISPC_BUILD:BOOL=TRUE

--- a/benchmarks/cmake/AddBenchmark.cmake
+++ b/benchmarks/cmake/AddBenchmark.cmake
@@ -126,7 +126,7 @@ function(add_ispc_to_target)
             OUTPUT ${ISPC_TARGET_OBJS} ${ISPC_TARGET_HEADERS}
             COMMENT "Compiling ${ISPC_SRC_FILE} for ${BENCHMARKS_ISPC_TARGETS} target(s)"
             COMMAND           ${ISPC_EXECUTABLE} ${SRC_LOCATION} -o ${ISPC_OBJ} -h ${ISPC_HEADER} --arch=${ISPC_ARCH} --target=${BENCHMARKS_ISPC_TARGETS} ${ISPC_PIC} "$<JOIN:${FLAGS},;>"
-            DEPENDS ${ISPC_EXECUTABLE} stdlibs-bc
+            DEPENDS ${ISPC_EXECUTABLE} ${ISPC_DEPS}
             DEPENDS ${ISPC_SRC_FILE}
             COMMAND_EXPAND_LISTS
         )

--- a/examples/cpu/cmake/AddISPCExampleLegacy.cmake
+++ b/examples/cpu/cmake/AddISPCExampleLegacy.cmake
@@ -59,7 +59,7 @@ function(add_ispc_example)
         COMMAND ${ISPC_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${ISPC_SRC_NAME}.ispc ${ISPC_FLAGS} --target=${ISPC_TARGETS} --arch=${ISPC_ARCH}
                                    -h ${ISPC_HEADER_NAME} -o ${ISPC_OBJ_NAME}
         VERBATIM
-        DEPENDS ${ISPC_EXECUTABLE}
+        DEPENDS ${ISPC_EXECUTABLE} ${ISPC_DEPS}
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${ISPC_SRC_NAME}.ispc")
 
     # To show ispc source in VS solution:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,7 +30,7 @@ list(APPEND LIT_ARGS "-Dps_enabled=$<IF:$<BOOL:${ISPC_PS_TARGET}>,ON,OFF>")
 list(APPEND LIT_ARGS "-Dmacos_arm_enabled=$<IF:$<BOOL:${ISPC_MACOS_ARM_TARGET}>,ON,OFF>")
 list(APPEND LIT_ARGS "-Dmacos_ios_enabled=$<IF:$<BOOL:${ISPC_IOS_ARM_TARGET}>,ON,OFF>")
 # TODO! generic target bc?
-add_custom_target(check-all DEPENDS ispc ispc-opt stdlibs-bc stdlib-headers
+add_custom_target(check-all DEPENDS ispc ispc-opt ${ISPC_DEPS}
     COMMAND ${LIT_COMMAND} ${LIT_ARGS} "--verbose"
     COMMENT "Running lit tests"
     USES_TERMINAL


### PR DESCRIPTION
Fix missing dependencies in ISPC components for builds with ISPC_SLIM_BINARY=ON. This issue could lead to build failures when using Ninja.