### PR TITLE
Fix uninit warning

### DIFF
--- a/src/func.cpp
+++ b/src/func.cpp
@@ -1140,9 +1140,8 @@ Symbol *FunctionTemplate::LookupInstantiation(const TemplateArgs &tArgs) {
 Symbol *FunctionTemplate::AddInstantiation(const TemplateArgs &tArgs, TemplateInstantiationKind kind, bool isInline,
                                            bool isNoinline) {
     for (size_t i = 0; i < tArgs.size(); i++) {
-        TemplateArg tArg = tArgs[i];
-        if (tArg.IsType()) {
-            const Type *argType = tArg.GetAsType();
+        if (tArgs[i].IsType()) {
+            const Type *argType = tArgs[i].GetAsType();
             if (argType && !argType->IsCompleteType()) {
                 Symbol *arg = args[i];
                 Error(arg->pos,


### PR DESCRIPTION
Although it looks like a FP, remove creation of a temporary variable.