### PR TITLE
Fix logic in treating pointers for IndexExpr lvalue

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -5130,18 +5130,16 @@ const Type *IndexExpr::GetLValueType() const {
 
     // Find the type of thing that we're indexing into
     const Type *elementType = nullptr;
-    const SequentialType *st = CastType<SequentialType>(baseExprLValueType->GetBaseType());
-    if (st != nullptr) {
-        elementType = st->GetElementType();
+    if (CastType<PointerType>(baseExprType) != nullptr) {
+        // For pointer indexing, element type is directly the base type of the pointer
+        elementType = CastType<PointerType>(baseExprType)->GetBaseType();
     } else {
-        const PointerType *pt = CastType<PointerType>(baseExprLValueType->GetBaseType());
-        // This assertion seems overly strict.
-        // Why does it need to be a pointer to a pointer?
-        // AssertPos(pos, pt != nullptr);
-
-        if (pt != nullptr) {
-            elementType = pt->GetBaseType();
+        // For arrays and vectors, get the element type from the sequential type
+        const SequentialType *st = CastType<SequentialType>(baseExprLValueType->GetBaseType());
+        if (st != nullptr) {
+            elementType = st->GetElementType();
         } else {
+            // Fallback case
             elementType = baseExprLValueType->GetBaseType();
         }
     }

--- a/tests/lit-tests/2186.ispc
+++ b/tests/lit-tests/2186.ispc
@@ -1,0 +1,21 @@
+// This test checks that there is no ICE on the following code.
+
+// RUN: %{ispc} --target=host --nowrap --nostdlib --emit-llvm-text --debug-phase=210:210 %s -o - | FileCheck %s
+
+// CHECK-NOT: FATAL ERROR: Unhandled signal sent to process
+typedef float<4> vec4;
+
+struct MyStruct {
+    float* data;
+};
+
+// CHECK-LABEL: @GetData1
+// CHECK-COUNT-4: __pseudo_masked_store_float
+unmasked vec4 GetData1(MyStruct& from, int index) {
+    return ((vec4*)from.data)[index];
+}
+// CHECK-LABEL: @GetData2
+// CHECK-COUNT-4: __pseudo_masked_store_float
+unmasked vec4 GetData2(MyStruct& from, int index) {
+    return ((vec4*)from.data)->x;
+}


### PR DESCRIPTION
Fixes #2186 .
this PR aligns logic between `IndexExpr::GetLValueType()` and `IndexExpr::GetLValue()`.
The new code checks if `baseExprType` is a pointer first, which matches how `GetLValue` branches its logic