### PR TITLE
lex.ll: fix token types emitted for identifiers

### DIFF
--- a/src/lex.ll
+++ b/src/lex.ll
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2024, Intel Corporation
+  Copyright (c) 2010-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -409,6 +409,8 @@ L?\"(\\.|[^\\"])*\" { lStringConst(&yylval, &yylloc); return TOKEN_STRING_LITERA
     yylval.stringVal = new std::string(yytext);
     if (m->symbolTable->LookupType(yytext) != nullptr)
         return TOKEN_TYPE_NAME;
+    else if (m->symbolTable->LookupVariable(yytext))
+        return TOKEN_IDENTIFIER;
     else if (m->symbolTable->LookupFunctionTemplate(yytext))
         return TOKEN_TEMPLATE_NAME;
     else

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1037,7 +1037,7 @@ assignment_expression
       { $$ = new AssignExpr(AssignExpr::OrAssign, $1, $3, Union(@1, @3)); }
     | template_identifier {
         // It looks like the proper place is under primary_expression, but
-        // there are shift/reduce conflicts there. So, we handle it here.
+        // there are reduce/reduce conflicts there. So, we handle it here.
         const std::string name = $1;
         std::vector<Symbol *> funcs;
         m->symbolTable->LookupFunction(name.c_str(), &funcs);

--- a/tests/lit-tests/3355.ispc
+++ b/tests/lit-tests/3355.ispc
@@ -1,0 +1,16 @@
+// RUN: %{ispc} --target=host --nowrap --nostdlib --emit-llvm-text %s -o - 2>&1 | FileCheck %s
+
+// CHECK-LABEL: @bar___uni
+// CHECK-DAG: ret i32 9
+
+// CHECK-NOT: Error: Ambiguous use of overloaded function "fname".
+
+template <typename T> uniform int fname(T x);
+
+uniform int bar(uniform int x) {
+    uniform int fname = 9;
+    if (fname == 0) {
+        return -fname;
+    }
+    return fname;
+}


### PR DESCRIPTION
Prioritize TOKEN_IDENTIFIER over TOKEN_TEMPLATE_NAME. In case, when both variable and template have same name it allows to shadow template with local variable.

This PR fixes #3355 