### PR TITLE
CMake: pass NDEBUG on all platforms for non-debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,9 +558,11 @@ if (UNIX)
     endif()
 else()
     list(APPEND COMPILE_DEFINITIONS NOMINMAX)
-    if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-        list(APPEND COMPILE_DEFINITIONS NDEBUG)
-    endif()
+endif()
+
+# Pass NDEBUG for non-debug builds on all platforms
+if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    list(APPEND COMPILE_DEFINITIONS NDEBUG)
 endif()
 
 # TODO: It may be confusing that some CMake variables start with ISPC but some


### PR DESCRIPTION
This is needed at least to avoid unnecessary enabling dump methods guarded by `if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)` like, e.g., `ScaledNumber<T>::dump()` in `llvm/include/Support/ScaledNumber.h`. Their presence results in a linking error.

When we don't pass `NDEBUG` we need to link with the debug LLVM build. This wasn't a problem until the recent changes in the upstream where they guarded more API methods as DEBUG ones.

This fixes ISPC build with the recent upstream changes https://github.com/llvm/llvm-project/pull/139804