### PR TITLE
Fix issue #3404 (unhandled atomic type crash)

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -9088,6 +9088,8 @@ static bool lIsMatchWithTypeWidening(const Type *callType, const Type *funcArgTy
         return (funcAt->basicType == AtomicType::TYPE_INT64 || funcAt->basicType == AtomicType::TYPE_UINT64);
     case AtomicType::TYPE_DOUBLE:
         return false;
+    case AtomicType::TYPE_VOID:
+        return false;
     default:
         FATAL("Unhandled atomic type");
         return false;

--- a/tests/lit-tests/3404.ispc
+++ b/tests/lit-tests/3404.ispc
@@ -1,0 +1,16 @@
+// This test checks that the compiler reports an error when calling a function 
+// taking a void-typed value in argument (rather than a float-convertible value), 
+// instead of a crash (fatal error).
+
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error: Unable to find any matching overload for call to function "cube".
+// CHECK-NOT: FATAL ERROR:
+
+void cube(float x) {
+    return x * x * x;
+}
+
+export void power_9_3(uniform float values[]) {
+    cube(cube(values[programIndex]));
+}


### PR DESCRIPTION
This PR fixes the issue #3404 about an unhandled atomic type fatal error.

The problem is that `lIsMatchWithTypeWidening` is called with a `callType` argument being of type `AtomicType::TYPE_VOID` so it is not supported by the `switch` resulting in a fatal error. I think this happens because ISPC tries to check if the second `cube` function (taking a `float` in parameter) can take in input the result of the first `cube` call (of type `void`) even possibly using an implicit (safe) conversion. 

Here is the callstack when the fatal error happens for a better context:

```
#4  ispc::FatalError at ispc/src/util.cpp:462
#5  lIsMatchWithTypeWidening at ispc/src/expr.cpp:9092
#6  ispc::FunctionSymbolExpr::computeOverloadCost at ispc/src/expr.cpp:9608
#7  ispc::FunctionSymbolExpr::FindBestMatchCost at ispc/src/expr.cpp:9665
#8  ispc::FunctionSymbolExpr::ResolveOverloads at ispc/src/expr.cpp:9772
#9  ispc::FunctionCallExpr::TypeCheck at ispc/src/expr.cpp:4301
#10 lTypeCheckNode at ispc/src/ast.cpp:337
#11 ispc::WalkAST at ispc/src/ast.cpp:323
#12 ispc::WalkAST at ispc/src/ast.cpp:275
#13 ispc::WalkAST at ispc/src/ast.cpp:204
#14 ispc::WalkAST at ispc/src/ast.cpp:251
#15 ispc::WalkAST at ispc/src/ast.cpp:228
#16 ispc::WalkAST at ispc/src/ast.cpp:251
#17 ispc::TypeCheck at ispc/src/ast.cpp:339
#18 ispc::TypeCheck at ispc/src/ast.cpp:343
#19 ispc::Function::typeCheckAndOptimize at ispc/src/func.cpp:227
#20 ispc::Function::Function at ispc/src/func.cpp:196
#21 ispc::AST::AddFunction at ispc/src/ast.cpp:127
#22 ispc::Module::AddFunctionDefinition at ispc/src/module.cpp:1236
#23 yyparse at src/parse.yy:2778
#24 lParseCPPBuffer at ispc/src/preprocessor.cpp:552
#25 ispc::Module::preprocessAndParse at ispc/src/preprocessor.cpp:575
#26 ispc::Module::CompileFile at ispc/src/module.cpp:359
#27 ispc::Module::CompileSingleTarget at ispc/src/module.cpp:2329
#28 ispc::Module::CompileAndOutput at ispc/src/module.cpp:2675
#29 main at ispc/src/main.cpp:1354
```

I think this type is not expected because it the function call to `lIsMatchWithTypeWidening` is done quite early so the type checking errors are not yet generated. 

Since the `nullptr` is already handled by the function, I think it is safe to just add naively a new entry in the `switch` and return `false` in this case. If such a type is encountered, a ISPC should always be raised anyway and there is no case where the conversion can be true since no function parameter is supposed to have a type `void`. Once this is done, I get this (expected) error:

```
/tmp/test.ispc:9:25: Error: Unable to find any matching overload for call to function "cube". 
        Passed types: (void) 
        Candidate: void(varying float x) 
        values[index] = cube(cube(values[index]));
                        ^^^^

/tmp/test.ispc:2:12: Error: Can't return non-void type "varying float" from void function. 
    return x * x * x;
           ^^^^^^^^^
```

I also added a lit-test for that (and formatted the code properly).
