### PR TITLE
Move HasAmbiguousVariability to TypeCheck stage

### DIFF
--- a/src/expr.h
+++ b/src/expr.h
@@ -561,6 +561,7 @@ class ConstExpr : public Expr {
 class TypeCastExpr : public Expr {
   public:
     TypeCastExpr(const Type *t, Expr *e, SourcePos p);
+    TypeCastExpr(const Type *t, const Type *prechecked, Expr *e, SourcePos p);
 
     static inline bool classof(TypeCastExpr const *) { return true; }
     static inline bool classof(ASTNode const *N) { return N->getValueID() == TypeCastExprID; }
@@ -580,7 +581,8 @@ class TypeCastExpr : public Expr {
     bool HasAmbiguousVariability(std::vector<const Expr *> &warn) const;
     void PrintAmbiguousVariability() const;
 
-    const Type *type;
+    const Type *type;         // Current/resolved target type
+    const Type *preCheckType; // Target type before type checking
     Expr *expr;
 };
 

--- a/tests/lit-tests/3295.ispc
+++ b/tests/lit-tests/3295.ispc
@@ -4,7 +4,6 @@
 // RUN: not %{ispc} --target=host --nowrap %s -o - 2>&1 | FileCheck %s
 
 // CHECK-NOT: Error: Assertion failed
-// CHECK: Error: Unsupported binary operator "%" for pointer type: "uniform int32 * uniform"
 // CHECK: Error: First operand to binary operator "%" is of invalid type "uniform int32 * uniform".
 
 export uniform int gather_ints_buffer(uniform int values[]) { assume(&values[0] % programCount == 0); }


### PR DESCRIPTION
## Description
This PR moves checking of unbound parameters in FunctionCallExpr (performed in `HasAmbiguousVariability `) from constructor to  `TypeCheck` stage. To keep the original type before `TypeCheck`, `preCheckType` is introduced.
Refactoring for further operators support.

## Related Issue
- [ ] Linked to relevant issue(s). 

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests). - Existing test 1886.ispc
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed