### PR TITLE
Improve error reports for intrinsics

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -16,6 +16,7 @@
 #include <llvm/Bitcode/BitcodeWriter.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Module.h>
+#include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
 #ifdef ISPC_XE_ENABLED
 #include <llvm/GenXIntrinsics/GenXIntrinsics.h>
@@ -262,6 +263,13 @@ static const Type *lLLVMTypeToISPCType(const llvm::Type *t, bool intAsUnsigned) 
     return nullptr;
 }
 
+std::string lGetTypeString(const llvm::Type *Ty) {
+    std::string TypeStr;
+    llvm::raw_string_ostream RSO(TypeStr);
+    Ty->print(RSO);
+    return RSO.str();
+}
+
 /** Create ISPC symbol for LLVM intrinsics and add it to the given module.
 
     @param func            llvm::Function for the intrinsic to be added
@@ -279,10 +287,8 @@ Symbol *lCreateISPCSymbolForLLVMIntrinsic(llvm::Function *func, SymbolTable *sym
     std::string name = std::string(func->getName());
     const Type *returnType = lLLVMTypeToISPCType(ftype->getReturnType(), false);
     if (returnType == nullptr) {
-        Error(SourcePos(),
-              "Return type not representable for "
-              "Intrinsic %s.",
-              name.c_str());
+        Error(SourcePos(), "Return type \"%s\" not representable as ISPC type for Intrinsic %s.",
+              lGetTypeString(ftype->getReturnType()).c_str(), name.c_str());
         // return type not representable in ispc -> not callable from ispc
         return nullptr;
     }
@@ -291,10 +297,8 @@ Symbol *lCreateISPCSymbolForLLVMIntrinsic(llvm::Function *func, SymbolTable *sym
         const llvm::Type *llvmArgType = ftype->getParamType(j);
         const Type *type = lLLVMTypeToISPCType(llvmArgType, false);
         if (type == nullptr) {
-            Error(SourcePos(),
-                  "Type of parameter %d not "
-                  "representable for Intrinsic %s",
-                  j, name.c_str());
+            Error(SourcePos(), "Type \"%s\" of parameter %d not representable as ISPC type for Intrinsic %s",
+                  lGetTypeString(llvmArgType).c_str(), j, name.c_str());
             return nullptr;
         }
         argTypes.push_back(type);

--- a/tests/lit-tests/3116.ispc
+++ b/tests/lit-tests/3116.ispc
@@ -1,0 +1,11 @@
+// RUN: not %{ispc} --target=avx2-i32x8 --nowrap --nostdlib t.ispc --emit-llvm-text -o - --enable-llvm-intrinsics
+
+// REQUIRES: X86_ENABLED
+
+// CHECK: Error: Unable to find any matching overload for call to function "llvm.x86.ssse3.pmul.hr.sw".
+// CHECK-NEXT: Passed types: (varying int16, varying int16)
+// CHECK-NEXT: Candidate: uniform int64<1>(uniform int64<1> , uniform int64<1> )
+
+int16 test(int16 t) {
+    return @llvm.x86.ssse3.pmul.hr.sw(t, t);
+}

--- a/tests/lit-tests/3141.ispc
+++ b/tests/lit-tests/3141.ispc
@@ -14,7 +14,7 @@
 
 // This error is expected because the logic of mapping LLVM function signatures
 // to ISPC ones does not support the struct return type.
-// CHECK: Error: Return type not representable for Intrinsic
+// CHECK: Return type "{ <4 x float>, <4 x float> }" not representable as ISPC type for Intrinsic
 void __deinterleave2(uniform float<8> val) {
     @DEINTERLEAVE2(val);
 }


### PR DESCRIPTION
Report unrepresentable LLVM IR types and fix reporting candidates when ISPC is unable to find the proper overload for a function call.

This PR fixes #3116 