### PR TITLE
Extended dot product support for AVX10.2

### DIFF
--- a/builtins/generic.ispc
+++ b/builtins/generic.ispc
@@ -510,27 +510,40 @@ EXT READNONE uniform double __rsqrt_uniform_double(uniform double) { __not_suppo
 EXT READNONE varying double __rsqrt_varying_double(varying double) { __not_supported(); }
 
 // dot product
-// __have_dot_product_vnni
-EXT READNONE varying int32 __dot2add_i16i16packed_sat(varying uint32, varying uint32, varying int32) { __not_supported(); }
+// __have_intel_vnni
+EXT READNONE varying int32 __dot2add_i16i16packed_sat(varying uint32, varying uint32, varying int32) {
+    __not_supported();
+}
 EXT READNONE varying int32 __dot2add_i16i16packed(varying uint32, varying uint32, varying int32) { __not_supported(); }
 EXT READNONE varying int32 __dot4add_u8i8packed_sat(varying uint32, varying uint32, varying int32) {
     __not_supported();
 }
+// __have_intel_vnni || __have_arm_i8mm
 EXT READNONE varying int32 __dot4add_u8i8packed(varying uint32, varying uint32, varying int32) { __not_supported(); }
 
-// __have_dot_product_arm || __have_intel_vnni_int8
+// __have_arm_dot_product || __have_intel_vnni_int8
 EXT READNONE varying uint32 __dot4add_u8u8packed(varying uint32, varying uint32, varying uint32) { __not_supported(); }
 EXT READNONE varying int32 __dot4add_i8i8packed(varying uint32, varying uint32, varying int32) { __not_supported(); }
 
 // __have_intel_vnni_int8
-EXT READNONE varying uint32 __dot4add_u8u8packed_sat(varying uint32, varying uint32, varying uint32) { __not_supported(); }
-EXT READNONE varying int32 __dot4add_i8i8packed_sat(varying uint32, varying uint32, varying int32) { __not_supported(); }
+EXT READNONE varying uint32 __dot4add_u8u8packed_sat(varying uint32, varying uint32, varying uint32) {
+    __not_supported();
+}
+EXT READNONE varying int32 __dot4add_i8i8packed_sat(varying uint32, varying uint32, varying int32) {
+    __not_supported();
+}
 
 // __have_intel_vnni_int16
-EXT READNONE varying uint32 __dot2add_u16u16packed_sat(varying uint32, varying uint32, varying uint32) { __not_supported(); }
-EXT READNONE varying uint32 __dot2add_u16u16packed(varying uint32, varying uint32, varying uint32) { __not_supported(); }
+EXT READNONE varying uint32 __dot2add_u16u16packed_sat(varying uint32, varying uint32, varying uint32) {
+    __not_supported();
+}
+EXT READNONE varying uint32 __dot2add_u16u16packed(varying uint32, varying uint32, varying uint32) {
+    __not_supported();
+}
 
-EXT READNONE varying int32 __dot2add_u16i16packed_sat(varying uint32, varying uint32, varying int32) { __not_supported(); }
+EXT READNONE varying int32 __dot2add_u16i16packed_sat(varying uint32, varying uint32, varying int32) {
+    __not_supported();
+}
 EXT READNONE varying int32 __dot2add_u16i16packed(varying uint32, varying uint32, varying int32) { __not_supported(); }
 
 // __have_native_half_converts

--- a/builtins/generic.ispc
+++ b/builtins/generic.ispc
@@ -518,9 +518,13 @@ EXT READNONE varying int32 __dot4add_u8i8packed_sat(varying uint32, varying uint
 }
 EXT READNONE varying int32 __dot4add_u8i8packed(varying uint32, varying uint32, varying int32) { __not_supported(); }
 
-// __have_dot_product_arm
+// __have_dot_product_arm || __have_intel_vnni_int8
 EXT READNONE varying uint32 __dot4add_u8u8packed(varying uint32, varying uint32, varying uint32) { __not_supported(); }
 EXT READNONE varying int32 __dot4add_i8i8packed(varying uint32, varying uint32, varying int32) { __not_supported(); }
+
+// __have_intel_vnni_int8
+EXT READNONE varying uint32 __dot4add_u8u8packed_sat(varying uint32, varying uint32, varying uint32) { __not_supported(); }
+EXT READNONE varying int32 __dot4add_i8i8packed_sat(varying uint32, varying uint32, varying int32) { __not_supported(); }
 
 // __have_native_half_converts
 EXT uniform int16 __float_to_half_uniform(uniform float x) { __not_supported(); }

--- a/builtins/generic.ispc
+++ b/builtins/generic.ispc
@@ -511,8 +511,8 @@ EXT READNONE varying double __rsqrt_varying_double(varying double) { __not_suppo
 
 // dot product
 // __have_dot_product_vnni
-EXT READNONE varying int32 __dot2add_i16packed_sat(varying uint32, varying uint32, varying int32) { __not_supported(); }
-EXT READNONE varying int32 __dot2add_i16packed(varying uint32, varying uint32, varying int32) { __not_supported(); }
+EXT READNONE varying int32 __dot2add_i16i16packed_sat(varying uint32, varying uint32, varying int32) { __not_supported(); }
+EXT READNONE varying int32 __dot2add_i16i16packed(varying uint32, varying uint32, varying int32) { __not_supported(); }
 EXT READNONE varying int32 __dot4add_u8i8packed_sat(varying uint32, varying uint32, varying int32) {
     __not_supported();
 }
@@ -525,6 +525,13 @@ EXT READNONE varying int32 __dot4add_i8i8packed(varying uint32, varying uint32, 
 // __have_intel_vnni_int8
 EXT READNONE varying uint32 __dot4add_u8u8packed_sat(varying uint32, varying uint32, varying uint32) { __not_supported(); }
 EXT READNONE varying int32 __dot4add_i8i8packed_sat(varying uint32, varying uint32, varying int32) { __not_supported(); }
+
+// __have_intel_vnni_int16
+EXT READNONE varying uint32 __dot2add_u16u16packed_sat(varying uint32, varying uint32, varying uint32) { __not_supported(); }
+EXT READNONE varying uint32 __dot2add_u16u16packed(varying uint32, varying uint32, varying uint32) { __not_supported(); }
+
+EXT READNONE varying int32 __dot2add_u16i16packed_sat(varying uint32, varying uint32, varying int32) { __not_supported(); }
+EXT READNONE varying int32 __dot2add_u16i16packed(varying uint32, varying uint32, varying int32) { __not_supported(); }
 
 // __have_native_half_converts
 EXT uniform int16 __float_to_half_uniform(uniform float x) { __not_supported(); }

--- a/builtins/target-avx10_2-x16.ll
+++ b/builtins/target-avx10_2-x16.ll
@@ -4,3 +4,27 @@
 
 define(`WIDTH',`16')
 define(`ISA',`AVX10_2')
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; dot product
+declare <16 x i32> @llvm.x86.avx10.vpdpbssd.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <16 x i32> @__dot4add_i8i8packed(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <16 x i32> @llvm.x86.avx10.vpdpbssd.512(<16 x i32> %acc, <16 x i32> %a, <16 x i32> %b)
+  ret <16 x i32> %ret
+}
+declare <16 x i32> @llvm.x86.avx10.vpdpbssds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <16 x i32> @__dot4add_i8i8packed_sat(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <16 x i32> @llvm.x86.avx10.vpdpbssds.512(<16 x i32> %acc, <16 x i32> %a, <16 x i32> %b)
+  ret <16 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpbuud.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <16 x i32> @__dot4add_u8u8packed(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <16 x i32> @llvm.x86.avx10.vpdpbuud.512(<16 x i32> %acc, <16 x i32> %a, <16 x i32> %b)
+  ret <16 x i32> %ret
+}
+declare <16 x i32> @llvm.x86.avx10.vpdpbuuds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <16 x i32> @__dot4add_u8u8packed_sat(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <16 x i32> @llvm.x86.avx10.vpdpbuuds.512(<16 x i32> %acc, <16 x i32> %a, <16 x i32> %b)
+  ret <16 x i32> %ret
+}

--- a/builtins/target-avx10_2-x16.ll
+++ b/builtins/target-avx10_2-x16.ll
@@ -28,3 +28,27 @@ define <16 x i32> @__dot4add_u8u8packed_sat(<16 x i32> %a, <16 x i32> %b, <16 x 
   %ret = call <16 x i32> @llvm.x86.avx10.vpdpbuuds.512(<16 x i32> %acc, <16 x i32> %a, <16 x i32> %b)
   ret <16 x i32> %ret
 }
+
+declare <16 x i32> @llvm.x86.avx10.vpdpwuud.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <16 x i32> @__dot2add_u16u16packed(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <16 x i32> @llvm.x86.avx10.vpdpwuud.512(<16 x i32> %acc, <16 x i32> %a, <16 x i32> %b)
+  ret <16 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpwuuds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <16 x i32> @__dot2add_u16u16packed_sat(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <16 x i32> @llvm.x86.avx10.vpdpwuuds.512(<16 x i32> %acc, <16 x i32> %a, <16 x i32> %b)
+  ret <16 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpwusd.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <16 x i32> @__dot2add_u16i16packed(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <16 x i32> @llvm.x86.avx10.vpdpwusd.512(<16 x i32> %acc, <16 x i32> %a, <16 x i32> %b)
+  ret <16 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpwusds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <16 x i32> @__dot2add_u16i16packed_sat(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <16 x i32> @llvm.x86.avx10.vpdpwusds.512(<16 x i32> %acc, <16 x i32> %a, <16 x i32> %b)
+  ret <16 x i32> %ret
+}

--- a/builtins/target-avx10_2-x32.ll
+++ b/builtins/target-avx10_2-x32.ll
@@ -4,3 +4,51 @@
 
 define(`WIDTH',`32')
 define(`ISA',`AVX10_2')
+
+include(`util.m4')
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; dot product
+declare <16 x i32> @llvm.x86.avx10.vpdpbssd.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <32 x i32> @__dot4add_i8i8packed(<32 x i32> %a, <32 x i32> %b, <32 x i32> %acc) nounwind readnone alwaysinline {
+  v32tov16(i32, %a, %a0, %a1)
+  v32tov16(i32, %b, %b0, %b1)
+  v32tov16(i32, %acc, %acc0, %acc1)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpbssd.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpbssd.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  v16tov32(i32, %ret0, %ret1, %ret)
+  ret <32 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpbssds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <32 x i32> @__dot4add_i8i8packed_sat(<32 x i32> %a, <32 x i32> %b, <32 x i32> %acc) nounwind readnone alwaysinline {
+  v32tov16(i32, %a, %a0, %a1)
+  v32tov16(i32, %b, %b0, %b1)
+  v32tov16(i32, %acc, %acc0, %acc1)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpbssds.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpbssds.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  v16tov32(i32, %ret0, %ret1, %ret)
+  ret <32 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpbuud.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <32 x i32> @__dot4add_u8u8packed(<32 x i32> %a, <32 x i32> %b, <32 x i32> %acc) nounwind readnone alwaysinline {
+  v32tov16(i32, %a, %a0, %a1)
+  v32tov16(i32, %b, %b0, %b1)
+  v32tov16(i32, %acc, %acc0, %acc1)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpbuud.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpbuud.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  v16tov32(i32, %ret0, %ret1, %ret)
+  ret <32 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpbuuds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <32 x i32> @__dot4add_u8u8packed_sat(<32 x i32> %a, <32 x i32> %b, <32 x i32> %acc) nounwind readnone alwaysinline {
+  v32tov16(i32, %a, %a0, %a1)
+  v32tov16(i32, %b, %b0, %b1)
+  v32tov16(i32, %acc, %acc0, %acc1)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpbuuds.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpbuuds.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  v16tov32(i32, %ret0, %ret1, %ret)
+  ret <32 x i32> %ret
+}

--- a/builtins/target-avx10_2-x32.ll
+++ b/builtins/target-avx10_2-x32.ll
@@ -52,3 +52,47 @@ define <32 x i32> @__dot4add_u8u8packed_sat(<32 x i32> %a, <32 x i32> %b, <32 x 
   v16tov32(i32, %ret0, %ret1, %ret)
   ret <32 x i32> %ret
 }
+
+declare <16 x i32> @llvm.x86.avx10.vpdpwusd.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <32 x i32> @__dot2add_u16i16packed(<32 x i32> %a, <32 x i32> %b, <32 x i32> %acc) nounwind readnone alwaysinline {
+  v32tov16(i32, %a, %a0, %a1)
+  v32tov16(i32, %b, %b0, %b1)
+  v32tov16(i32, %acc, %acc0, %acc1)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpwusd.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpwusd.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  v16tov32(i32, %ret0, %ret1, %ret)
+  ret <32 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpwusds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <32 x i32> @__dot2add_u16i16packed_sat(<32 x i32> %a, <32 x i32> %b, <32 x i32> %acc) nounwind readnone alwaysinline {
+  v32tov16(i32, %a, %a0, %a1)
+  v32tov16(i32, %b, %b0, %b1)
+  v32tov16(i32, %acc, %acc0, %acc1)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpwusds.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpwusds.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  v16tov32(i32, %ret0, %ret1, %ret)
+  ret <32 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpwuud.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <32 x i32> @__dot2add_u16u16packed(<32 x i32> %a, <32 x i32> %b, <32 x i32> %acc) nounwind readnone alwaysinline {
+  v32tov16(i32, %a, %a0, %a1)
+  v32tov16(i32, %b, %b0, %b1)
+  v32tov16(i32, %acc, %acc0, %acc1)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpwuud.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpwuud.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  v16tov32(i32, %ret0, %ret1, %ret)
+  ret <32 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpwuuds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <32 x i32> @__dot2add_u16u16packed_sat(<32 x i32> %a, <32 x i32> %b, <32 x i32> %acc) nounwind readnone alwaysinline {
+  v32tov16(i32, %a, %a0, %a1)
+  v32tov16(i32, %b, %b0, %b1)
+  v32tov16(i32, %acc, %acc0, %acc1)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpwuuds.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpwuuds.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  v16tov32(i32, %ret0, %ret1, %ret)
+  ret <32 x i32> %ret
+}

--- a/builtins/target-avx10_2-x4.ll
+++ b/builtins/target-avx10_2-x4.ll
@@ -4,3 +4,28 @@
 
 define(`WIDTH',`4')
 define(`ISA',`AVX10_2')
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; dot product
+declare <4 x i32> @llvm.x86.avx2.vpdpbssd.128(<4 x i32>, <4 x i32>, <4 x i32>) nounwind readnone
+define <4 x i32> @__dot4add_i8i8packed(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <4 x i32> @llvm.x86.avx2.vpdpbssd.128(<4 x i32> %acc, <4 x i32> %a, <4 x i32> %b)
+  ret <4 x i32> %ret
+}
+declare <4 x i32> @llvm.x86.avx2.vpdpbssds.128(<4 x i32>, <4 x i32>, <4 x i32>) nounwind readnone
+define <4 x i32> @__dot4add_i8i8packed_sat(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <4 x i32> @llvm.x86.avx2.vpdpbssds.128(<4 x i32> %acc, <4 x i32> %a, <4 x i32> %b)
+  ret <4 x i32> %ret
+}
+
+declare <4 x i32> @llvm.x86.avx2.vpdpbuud.128(<4 x i32>, <4 x i32>, <4 x i32>) nounwind readnone
+define <4 x i32> @__dot4add_u8u8packed(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <4 x i32> @llvm.x86.avx2.vpdpbuud.128(<4 x i32> %acc, <4 x i32> %a, <4 x i32> %b)
+  ret <4 x i32> %ret
+}
+declare <4 x i32> @llvm.x86.avx2.vpdpbuuds.128(<4 x i32>, <4 x i32>, <4 x i32>) nounwind readnone
+define <4 x i32> @__dot4add_u8u8packed_sat(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <4 x i32> @llvm.x86.avx2.vpdpbuuds.128(<4 x i32> %acc, <4 x i32> %a, <4 x i32> %b)
+  ret <4 x i32> %ret
+}
+

--- a/builtins/target-avx10_2-x4.ll
+++ b/builtins/target-avx10_2-x4.ll
@@ -29,3 +29,27 @@ define <4 x i32> @__dot4add_u8u8packed_sat(<4 x i32> %a, <4 x i32> %b, <4 x i32>
   ret <4 x i32> %ret
 }
 
+declare <4 x i32> @llvm.x86.avx2.vpdpwusd.128(<4 x i32>, <4 x i32>, <4 x i32>) nounwind readnone
+define <4 x i32> @__dot2add_u16i16packed(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <4 x i32> @llvm.x86.avx2.vpdpwusd.128(<4 x i32> %acc, <4 x i32> %a, <4 x i32> %b)
+  ret <4 x i32> %ret
+}
+
+declare <4 x i32> @llvm.x86.avx2.vpdpwusds.128(<4 x i32>, <4 x i32>, <4 x i32>) nounwind readnone
+define <4 x i32> @__dot2add_u16i16packed_sat(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <4 x i32> @llvm.x86.avx2.vpdpwusds.128(<4 x i32> %acc, <4 x i32> %a, <4 x i32> %b)
+  ret <4 x i32> %ret
+}
+
+declare <4 x i32> @llvm.x86.avx2.vpdpwuud.128(<4 x i32>, <4 x i32>, <4 x i32>) nounwind readnone
+define <4 x i32> @__dot2add_u16u16packed(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <4 x i32> @llvm.x86.avx2.vpdpwuud.128(<4 x i32> %acc, <4 x i32> %a, <4 x i32> %b)
+  ret <4 x i32> %ret
+}
+
+declare <4 x i32> @llvm.x86.avx2.vpdpwuuds.128(<4 x i32>, <4 x i32>, <4 x i32>) nounwind readnone
+define <4 x i32> @__dot2add_u16u16packed_sat(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <4 x i32> @llvm.x86.avx2.vpdpwuuds.128(<4 x i32> %acc, <4 x i32> %a, <4 x i32> %b)
+  ret <4 x i32> %ret
+}
+

--- a/builtins/target-avx10_2-x64.ll
+++ b/builtins/target-avx10_2-x64.ll
@@ -60,3 +60,55 @@ define <64 x i32> @__dot4add_u8u8packed_sat(<64 x i32> %a, <64 x i32> %b, <64 x 
   v16tov64(i32, %ret0, %ret1, %ret2, %ret3, %ret)
   ret <64 x i32> %ret
 }
+
+declare <16 x i32> @llvm.x86.avx10.vpdpwusd.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <64 x i32> @__dot2add_u16i16packed(<64 x i32> %a, <64 x i32> %b, <64 x i32> %acc) nounwind readnone alwaysinline {
+  v64tov16(i32, %a, %a0, %a1, %a2, %a3)
+  v64tov16(i32, %b, %b0, %b1, %b2, %b3)
+  v64tov16(i32, %acc, %acc0, %acc1, %acc2, %acc3)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpwusd.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpwusd.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  %ret2 = call <16 x i32> @llvm.x86.avx10.vpdpwusd.512(<16 x i32> %acc2, <16 x i32> %a2, <16 x i32> %b2)
+  %ret3 = call <16 x i32> @llvm.x86.avx10.vpdpwusd.512(<16 x i32> %acc3, <16 x i32> %a3, <16 x i32> %b3)
+  v16tov64(i32, %ret0, %ret1, %ret2, %ret3, %ret)
+  ret <64 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpwusds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <64 x i32> @__dot2add_u16i16packed_sat(<64 x i32> %a, <64 x i32> %b, <64 x i32> %acc) nounwind readnone alwaysinline {
+  v64tov16(i32, %a, %a0, %a1, %a2, %a3)
+  v64tov16(i32, %b, %b0, %b1, %b2, %b3)
+  v64tov16(i32, %acc, %acc0, %acc1, %acc2, %acc3)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpwusds.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpwusds.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  %ret2 = call <16 x i32> @llvm.x86.avx10.vpdpwusds.512(<16 x i32> %acc2, <16 x i32> %a2, <16 x i32> %b2)
+  %ret3 = call <16 x i32> @llvm.x86.avx10.vpdpwusds.512(<16 x i32> %acc3, <16 x i32> %a3, <16 x i32> %b3)
+  v16tov64(i32, %ret0, %ret1, %ret2, %ret3, %ret)
+  ret <64 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpwuud.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <64 x i32> @__dot2add_u16u16packed(<64 x i32> %a, <64 x i32> %b, <64 x i32> %acc) nounwind readnone alwaysinline {
+  v64tov16(i32, %a, %a0, %a1, %a2, %a3)
+  v64tov16(i32, %b, %b0, %b1, %b2, %b3)
+  v64tov16(i32, %acc, %acc0, %acc1, %acc2, %acc3)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpwuud.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpwuud.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  %ret2 = call <16 x i32> @llvm.x86.avx10.vpdpwuud.512(<16 x i32> %acc2, <16 x i32> %a2, <16 x i32> %b2)
+  %ret3 = call <16 x i32> @llvm.x86.avx10.vpdpwuud.512(<16 x i32> %acc3, <16 x i32> %a3, <16 x i32> %b3)
+  v16tov64(i32, %ret0, %ret1, %ret2, %ret3, %ret)
+  ret <64 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpwuuds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <64 x i32> @__dot2add_u16u16packed_sat(<64 x i32> %a, <64 x i32> %b, <64 x i32> %acc) nounwind readnone alwaysinline {
+  v64tov16(i32, %a, %a0, %a1, %a2, %a3)
+  v64tov16(i32, %b, %b0, %b1, %b2, %b3)
+  v64tov16(i32, %acc, %acc0, %acc1, %acc2, %acc3)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpwuuds.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpwuuds.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  %ret2 = call <16 x i32> @llvm.x86.avx10.vpdpwuuds.512(<16 x i32> %acc2, <16 x i32> %a2, <16 x i32> %b2)
+  %ret3 = call <16 x i32> @llvm.x86.avx10.vpdpwuuds.512(<16 x i32> %acc3, <16 x i32> %a3, <16 x i32> %b3)
+  v16tov64(i32, %ret0, %ret1, %ret2, %ret3, %ret)
+  ret <64 x i32> %ret
+}

--- a/builtins/target-avx10_2-x64.ll
+++ b/builtins/target-avx10_2-x64.ll
@@ -4,3 +4,59 @@
 
 define(`WIDTH',`64')
 define(`ISA',`AVX10_2')
+
+include(`util.m4')
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; dot product
+declare <16 x i32> @llvm.x86.avx10.vpdpbssd.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <64 x i32> @__dot4add_i8i8packed(<64 x i32> %a, <64 x i32> %b, <64 x i32> %acc) nounwind readnone alwaysinline {
+  v64tov16(i32, %a, %a0, %a1, %a2, %a3)
+  v64tov16(i32, %b, %b0, %b1, %b2, %b3)
+  v64tov16(i32, %acc, %acc0, %acc1, %acc2, %acc3)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpbssd.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpbssd.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  %ret2 = call <16 x i32> @llvm.x86.avx10.vpdpbssd.512(<16 x i32> %acc2, <16 x i32> %a2, <16 x i32> %b2)
+  %ret3 = call <16 x i32> @llvm.x86.avx10.vpdpbssd.512(<16 x i32> %acc3, <16 x i32> %a3, <16 x i32> %b3)
+  v16tov64(i32, %ret0, %ret1, %ret2, %ret3, %ret)
+  ret <64 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpbssds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <64 x i32> @__dot4add_i8i8packed_sat(<64 x i32> %a, <64 x i32> %b, <64 x i32> %acc) nounwind readnone alwaysinline {
+  v64tov16(i32, %a, %a0, %a1, %a2, %a3)
+  v64tov16(i32, %b, %b0, %b1, %b2, %b3)
+  v64tov16(i32, %acc, %acc0, %acc1, %acc2, %acc3)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpbssds.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpbssds.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  %ret2 = call <16 x i32> @llvm.x86.avx10.vpdpbssds.512(<16 x i32> %acc2, <16 x i32> %a2, <16 x i32> %b2)
+  %ret3 = call <16 x i32> @llvm.x86.avx10.vpdpbssds.512(<16 x i32> %acc3, <16 x i32> %a3, <16 x i32> %b3)
+  v16tov64(i32, %ret0, %ret1, %ret2, %ret3, %ret)
+  ret <64 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpbuud.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <64 x i32> @__dot4add_u8u8packed(<64 x i32> %a, <64 x i32> %b, <64 x i32> %acc) nounwind readnone alwaysinline {
+  v64tov16(i32, %a, %a0, %a1, %a2, %a3)
+  v64tov16(i32, %b, %b0, %b1, %b2, %b3)
+  v64tov16(i32, %acc, %acc0, %acc1, %acc2, %acc3)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpbuud.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpbuud.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  %ret2 = call <16 x i32> @llvm.x86.avx10.vpdpbuud.512(<16 x i32> %acc2, <16 x i32> %a2, <16 x i32> %b2)
+  %ret3 = call <16 x i32> @llvm.x86.avx10.vpdpbuud.512(<16 x i32> %acc3, <16 x i32> %a3, <16 x i32> %b3)
+  v16tov64(i32, %ret0, %ret1, %ret2, %ret3, %ret)
+  ret <64 x i32> %ret
+}
+
+declare <16 x i32> @llvm.x86.avx10.vpdpbuuds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
+define <64 x i32> @__dot4add_u8u8packed_sat(<64 x i32> %a, <64 x i32> %b, <64 x i32> %acc) nounwind readnone alwaysinline {
+  v64tov16(i32, %a, %a0, %a1, %a2, %a3)
+  v64tov16(i32, %b, %b0, %b1, %b2, %b3)
+  v64tov16(i32, %acc, %acc0, %acc1, %acc2, %acc3)
+  %ret0 = call <16 x i32> @llvm.x86.avx10.vpdpbuuds.512(<16 x i32> %acc0, <16 x i32> %a0, <16 x i32> %b0)
+  %ret1 = call <16 x i32> @llvm.x86.avx10.vpdpbuuds.512(<16 x i32> %acc1, <16 x i32> %a1, <16 x i32> %b1)
+  %ret2 = call <16 x i32> @llvm.x86.avx10.vpdpbuuds.512(<16 x i32> %acc2, <16 x i32> %a2, <16 x i32> %b2)
+  %ret3 = call <16 x i32> @llvm.x86.avx10.vpdpbuuds.512(<16 x i32> %acc3, <16 x i32> %a3, <16 x i32> %b3)
+  v16tov64(i32, %ret0, %ret1, %ret2, %ret3, %ret)
+  ret <64 x i32> %ret
+}

--- a/builtins/target-avx10_2-x8.ll
+++ b/builtins/target-avx10_2-x8.ll
@@ -4,3 +4,28 @@
 
 define(`WIDTH',`8')
 define(`ISA',`AVX10_2')
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; dot product
+declare <8 x i32> @llvm.x86.avx2.vpdpbssd.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
+define <8 x i32> @__dot4add_i8i8packed(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <8 x i32> @llvm.x86.avx2.vpdpbssd.256(<8 x i32> %acc, <8 x i32> %a, <8 x i32> %b)
+  ret <8 x i32> %ret
+}
+declare <8 x i32> @llvm.x86.avx2.vpdpbssds.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
+define <8 x i32> @__dot4add_i8i8packed_sat(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <8 x i32> @llvm.x86.avx2.vpdpbssds.256(<8 x i32> %acc, <8 x i32> %a, <8 x i32> %b)
+  ret <8 x i32> %ret
+}
+
+declare <8 x i32> @llvm.x86.avx2.vpdpbuud.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
+define <8 x i32> @__dot4add_u8u8packed(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <8 x i32> @llvm.x86.avx2.vpdpbuud.256(<8 x i32> %acc, <8 x i32> %a, <8 x i32> %b)
+  ret <8 x i32> %ret
+}
+declare <8 x i32> @llvm.x86.avx2.vpdpbuuds.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
+define <8 x i32> @__dot4add_u8u8packed_sat(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <8 x i32> @llvm.x86.avx2.vpdpbuuds.256(<8 x i32> %acc, <8 x i32> %a, <8 x i32> %b)
+  ret <8 x i32> %ret
+}
+

--- a/builtins/target-avx10_2-x8.ll
+++ b/builtins/target-avx10_2-x8.ll
@@ -29,3 +29,27 @@ define <8 x i32> @__dot4add_u8u8packed_sat(<8 x i32> %a, <8 x i32> %b, <8 x i32>
   ret <8 x i32> %ret
 }
 
+declare <8 x i32> @llvm.x86.avx2.vpdpwuud.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
+define <8 x i32> @__dot2add_u16u16packed(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <8 x i32> @llvm.x86.avx2.vpdpwuud.256(<8 x i32> %acc, <8 x i32> %a, <8 x i32> %b)
+  ret <8 x i32> %ret
+}
+
+declare <8 x i32> @llvm.x86.avx2.vpdpwuuds.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
+define <8 x i32> @__dot2add_u16u16packed_sat(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <8 x i32> @llvm.x86.avx2.vpdpwuuds.256(<8 x i32> %acc, <8 x i32> %a, <8 x i32> %b)
+  ret <8 x i32> %ret
+}
+
+declare <8 x i32> @llvm.x86.avx2.vpdpwusd.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
+define <8 x i32> @__dot2add_u16i16packed(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <8 x i32> @llvm.x86.avx2.vpdpwusd.256(<8 x i32> %acc, <8 x i32> %a, <8 x i32> %b)
+  ret <8 x i32> %ret
+}
+
+declare <8 x i32> @llvm.x86.avx2.vpdpwusds.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
+define <8 x i32> @__dot2add_u16i16packed_sat(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
+  %ret = call <8 x i32> @llvm.x86.avx2.vpdpwusds.256(<8 x i32> %acc, <8 x i32> %a, <8 x i32> %b)
+  ret <8 x i32> %ret
+}
+

--- a/builtins/target-avx2vnni-i32x16.ll
+++ b/builtins/target-avx2vnni-i32x16.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2024, Intel Corporation
+;;  Copyright (c) 2024-2025, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -31,7 +31,7 @@ define <16 x i32> @__dot4add_u8i8packed_sat(<16 x i32> %a, <16 x i32> %b, <16 x 
 }
 
 declare <8 x i32> @llvm.x86.avx512.vpdpwssd.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
-define <16 x i32> @__dot2add_i16packed(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
+define <16 x i32> @__dot2add_i16i16packed(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
   v16tov8(i32, %a, %a0, %a1)
   v16tov8(i32, %b, %b0, %b1)
   v16tov8(i32, %acc, %acc0, %acc1)
@@ -42,7 +42,7 @@ define <16 x i32> @__dot2add_i16packed(<16 x i32> %a, <16 x i32> %b, <16 x i32> 
 }
 
 declare <8 x i32> @llvm.x86.avx512.vpdpwssds.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
-define <16 x i32> @__dot2add_i16packed_sat(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
+define <16 x i32> @__dot2add_i16i16packed_sat(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
   v16tov8(i32, %a, %a0, %a1)
   v16tov8(i32, %b, %b0, %b1)
   v16tov8(i32, %acc, %acc0, %acc1)

--- a/builtins/target-avx2vnni-i32x4.ll
+++ b/builtins/target-avx2vnni-i32x4.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2024, Intel Corporation
+;;  Copyright (c) 2024-2025, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -20,12 +20,12 @@ define <4 x i32> @__dot4add_u8i8packed_sat(<4 x i32> %a, <4 x i32> %b, <4 x i32>
 }
 
 declare <4 x i32> @llvm.x86.avx512.vpdpwssd.128(<4 x i32>, <4 x i32>, <4 x i32>) nounwind readnone
-define <4 x i32> @__dot2add_i16packed(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
+define <4 x i32> @__dot2add_i16i16packed(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
   %ret = call <4 x i32> @llvm.x86.avx512.vpdpwssd.128(<4 x i32> %acc, <4 x i32> %a, <4 x i32> %b)
   ret <4 x i32> %ret
 }
 declare <4 x i32> @llvm.x86.avx512.vpdpwssds.128(<4 x i32>, <4 x i32>, <4 x i32>) nounwind readnone
-define <4 x i32> @__dot2add_i16packed_sat(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
+define <4 x i32> @__dot2add_i16i16packed_sat(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
   %ret = call <4 x i32> @llvm.x86.avx512.vpdpwssds.128(<4 x i32> %acc, <4 x i32> %a, <4 x i32> %b)
   ret <4 x i32> %ret
 }

--- a/builtins/target-avx2vnni-i32x8.ll
+++ b/builtins/target-avx2vnni-i32x8.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2024, Intel Corporation
+;;  Copyright (c) 2024-2025, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -20,12 +20,12 @@ define <8 x i32> @__dot4add_u8i8packed_sat(<8 x i32> %a, <8 x i32> %b, <8 x i32>
 }
 
 declare <8 x i32> @llvm.x86.avx512.vpdpwssd.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
-define <8 x i32> @__dot2add_i16packed(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
+define <8 x i32> @__dot2add_i16i16packed(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
   %ret = call <8 x i32> @llvm.x86.avx512.vpdpwssd.256(<8 x i32> %acc, <8 x i32> %a, <8 x i32> %b)
   ret <8 x i32> %ret
 }
 declare <8 x i32> @llvm.x86.avx512.vpdpwssds.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
-define <8 x i32> @__dot2add_i16packed_sat(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
+define <8 x i32> @__dot2add_i16i16packed_sat(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
   %ret = call <8 x i32> @llvm.x86.avx512.vpdpwssds.256(<8 x i32> %acc, <8 x i32> %a, <8 x i32> %b)
   ret <8 x i32> %ret
 }

--- a/builtins/target-avx512icl-x16.ll
+++ b/builtins/target-avx512icl-x16.ll
@@ -52,12 +52,12 @@ define <16 x i32> @__dot4add_u8i8packed_sat(<16 x i32> %a, <16 x i32> %b, <16 x 
 }
 
 declare <16 x i32> @llvm.x86.avx512.vpdpwssd.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
-define <16 x i32> @__dot2add_i16packed(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
+define <16 x i32> @__dot2add_i16i16packed(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
   %ret = call <16 x i32> @llvm.x86.avx512.vpdpwssd.512(<16 x i32> %acc, <16 x i32> %a, <16 x i32> %b)
   ret <16 x i32> %ret
 }
 declare <16 x i32> @llvm.x86.avx512.vpdpwssds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
-define <16 x i32> @__dot2add_i16packed_sat(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
+define <16 x i32> @__dot2add_i16i16packed_sat(<16 x i32> %a, <16 x i32> %b, <16 x i32> %acc) nounwind readnone alwaysinline {
   %ret = call <16 x i32> @llvm.x86.avx512.vpdpwssds.512(<16 x i32> %acc, <16 x i32> %a, <16 x i32> %b)
   ret <16 x i32> %ret
 }

--- a/builtins/target-avx512icl-x32.ll
+++ b/builtins/target-avx512icl-x32.ll
@@ -35,7 +35,7 @@ define <32 x i32> @__dot4add_u8i8packed_sat(<32 x i32> %a, <32 x i32> %b, <32 x 
 }
 
 declare <16 x i32> @llvm.x86.avx512.vpdpwssd.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
-define <32 x i32> @__dot2add_i16packed(<32 x i32> %a, <32 x i32> %b, <32 x i32> %acc) nounwind readnone alwaysinline {
+define <32 x i32> @__dot2add_i16i16packed(<32 x i32> %a, <32 x i32> %b, <32 x i32> %acc) nounwind readnone alwaysinline {
   v32tov16(i32, %a, %a0, %a1)
   v32tov16(i32, %b, %b0, %b1)
   v32tov16(i32, %acc, %acc0, %acc1)
@@ -46,7 +46,7 @@ define <32 x i32> @__dot2add_i16packed(<32 x i32> %a, <32 x i32> %b, <32 x i32> 
 }
 
 declare <16 x i32> @llvm.x86.avx512.vpdpwssds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
-define <32 x i32> @__dot2add_i16packed_sat(<32 x i32> %a, <32 x i32> %b, <32 x i32> %acc) nounwind readnone alwaysinline {
+define <32 x i32> @__dot2add_i16i16packed_sat(<32 x i32> %a, <32 x i32> %b, <32 x i32> %acc) nounwind readnone alwaysinline {
   v32tov16(i32, %a, %a0, %a1)
   v32tov16(i32, %b, %b0, %b1)
   v32tov16(i32, %acc, %acc0, %acc1)

--- a/builtins/target-avx512icl-x4.ll
+++ b/builtins/target-avx512icl-x4.ll
@@ -19,12 +19,12 @@ define <4 x i32> @__dot4add_u8i8packed_sat(<4 x i32> %a, <4 x i32> %b, <4 x i32>
 }
 
 declare <4 x i32> @llvm.x86.avx512.vpdpwssd.128(<4 x i32>, <4 x i32>, <4 x i32>) nounwind readnone
-define <4 x i32> @__dot2add_i16packed(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
+define <4 x i32> @__dot2add_i16i16packed(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
   %ret = call <4 x i32> @llvm.x86.avx512.vpdpwssd.128(<4 x i32> %acc, <4 x i32> %a, <4 x i32> %b)
   ret <4 x i32> %ret
 }
 declare <4 x i32> @llvm.x86.avx512.vpdpwssds.128(<4 x i32>, <4 x i32>, <4 x i32>) nounwind readnone
-define <4 x i32> @__dot2add_i16packed_sat(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
+define <4 x i32> @__dot2add_i16i16packed_sat(<4 x i32> %a, <4 x i32> %b, <4 x i32> %acc) nounwind readnone alwaysinline {
   %ret = call <4 x i32> @llvm.x86.avx512.vpdpwssds.128(<4 x i32> %acc, <4 x i32> %a, <4 x i32> %b)
   ret <4 x i32> %ret
 }

--- a/builtins/target-avx512icl-x64.ll
+++ b/builtins/target-avx512icl-x64.ll
@@ -39,7 +39,7 @@ define <64 x i32> @__dot4add_u8i8packed_sat(<64 x i32> %a, <64 x i32> %b, <64 x 
 }
 
 declare <16 x i32> @llvm.x86.avx512.vpdpwssd.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
-define <64 x i32> @__dot2add_i16packed(<64 x i32> %a, <64 x i32> %b, <64 x i32> %acc) nounwind readnone alwaysinline {
+define <64 x i32> @__dot2add_i16i16packed(<64 x i32> %a, <64 x i32> %b, <64 x i32> %acc) nounwind readnone alwaysinline {
   v64tov16(i32, %a, %a0, %a1, %a2, %a3)
   v64tov16(i32, %b, %b0, %b1, %b2, %b3)
   v64tov16(i32, %acc, %acc0, %acc1, %acc2, %acc3)
@@ -52,7 +52,7 @@ define <64 x i32> @__dot2add_i16packed(<64 x i32> %a, <64 x i32> %b, <64 x i32> 
 }
 
 declare <16 x i32> @llvm.x86.avx512.vpdpwssds.512(<16 x i32>, <16 x i32>, <16 x i32>) nounwind readnone
-define <64 x i32> @__dot2add_i16packed_sat(<64 x i32> %a, <64 x i32> %b, <64 x i32> %acc) nounwind readnone alwaysinline {
+define <64 x i32> @__dot2add_i16i16packed_sat(<64 x i32> %a, <64 x i32> %b, <64 x i32> %acc) nounwind readnone alwaysinline {
   v64tov16(i32, %a, %a0, %a1, %a2, %a3)
   v64tov16(i32, %b, %b0, %b1, %b2, %b3)
   v64tov16(i32, %acc, %acc0, %acc1, %acc2, %acc3)

--- a/builtins/target-avx512icl-x8.ll
+++ b/builtins/target-avx512icl-x8.ll
@@ -19,12 +19,12 @@ define <8 x i32> @__dot4add_u8i8packed_sat(<8 x i32> %a, <8 x i32> %b, <8 x i32>
 }
 
 declare <8 x i32> @llvm.x86.avx512.vpdpwssd.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
-define <8 x i32> @__dot2add_i16packed(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
+define <8 x i32> @__dot2add_i16i16packed(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
   %ret = call <8 x i32> @llvm.x86.avx512.vpdpwssd.256(<8 x i32> %acc, <8 x i32> %a, <8 x i32> %b)
   ret <8 x i32> %ret
 }
 declare <8 x i32> @llvm.x86.avx512.vpdpwssds.256(<8 x i32>, <8 x i32>, <8 x i32>) nounwind readnone
-define <8 x i32> @__dot2add_i16packed_sat(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
+define <8 x i32> @__dot2add_i16i16packed_sat(<8 x i32> %a, <8 x i32> %b, <8 x i32> %acc) nounwind readnone alwaysinline {
   %ret = call <8 x i32> @llvm.x86.avx512.vpdpwssds.256(<8 x i32> %acc, <8 x i32> %a, <8 x i32> %b)
   ret <8 x i32> %ret
 }

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -744,6 +744,8 @@ generates correct code for such cases involving unsigned integer types.
 Enhanced dot product functionality with mixed signedness support for 16-bit integers.
 Now supporting three input combinations: unsignedxunsigned (u16xu16),
 signedxsigned (i16xi16), and mixed signedness (u16xi16) operations.
+Note that ``dot2add_i16_packed`` was renamed to ``dot2add_i16i16_packed`` for consistency
+with the ``dot4add_*`` functions naming.
 
 Getting Started with ISPC
 =========================

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -741,6 +741,10 @@ offsets was flawed due to overflow caused by sign extension when promoting the
 index to pointer size. This issue has been resolved, and the compiler now
 generates correct code for such cases involving unsigned integer types.
 
+Enhanced dot product functionality with mixed signedness support for 16-bit integers.
+Now supporting three input combinations: unsignedxunsigned (u16xu16),
+signedxsigned (i16xi16), and mixed signedness (u16xi16) operations.
+
 Getting Started with ISPC
 =========================
 
@@ -4906,8 +4910,8 @@ Dot product
 ISPC supports dot product operations for both unsigned and signed int8 and int16 data types, 
 utilizing the AVX-VNNI, AVX512-VNNI, and AARCH64 instruction sets. The ISPC targets that
 include native dot product instruction support are ``avx2vnni-i32x*``, ``avx512icl-i32x*``,
-and ``avx512spr-i32x*`` on x86, as well as ``neon-i32x*`` on ARM hardware with native dot
-product capabilities.
+``avx512spr-i32x*`` and newer targets on x86, as well as ``neon-i32x*`` on ARM hardware with
+native dot product capabilities.
 
 Please note that not all combinations of signed and unsigned data types are supported on these
 targets. For instance, some versions of ARMv8 natively supports only signed/signed and
@@ -4965,15 +4969,37 @@ The sum of these values, in combination with the ``acc`` accumulator, is then re
 
 For 16-bit Integer Vectors:
 
-The functions multiply groups of two signed 16-bit integers packed in ``a`` with corresponding
+The functions below multiply groups of two unsigned 16-bit integers packed in ``a`` with corresponding
+two signed 16-bit integers packed in ``b``, resulting in two intermediate signed 32-bit values.
+The sum of these values, in combination with the ``acc`` accumulator, is then returned as the final result.
+
+::
+
+    varying int32 dot2add_u16i16packed(varying uint32 a, varying uint32 b,
+                                      varying int32 acc)
+    varying int32 dot2add_u16i16packed_sat(varying uint32 a, varying uint32 b,
+                                          varying int32 acc) // saturate the result
+
+The functions below multiply groups of two unsigned 16-bit integers packed in ``a`` with corresponding
+two unsigned 16-bit integers packed in ``b``, resulting in two intermediate unsigned 32-bit values.
+The sum of these values, in combination with the ``acc`` accumulator, is then returned as the final result.
+
+::
+
+    varying uint32 dot2add_u16u16packed(varying uint32 a, varying uint32 b,
+                                       varying uint32 acc)
+    varying uint32 dot2add_u16u16packed_sat(varying uint32 a, varying uint32 b,
+                                           varying uint32 acc) // saturate the result
+
+The functions below multiply groups of two signed 16-bit integers packed in ``a`` with corresponding
 two signed 16-bit integers packed in ``b``, yielding two intermediate signed 32-bit results.
 The sum of these results, combined with the ``acc`` accumulator, is then returned as the final result.
 
 ::
 
-    varying int32 dot2add_i16packed(varying uint32 a, varying uint32 b,
+    varying int32 dot2add_i16i16packed(varying uint32 a, varying uint32 b,
                                     varying int32 acc)
-    varying int32 dot2add_i16packed_sat(varying uint32 a, varying uint32 b,
+    varying int32 dot2add_i16i16packed_sat(varying uint32 a, varying uint32 b,
                                         varying int32 acc) // saturate the result
 
 

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -4936,7 +4936,7 @@ necessitating proper packing or casting of input vectors by the programmer befor
 For 8-bit Integer Vectors:
 
 The functions below multiply groups of four unsigned 8-bit integers packed in ``a`` with corresponding
-four signed 8-bit integers packed in ``b``, resulting in four intermediate signed 16-bit values.
+four signed 8-bit integers packed in ``b``, resulting in four intermediate unsigned 16-bit values.
 The sum of these values, in combination with the ``acc`` accumulator, is then returned as the final result.
 
 ::
@@ -4947,7 +4947,7 @@ The sum of these values, in combination with the ``acc`` accumulator, is then re
                                          varying int32 acc) // saturate the result
 
 The functions below multiply groups of four unsigned 8-bit integers packed in ``a`` with corresponding
-four unsigned 8-bit integers packed in ``b``, resulting in four intermediate signed 16-bit values.
+four unsigned 8-bit integers packed in ``b``, resulting in four intermediate unsigned 16-bit values.
 The sum of these values, in combination with the ``acc`` accumulator, is then returned as the final result.
 
 ::

--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -123,8 +123,8 @@ void lSetInternalLinkageGlobals(llvm::Module *module) {
     lSetInternalLinkageGlobal(module, "__fast_masked_vload");
     lSetInternalLinkageGlobal(module, "__math_lib");
     lSetInternalLinkageGlobal(module, "__memory_alignment");
-    lSetInternalLinkageGlobal(module, "__have_dot_product_arm");
-    lSetInternalLinkageGlobal(module, "__have_i8_matmul_arm");
+    lSetInternalLinkageGlobal(module, "__have_arm_dot_product");
+    lSetInternalLinkageGlobal(module, "__have_arm_i8mm");
 }
 
 void lAddBitcodeToModule(llvm::Module *bcModule, llvm::Module *module) {

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -883,11 +883,11 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
       m_isa(SSE2), m_arch(Arch::none), m_is32Bit(true), m_cpu(""), m_attributes(""), m_tf_attributes(nullptr),
       m_nativeVectorWidth(-1), m_nativeVectorAlignment(-1), m_dataTypeWidth(-1), m_vectorWidth(-1),
       m_picLevel(picLevel), m_codeModel(code_model), m_maskingIsFree(false), m_maskBitCount(-1),
-      m_hasDotProductVNNI(false), m_hasIntelVNNI_Int8(false), m_hasDotProductARM(false), m_hasI8MatrixMulARM(false), m_hasHalfConverts(false),
-      m_hasHalfFullSupport(false), m_hasRand(false), m_hasGather(false), m_hasScatter(false),
-      m_hasTranscendentals(false), m_hasTrigonometry(false), m_hasRsqrtd(false), m_hasRcpd(false),
-      m_hasVecPrefetch(false), m_hasSaturatingArithmetic(false), m_hasFp16Support(false), m_hasFp64Support(true),
-      m_hasConflictDetection(false), m_warnings(0) {
+      m_hasDotProductVNNI(false), m_hasIntelVNNI_Int8(false), m_hasIntelVNNI_Int16(false), m_hasDotProductARM(false),
+      m_hasI8MatrixMulARM(false), m_hasHalfConverts(false), m_hasHalfFullSupport(false), m_hasRand(false),
+      m_hasGather(false), m_hasScatter(false), m_hasTranscendentals(false), m_hasTrigonometry(false),
+      m_hasRsqrtd(false), m_hasRcpd(false), m_hasVecPrefetch(false), m_hasSaturatingArithmetic(false),
+      m_hasFp16Support(false), m_hasFp64Support(true), m_hasConflictDetection(false), m_warnings(0) {
     DeviceType CPUID = CPU_None, CPUfromISA = CPU_None;
     AllCPUs a;
     std::string featuresString;
@@ -1661,6 +1661,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasFp16Support = true;
         this->m_hasDotProductVNNI = true;
         this->m_hasIntelVNNI_Int8 = true;
+        this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
         /* TODO: target specific implementations for the features below are required
         this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
@@ -1686,6 +1687,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasFp16Support = true;
         this->m_hasDotProductVNNI = true;
         this->m_hasIntelVNNI_Int8 = true;
+        this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
         /* TODO: target specific implementations for the features below are required
         this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
@@ -1711,6 +1713,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasFp16Support = true;
         this->m_hasDotProductVNNI = true;
         this->m_hasIntelVNNI_Int8 = true;
+        this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
         /* TODO: target specific implementations for the features below are required
         this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
@@ -1741,6 +1744,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasFp16Support = true;
         this->m_hasDotProductVNNI = true;
         this->m_hasIntelVNNI_Int8 = true;
+        this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
         /* TODO: target specific implementations for the features below are required
         this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
@@ -1764,6 +1768,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasFp16Support = true;
         this->m_hasDotProductVNNI = true;
         this->m_hasIntelVNNI_Int8 = true;
+        this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
         /* TODO: target specific implementations for the features below are required
         this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1663,11 +1663,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasIntelVNNI_Int8 = true;
         this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
-        /* TODO: target specific implementations for the features below are required
-        this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
-        this->m_hasTrigonometry = true;    // TODO: AVX10 adds trigonometry support
         this->m_hasRsqrtd = this->m_hasRcpd = true;
-        this->m_hasVecPrefetch = true; // TODO: AVX10 supports vector prefetch*/
         CPUfromISA = CPU_DMR;
         this->m_funcAttributes.push_back(std::make_pair("prefer-vector-width", "256"));
         this->m_funcAttributes.push_back(std::make_pair("min-legal-vector-width", "256"));
@@ -1689,11 +1685,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasIntelVNNI_Int8 = true;
         this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
-        /* TODO: target specific implementations for the features below are required
-        this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
-        this->m_hasTrigonometry = true;    // TODO: AVX10 adds trigonometry support
         this->m_hasRsqrtd = this->m_hasRcpd = true;
-        this->m_hasVecPrefetch = true; // TODO: AVX10 supports vector prefetch*/
         CPUfromISA = CPU_DMR;
         this->m_funcAttributes.push_back(std::make_pair("prefer-vector-width", "256"));
         this->m_funcAttributes.push_back(std::make_pair("min-legal-vector-width", "256"));
@@ -1715,11 +1707,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasIntelVNNI_Int8 = true;
         this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
-        /* TODO: target specific implementations for the features below are required
-        this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
-        this->m_hasTrigonometry = true;    // TODO: AVX10 adds trigonometry support
         this->m_hasRsqrtd = this->m_hasRcpd = true;
-        this->m_hasVecPrefetch = true; // TODO: AVX10 supports vector prefetch*/
         CPUfromISA = CPU_DMR;
         if (g->opt.disableZMM) {
             this->m_funcAttributes.push_back(std::make_pair("prefer-vector-width", "256"));
@@ -1746,11 +1734,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasIntelVNNI_Int8 = true;
         this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
-        /* TODO: target specific implementations for the features below are required
-        this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
-        this->m_hasTrigonometry = true;    // TODO: AVX10 adds trigonometry support
-        this->m_hasRsqrtd = this->m_hasRcpd = true;
-        this->m_hasVecPrefetch = true; // TODO: AVX10 supports vector prefetch*/
+        this->m_hasRsqrtd = this->m_hasRcpd = false;
         CPUfromISA = CPU_DMR;
         break;
     case ISPCTarget::avx10_2_x64:
@@ -1770,11 +1754,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasIntelVNNI_Int8 = true;
         this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
-        /* TODO: target specific implementations for the features below are required
-        this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
-        this->m_hasTrigonometry = true;    // TODO: AVX10 adds trigonometry support
-        this->m_hasRsqrtd = this->m_hasRcpd = true;
-        this->m_hasVecPrefetch = true; // TODO: AVX10 supports vector prefetch*/
+        this->m_hasRsqrtd = this->m_hasRcpd = false;
         CPUfromISA = CPU_DMR;
         break;
 #else

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -883,7 +883,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
       m_isa(SSE2), m_arch(Arch::none), m_is32Bit(true), m_cpu(""), m_attributes(""), m_tf_attributes(nullptr),
       m_nativeVectorWidth(-1), m_nativeVectorAlignment(-1), m_dataTypeWidth(-1), m_vectorWidth(-1),
       m_picLevel(picLevel), m_codeModel(code_model), m_maskingIsFree(false), m_maskBitCount(-1),
-      m_hasDotProductVNNI(false), m_hasDotProductARM(false), m_hasI8MatrixMulARM(false), m_hasHalfConverts(false),
+      m_hasDotProductVNNI(false), m_hasIntelVNNI_Int8(false), m_hasDotProductARM(false), m_hasI8MatrixMulARM(false), m_hasHalfConverts(false),
       m_hasHalfFullSupport(false), m_hasRand(false), m_hasGather(false), m_hasScatter(false),
       m_hasTranscendentals(false), m_hasTrigonometry(false), m_hasRsqrtd(false), m_hasRcpd(false),
       m_hasVecPrefetch(false), m_hasSaturatingArithmetic(false), m_hasFp16Support(false), m_hasFp64Support(true),
@@ -1660,6 +1660,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasGather = this->m_hasScatter = true;
         this->m_hasFp16Support = true;
         this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI_Int8 = true;
         this->m_hasConflictDetection = true;
         /* TODO: target specific implementations for the features below are required
         this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
@@ -1684,6 +1685,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasGather = this->m_hasScatter = true;
         this->m_hasFp16Support = true;
         this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI_Int8 = true;
         this->m_hasConflictDetection = true;
         /* TODO: target specific implementations for the features below are required
         this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
@@ -1708,6 +1710,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasGather = this->m_hasScatter = true;
         this->m_hasFp16Support = true;
         this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI_Int8 = true;
         this->m_hasConflictDetection = true;
         /* TODO: target specific implementations for the features below are required
         this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
@@ -1737,6 +1740,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasGather = this->m_hasScatter = true;
         this->m_hasFp16Support = true;
         this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI_Int8 = true;
         this->m_hasConflictDetection = true;
         /* TODO: target specific implementations for the features below are required
         this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support
@@ -1759,6 +1763,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasGather = this->m_hasScatter = true;
         this->m_hasFp16Support = true;
         this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI_Int8 = true;
         this->m_hasConflictDetection = true;
         /* TODO: target specific implementations for the features below are required
         this->m_hasTranscendentals = true; // TODO: AVX10 adds transcendental support

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -882,12 +882,12 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
     : m_target(nullptr), m_targetMachine(nullptr), m_dataLayout(nullptr), m_valid(false), m_ispc_target(ispc_target),
       m_isa(SSE2), m_arch(Arch::none), m_is32Bit(true), m_cpu(""), m_attributes(""), m_tf_attributes(nullptr),
       m_nativeVectorWidth(-1), m_nativeVectorAlignment(-1), m_dataTypeWidth(-1), m_vectorWidth(-1),
-      m_picLevel(picLevel), m_codeModel(code_model), m_maskingIsFree(false), m_maskBitCount(-1),
-      m_hasDotProductVNNI(false), m_hasIntelVNNI_Int8(false), m_hasIntelVNNI_Int16(false), m_hasDotProductARM(false),
-      m_hasI8MatrixMulARM(false), m_hasHalfConverts(false), m_hasHalfFullSupport(false), m_hasRand(false),
-      m_hasGather(false), m_hasScatter(false), m_hasTranscendentals(false), m_hasTrigonometry(false),
-      m_hasRsqrtd(false), m_hasRcpd(false), m_hasVecPrefetch(false), m_hasSaturatingArithmetic(false),
-      m_hasFp16Support(false), m_hasFp64Support(true), m_hasConflictDetection(false), m_warnings(0) {
+      m_picLevel(picLevel), m_codeModel(code_model), m_maskingIsFree(false), m_maskBitCount(-1), m_hasIntelVNNI(false),
+      m_hasIntelVNNI_Int8(false), m_hasIntelVNNI_Int16(false), m_hasArmDotProduct(false), m_hasArmI8MM(false),
+      m_hasHalfConverts(false), m_hasHalfFullSupport(false), m_hasRand(false), m_hasGather(false), m_hasScatter(false),
+      m_hasTranscendentals(false), m_hasTrigonometry(false), m_hasRsqrtd(false), m_hasRcpd(false),
+      m_hasVecPrefetch(false), m_hasSaturatingArithmetic(false), m_hasFp16Support(false), m_hasFp64Support(true),
+      m_hasConflictDetection(false), m_warnings(0) {
     DeviceType CPUID = CPU_None, CPUfromISA = CPU_None;
     AllCPUs a;
     std::string featuresString;
@@ -1364,7 +1364,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasHalfConverts = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->m_hasDotProductVNNI = (m_ispc_target == ISPCTarget::avx2vnni_i32x4) ? true : false;
+        this->m_hasIntelVNNI = (m_ispc_target == ISPCTarget::avx2vnni_i32x4) ? true : false;
         CPUfromISA = (m_ispc_target == ISPCTarget::avx2vnni_i32x4) ? CPU_ADL : CPU_Haswell;
         break;
     case ISPCTarget::avx2_i32x8:
@@ -1379,7 +1379,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasHalfConverts = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->m_hasDotProductVNNI = (m_ispc_target == ISPCTarget::avx2vnni_i32x8) ? true : false;
+        this->m_hasIntelVNNI = (m_ispc_target == ISPCTarget::avx2vnni_i32x8) ? true : false;
         CPUfromISA = (m_ispc_target == ISPCTarget::avx2vnni_i32x8) ? CPU_ADL : CPU_Haswell;
         break;
     case ISPCTarget::avx2_i32x16:
@@ -1394,7 +1394,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasHalfConverts = true;
         this->m_hasRand = true;
         this->m_hasGather = true;
-        this->m_hasDotProductVNNI = (m_ispc_target == ISPCTarget::avx2vnni_i32x16) ? true : false;
+        this->m_hasIntelVNNI = (m_ispc_target == ISPCTarget::avx2vnni_i32x16) ? true : false;
         CPUfromISA = (m_ispc_target == ISPCTarget::avx2vnni_i32x16) ? CPU_ADL : CPU_Haswell;
         break;
     case ISPCTarget::avx2_i64x4:
@@ -1426,7 +1426,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasTrigonometry = false;
         this->m_hasRsqrtd = this->m_hasRcpd = true;
         this->m_hasVecPrefetch = false;
-        this->m_hasDotProductVNNI = (m_ispc_target == ISPCTarget::avx512icl_x4) ? true : false;
+        this->m_hasIntelVNNI = (m_ispc_target == ISPCTarget::avx512icl_x4) ? true : false;
         this->m_hasConflictDetection = true;
         CPUfromISA = (m_ispc_target == ISPCTarget::avx512icl_x4) ? CPU_ICL : CPU_SKX;
         this->m_funcAttributes.push_back(std::make_pair("prefer-vector-width", "256"));
@@ -1448,7 +1448,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasTrigonometry = false;
         this->m_hasRsqrtd = this->m_hasRcpd = true;
         this->m_hasVecPrefetch = false;
-        this->m_hasDotProductVNNI = (m_ispc_target == ISPCTarget::avx512icl_x8) ? true : false;
+        this->m_hasIntelVNNI = (m_ispc_target == ISPCTarget::avx512icl_x8) ? true : false;
         this->m_hasConflictDetection = true;
         CPUfromISA = (m_ispc_target == ISPCTarget::avx512icl_x8) ? CPU_ICL : CPU_SKX;
         this->m_funcAttributes.push_back(std::make_pair("prefer-vector-width", "256"));
@@ -1470,7 +1470,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasTrigonometry = false;
         this->m_hasRsqrtd = this->m_hasRcpd = true;
         this->m_hasVecPrefetch = false;
-        this->m_hasDotProductVNNI = (m_ispc_target == ISPCTarget::avx512icl_x16) ? true : false;
+        this->m_hasIntelVNNI = (m_ispc_target == ISPCTarget::avx512icl_x16) ? true : false;
         this->m_hasConflictDetection = true;
         CPUfromISA = (m_ispc_target == ISPCTarget::avx512icl_x16) ? CPU_ICL : CPU_SKX;
         if (g->opt.disableZMM) {
@@ -1501,7 +1501,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasTrigonometry = false;
         this->m_hasRsqrtd = this->m_hasRcpd = false;
         this->m_hasVecPrefetch = false;
-        this->m_hasDotProductVNNI = (m_ispc_target == ISPCTarget::avx512icl_x64) ? true : false;
+        this->m_hasIntelVNNI = (m_ispc_target == ISPCTarget::avx512icl_x64) ? true : false;
         this->m_hasConflictDetection = true;
         CPUfromISA = (m_ispc_target == ISPCTarget::avx512icl_x64) ? CPU_ICL : CPU_SKX;
         break;
@@ -1525,7 +1525,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasTrigonometry = false;
         this->m_hasRsqrtd = this->m_hasRcpd = false;
         this->m_hasVecPrefetch = false;
-        this->m_hasDotProductVNNI = (m_ispc_target == ISPCTarget::avx512icl_x32) ? true : false;
+        this->m_hasIntelVNNI = (m_ispc_target == ISPCTarget::avx512icl_x32) ? true : false;
         this->m_hasConflictDetection = true;
         CPUfromISA = (m_ispc_target == ISPCTarget::avx512icl_x32) ? CPU_ICL : CPU_SKX;
         break;
@@ -1546,7 +1546,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasRsqrtd = this->m_hasRcpd = true;
         this->m_hasVecPrefetch = false;
         this->m_hasFp16Support = true;
-        this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI = true;
         this->m_hasConflictDetection = true;
         CPUfromISA = CPU_SPR;
         this->m_funcAttributes.push_back(std::make_pair("prefer-vector-width", "256"));
@@ -1569,7 +1569,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasRsqrtd = this->m_hasRcpd = true;
         this->m_hasVecPrefetch = false;
         this->m_hasFp16Support = true;
-        this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI = true;
         this->m_hasConflictDetection = true;
         CPUfromISA = CPU_SPR;
         this->m_funcAttributes.push_back(std::make_pair("prefer-vector-width", "256"));
@@ -1592,7 +1592,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasRsqrtd = this->m_hasRcpd = true;
         this->m_hasVecPrefetch = false;
         this->m_hasFp16Support = true;
-        this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI = true;
         this->m_hasConflictDetection = true;
         CPUfromISA = CPU_SPR;
         if (g->opt.disableZMM) {
@@ -1620,7 +1620,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasRsqrtd = this->m_hasRcpd = false;
         this->m_hasVecPrefetch = false;
         this->m_hasFp16Support = true;
-        this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI = true;
         this->m_hasConflictDetection = true;
         CPUfromISA = CPU_SPR;
         break;
@@ -1641,7 +1641,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasRsqrtd = this->m_hasRcpd = false;
         this->m_hasVecPrefetch = false;
         this->m_hasFp16Support = true;
-        this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI = true;
         this->m_hasConflictDetection = true;
         CPUfromISA = CPU_SPR;
         break;
@@ -1659,7 +1659,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasRand = true;
         this->m_hasGather = this->m_hasScatter = true;
         this->m_hasFp16Support = true;
-        this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI = true;
         this->m_hasIntelVNNI_Int8 = true;
         this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
@@ -1685,7 +1685,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasRand = true;
         this->m_hasGather = this->m_hasScatter = true;
         this->m_hasFp16Support = true;
-        this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI = true;
         this->m_hasIntelVNNI_Int8 = true;
         this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
@@ -1711,7 +1711,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasRand = true;
         this->m_hasGather = this->m_hasScatter = true;
         this->m_hasFp16Support = true;
-        this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI = true;
         this->m_hasIntelVNNI_Int8 = true;
         this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
@@ -1742,7 +1742,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasRand = true;
         this->m_hasGather = this->m_hasScatter = true;
         this->m_hasFp16Support = true;
-        this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI = true;
         this->m_hasIntelVNNI_Int8 = true;
         this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
@@ -1766,7 +1766,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         this->m_hasRand = true;
         this->m_hasGather = this->m_hasScatter = true;
         this->m_hasFp16Support = true;
-        this->m_hasDotProductVNNI = true;
+        this->m_hasIntelVNNI = true;
         this->m_hasIntelVNNI_Int8 = true;
         this->m_hasIntelVNNI_Int16 = true;
         this->m_hasConflictDetection = true;
@@ -2248,8 +2248,8 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         if (arch == Arch::arm || arch == Arch::aarch64) {
             // Set the supported features for ARM target
             std::vector<llvm::StringRef> armFeatures = lGetARMTargetFeatures(arch, m_cpu);
-            m_hasDotProductARM = lIsARMFeatureSupported("dotprod", armFeatures);
-            m_hasI8MatrixMulARM = lIsARMFeatureSupported("i8mm", armFeatures);
+            m_hasArmDotProduct = lIsARMFeatureSupported("dotprod", armFeatures);
+            m_hasArmI8MM = lIsARMFeatureSupported("i8mm", armFeatures);
             featuresString = llvm::join(armFeatures, ",");
             this->m_funcAttributes.push_back(std::make_pair("target-features", featuresString));
         }

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -401,6 +401,8 @@ class Target {
 
     bool hasDotProductVNNI() const { return m_hasDotProductVNNI; }
 
+    bool hasIntelVNNI_Int8() const { return m_hasIntelVNNI_Int8; }
+
     bool hasDotProductARM() const { return m_hasDotProductARM; }
 
     bool hasI8MatrixMulARM() const { return m_hasI8MatrixMulARM; }
@@ -521,6 +523,11 @@ class Target {
      *  Supported data types are: signed/unsigned i8 and i16 with and without saturation
      */
     bool m_hasDotProductVNNI;
+
+    /** Indicates whether the CPU supports 8-bit integer VNNI operations specifically.
+     *  Enables all combinations of signed/unsigned int8 dot products with optional saturation.
+    */
+    bool m_hasIntelVNNI_Int8;
 
     /** Indicates whether the target has native support for ARM dot product.
      *  Supported data types are: signed/signed i8 and unsigned/unsigned i8

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -403,6 +403,8 @@ class Target {
 
     bool hasIntelVNNI_Int8() const { return m_hasIntelVNNI_Int8; }
 
+    bool hasIntelVNNI_Int16() const { return m_hasIntelVNNI_Int16; }
+
     bool hasDotProductARM() const { return m_hasDotProductARM; }
 
     bool hasI8MatrixMulARM() const { return m_hasI8MatrixMulARM; }
@@ -528,6 +530,11 @@ class Target {
      *  Enables all combinations of signed/unsigned int8 dot products with optional saturation.
     */
     bool m_hasIntelVNNI_Int8;
+
+    /** Indicates whether the CPU supports 16-bit integer VNNI operations specifically.
+     *  Enables all combinations of signed/unsigned int16 dot products with optional saturation.
+    */
+    bool m_hasIntelVNNI_Int16;
 
     /** Indicates whether the target has native support for ARM dot product.
      *  Supported data types are: signed/signed i8 and unsigned/unsigned i8

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -399,15 +399,15 @@ class Target {
 
     int getMaskBitCount() const { return m_maskBitCount; }
 
-    bool hasDotProductVNNI() const { return m_hasDotProductVNNI; }
+    bool hasIntelVNNI() const { return m_hasIntelVNNI; }
 
     bool hasIntelVNNI_Int8() const { return m_hasIntelVNNI_Int8; }
 
     bool hasIntelVNNI_Int16() const { return m_hasIntelVNNI_Int16; }
 
-    bool hasDotProductARM() const { return m_hasDotProductARM; }
+    bool hasArmDotProduct() const { return m_hasArmDotProduct; }
 
-    bool hasI8MatrixMulARM() const { return m_hasI8MatrixMulARM; }
+    bool hasArmI8MM() const { return m_hasArmI8MM; }
 
     bool hasHalfConverts() const { return m_hasHalfConverts; }
 
@@ -521,30 +521,36 @@ class Target {
         is 32 on SSE/AVX, since that matches the HW better. */
     int m_maskBitCount;
 
-    /** Indicates whether the target has native support for VNNI dot product.
-     *  Supported data types are: signed/unsigned i8 and i16 with and without saturation
+    /** Indicates whether the CPU has Intel VNNI (Vector Neural Network Instructions) support.
+     *  Enables accelerated dot product operations on:
+     *  - 8-bit integers (mixed sign only)
+     *  - 16-bit integers (mixed sign only)
+     *  - With optional saturation arithmetic
      */
-    bool m_hasDotProductVNNI;
+    bool m_hasIntelVNNI;
 
     /** Indicates whether the CPU supports 8-bit integer VNNI operations specifically.
      *  Enables all combinations of signed/unsigned int8 dot products with optional saturation.
-    */
+     */
     bool m_hasIntelVNNI_Int8;
 
     /** Indicates whether the CPU supports 16-bit integer VNNI operations specifically.
      *  Enables all combinations of signed/unsigned int16 dot products with optional saturation.
-    */
+     */
     bool m_hasIntelVNNI_Int16;
 
-    /** Indicates whether the target has native support for ARM dot product.
-     *  Supported data types are: signed/signed i8 and unsigned/unsigned i8
+    /** Indicates whether the CPU has ARM dot product instructions (SDOT/UDOT).
+     *  Enables accelerated dot product operations on:
+     *  - signedxsigned 8-bit integers operations only (SDOT)
+     *  - unsignedxunsigned 8-bit integers operations only (UDOT)
+     *  - No support for mixed sign operations
      */
-    bool m_hasDotProductARM;
+    bool m_hasArmDotProduct;
 
-    /** Indicates whether the target has support for i8 matrix multiplication
-     *  that required for dot product of i8 mixed-sign types.
+    /** Indicates whether the CPU supports ARM I8MM instructions for 8-bit integers matrix multiplication.
+     *  Provides capability for mixed-sign int8 operations not covered by basic ARM dot product.
      */
-    bool m_hasI8MatrixMulARM;
+    bool m_hasArmI8MM;
 
     /** Indicates whether the target has native support for float/half conversions. */
     bool m_hasHalfConverts;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3197,8 +3197,8 @@ static void lSetTargetSpecificMacroDefinitions(const std::shared_ptr<clang::Prep
     if (g->target->hasSatArith()) {
         opts->addMacroDef("ISPC_TARGET_HAS_SATURATING_ARITHMETIC");
     }
-    if (g->target->hasDotProductVNNI()) {
-        opts->addMacroDef("ISPC_TARGET_HAS_DOT_PRODUCT_VNNI");
+    if (g->target->hasIntelVNNI()) {
+        opts->addMacroDef("ISPC_TARGET_HAS_INTEL_VNNI");
     }
     if (g->target->hasIntelVNNI_Int8()) {
         opts->addMacroDef("ISPC_TARGET_HAS_INTEL_VNNI_INT8");
@@ -3273,11 +3273,11 @@ static void lSetCmdlineDependentMacroDefinitions(const std::shared_ptr<clang::Pr
     }
     opts->addMacroDef(memory_alignment);
 
-    if (g->target->hasDotProductARM()) {
-        opts->addMacroDef("ISPC_TARGET_HAS_DOT_PRODUCT_ARM");
+    if (g->target->hasArmDotProduct()) {
+        opts->addMacroDef("ISPC_TARGET_HAS_ARM_DOT_PRODUCT");
     }
-    if (g->target->hasI8MatrixMulARM()) {
-        opts->addMacroDef("ISPC_TARGET_HAS_I8_MATRIX_MUL_ARM");
+    if (g->target->hasArmI8MM()) {
+        opts->addMacroDef("ISPC_TARGET_HAS_ARM_I8MM");
     }
 }
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3203,6 +3203,9 @@ static void lSetTargetSpecificMacroDefinitions(const std::shared_ptr<clang::Prep
     if (g->target->hasIntelVNNI_Int8()) {
         opts->addMacroDef("ISPC_TARGET_HAS_INTEL_VNNI_INT8");
     }
+    if (g->target->hasIntelVNNI_Int16()) {
+        opts->addMacroDef("ISPC_TARGET_HAS_INTEL_VNNI_INT16");
+    }
     if (g->target->hasConflictDetection()) {
         opts->addMacroDef("ISPC_TARGET_HAS_CONFLICT_DETECTION");
     }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -3200,6 +3200,9 @@ static void lSetTargetSpecificMacroDefinitions(const std::shared_ptr<clang::Prep
     if (g->target->hasDotProductVNNI()) {
         opts->addMacroDef("ISPC_TARGET_HAS_DOT_PRODUCT_VNNI");
     }
+    if (g->target->hasIntelVNNI_Int8()) {
+        opts->addMacroDef("ISPC_TARGET_HAS_INTEL_VNNI_INT8");
+    }
     if (g->target->hasConflictDetection()) {
         opts->addMacroDef("ISPC_TARGET_HAS_CONFLICT_DETECTION");
     }

--- a/stdlib/include/builtins.isph
+++ b/stdlib/include/builtins.isph
@@ -316,8 +316,12 @@ EXT inline READNONE varying int64 __insert_int64(varying int64, uniform int32, u
 EXT inline READNONE varying int8 __insert_int8(varying int8, uniform int32, uniform int8);
 
 // dot product
-EXT READNONE varying int32 __dot2add_i16packed_sat(varying uint32, varying uint32, varying int32);
-EXT READNONE varying int32 __dot2add_i16packed(varying uint32, varying uint32, varying int32);
+EXT READNONE varying int32 __dot2add_i16i16packed_sat(varying uint32, varying uint32, varying int32);
+EXT READNONE varying int32 __dot2add_i16i16packed(varying uint32, varying uint32, varying int32);
+EXT READNONE varying int32 __dot2add_u16i16packed_sat(varying uint32, varying uint32, varying int32);
+EXT READNONE varying int32 __dot2add_u16i16packed(varying uint32, varying uint32, varying int32);
+EXT READNONE varying int32 __dot2add_u16u16packed_sat(varying uint32, varying uint32, varying int32);
+EXT READNONE varying int32 __dot2add_u16u16packed(varying uint32, varying uint32, varying int32);
 EXT READNONE varying int32 __dot4add_u8i8packed_sat(varying uint32, varying uint32, varying int32);
 EXT READNONE varying int32 __dot4add_u8i8packed(varying uint32, varying uint32, varying int32);
 EXT READNONE varying uint32 __dot4add_u8u8packed_sat(varying uint32, varying uint32, varying uint32);

--- a/stdlib/include/core.isph
+++ b/stdlib/include/core.isph
@@ -73,16 +73,16 @@ static const int32 programIndex = {ISPC_PROGRAM_INDEX_INITIALIZER};
 #error ISPC_MATH_LIB_VAL undefined
 #endif
 
-#ifdef ISPC_TARGET_HAS_DOT_PRODUCT_ARM
-#define ISPC_TARGET_HAS_DOT_PRODUCT_ARM_VAL 1
+#ifdef ISPC_TARGET_HAS_ARM_DOT_PRODUCT
+#define ISPC_TARGET_HAS_ARM_DOT_PRODUCT_VAL 1
 #else
-#define ISPC_TARGET_HAS_DOT_PRODUCT_ARM_VAL 0
+#define ISPC_TARGET_HAS_ARM_DOT_PRODUCT_VAL 0
 #endif
 
-#ifdef ISPC_TARGET_HAS_I8_MATRIX_MUL_ARM
-#define ISPC_TARGET_HAS_I8_MATRIX_MUL_ARM_VAL 1
+#ifdef ISPC_TARGET_HAS_ARM_I8MM
+#define ISPC_TARGET_HAS_ARM_I8MM_VAL 1
 #else
-#define ISPC_TARGET_HAS_I8_MATRIX_MUL_ARM_VAL 0
+#define ISPC_TARGET_HAS_ARM_I8MM_VAL 0
 #endif
 
 #ifdef ISPC_INTERNAL_STDLIB_COMPILATION
@@ -94,9 +94,9 @@ const uniform int32 __math_lib;
 
 const uniform int32 __memory_alignment;
 
-const uniform int32 __have_dot_product_arm;
+const uniform int32 __have_arm_dot_product;
 
-const uniform int32 __have_i8_matmul_arm;
+const uniform int32 __have_arm_i8mm;
 #else
 // Compilation of user code with the actual values provided by user via command
 // line flags.
@@ -106,9 +106,9 @@ const uniform int32 __math_lib = ISPC_MATH_LIB_VAL;
 
 const uniform int32 __memory_alignment = ISPC_MEMORY_ALIGNMENT_VAL;
 
-const uniform int32 __have_dot_product_arm = ISPC_TARGET_HAS_DOT_PRODUCT_ARM_VAL;
+const uniform int32 __have_arm_dot_product = ISPC_TARGET_HAS_ARM_DOT_PRODUCT_VAL;
 
-const uniform int32 __have_i8_matmul_arm = ISPC_TARGET_HAS_I8_MATRIX_MUL_ARM_VAL;
+const uniform int32 __have_arm_i8mm = ISPC_TARGET_HAS_ARM_I8MM_VAL;
 #endif
 
 typedef uniform int8 *uniform opaque_ptr_t;

--- a/stdlib/include/stdlib.isph
+++ b/stdlib/include/stdlib.isph
@@ -1249,12 +1249,36 @@ __declspec(safe) inline varying int32 dot4add_i8i8packed_sat(varying uint32 a, v
 // Multiply groups of 2 adjacent pairs of signed 16-bit integers in a
 // with corresponding 16-bit integers in b, producing 2 intermediate signed 32-bit results.
 // Sum these 2 results with the corresponding 32-bit integer in src, and return the result.
-__declspec(safe) inline varying int32 dot2add_i16packed(varying uint32 a, varying uint32 b, varying int32 acc);
+__declspec(safe) inline varying int32 dot2add_i16i16packed(varying uint32 a, varying uint32 b, varying int32 acc);
 
 // Multiply groups of 2 adjacent pairs of signed 16-bit integers in a
 // with corresponding 16-bit integers in b, producing 2 intermediate signed 32-bit results.
 // Sum these 2 results with the corresponding 32-bit integer in src using signed saturation, and return the result.
-__declspec(safe) inline varying int32 dot2add_i16packed_sat(varying uint32 a, varying uint32 b, varying int32 acc);
+__declspec(safe) inline varying int32 dot2add_i16i16packed_sat(varying uint32 a, varying uint32 b, varying int32 acc);
+
+// Multiply groups of 2 adjacent pairs of unsigned 16-bit integers in a
+// with corresponding unsigned 16-bit integers in b, producing 2 intermediate unsigned 32-bit results.
+// Sum these 2 results with the corresponding 32-bit integer in acc, and return the result.
+__declspec(safe) static inline varying uint32 dot2add_u16u16packed(varying uint32 a, varying uint32 b,
+                                                                   varying uint32 acc);
+
+// Multiply groups of 2 adjacent pairs of unsigned 16-bit integers in a
+// with corresponding unsigned 16-bit integers in b, producing 2 intermediate unsigned 32-bit results.
+// Sum these 2 results with the corresponding 32-bit integer in acc using unsigned saturation, and return the result.
+__declspec(safe) static inline varying uint32 dot2add_u16u16packed_sat(varying uint32 a, varying uint32 b,
+                                                                       varying uint32 acc);
+
+// Multiply groups of 2 adjacent pairs of unsigned 16-bit integers in a
+// with corresponding signed 16-bit integers in b, producing 2 intermediate signed 32-bit results.
+// Sum these 2 results with the corresponding 32-bit integer in acc, and return the result.
+__declspec(safe) static inline varying int32 dot2add_u16i16packed(varying uint32 a, varying uint32 b,
+                                                                  varying int32 acc);
+
+// Multiply groups of 2 adjacent pairs of unsigned 16-bit integers in a
+// with corresponding signed 16-bit integers in b, producing 2 intermediate signed 32-bit results.
+// Sum these 2 results with the corresponding 32-bit integer in acc using signed saturation, and return the result.
+__declspec(safe) static inline varying int32 dot2add_u16i16packed_sat(varying uint32 a, varying uint32 b,
+                                                                      varying int32 acc);
 
 // Below the place for the real implementations of the functions using templates
 

--- a/stdlib/include/stdlib.isph
+++ b/stdlib/include/stdlib.isph
@@ -1227,12 +1227,12 @@ __declspec(safe) inline varying int32 dot4add_u8i8packed(varying uint32 a, varyi
 __declspec(safe) inline varying int32 dot4add_u8i8packed_sat(varying uint32 a, varying uint32 b, varying int32 acc);
 
 // Multiply groups of 4 adjacent pairs of unsigned 8-bit integers in a with corresponding unsigned
-// 8-bit integers in b, producing 4 intermediate signed 16-bit results.
+// 8-bit integers in b, producing 4 intermediate unsigned 16-bit results.
 // Sum these 4 results with the corresponding 32-bit integer in acc, and return the result.
 __declspec(safe) inline varying uint32 dot4add_u8u8packed(varying uint32 a, varying uint32 b, varying uint32 acc);
 
 // Multiply groups of 4 adjacent pairs of unsigned 8-bit integers in a with corresponding unsigned
-// 8-bit integers in b, producing 4 intermediate signed 16-bit results.
+// 8-bit integers in b, producing 4 intermediate unsigned 16-bit results.
 // Sum these 4 results with the corresponding 32-bit integer in acc using unsigned saturation, and return the result.
 __declspec(safe) inline varying uint32 dot4add_u8u8packed_sat(varying uint32 a, varying uint32 b, varying uint32 acc);
 

--- a/stdlib/include/target.isph
+++ b/stdlib/include/target.isph
@@ -104,6 +104,14 @@ static const uniform int32 __have_saturating_arithmetic = ISPC_TARGET_HAS_SATURA
 
 static const uniform int32 __have_dot_product_vnni = ISPC_TARGET_HAS_DOT_PRODUCT_VNNI_VAL;
 
+#ifdef ISPC_TARGET_HAS_INTEL_VNNI_INT8
+#define ISPC_TARGET_HAS_INTEL_VNNI_INT8_VAL 1
+#else
+#define ISPC_TARGET_HAS_INTEL_VNNI_INT8_VAL 0
+#endif
+
+static const uniform int32 __have_intel_vnni_int8 = ISPC_TARGET_HAS_INTEL_VNNI_INT8_VAL;
+
 #ifdef ISPC_TARGET_HAS_CONFLICT_DETECTION
 #define ISPC_TARGET_HAS_CONFLICT_DETECTION 1
 #else

--- a/stdlib/include/target.isph
+++ b/stdlib/include/target.isph
@@ -96,13 +96,13 @@ static const uniform int32 __have_native_rcpd = ISPC_TARGET_HAS_RCPD_VAL;
 
 static const uniform int32 __have_saturating_arithmetic = ISPC_TARGET_HAS_SATURATING_ARITHMETIC_VAL;
 
-#ifdef ISPC_TARGET_HAS_DOT_PRODUCT_VNNI
-#define ISPC_TARGET_HAS_DOT_PRODUCT_VNNI_VAL 1
+#ifdef ISPC_TARGET_HAS_INTEL_VNNI
+#define ISPC_TARGET_HAS_INTEL_VNNI_VAL 1
 #else
-#define ISPC_TARGET_HAS_DOT_PRODUCT_VNNI_VAL 0
+#define ISPC_TARGET_HAS_INTEL_VNNI_VAL 0
 #endif
 
-static const uniform int32 __have_dot_product_vnni = ISPC_TARGET_HAS_DOT_PRODUCT_VNNI_VAL;
+static const uniform int32 __have_intel_vnni = ISPC_TARGET_HAS_INTEL_VNNI_VAL;
 
 #ifdef ISPC_TARGET_HAS_INTEL_VNNI_INT8
 #define ISPC_TARGET_HAS_INTEL_VNNI_INT8_VAL 1

--- a/stdlib/include/target.isph
+++ b/stdlib/include/target.isph
@@ -112,6 +112,14 @@ static const uniform int32 __have_dot_product_vnni = ISPC_TARGET_HAS_DOT_PRODUCT
 
 static const uniform int32 __have_intel_vnni_int8 = ISPC_TARGET_HAS_INTEL_VNNI_INT8_VAL;
 
+#ifdef ISPC_TARGET_HAS_INTEL_VNNI_INT16
+#define ISPC_TARGET_HAS_INTEL_VNNI_INT16_VAL 1
+#else
+#define ISPC_TARGET_HAS_INTEL_VNNI_INT16_VAL 0
+#endif
+
+static const uniform int32 __have_intel_vnni_int16 = ISPC_TARGET_HAS_INTEL_VNNI_INT16_VAL;
+
 #ifdef ISPC_TARGET_HAS_CONFLICT_DETECTION
 #define ISPC_TARGET_HAS_CONFLICT_DETECTION 1
 #else

--- a/stdlib/stdlib.ispc
+++ b/stdlib/stdlib.ispc
@@ -6041,9 +6041,10 @@ __declspec(safe) static inline varying int32 dot4add_i8i8packed_sat(varying uint
 // Multiply groups of 2 adjacent pairs of signed 16-bit integers in a
 // with corresponding 16-bit integers in b, producing 2 intermediate signed 32-bit results.
 // Sum these 2 results with the corresponding 32-bit integer in src, and return the result.
-__declspec(safe) static inline varying int32 dot2add_i16packed(varying uint32 a, varying uint32 b, varying int32 acc) {
+__declspec(safe) static inline varying int32 dot2add_i16i16packed(varying uint32 a, varying uint32 b,
+                                                                  varying int32 acc) {
     if (__have_dot_product_vnni) {
-        return __dot2add_i16packed(a, b, acc);
+        return __dot2add_i16i16packed(a, b, acc);
     } else {
         int32 tmp1 = (int32)((int16)((a >> 16) & 0xFFFF)) * (int32)((int16)((b >> 16) & 0xFFFF));
         int32 tmp2 = (int32)((int16)(a & 0xFFFF)) * (int32)((int16)(b & 0xFFFF));
@@ -6054,13 +6055,75 @@ __declspec(safe) static inline varying int32 dot2add_i16packed(varying uint32 a,
 // Multiply groups of 2 adjacent pairs of signed 16-bit integers in a
 // with corresponding 16-bit integers in b, producing 2 intermediate signed 32-bit results.
 // Sum these 2 results with the corresponding 32-bit integer in src using signed saturation, and return the result.
-__declspec(safe) static inline varying int32 dot2add_i16packed_sat(varying uint32 a, varying uint32 b,
-                                                                   varying int32 acc) {
+__declspec(safe) static inline varying int32 dot2add_i16i16packed_sat(varying uint32 a, varying uint32 b,
+                                                                      varying int32 acc) {
     if (__have_dot_product_vnni) {
-        return __dot2add_i16packed_sat(a, b, acc);
+        return __dot2add_i16i16packed_sat(a, b, acc);
     } else {
         int32 tmp1 = (int32)((int16)((a >> 16) & 0xFFFF)) * (int32)((int16)((b >> 16) & 0xFFFF));
         int32 tmp2 = (int32)((int16)(a & 0xFFFF)) * (int32)((int16)(b & 0xFFFF));
         return saturating_add(saturating_add(tmp1, tmp2), acc);
+    }
+}
+
+// Multiply groups of 2 adjacent pairs of unsigned 16-bit integers in a
+// with corresponding unsigned 16-bit integers in b, producing 2 intermediate unsigned 32-bit results.
+// Sum these 2 results with the corresponding 32-bit integer in acc, and return the result.
+__declspec(safe) static inline varying uint32 dot2add_u16u16packed(varying uint32 a, varying uint32 b,
+                                                                   varying uint32 acc) {
+    if (__have_intel_vnni_int8) {
+        return __dot2add_u16u16packed(a, b, acc);
+    } else {
+        // Zero-extend both operands as per the pseudocode (UU version)
+        uint32 tmp1 = (uint32)((a >> 16) & 0xFFFF) * (uint32)((b >> 16) & 0xFFFF);
+        uint32 tmp2 = (uint32)(a & 0xFFFF) * (uint32)(b & 0xFFFF);
+        return acc + tmp1 + tmp2;
+    }
+}
+
+// Multiply groups of 2 adjacent pairs of unsigned 16-bit integers in a
+// with corresponding unsigned 16-bit integers in b, producing 2 intermediate unsigned 32-bit results.
+// Sum these 2 results with the corresponding 32-bit integer in acc using unsigned saturation, and return the result.
+__declspec(safe) static inline varying uint32 dot2add_u16u16packed_sat(varying uint32 a, varying uint32 b,
+                                                                       varying uint32 acc) {
+    if (__have_intel_vnni_int8) {
+        return __dot2add_u16u16packed_sat(a, b, acc);
+    } else {
+        // Zero-extend both operands as per the pseudocode (UU version)
+        uint32 tmp1 = (uint32)((a >> 16) & 0xFFFF) * (uint32)((b >> 16) & 0xFFFF);
+        uint32 tmp2 = (uint32)(a & 0xFFFF) * (uint32)(b & 0xFFFF);
+        // Use unsigned saturation for UU version
+        return saturating_add(saturating_add(acc, tmp1), tmp2);
+    }
+}
+
+// Multiply groups of 2 adjacent pairs of unsigned 16-bit integers in a
+// with corresponding signed 16-bit integers in b, producing 2 intermediate signed 32-bit results.
+// Sum these 2 results with the corresponding 32-bit integer in acc, and return the result.
+__declspec(safe) static inline varying int32 dot2add_u16i16packed(varying uint32 a, varying uint32 b,
+                                                                  varying int32 acc) {
+    if (__have_intel_vnni_int8) {
+        return __dot2add_u16i16packed(a, b, acc);
+    } else {
+        // Zero-extend operand a, sign-extend operand b as per pseudocode (US version)
+        int32 tmp1 = (int32)((uint16)((a >> 16) & 0xFFFF)) * (int32)((int16)((b >> 16) & 0xFFFF));
+        int32 tmp2 = (int32)((uint16)(a & 0xFFFF)) * (int32)((int16)(b & 0xFFFF));
+        return acc + tmp1 + tmp2;
+    }
+}
+
+// Multiply groups of 2 adjacent pairs of unsigned 16-bit integers in a
+// with corresponding signed 16-bit integers in b, producing 2 intermediate signed 32-bit results.
+// Sum these 2 results with the corresponding 32-bit integer in acc using signed saturation, and return the result.
+__declspec(safe) static inline varying int32 dot2add_u16i16packed_sat(varying uint32 a, varying uint32 b,
+                                                                      varying int32 acc) {
+    if (__have_intel_vnni_int8) {
+        return __dot2add_u16i16packed_sat(a, b, acc);
+    } else {
+        // Zero-extend operand a, sign-extend operand b as per pseudocode (US version)
+        int32 tmp1 = (int32)((uint16)((a >> 16) & 0xFFFF)) * (int32)((int16)((b >> 16) & 0xFFFF));
+        int32 tmp2 = (int32)((uint16)(a & 0xFFFF)) * (int32)((int16)(b & 0xFFFF));
+        // Use signed saturation for US version
+        return saturating_add(saturating_add(acc, tmp1), tmp2);
     }
 }

--- a/stdlib/stdlib.ispc
+++ b/stdlib/stdlib.ispc
@@ -5974,7 +5974,7 @@ __declspec(safe) static inline varying int32 dot4add_u8i8packed_sat(varying uint
 }
 
 // Multiply groups of 4 adjacent pairs of unsigned 8-bit integers in a with corresponding unsigned
-// 8-bit integers in b, producing 4 intermediate signed 16-bit results.
+// 8-bit integers in b, producing 4 intermediate unsigned 16-bit results.
 // Sum these 4 results with the corresponding 32-bit integer in acc, and return the result.
 __declspec(safe) static inline varying uint32 dot4add_u8u8packed(varying uint32 a, varying uint32 b,
                                                                  varying uint32 acc) {
@@ -5990,17 +5990,17 @@ __declspec(safe) static inline varying uint32 dot4add_u8u8packed(varying uint32 
 }
 
 // Multiply groups of 4 adjacent pairs of unsigned 8-bit integers in a with corresponding unsigned
-// 8-bit integers in b, producing 4 intermediate signed 16-bit results.
+// 8-bit integers in b, producing 4 intermediate unsigned 16-bit results.
 // Sum these 4 results with the corresponding 32-bit integer in acc using unsigned saturation, and return the result.
 __declspec(safe) static inline varying uint32 dot4add_u8u8packed_sat(varying uint32 a, varying uint32 b,
                                                                      varying uint32 acc) {
     if (__have_intel_vnni_int8) {
         return __dot4add_u8u8packed_sat(a, b, acc);
     } else {
-        int16 tmp1 = (int16)((a >> 24) & 0xFF) * (int16)((b >> 24) & 0xFF);
-        int16 tmp2 = (int16)((a >> 16) & 0xFF) * (int16)((b >> 16) & 0xFF);
-        int16 tmp3 = (int16)((a >> 8) & 0xFF) * (int16)((b >> 8) & 0xFF);
-        int16 tmp4 = (int16)(a & 0xFF) * (int16)(b & 0xFF);
+        uint16 tmp1 = (uint16)((a >> 24) & 0xFF) * (uint16)((b >> 24) & 0xFF);
+        uint16 tmp2 = (uint16)((a >> 16) & 0xFF) * (uint16)((b >> 16) & 0xFF);
+        uint16 tmp3 = (uint16)((a >> 8) & 0xFF) * (uint16)((b >> 8) & 0xFF);
+        uint16 tmp4 = (uint16)(a & 0xFF) * (uint16)(b & 0xFF);
         uint32 tmp1234 = ((uint32)tmp1) + ((uint32)tmp2) + ((uint32)tmp3) + ((uint32)tmp4);
         return saturating_add(tmp1234, acc);
     }

--- a/stdlib/stdlib.ispc
+++ b/stdlib/stdlib.ispc
@@ -5945,7 +5945,7 @@ __declspec(safe) static inline void assume(uniform bool test) {
 // 8-bit integers in b, producing 4 intermediate signed 16-bit results.
 // Sum these 4 results with the corresponding 32-bit integer in acc, and return the result.
 __declspec(safe) static inline varying int32 dot4add_u8i8packed(varying uint32 a, varying uint32 b, varying int32 acc) {
-    if (__have_dot_product_vnni || __have_i8_matmul_arm) {
+    if (__have_intel_vnni || __have_arm_i8mm) {
         return __dot4add_u8i8packed(a, b, acc);
     } else {
         int16 tmp1 = (int16)((a >> 24) & 0xFF) * (int16)((int8)((b >> 24) & 0xFF));
@@ -5961,7 +5961,7 @@ __declspec(safe) static inline varying int32 dot4add_u8i8packed(varying uint32 a
 // Sum these 4 results with the corresponding 32-bit integer in acc using signed saturation, and return the result.
 __declspec(safe) static inline varying int32 dot4add_u8i8packed_sat(varying uint32 a, varying uint32 b,
                                                                     varying int32 acc) {
-    if (__have_dot_product_vnni) {
+    if (__have_intel_vnni) {
         return __dot4add_u8i8packed_sat(a, b, acc);
     } else {
         int16 tmp1 = (int16)((a >> 24) & 0xFF) * (int16)((int8)((b >> 24) & 0xFF));
@@ -5978,7 +5978,7 @@ __declspec(safe) static inline varying int32 dot4add_u8i8packed_sat(varying uint
 // Sum these 4 results with the corresponding 32-bit integer in acc, and return the result.
 __declspec(safe) static inline varying uint32 dot4add_u8u8packed(varying uint32 a, varying uint32 b,
                                                                  varying uint32 acc) {
-    if (__have_dot_product_arm || __have_intel_vnni_int8) {
+    if (__have_arm_dot_product || __have_intel_vnni_int8) {
         return __dot4add_u8u8packed(a, b, acc);
     } else {
         int16 tmp1 = (int16)((a >> 24) & 0xFF) * (int16)((b >> 24) & 0xFF);
@@ -6010,7 +6010,7 @@ __declspec(safe) static inline varying uint32 dot4add_u8u8packed_sat(varying uin
 // 8-bit integers in b, producing 4 intermediate signed 16-bit results.
 // Sum these 4 results with the corresponding 32-bit integer in acc, and return the result.
 __declspec(safe) static inline varying int32 dot4add_i8i8packed(varying uint32 a, varying uint32 b, varying int32 acc) {
-    if (__have_dot_product_arm || __have_intel_vnni_int8) {
+    if (__have_arm_dot_product || __have_intel_vnni_int8) {
         return __dot4add_i8i8packed(a, b, acc);
     } else {
         int16 tmp1 = (int16)((int8)((a >> 24) & 0xFF)) * (int16)((int8)((b >> 24) & 0xFF));
@@ -6043,7 +6043,7 @@ __declspec(safe) static inline varying int32 dot4add_i8i8packed_sat(varying uint
 // Sum these 2 results with the corresponding 32-bit integer in src, and return the result.
 __declspec(safe) static inline varying int32 dot2add_i16i16packed(varying uint32 a, varying uint32 b,
                                                                   varying int32 acc) {
-    if (__have_dot_product_vnni) {
+    if (__have_intel_vnni) {
         return __dot2add_i16i16packed(a, b, acc);
     } else {
         int32 tmp1 = (int32)((int16)((a >> 16) & 0xFFFF)) * (int32)((int16)((b >> 16) & 0xFFFF));
@@ -6057,7 +6057,7 @@ __declspec(safe) static inline varying int32 dot2add_i16i16packed(varying uint32
 // Sum these 2 results with the corresponding 32-bit integer in src using signed saturation, and return the result.
 __declspec(safe) static inline varying int32 dot2add_i16i16packed_sat(varying uint32 a, varying uint32 b,
                                                                       varying int32 acc) {
-    if (__have_dot_product_vnni) {
+    if (__have_intel_vnni) {
         return __dot2add_i16i16packed_sat(a, b, acc);
     } else {
         int32 tmp1 = (int32)((int16)((a >> 16) & 0xFFFF)) * (int32)((int16)((b >> 16) & 0xFFFF));

--- a/stdlib/stdlib.ispc
+++ b/stdlib/stdlib.ispc
@@ -5978,7 +5978,7 @@ __declspec(safe) static inline varying int32 dot4add_u8i8packed_sat(varying uint
 // Sum these 4 results with the corresponding 32-bit integer in acc, and return the result.
 __declspec(safe) static inline varying uint32 dot4add_u8u8packed(varying uint32 a, varying uint32 b,
                                                                  varying uint32 acc) {
-    if (__have_dot_product_arm) {
+    if (__have_dot_product_arm || __have_intel_vnni_int8) {
         return __dot4add_u8u8packed(a, b, acc);
     } else {
         int16 tmp1 = (int16)((a >> 24) & 0xFF) * (int16)((b >> 24) & 0xFF);
@@ -5994,19 +5994,23 @@ __declspec(safe) static inline varying uint32 dot4add_u8u8packed(varying uint32 
 // Sum these 4 results with the corresponding 32-bit integer in acc using unsigned saturation, and return the result.
 __declspec(safe) static inline varying uint32 dot4add_u8u8packed_sat(varying uint32 a, varying uint32 b,
                                                                      varying uint32 acc) {
-    int16 tmp1 = (int16)((a >> 24) & 0xFF) * (int16)((b >> 24) & 0xFF);
-    int16 tmp2 = (int16)((a >> 16) & 0xFF) * (int16)((b >> 16) & 0xFF);
-    int16 tmp3 = (int16)((a >> 8) & 0xFF) * (int16)((b >> 8) & 0xFF);
-    int16 tmp4 = (int16)(a & 0xFF) * (int16)(b & 0xFF);
-    uint32 tmp1234 = ((uint32)tmp1) + ((uint32)tmp2) + ((uint32)tmp3) + ((uint32)tmp4);
-    return saturating_add(tmp1234, acc);
+    if (__have_intel_vnni_int8) {
+        return __dot4add_u8u8packed_sat(a, b, acc);
+    } else {
+        int16 tmp1 = (int16)((a >> 24) & 0xFF) * (int16)((b >> 24) & 0xFF);
+        int16 tmp2 = (int16)((a >> 16) & 0xFF) * (int16)((b >> 16) & 0xFF);
+        int16 tmp3 = (int16)((a >> 8) & 0xFF) * (int16)((b >> 8) & 0xFF);
+        int16 tmp4 = (int16)(a & 0xFF) * (int16)(b & 0xFF);
+        uint32 tmp1234 = ((uint32)tmp1) + ((uint32)tmp2) + ((uint32)tmp3) + ((uint32)tmp4);
+        return saturating_add(tmp1234, acc);
+    }
 }
 
 // Multiply groups of 4 adjacent pairs of unsigned 8-bit integers in a with corresponding signed
 // 8-bit integers in b, producing 4 intermediate signed 16-bit results.
 // Sum these 4 results with the corresponding 32-bit integer in acc, and return the result.
 __declspec(safe) static inline varying int32 dot4add_i8i8packed(varying uint32 a, varying uint32 b, varying int32 acc) {
-    if (__have_dot_product_arm) {
+    if (__have_dot_product_arm || __have_intel_vnni_int8) {
         return __dot4add_i8i8packed(a, b, acc);
     } else {
         int16 tmp1 = (int16)((int8)((a >> 24) & 0xFF)) * (int16)((int8)((b >> 24) & 0xFF));
@@ -6022,12 +6026,16 @@ __declspec(safe) static inline varying int32 dot4add_i8i8packed(varying uint32 a
 // Sum these 4 results with the corresponding 32-bit integer in acc using signed saturation, and return the result.
 __declspec(safe) static inline varying int32 dot4add_i8i8packed_sat(varying uint32 a, varying uint32 b,
                                                                     varying int32 acc) {
-    int16 tmp1 = (int16)((a >> 24) & 0xFF) * (int16)((b >> 24) & 0xFF);
-    int16 tmp2 = (int16)((a >> 16) & 0xFF) * (int16)((b >> 16) & 0xFF);
-    int16 tmp3 = (int16)((a >> 8) & 0xFF) * (int16)((b >> 8) & 0xFF);
-    int16 tmp4 = (int16)(a & 0xFF) * (int16)(b & 0xFF);
-    int32 tmp1234 = ((int32)tmp1) + ((int32)tmp2) + ((int32)tmp3) + ((int32)tmp4);
-    return saturating_add(tmp1234, acc);
+    if (__have_intel_vnni_int8) {
+        return __dot4add_i8i8packed_sat(a, b, acc);
+    } else {
+        int16 tmp1 = (int16)((a >> 24) & 0xFF) * (int16)((b >> 24) & 0xFF);
+        int16 tmp2 = (int16)((a >> 16) & 0xFF) * (int16)((b >> 16) & 0xFF);
+        int16 tmp3 = (int16)((a >> 8) & 0xFF) * (int16)((b >> 8) & 0xFF);
+        int16 tmp4 = (int16)(a & 0xFF) * (int16)(b & 0xFF);
+        int32 tmp1234 = ((int32)tmp1) + ((int32)tmp2) + ((int32)tmp3) + ((int32)tmp4);
+        return saturating_add(tmp1234, acc);
+    }
 }
 
 // Multiply groups of 2 adjacent pairs of signed 16-bit integers in a

--- a/tests/func-tests/dot2add_i16i16-1.ispc
+++ b/tests/func-tests/dot2add_i16i16-1.ispc
@@ -1,7 +1,6 @@
 #include "test_static.isph"
 #define N 256
 
-uniform int int_max = 0x7FFFFFFF; // use INT_MAX to check that result is not saturated
 // Init a and b with positive values
 void init(uniform int16 a[], uniform int16 b[]) {
     for (uniform int i = 0; i < N; i++) {
@@ -19,7 +18,7 @@ task void f_v(uniform float dst[]) {
     pack2toint<uniform int16>(b, b_packed, N);
 
     foreach (i = 0 ... N / 2) {
-        dst[i] = dot2add_i16packed(a_packed[i], b_packed[i], int_max);
+        dst[i] = dot2add_i16i16packed(a_packed[i], b_packed[i], i);
     }
 }
 
@@ -27,13 +26,12 @@ task void result(uniform float dst[]) {
     uniform int16 a[N];
     uniform int16 b[N];
     init(a, b);
-
     for (uniform int i = 0; i < N; i += 2) {
         uniform int result = 0;
         for (uniform int j = 0; j < 2; ++j) {
             uniform int32 product = (uniform int32)(a[i + j]) * (uniform int32)(b[i + j]);
             result += (uniform int32)(product);
         }
-        dst[i / 2] = result + int_max;
+        dst[i / 2] = result + i / 2;
     }
 }

--- a/tests/func-tests/dot2add_i16i16-2.ispc
+++ b/tests/func-tests/dot2add_i16i16-2.ispc
@@ -18,7 +18,7 @@ task void f_v(uniform float dst[]) {
     pack2toint<uniform int16>(b, b_packed, N);
 
     foreach (i = 0 ... N / 2) {
-        dst[i] = dot2add_i16packed(a_packed[i], b_packed[i], i);
+        dst[i] = dot2add_i16i16packed(a_packed[i], b_packed[i], i);
     }
 }
 

--- a/tests/func-tests/dot2add_i16i16-3.ispc
+++ b/tests/func-tests/dot2add_i16i16-3.ispc
@@ -1,0 +1,39 @@
+#include "test_static.isph"
+#define N 256
+
+uniform int int_max = 0x7FFFFFFF; // use INT_MAX to check that result is not saturated
+// Init a and b with positive values
+void init(uniform int16 a[], uniform int16 b[]) {
+    for (uniform int i = 0; i < N; i++) {
+        a[i] = (uniform int16)i;
+        b[i] = (uniform int16)i;
+    }
+}
+task void f_v(uniform float dst[]) {
+    uniform int16 a[N];
+    uniform int16 b[N];
+    init(a, b);
+    uniform uint a_packed[N / 2];
+    pack2toint<uniform int16>(a, a_packed, N);
+    uniform uint b_packed[N / 2];
+    pack2toint<uniform int16>(b, b_packed, N);
+
+    foreach (i = 0 ... N / 2) {
+        dst[i] = dot2add_i16i16packed(a_packed[i], b_packed[i], int_max);
+    }
+}
+
+task void result(uniform float dst[]) {
+    uniform int16 a[N];
+    uniform int16 b[N];
+    init(a, b);
+
+    for (uniform int i = 0; i < N; i += 2) {
+        uniform int result = 0;
+        for (uniform int j = 0; j < 2; ++j) {
+            uniform int32 product = (uniform int32)(a[i + j]) * (uniform int32)(b[i + j]);
+            result += (uniform int32)(product);
+        }
+        dst[i / 2] = result + int_max;
+    }
+}

--- a/tests/func-tests/dot2add_i16i16-sat-1.ispc
+++ b/tests/func-tests/dot2add_i16i16-sat-1.ispc
@@ -20,7 +20,7 @@ task void f_v(uniform float dst[]) {
     pack2toint<uniform int16>(b, b_packed, N);
 
     foreach (i = 0 ... N / 2) {
-        dst[i] = dot2add_i16packed_sat(a_packed[i], b_packed[i], int_max);
+        dst[i] = dot2add_i16i16packed_sat(a_packed[i], b_packed[i], int_max);
     }
 }
 

--- a/tests/func-tests/dot2add_i16i16-sat-2.ispc
+++ b/tests/func-tests/dot2add_i16i16-sat-2.ispc
@@ -20,7 +20,7 @@ task void f_v(uniform float dst[]) {
     pack2toint<uniform int16>(b, b_packed, N);
     int acc = 0X80000000 + 1;
     foreach (i = 0 ... N / 2) {
-        dst[i] = dot2add_i16packed_sat(a_packed[i], b_packed[i], acc);
+        dst[i] = dot2add_i16i16packed_sat(a_packed[i], b_packed[i], acc);
     }
 }
 

--- a/tests/func-tests/dot2add_u16i16-1.ispc
+++ b/tests/func-tests/dot2add_u16i16-1.ispc
@@ -1,36 +1,37 @@
 #include "test_static.isph"
 #define N 256
 
-// Init a and b with positive values
-void init(uniform int16 a[], uniform int16 b[]) {
+// Test 1: Init a with unsigned and b with signed positive values
+void init(uniform uint16 a[], uniform int16 b[]) {
     for (uniform int i = 0; i < N; i++) {
-        a[i] = (uniform int16)i;
-        b[i] = (uniform int16)i;
+        a[i] = (uniform uint16)(i % 32768);
+        b[i] = (uniform int16)(i % 32768);
     }
 }
 task void f_v(uniform float dst[]) {
-    uniform int16 a[N];
+    uniform uint16 a[N];
     uniform int16 b[N];
     init(a, b);
     uniform uint a_packed[N / 2];
-    pack2toint<uniform int16>(a, a_packed, N);
+    pack2toint<uniform uint16>(a, a_packed, N);
     uniform uint b_packed[N / 2];
     pack2toint<uniform int16>(b, b_packed, N);
 
     foreach (i = 0 ... N / 2) {
-        dst[i] = dot2add_i16packed(a_packed[i], b_packed[i], i);
+        dst[i] = dot2add_u16i16packed(a_packed[i], b_packed[i], i);
     }
 }
 
 task void result(uniform float dst[]) {
-    uniform int16 a[N];
+    uniform uint16 a[N];
     uniform int16 b[N];
     init(a, b);
     for (uniform int i = 0; i < N; i += 2) {
         uniform int result = 0;
         for (uniform int j = 0; j < 2; ++j) {
-            uniform int32 product = (uniform int32)(a[i + j]) * (uniform int32)(b[i + j]);
-            result += (uniform int32)(product);
+            // Zero-extend a, sign-extend b
+            uniform int32 product = (uniform int32)(uniform uint32)(a[i + j]) * (uniform int32)(b[i + j]);
+            result += product;
         }
         dst[i / 2] = result + i / 2;
     }

--- a/tests/func-tests/dot2add_u16i16-2.ispc
+++ b/tests/func-tests/dot2add_u16i16-2.ispc
@@ -1,0 +1,38 @@
+#include "test_static.isph"
+#define N 256
+
+// Test 2: Init a with unsigned values and b with negative signed values
+void init(uniform uint16 a[], uniform int16 b[]) {
+    for (uniform int i = N - 1; i >= 0; i--) {
+        a[i] = (uniform uint16)(i % 32768);
+        b[i] = (uniform int16)(-i % 32768);
+    }
+}
+task void f_v(uniform float dst[]) {
+    uniform uint16 a[N];
+    uniform int16 b[N];
+    init(a, b);
+    uniform uint a_packed[N / 2];
+    pack2toint<uniform uint16>(a, a_packed, N);
+    uniform uint b_packed[N / 2];
+    pack2toint<uniform int16>(b, b_packed, N);
+
+    foreach (i = 0 ... N / 2) {
+        dst[i] = dot2add_u16i16packed(a_packed[i], b_packed[i], i);
+    }
+}
+
+task void result(uniform float dst[]) {
+    uniform uint16 a[N];
+    uniform int16 b[N];
+    init(a, b);
+    for (uniform int i = 0; i < N; i += 2) {
+        uniform int result = 0;
+        for (uniform int j = 0; j < 2; ++j) {
+            // Zero-extend a, sign-extend b
+            uniform int32 product = (uniform int32)(uniform uint32)(a[i + j]) * (uniform int32)(b[i + j]);
+            result += product;
+        }
+        dst[i / 2] = result + i / 2;
+    }
+}

--- a/tests/func-tests/dot2add_u16i16-3.ispc
+++ b/tests/func-tests/dot2add_u16i16-3.ispc
@@ -1,0 +1,43 @@
+#include "test_static.isph"
+#define N 256
+
+// Test 3: Init a with unsigned values and b with mixed signed values
+// Also testing with negative accumulator
+void init(uniform uint16 a[], uniform int16 b[]) {
+    for (uniform int i = 0; i < N; i++) {
+        a[i] = (uniform uint16)(i % 32768);
+        // Alternate between positive and negative values for b
+        if (i % 2 == 0)
+            b[i] = (uniform int16)(i % 32767);
+        else
+            b[i] = (uniform int16)(-i % 32768);
+    }
+}
+task void f_v(uniform float dst[]) {
+    uniform uint16 a[N];
+    uniform int16 b[N];
+    init(a, b);
+    uniform uint a_packed[N / 2];
+    pack2toint<uniform uint16>(a, a_packed, N);
+    uniform uint b_packed[N / 2];
+    pack2toint<uniform int16>(b, b_packed, N);
+
+    foreach (i = 0 ... N / 2) {
+        dst[i] = dot2add_u16i16packed(a_packed[i], b_packed[i], -i /*Use negative accumulator */);
+    }
+}
+
+task void result(uniform float dst[]) {
+    uniform uint16 a[N];
+    uniform int16 b[N];
+    init(a, b);
+    for (uniform int i = 0; i < N; i += 2) {
+        uniform int result = 0;
+        for (uniform int j = 0; j < 2; ++j) {
+            // Zero-extend a, sign-extend b
+            uniform int32 product = (uniform int32)(uniform uint32)(a[i + j]) * (uniform int32)(b[i + j]);
+            result += product;
+        }
+        dst[i / 2] = result + (-i / 2);
+    }
+}

--- a/tests/func-tests/dot2add_u16i16-sat-1.ispc
+++ b/tests/func-tests/dot2add_u16i16-sat-1.ispc
@@ -1,0 +1,39 @@
+#include "test_static.isph"
+#define N 256
+
+// Init a with unsigned and b with signed positive values
+void init(uniform uint16 a[], uniform int16 b[]) {
+    for (uniform int i = 0; i < N; i++) {
+        a[i] = (uniform uint16)(i % 32768);
+        b[i] = (uniform int16)(i % 32768);
+    }
+}
+task void f_v(uniform float dst[]) {
+    uniform uint16 a[N];
+    uniform int16 b[N];
+    init(a, b);
+    uniform uint a_packed[N / 2];
+    pack2toint<uniform uint16>(a, a_packed, N);
+    uniform uint b_packed[N / 2];
+    pack2toint<uniform int16>(b, b_packed, N);
+
+    foreach (i = 0 ... N / 2) {
+        dst[i] = dot2add_u16i16packed_sat(a_packed[i], b_packed[i], INT32_MAX);
+    }
+}
+
+task void result(uniform float dst[]) {
+    uniform uint16 a[N];
+    uniform int16 b[N];
+    init(a, b);
+
+    for (uniform int i = 0; i < N; i += 2) {
+        uniform int result = 0;
+        for (uniform int j = 0; j < 2; ++j) {
+            // Zero-extend a, sign-extend b
+            uniform int32 product = (uniform int32)(uniform uint32)(a[i + j]) * (uniform int32)(b[i + j]);
+            result += product;
+        }
+        dst[i / 2] = saturating_add(result, INT32_MAX);
+    }
+}

--- a/tests/func-tests/dot2add_u16u16-1.ispc
+++ b/tests/func-tests/dot2add_u16u16-1.ispc
@@ -1,0 +1,37 @@
+#include "test_static.isph"
+#define N 256
+
+// Init a and b with positive values
+void init(uniform uint16 a[], uniform uint16 b[]) {
+    for (uniform int i = 0; i < N; i++) {
+        a[i] = (uniform uint16)(i % 32768);
+        b[i] = (uniform uint16)(i % 32768);
+    }
+}
+task void f_v(uniform float dst[]) {
+    uniform uint16 a[N];
+    uniform uint16 b[N];
+    init(a, b);
+    uniform uint a_packed[N / 2];
+    pack2toint<uniform uint16>(a, a_packed, N);
+    uniform uint b_packed[N / 2];
+    pack2toint<uniform uint16>(b, b_packed, N);
+
+    foreach (i = 0 ... N / 2) {
+        dst[i] = dot2add_u16u16packed(a_packed[i], b_packed[i], i);
+    }
+}
+
+task void result(uniform float dst[]) {
+    uniform uint16 a[N];
+    uniform uint16 b[N];
+    init(a, b);
+    for (uniform int i = 0; i < N; i += 2) {
+        uniform uint result = 0;
+        for (uniform int j = 0; j < 2; ++j) {
+            uniform uint32 product = (uniform uint32)(a[i + j]) * (uniform uint32)(b[i + j]);
+            result += product;
+        }
+        dst[i / 2] = result + i / 2;
+    }
+}

--- a/tests/func-tests/dot2add_u16u16-sat-1.ispc
+++ b/tests/func-tests/dot2add_u16u16-sat-1.ispc
@@ -1,0 +1,37 @@
+#include "test_static.isph"
+#define N 256
+
+// Init a and b with positive numbers
+void init(uniform uint16 a[], uniform uint16 b[]) {
+    for (uniform int i = 0; i < N; i++) {
+        a[i] = (uniform uint16)(i % 32768);
+        b[i] = (uniform uint16)(i % 32768);
+    }
+}
+task void f_v(uniform float dst[]) {
+    uniform uint16 a[N];
+    uniform uint16 b[N];
+    init(a, b);
+    uniform uint a_packed[N / 2];
+    pack2toint<uniform uint16>(a, a_packed, N);
+    uniform uint b_packed[N / 2];
+    pack2toint<uniform uint16>(b, b_packed, N);
+
+    foreach (i = 0 ... N / 2) {
+        dst[i] = dot2add_u16u16packed_sat(a_packed[i], b_packed[i], UINT32_MAX);
+    }
+}
+
+task void result(uniform float dst[]) {
+    uniform uint16 a[N];
+    uniform uint16 b[N];
+    init(a, b);
+    for (uniform int i = 0; i < N; i += 2) {
+        uniform uint result = 0;
+        for (uniform int j = 0; j < 2; ++j) {
+            uniform uint32 product = (uniform uint32)(a[i + j]) * (uniform uint32)(b[i + j]);
+            result += product;
+        }
+        dst[i / 2] = saturating_add(result, UINT32_MAX);
+    }
+}

--- a/tests/lit-tests/vnni-1.ispc
+++ b/tests/lit-tests/vnni-1.ispc
@@ -41,7 +41,7 @@ void dot4add_u8i8_sat(uniform uint a[], uniform uint b[], uniform int dst[]) {
 // CHECK_YMMX4-COUNT-4: vpdpwssd {{.*}} %ymm
 // CHECK_ZMM: vpdpwssd	{{.*}} %zmm
 void dot2add_i16(uniform uint a[], uniform uint b[], uniform int dst[]) {
-    dst[programIndex] = dot2add_i16packed(a[programIndex], b[programIndex], programIndex);
+    dst[programIndex] = dot2add_i16i16packed(a[programIndex], b[programIndex], programIndex);
 }
 
 // CHECK_ALL-LABEL: dot2add_i16_sat
@@ -51,5 +51,5 @@ void dot2add_i16(uniform uint a[], uniform uint b[], uniform int dst[]) {
 // CHECK_YMMX4-COUNT-4: vpdpwssds {{.*}} %ymm
 // CHECK_ZMM: vpdpwssds	{{.*}} %zmm
 void dot2add_i16_sat(uniform uint a[], uniform uint b[], uniform int dst[]) {
-    dst[programIndex] = dot2add_i16packed_sat(a[programIndex], b[programIndex], programIndex);
+    dst[programIndex] = dot2add_i16i16packed_sat(a[programIndex], b[programIndex], programIndex);
 }

--- a/tests/lit-tests/vnni-2.ispc
+++ b/tests/lit-tests/vnni-2.ispc
@@ -31,12 +31,12 @@ void dot4add_u8i8_sat(uniform int a[], uniform int b[], uniform int dst[]) {
 // CHECK_ZMMX2-COUNT-2: vpdpwssd {{.*}} %zmm
 // CHECK_ZMMX4-COUNT-4: vpdpwssd {{.*}} %zmm
 unmasked void dot2add_i16(uniform int a[], uniform int b[], uniform int dst[]) {
-    dst[programIndex] = dot2add_i16packed(a[programIndex], b[programIndex], programIndex);
+    dst[programIndex] = dot2add_i16i16packed(a[programIndex], b[programIndex], programIndex);
 }
 
 // CHECK_ALL-LABEL: dot2add_i16_sat
 // CHECK_ZMMX2-COUNT-2: vpdpwssds {{.*}} %zmm
 // CHECK_ZMMX4-COUNT-4: vpdpwssds {{.*}} %zmm
 void dot2add_i16_sat(uniform int a[], uniform int b[], uniform int dst[]) {
-    dst[programIndex] = dot2add_i16packed_sat(a[programIndex], b[programIndex], programIndex);
+    dst[programIndex] = dot2add_i16i16packed_sat(a[programIndex], b[programIndex], programIndex);
 }

--- a/tests/lit-tests/vnni-avx10.2.ispc
+++ b/tests/lit-tests/vnni-avx10.2.ispc
@@ -1,0 +1,49 @@
+// Test checks emitted code for VNNI dot product instructions.
+
+// RUN: %{ispc} %s --target=avx10.2-x4 --emit-asm -o - | FileCheck %s -check-prefixes=CHECK_ALL,CHECK_XMM
+// RUN: %{ispc} %s --target=avx10.2-x8 --emit-asm -o - | FileCheck %s -check-prefixes=CHECK_ALL,CHECK_YMM
+// RUN: %{ispc} %s --target=avx10.2-x16 --emit-asm -o - | FileCheck %s -check-prefixes=CHECK_ALL,CHECK_ZMM
+// RUN: %{ispc} %s --target=avx10.2-x32 --emit-asm -o - | FileCheck %s -check-prefixes=CHECK_ALL,CHECK_ZMMX2
+// RUN: %{ispc} %s --target=avx10.2-x64 --emit-asm -o - | FileCheck %s -check-prefixes=CHECK_ALL,CHECK_ZMMX4
+
+// REQUIRES: X86_ENABLED && !MACOS_HOST && LLVM_20_0+
+
+// CHECK_ALL-LABEL: dot4add_i8i8
+// CHECK_XMM: vpdpbssd	{{.*}} %xmm
+// CHECK_YMM: vpdpbssd	{{.*}} %ymm
+// CHECK_ZMM: vpdpbssd	{{.*}} %zmm
+// CEHCK_ZMMX2-COUNT-2: vpdpbssd {{.*}} %zmm
+// CHECK_ZMMX4-COUNT-4: vpdpbssd {{.*}} %zmm
+unmasked void dot4add_i8i8(uniform uint a[], uniform uint b[], uniform int dst[]) {
+    dst[programIndex] = dot4add_i8i8packed(a[programIndex], b[programIndex], programIndex);
+}
+
+// CHECK_ALL-LABEL: dot4add_i8i8_sat
+// CHECK_XMM: vpdpbssds	{{.*}} %xmm
+// CHECK_YMM: vpdpbssds	{{.*}} %ymm
+// CHECK_ZMM: vpdpbssds	{{.*}} %zmm
+// CHECK_ZMMX2-COUNT-2: vpdpbssds {{.*}} %zmm
+// CHECK_ZMMX4-COUNT-4: vpdpbssds {{.*}} %zmm
+unmasked void dot4add_i8i8_sat(uniform uint a[], uniform uint b[], uniform int dst[]) {
+    dst[programIndex] = dot4add_i8i8packed_sat(a[programIndex], b[programIndex], programIndex);
+}
+
+// CHECK_ALL-LABEL: dot4add_u8u8
+// CHECK_XMM: vpdpbuud	{{.*}} %xmm
+// CHECK_YMM: vpdpbuud	{{.*}} %ymm
+// CHECK_ZMM: vpdpbuud	{{.*}} %zmm
+// CHECK_ZMMX2-COUNT-2: vpdpbuud {{.*}} %zmm
+// CHECK_ZMMX4-COUNT-4: vpdpbuud {{.*}} %zmm
+unmasked void dot4add_u8u8(uniform uint a[], uniform uint b[], uniform int dst[]) {
+    dst[programIndex] = dot4add_u8u8packed(a[programIndex], b[programIndex], programIndex);
+}
+
+// CHECK_ALL-LABEL: dot4add_u8u8_sat
+// CHECK_XMM: vpdpbuuds	{{.*}} %xmm
+// CHECK_YMM: vpdpbuuds	{{.*}} %ymm
+// CHECK_ZMM: vpdpbuuds	{{.*}} %zmm
+// CHECK_ZMMX2-COUNT-2: vpdpbuuds {{.*}} %zmm
+// CHECK_ZMMX4-COUNT-4: vpdpbuuds {{.*}} %zmm
+unmasked void dot4add_u8u8_sat(uniform uint a[], uniform uint b[], uniform int dst[]) {
+    dst[programIndex] = dot4add_u8u8packed_sat(a[programIndex], b[programIndex], programIndex);
+}

--- a/tests/lit-tests/vnni-avx10.2.ispc
+++ b/tests/lit-tests/vnni-avx10.2.ispc
@@ -47,3 +47,43 @@ unmasked void dot4add_u8u8(uniform uint a[], uniform uint b[], uniform int dst[]
 unmasked void dot4add_u8u8_sat(uniform uint a[], uniform uint b[], uniform int dst[]) {
     dst[programIndex] = dot4add_u8u8packed_sat(a[programIndex], b[programIndex], programIndex);
 }
+
+// CHECK_ALL-LABEL: dot2add_u16u16
+// CHECK_XMM: vpdpwuud	{{.*}} %xmm
+// CHECK_YMM: vpdpwuud	{{.*}} %ymm
+// CHECK_ZMM: vpdpwuud	{{.*}} %zmm
+// CHECK_ZMMX2-COUNT-2: vpdpwuud {{.*}} %zmm
+// CHECK_ZMMX4-COUNT-4: vpdpwuud {{.*}} %zmm
+unmasked void dot2add_u16u16(uniform uint a[], uniform uint b[], uniform uint dst[]) {
+    dst[programIndex] = dot2add_u16u16packed(a[programIndex], b[programIndex], programIndex);
+}
+
+// CHECK_ALL-LABEL: dot2add_u16u16_sat
+// CHECK_XMM: vpdpwuuds	{{.*}} %xmm
+// CHECK_YMM: vpdpwuuds	{{.*}} %ymm
+// CHECK_ZMM: vpdpwuuds	{{.*}} %zmm
+// CHECK_ZMMX2-COUNT-2: vpdpwuuds {{.*}} %zmm
+// CHECK_ZMMX4-COUNT-4: vpdpwuuds {{.*}} %zmm
+unmasked void dot2add_u16u16_sat(uniform uint a[], uniform uint b[], uniform uint dst[]) {
+    dst[programIndex] = dot2add_u16u16packed_sat(a[programIndex], b[programIndex], programIndex);
+}
+
+// CHECK_ALL-LABEL: dot2add_u16i16
+// CHECK_XMM: vpdpwusd	{{.*}} %xmm
+// CHECK_YMM: vpdpwusd	{{.*}} %ymm
+// CHECK_ZMM: vpdpwusd	{{.*}} %zmm
+// CHECK_ZMMX2-COUNT-2: vpdpwusd {{.*}} %zmm
+// CHECK_ZMMX4-COUNT-4: vpdpwusd {{.*}} %zmm
+unmasked void dot2add_u16i16(uniform uint a[], uniform uint b[], uniform int dst[]) {
+    dst[programIndex] = dot2add_u16i16packed(a[programIndex], b[programIndex], programIndex);
+}
+
+// CHECK_ALL-LABEL: dot2add_u16i16_sat
+// CHECK_XMM: vpdpwusds	{{.*}} %xmm
+// CHECK_YMM: vpdpwusds	{{.*}} %ymm
+// CHECK_ZMM: vpdpwusds	{{.*}} %zmm
+// CHECK_ZMMX2-COUNT-2: vpdpwusds {{.*}} %zmm
+// CHECK_ZMMX4-COUNT-4: vpdpwusds {{.*}} %zmm
+unmasked void dot2add_u16i16_sat(uniform uint a[], uniform uint b[], uniform int dst[]) {
+    dst[programIndex] = dot2add_u16i16packed_sat(a[programIndex], b[programIndex], programIndex);
+}


### PR DESCRIPTION
This PR introduces several updates to dot product support:
1. adds AVX10.2 target-specific implementation of dot product for signed/signed int8 and unsigned/unsigned int8.
2. extends dot product for int16 type with all possible signed/unsigned combinations
3. refactors naming of dot-related features
4. resolves missed TODO for AVX10.2 targets