### PR TITLE
Fix fmod for float16 on platforms without native half support

### DIFF
--- a/tests/func-tests/fmod-float16-uniform.ispc
+++ b/tests/func-tests/fmod-float16-uniform.ispc
@@ -8,28 +8,28 @@ task void f_f(uniform float RET[], uniform float aFOO[]) {
     uniform float16 x = aFOO[programCount / 2];
     uniform float16 y = 0.8;
     uniform float16 testVal = fmod(x, y);
-    uniform float16 baseRes = x - trunc(x / y) * y;
+    uniform float16 baseRes = x - trunc(x * rcp(y)) * y;
     RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
 
     // Case 2: x is negative, y is positive
     x = -aFOO[programCount / 2];
     y = 0.8;
     testVal = fmod(x, y);
-    baseRes = x - trunc(x / y) * y;
+    baseRes = x - trunc(x * rcp(y)) * y;
     RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
 
     // Case 3: x is positive, y is negative
     x = aFOO[programCount / 2];
     y = -0.8;
     testVal = fmod(x, y);
-    baseRes = x - trunc(x / y) * y;
+    baseRes = x - trunc(x * rcp(y)) * y;
     RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
 
     // Case 4: x and y are negative
     x = -aFOO[programCount / 2];
     y = -0.8;
     testVal = fmod(x, y);
-    baseRes = x - trunc(x / y) * y;
+    baseRes = x - trunc(x * rcp(y)) * y;
     RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
 
     // Case 5.1: x is +inf, y is positive

--- a/tests/func-tests/fmod-float16-varying.ispc
+++ b/tests/func-tests/fmod-float16-varying.ispc
@@ -8,28 +8,28 @@ task void f_f(uniform float RET[], uniform float aFOO[]) {
     float16 x = aFOO[programIndex] - (programCount / 2);
     float16 y = 0.8;
     float16 testVal = fmod(x, y);
-    float16 baseRes = x - trunc(x / y) * y;
+    float16 baseRes = x - trunc(x * rcp(y)) * y;
     RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
 
     // Case 2: x is negative, y is positive
     x = -aFOO[programCount / 2];
     y = 0.8;
     testVal = fmod(x, y);
-    baseRes = x - trunc(x / y) * y;
+    baseRes = x - trunc(x * rcp(y)) * y;
     RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
 
     // Case 3: x is positive, y is negative
     x = aFOO[programCount / 2];
     y = -0.8;
     testVal = fmod(x, y);
-    baseRes = x - trunc(x / y) * y;
+    baseRes = x - trunc(x * rcp(y)) * y;
     RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
 
     // Case 4: x and y are negative
     x = -aFOO[programCount / 2];
     y = -0.8;
     testVal = fmod(x, y);
-    baseRes = x - trunc(x / y) * y;
+    baseRes = x - trunc(x * rcp(y)) * y;
     RET[programIndex] += (abs(baseRes - testVal) < 1e-6) ? 0 : 1;
 
     // Case 5.1: x is +inf, y is positive


### PR DESCRIPTION
This PR updates fmod-float16 tests to use the same implementation for `fmod` operation as in stdlib. Looks like LLVM 18 preserves precision better and LLVM 20 performs more aggressive optimizations so the difference between `x* 1/y` and `x*rcp(y)` is quite significant on the platforms without native half support.
