### PR TITLE
[WIP] Fix--opt=disable-zmm for avx512* targets

### DIFF
--- a/tests/lit-tests/1875.ispc
+++ b/tests/lit-tests/1875.ispc
@@ -1,0 +1,18 @@
+// This test checks that --opt=disable-zmm is supported for generic targets
+
+// RUN: %{ispc} -O2 --target=generic-i1x16 --opt=disable-zmm --cpu=spr --emit-asm --x86-asm-syntax=intel %s -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} -O2 --target=generic-i1x32 --opt=disable-zmm --cpu=skx --emit-asm --x86-asm-syntax=intel %s -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} -O2 --target=generic-i1x64 --opt=disable-zmm --cpu=icl --emit-asm --x86-asm-syntax=intel %s -o - 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK: ymm
+// CHECK-NOT: zmm
+
+export void Max(uniform float Result[], const uniform float Source1[], const uniform float Source2[], const uniform int Iterations)
+{
+    foreach(i = 0 ... Iterations)
+    {
+        Result[i] = max(Source1[i], Source2[i]);
+    }
+}

--- a/tests/lit-tests/2792.ispc
+++ b/tests/lit-tests/2792.ispc
@@ -1,0 +1,16 @@
+// This test checks that --opt=disable-zmm is supported for generic targets
+
+// RUN: %{ispc} -O2 --target=generic-i1x16 --opt=disable-zmm --cpu=skx --emit-asm --x86-asm-syntax=intel %s -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} -O2 --target=generic-i1x32 --opt=disable-zmm --cpu=icl --emit-asm --x86-asm-syntax=intel %s -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} -O2 --target=generic-i1x64 --opt=disable-zmm --cpu=spr --emit-asm --x86-asm-syntax=intel %s -o - 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK: ymm
+// CHECK-NOT: zmm
+
+void foo(uniform float output[], float a, float b)
+{
+   float m = max(a, b);
+   output[programIndex] = m;
+}

--- a/tests/lit-tests/avx512skx-registers.ispc
+++ b/tests/lit-tests/avx512skx-registers.ispc
@@ -5,13 +5,15 @@
 // This code is especially problematic, as shuffle generates a sequence of gep
 // instructions, which are later combined to shuffle by code gen.
 
-// RUN: %{ispc} %s --emit-asm --target=avx512skx-x16 -o - 2>&1 | FileCheck %s -check-prefix=ZMM
-// RUN: %{ispc} %s --emit-asm --target=avx512skx-x16 --opt=disable-zmm -o - 2>&1 | FileCheck %s -check-prefix=YMM
+// RUN: %{ispc} %s --nowrap --emit-asm --target=avx512skx-x16 -o - 2>&1 | FileCheck %s -check-prefix=ZMM
+// RUN: %{ispc} %s --nowrap --emit-asm --target=avx512skx-x16 --opt=disable-zmm -o - 2>&1 | FileCheck %s -check-prefix=YMM
 
 // REQUIRES: X86_ENABLED
 
 // ZMM-NOT: ymm
 // YMM-NOT: zmm
+
+// YMM: Warning: Using --opt=disable-zmm for avx512skx-x16 target can lead to compiler crashes, consider using the generic target instead: `--target=generic-i1x16 --cpu=skx --opt=disable-zmm`
 
 struct FM {
     float M[16];


### PR DESCRIPTION
Supported targets:
- generic-i32x16
- generic-i1x16
- generic-i1x32
- generic-i1x64

Also report warnings that --opt=disable-zmm is unsupported or erroneous for targets that support avx512. It was implemented only for x16 wide targets, but not every program could be compiled because builtins use LLVM intrinsics that require zmm registers. For x32 and x64 targets, it was not implemented at all.

On the contrary, builtins of generic targets do not use target specific builtins so we can use them with --opt=disable-zmm and the proper CPUs, e.g., --opt=disable-zmm --target=generic-i1x16 --cpu=skx

This addresses issue #1875 and #2792.