### PR TITLE
Fix the crash of #3388

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -4532,7 +4532,7 @@ static std::pair<llvm::Constant *, bool> lGetExprListConstant(const Type *type, 
     bool isVaryingInit = false;
     bool isNotValidForMultiTargetGlobal = false;
     if (exprs.size() == 1 && (CastType<AtomicType>(type) != nullptr || CastType<EnumType>(type) != nullptr ||
-                              CastType<PointerType>(type) != nullptr)) {
+                              CastType<PointerType>(type) != nullptr) && exprs[0] != nullptr) {
         if (isStorageType) {
             return exprs[0]->GetStorageConstant(type);
         } else {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -4532,7 +4532,10 @@ static std::pair<llvm::Constant *, bool> lGetExprListConstant(const Type *type, 
     bool isVaryingInit = false;
     bool isNotValidForMultiTargetGlobal = false;
     if (exprs.size() == 1 && (CastType<AtomicType>(type) != nullptr || CastType<EnumType>(type) != nullptr ||
-                              CastType<PointerType>(type) != nullptr) && exprs[0] != nullptr) {
+                              CastType<PointerType>(type) != nullptr)) {
+        if (exprs[0] == nullptr) {
+            return std::pair<llvm::Constant *, bool>(nullptr, false);
+        }
         if (isStorageType) {
             return exprs[0]->GetStorageConstant(type);
         } else {

--- a/tests/lit-tests/3388.ispc
+++ b/tests/lit-tests/3388.ispc
@@ -1,0 +1,12 @@
+// This test checks that the compiler reports an error when performing an 
+// extra index access in aggregate initialization instead of a crash 
+// (segmentation fault).
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error: Trying to index into non-array, vector, or pointer type "const uniform float".
+// CHECK-NOT: FATAL ERROR:
+
+export void test(const uniform float a[]) {
+    const uniform float v = {a[0][0]};
+}


### PR DESCRIPTION
This PR fix the crash of #3388 in a naive way:
ISPC crashes because `exprs[0]` is null hence the segmentation fault. If we add a check then this does not cause any segfault on the example. That being said, this is a naive fix because I do not know if having a `nullptr` in `exprs` is actually normal. If not, then another more complex fix is needed.