### PR TITLE
Fix unsized globals and incomplete types error reports

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -9471,7 +9471,10 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
             funcSym = templSym->functionTemplate->AddInstantiation(deducedArgs, TemplateInstantiationKind::Implicit,
                                                                    templSym->isInline, templSym->isNoInline);
         }
-        AssertPos(pos, funcSym);
+        if (funcSym == nullptr) {
+            Error(pos, "Failed to get a candidate for template instantiation");
+            return std::vector<Symbol *>();
+        }
         // Success
         ret.push_back(funcSym);
     }

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -1139,6 +1139,20 @@ Symbol *FunctionTemplate::LookupInstantiation(const TemplateArgs &tArgs) {
 
 Symbol *FunctionTemplate::AddInstantiation(const TemplateArgs &tArgs, TemplateInstantiationKind kind, bool isInline,
                                            bool isNoinline) {
+    for (size_t i = 0; i < tArgs.size(); i++) {
+        TemplateArg tArg = tArgs[i];
+        if (tArg.IsType()) {
+            const Type *argType = tArg.GetAsType();
+            if (argType && !argType->IsCompleteType()) {
+                Symbol *arg = args[i];
+                Error(arg->pos,
+                      "Template parameter '%s' with type '%s' can't be instantiated with incomplete type '%s'\n",
+                      arg->name.c_str(), arg->type->GetString().c_str(), argType->GetString().c_str());
+                return nullptr;
+            }
+        }
+    }
+
     const TemplateParms *typenames = GetTemplateParms();
     Assert(typenames);
     TemplateInstantiation templInst(*typenames, tArgs, isInline, isNoinline);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -663,6 +663,11 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
         return;
     }
 
+    if (!type->IsCompleteType()) {
+        Error(pos, "variable \"%s\" has incomplete type \"%s\"", name.c_str(), type->GetString().c_str());
+        return;
+    }
+
     type = ArrayType::SizeUnsizedArrays(type, initExpr);
     if (type == nullptr) {
         return;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1075,6 +1075,15 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
     auto [name_pref, name_suf] = functionType->GetFunctionMangledName(false);
     std::string functionName = name_pref + name + name_suf;
 
+    for (int i = 0; i < functionType->GetNumParameters(); i++) {
+        const Type *t = functionType->GetParameterType(i);
+        if (!t->IsCompleteType()) {
+            const SourcePos paramPos = functionType->GetParameterSourcePos(i);
+            const std::string paramName = functionType->GetParameterName(i);
+            Error(paramPos, "parameter '%s' has incomplete type '%s'", paramName.c_str(), t->GetString().c_str());
+            return;
+        }
+    }
     llvm::Function *function = functionType->CreateLLVMFunction(functionName, g->ctx, /*disableMask*/ isExternCorSYCL);
 
     if (g->target_os == TargetOS::windows) {

--- a/src/opt/PeepholePass.cpp
+++ b/src/opt/PeepholePass.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2022-2024, Intel Corporation
+  Copyright (c) 2022-2025, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -7,6 +7,11 @@
 #include "PeepholePass.h"
 #include "builtins-decl.h"
 
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_21_0
+#define CONST_METHOD const
+#else
+#define CONST_METHOD
+#endif
 namespace ispc {
 
 using namespace llvm::PatternMatch;
@@ -18,7 +23,7 @@ template <typename Op_t, unsigned Opcode> struct CastClassTypes_match {
     CastClassTypes_match(const Op_t &OpMatch, const llvm::Type *f, const llvm::Type *t)
         : Op(OpMatch), fromType(f), toType(t) {}
 
-    template <typename OpTy> bool match(OpTy *V) {
+    template <typename OpTy> bool match(OpTy *V) CONST_METHOD {
         if (llvm::Operator *O = llvm::dyn_cast<llvm::Operator>(V)) {
             return (O->getOpcode() == Opcode && Op.match(O->getOperand(0)) && O->getType() == toType &&
                     O->getOperand(0)->getType() == fromType);
@@ -62,7 +67,7 @@ template <typename Op_t> struct UDiv2_match {
 
     UDiv2_match(const Op_t &OpMatch) : Op(OpMatch) {}
 
-    template <typename OpTy> bool match(OpTy *V) {
+    template <typename OpTy> bool match(OpTy *V) CONST_METHOD {
         llvm::BinaryOperator *bop = nullptr;
         llvm::ConstantDataVector *cdv = nullptr;
         if ((bop = llvm::dyn_cast<llvm::BinaryOperator>(V)) &&
@@ -91,7 +96,7 @@ template <typename Op_t> struct SDiv2_match {
 
     SDiv2_match(const Op_t &OpMatch) : Op(OpMatch) {}
 
-    template <typename OpTy> bool match(OpTy *V) {
+    template <typename OpTy> bool match(OpTy *V) CONST_METHOD {
         llvm::BinaryOperator *bop = nullptr;
         llvm::ConstantDataVector *cdv = nullptr;
         if ((bop = llvm::dyn_cast<llvm::BinaryOperator>(V)) &&

--- a/tests/lit-tests/2844-2.ispc
+++ b/tests/lit-tests/2844-2.ispc
@@ -2,10 +2,10 @@
 
 // RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s
 
-// CHECK: Error: parameter 'a' is an incomplete type: varying struct Sy
+// CHECK: Error: parameter 'a' has incomplete type 'varying struct Sy'
 int bar(struct Sy a) {}
 
-// CHECK-NOT: Error: parameter 'b' is an incomplete type: varying struct Sx
+// CHECK: Error: parameter 'b' has incomplete type 'varying struct Sx'
 int foo(struct Sx b);
 
 // CHECK-NOT: Error: parameter 'n' is an incomplete

--- a/tests/lit-tests/2844-7.ispc
+++ b/tests/lit-tests/2844-7.ispc
@@ -3,10 +3,9 @@
 // RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s
 
 // CHECK: Error: variable 'x' has incomplete struct type 'varying struct Si' and cannot be defined
-// CHECK: Error: return type is an incomplete type: varying struct Si
-// CHECK: Error: parameter 'a' is an incomplete type: varying struct Si
-// CHECK: Error: Attempt to allocate memory for incomplete type "varying struct Si".
-// CHECK: Error: Malformed return value in function with non-void return type.
+// CHECK: Error: Template parameter 'a' with type '/*unbound*/ T' can't be instantiated with incomplete type 'varying struct Si'
+// CHECK: Error: Failed to get a candidate for template instantiation
+// CHECK: Error: Unable to find any matching overload for call to function "bar".
 template <typename T> T bar(T a) { return a; }
 
 int foo() {

--- a/tests/lit-tests/2844-8.ispc
+++ b/tests/lit-tests/2844-8.ispc
@@ -1,0 +1,6 @@
+// Test that we catch incomplete struct types in global variable declarations.
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s
+
+// CHECK: Error: variable "x" has incomplete type "varying struct S"
+struct S x;

--- a/tests/lit-tests/aligned-attr-type.ispc
+++ b/tests/lit-tests/aligned-attr-type.ispc
@@ -4,9 +4,6 @@
 
 // RUN: %{ispc} --target=host --emit-llvm-text -o - %s 2>&1 | FileCheck %s
 
-// CHECK: @x = local_unnamed_addr global %v{{.*}}_varying_S zeroinitializer
-struct S x;
-
 struct Sy { int8 x; int y; } __attribute__((aligned(8)));
 
 // CHECK: @y8 = local_unnamed_addr global %v{{.*}}_varying_Sy zeroinitializer, align 8

--- a/tests/lit-tests/bool-store-vector.ispc
+++ b/tests/lit-tests/bool-store-vector.ispc
@@ -1,13 +1,14 @@
 // RUN: %{ispc} --target=host --nowrap --nostdlib -O2 --emit-llvm-text %s -o - | FileCheck %s
 
-// REQUIRES: X86_ENABLED && !ARM_ENABLED
+// REQUIRES: X86_ENABLED
 
+// Storage bools need to be zero extended
 uniform bool<4> x;
 
 // CHECK-LABEL: @foo___unT_3C_4_3E_unT_3C_4_3E_(
 // CHECK-NEXT: allocas:
 // CHECK-NEXT: [[CMP:%.*]] = icmp ult <4 x i8> %a, %b
-// CHECK-NEXT: [[CAST:%.*]] = sext <4 x i1> [[CMP]] to <4 x i8>
+// CHECK-NEXT: [[CAST:%.*]] = zext <4 x i1> [[CMP]] to <4 x i8>
 // CHECK-NEXT: store <4 x i8> [[CAST]], {{.*}} @x
 // CHECK-NEXT: ret void
 
@@ -18,7 +19,7 @@ void foo(uniform uint8<4> a, uniform uint8<4> b)
 
 // CHECK-LABEL: @boo___unb_3C_4_3E_(
 // CHECK-NEXT: allocas:
-// CHECK-NEXT: [[CAST:%.*]] = sext <4 x i1> %a to <4 x i8>
+// CHECK-NEXT: [[CAST:%.*]] = zext <4 x i1> %a to <4 x i8>
 // CHECK-NEXT: store <4 x i8> [[CAST]], {{.*}} @x
 // CHECK-NEXT: ret void
 

--- a/tests/lit-tests/ispc-opt.ll
+++ b/tests/lit-tests/ispc-opt.ll
@@ -19,6 +19,8 @@
 
 ; RUN: %{ispc-opt} --target=neon-i32x4 --passes=peephole %s -o - | FileCheck --check-prefix=CHECK-PEEPHOLE %s
 
+; REQUIRES: ARM_ENABLED
+
 declare <4 x i16> @llvm.aarch64.neon.uhadd.v4i16(<4 x i16>, <4 x i16>)
 define <4 x i16> @__avg_down_uint16(<4 x i16> %0, <4 x i16> %1) {
   %r = call <4 x i16> @llvm.aarch64.neon.uhadd.v4i16(<4 x i16> %0, <4 x i16> %1)


### PR DESCRIPTION
This PR fixes error reporting for unsized globals and incomplete type in function arguments. It mostly caused by changes in upstream. It doesn't allow to create unsized global variables on IR level anymore.