### PR TITLE
Fix assert if intrinsics is not supported

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -641,7 +641,9 @@ Symbol *Module::AddLLVMIntrinsicDecl(const std::string &name, ExprList *args, So
     }
 
     llvm::Function *funcDecl = lGetIntrinsicDeclaration(module, name, args, pos);
-    Assert(funcDecl != nullptr);
+    if (funcDecl == nullptr) {
+        return nullptr;
+    }
 
     Symbol *funcSym = lCreateISPCSymbolForLLVMIntrinsic(funcDecl, symbolTable);
     return funcSym;

--- a/tests/lit-tests/3360.ispc
+++ b/tests/lit-tests/3360.ispc
@@ -1,0 +1,10 @@
+// RUN: not %{ispc} %s --nowrap --target=neon-i32x4 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+
+// CHECK: Error: LLVM intrinsic "ssse3.pmul.hr.sw.128" supported only on "x86" target architecture.
+// CHECK-NOT: Assertion failed
+
+// REQUIRES: ARM_ENABLED
+
+int16 mul_16x8_high(int16 a, int16 b) {
+    return @llvm.x86.ssse3.pmul.hr.sw.128(a, b);
+}


### PR DESCRIPTION
The assert `Assert(funcDecl != nullptr);` is overprotective. Just return `nullptr` if intrinisc is not supported, the result of this function is checked further in parser.
Fixes #3360 