### PR TITLE
Add disjoint check to IsOrEquivalentToAdd

### DIFF
--- a/tests/lit-tests/3399.ispc
+++ b/tests/lit-tests/3399.ispc
@@ -1,0 +1,17 @@
+// This test checks that the code below folds to simple paddb instructions on SSE2/SSE4 targets.
+// RUN: %{ispc} %s --target=sse2-i32x4 --emit-asm --nostdlib -o - | FileCheck %s
+// RUN: %{ispc} %s --target=sse2-i32x8 --emit-asm --nostdlib -o - | FileCheck %s
+// RUN: %{ispc} %s --target=sse4.2-i32x4 --emit-asm --nostdlib -o - | FileCheck %s
+// RUN: %{ispc} %s --target=sse4.2-i32x8 --emit-asm --nostdlib -o - | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK: paddb
+// CHECK-NEXT: retq
+unmasked uniform int32<4> test_add(uniform int32<4> _A, uniform int32<4> _B) {
+    uniform int32<4> Result;
+    foreach (i = 0 ... 16) {
+        ((uniform int8 *)&Result)[i] = ((uniform int8 *)&_A)[i] + ((uniform int8 *)&_B)[i];
+    }
+    return Result;
+}


### PR DESCRIPTION
This PR adds check for `disjoint` attribute in `or` instruction.
`disjoint` attribute was introduced in LLVM 18 and means that for each bit, that bit is zero in at least one of the inputs. This allows the Or to be treated as an Add since no carry can occur from any bit.
This unblocks ImrpoveMemoryOps optimization in some cases (discovered with SSE4 and SSE2 targets).
Fixes #3399 