### PR TITLE
Enforce type check

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -364,16 +364,7 @@ static ASTNode *lOptimizeNode(ASTNode *node, void *) {
         return node;
     }
 
-    // TODO: Uncomment this if you want to enforce type checking before optimization
-    // Note: This is commented out because causes some lit tests failing
-    // Eventually we should ensure that all nodes are type-checked before optimization.
-    /*if (!node->IsTypeChecked()) {
-        node = lTypeCheckNode(node, nullptr);
-        if (!node) {
-            return nullptr;
-        }
-    }
-    Assert(node->IsTypeChecked() && "Node must be type-checked before optimization");*/
+    Assert(node->IsTypeChecked() && "Node must be type-checked before optimization");
 
     // Mark that we're starting the optimization process for this node
     node->StartOptimize();
@@ -401,6 +392,35 @@ ASTNode *ispc::TypeCheck(ASTNode *root) { return WalkAST(root, nullptr, lTypeChe
 Expr *ispc::TypeCheck(Expr *expr) { return (Expr *)TypeCheck((ASTNode *)expr); }
 
 Stmt *ispc::TypeCheck(Stmt *stmt) { return (Stmt *)TypeCheck((ASTNode *)stmt); }
+
+/**
+ * Performs type checking followed by optimization on the given node.
+ * This encapsulates the common pattern of calling TypeCheck() followed by Optimize().
+ */
+ASTNode *ispc::TypeCheckAndOptimize(ASTNode *root) {
+    if (root == nullptr) {
+        return nullptr;
+    }
+
+    // First type check
+    ASTNode *result = TypeCheck(root);
+    if (result == nullptr) {
+        return nullptr;
+    }
+
+    // Then optimize
+    return Optimize(result);
+}
+
+/**
+ * Convenience version of TypeCheckAndOptimize() for Expr *s
+ */
+Expr *ispc::TypeCheckAndOptimize(Expr *expr) { return (Expr *)TypeCheckAndOptimize((ASTNode *)expr); }
+
+/**
+ * Convenience version of TypeCheckAndOptimize() for Stmt *s
+ */
+Stmt *ispc::TypeCheckAndOptimize(Stmt *stmt) { return (Stmt *)TypeCheckAndOptimize((ASTNode *)stmt); }
 
 struct CostData {
     CostData() { cost = foreachDepth = 0; }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -332,7 +332,20 @@ static ASTNode *lTypeCheckNode(ASTNode *node, void *) {
         return node;
     }
 
+    if (node->IsTypeCheckInProgress()) {
+        // It should not happen but if it did return node without marking it as type-checked to avoid recursion
+        Assert(node->IsTypeCheckInProgress());
+        return node;
+    }
+
+    // Mark that we're starting the type check process for this node
+    node->StartTypeCheck();
+
     ASTNode *result = node->TypeCheck();
+
+    // Mark that we're finished with type checking this node
+    node->FinishTypeCheck();
+
     if (result) {
         // Mark result as type-checked too
         result->SetTypeChecked();
@@ -343,6 +356,11 @@ static ASTNode *lTypeCheckNode(ASTNode *node, void *) {
 static ASTNode *lOptimizeNode(ASTNode *node, void *) {
     // Skip if already optimized
     if (node->IsOptimized()) {
+        return node;
+    }
+
+    if (node->IsOptimizeInProgress()) {
+        // It should not happen but if it did return node without marking it as optimized to avoid recursion
         return node;
     }
 
@@ -357,8 +375,15 @@ static ASTNode *lOptimizeNode(ASTNode *node, void *) {
     }
     Assert(node->IsTypeChecked() && "Node must be type-checked before optimization");*/
 
+    // Mark that we're starting the optimization process for this node
+    node->StartOptimize();
+
     // Now proceed with optimization
     ASTNode *result = node->Optimize();
+
+    // Mark that we're finished with optimizing this node
+    node->FinishOptimize();
+
     if (result) {
         result->SetOptimized();
     }

--- a/src/ast.h
+++ b/src/ast.h
@@ -275,6 +275,16 @@ extern Expr *TypeCheck(Expr *);
 /** Convenience version of TypeCheck() for Stmt *s that returns an Stmt *. */
 extern Stmt *TypeCheck(Stmt *);
 
+/** Performs both type checking and optimization on the given AST (or portion of one) in a single call.
+    Returns a pointer to the root of the resulting AST. */
+extern ASTNode *TypeCheckAndOptimize(ASTNode *root);
+
+/** Convenience version of TypeCheckAndOptimize() for Expr *s that returns an Expr *. */
+extern Expr *TypeCheckAndOptimize(Expr *);
+
+/** Convenience version of TypeCheckAndOptimize() for Stmt *s that returns a Stmt *. */
+extern Stmt *TypeCheckAndOptimize(Stmt *);
+
 /** Returns an estimate of the execution cost of the tree starting at
     the given root. */
 extern int EstimateCost(ASTNode *root);

--- a/src/ast.h
+++ b/src/ast.h
@@ -170,8 +170,10 @@ class ASTNode : public Traceable {
     };
 
     enum StateFlag : uint32_t {
-        OPTIMIZED_FLAG = 1 << 0,  // 0x01
-        TYPECHECKED_FLAG = 1 << 1 // 0x02
+        OPTIMIZED_FLAG = 1 << 0,              // 0x01
+        TYPECHECKED_FLAG = 1 << 1,            // 0x02
+        TYPE_CHECK_IN_PROGRESS_FLAG = 1 << 2, // 0x04
+        OPTIMIZE_IN_PROGRESS_FLAG = 1 << 3    // 0x08
     };
     /** Return an ID for the concrete type of this object. This is used to
         implement the classof checks.  This should not be used for any
@@ -192,8 +194,18 @@ class ASTNode : public Traceable {
     // State methods
     bool IsOptimized() const { return StateFlags & OPTIMIZED_FLAG; }
     bool IsTypeChecked() const { return StateFlags & TYPECHECKED_FLAG; }
+    bool IsTypeCheckInProgress() const { return StateFlags & TYPE_CHECK_IN_PROGRESS_FLAG; }
+    bool IsOptimizeInProgress() const { return StateFlags & OPTIMIZE_IN_PROGRESS_FLAG; }
     void SetOptimized() const { StateFlags |= OPTIMIZED_FLAG; }
     void SetTypeChecked() const { StateFlags |= TYPECHECKED_FLAG; }
+    // The method below prevent recursive type checking (when we call GetType() from TypeCheck())
+    // and must always be paired with a corresponding FinishTypeCheck() call.
+    void StartTypeCheck() { StateFlags |= TYPE_CHECK_IN_PROGRESS_FLAG; }
+    void FinishTypeCheck() { StateFlags &= ~TYPE_CHECK_IN_PROGRESS_FLAG; }
+    // The method below prevent recursive optimization (when we call GetType() from Optimize())
+    // and must always be paired with a corresponding FinishTypeCheck() call.
+    void StartOptimize() { StateFlags |= OPTIMIZE_IN_PROGRESS_FLAG; }
+    void FinishOptimize() { StateFlags &= ~OPTIMIZE_IN_PROGRESS_FLAG; }
 
     // State transfer helper for when nodes are replaced
     void CopyStateTo(ASTNode *other) const { other->StateFlags = this->StateFlags; }

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -1016,8 +1016,7 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
             // Try to find an initializer expression.
             while (decl != nullptr) {
                 if (decl->initExpr != nullptr) {
-                    decl->initExpr = TypeCheck(decl->initExpr);
-                    decl->initExpr = Optimize(decl->initExpr);
+                    decl->initExpr = TypeCheckAndOptimize(decl->initExpr);
                     if (decl->initExpr != nullptr) {
                         init = llvm::dyn_cast<ConstExpr>(decl->initExpr);
                         if (init == nullptr) {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1857,8 +1857,12 @@ bool lCreateBinaryOperatorCall(const BinaryExpr::Op bop, Expr *a0, Expr *a1, Exp
     if ((a0 == nullptr) || (a1 == nullptr)) {
         return abort;
     }
-    Expr *arg0 = a0;
-    Expr *arg1 = a1;
+    Expr *arg0 = TypeCheck(a0);
+    Expr *arg1 = TypeCheck(a1);
+
+    if ((arg0 == nullptr) || (arg1 == nullptr)) {
+        return false;
+    }
 
     const Type *type0 = arg0->GetType();
     const Type *type1 = arg1->GetType();

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1504,7 +1504,7 @@ std::string UnaryExpr::GetString() const {
 }
 
 void UnaryExpr::Print(Indent &indent) const {
-    if (!expr || !GetType()) {
+    if (!expr || !GetTypeUnsafe()) {
         indent.Print("UnaryExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -1512,7 +1512,7 @@ void UnaryExpr::Print(Indent &indent) const {
 
     indent.Print("UnaryExpr", pos);
 
-    printf("[ %s ] ", GetType()->GetString().c_str());
+    printf("[ %s ] ", GetTypeUnsafe()->GetString().c_str());
     switch (op) {
     case PreInc: ///< Pre-increment
         printf("prefix '++'");
@@ -3117,7 +3117,7 @@ std::string BinaryExpr::GetString() const {
 }
 
 void BinaryExpr::Print(Indent &indent) const {
-    if (!arg0 || !arg1 || !GetType()) {
+    if (!arg0 || !arg1 || !GetTypeUnsafe()) {
         indent.Print("BinaryExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -3125,7 +3125,7 @@ void BinaryExpr::Print(Indent &indent) const {
 
     indent.Print("BinaryExpr", pos);
 
-    printf("[ %s ], '%s'\n", GetType()->GetString().c_str(), lOpString(op));
+    printf("[ %s ], '%s'\n", GetTypeUnsafe()->GetString().c_str(), lOpString(op));
     indent.pushList(2);
     arg0->Print(indent);
     arg1->Print(indent);
@@ -3598,7 +3598,7 @@ std::string AssignExpr::GetString() const {
 }
 
 void AssignExpr::Print(Indent &indent) const {
-    if (!lvalue || !rvalue || !GetType()) {
+    if (!lvalue || !rvalue || !GetTypeUnsafe()) {
         indent.Print("AssignExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -3606,7 +3606,7 @@ void AssignExpr::Print(Indent &indent) const {
 
     indent.Print("AssignExpr", pos);
 
-    printf("[%s], '%s'\n", GetType()->GetString().c_str(), lOpString(op));
+    printf("[%s], '%s'\n", GetTypeUnsafe()->GetString().c_str(), lOpString(op));
     indent.pushList(2);
     lvalue->Print(indent);
     rvalue->Print(indent);
@@ -4030,7 +4030,7 @@ std::string SelectExpr::GetString() const {
 }
 
 void SelectExpr::Print(Indent &indent) const {
-    if (!test || !expr1 || !expr2 || !GetType()) {
+    if (!test || !expr1 || !expr2 || !GetTypeUnsafe()) {
         indent.Print("SelectExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -4038,7 +4038,7 @@ void SelectExpr::Print(Indent &indent) const {
 
     indent.Print("SelectExpr", pos);
 
-    printf("[%s]\n", GetType()->GetString().c_str());
+    printf("[%s]\n", GetTypeUnsafe()->GetString().c_str());
     indent.pushList(3);
     test->Print(indent);
     expr1->Print(indent);
@@ -4492,14 +4492,15 @@ std::string FunctionCallExpr::GetString() const {
 }
 
 void FunctionCallExpr::Print(Indent &indent) const {
-    if (!func || !args || !GetType()) {
+    if (!func || !args || !GetTypeUnsafe()) {
         indent.Print("FunctionCallExpr: <NULL EXPR>\n");
         indent.Done();
         return;
     }
     indent.Print("FunctionCallExpr", pos);
 
-    printf("[%s] %s %s\n", GetType()->GetString().c_str(), isLaunch ? "launch" : "", isInvoke ? "invoke_sycl" : "");
+    printf("[%s] %s %s\n", GetTypeUnsafe()->GetString().c_str(), isLaunch ? "launch" : "",
+           isInvoke ? "invoke_sycl" : "");
     indent.pushList(2);
     indent.setNextLabel("func");
     func->Print(indent);
@@ -5303,7 +5304,7 @@ std::string IndexExpr::GetString() const {
 }
 
 void IndexExpr::Print(Indent &indent) const {
-    if (!baseExpr || !index || !GetType()) {
+    if (!baseExpr || !index || !GetTypeUnsafe()) {
         indent.Print("IndexExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -5311,7 +5312,7 @@ void IndexExpr::Print(Indent &indent) const {
 
     indent.Print("IndexExpr", pos);
 
-    printf("[%s]\n", GetType()->GetString().c_str());
+    printf("[%s]\n", GetTypeUnsafe()->GetString().c_str());
     indent.pushList(2);
     baseExpr->Print(indent);
     index->Print(indent);
@@ -5905,13 +5906,13 @@ void MemberExpr::Print(Indent &indent) const {
         indent.Print("MemberExpr", pos);
     }
 
-    if (!expr || !GetType()) {
+    if (!expr || !GetTypeUnsafe()) {
         indent.Print(" <NULL EXPR>\n");
         indent.Done();
         return;
     }
 
-    printf("[%s] %s %s\n", GetType()->GetString().c_str(), dereferenceExpr ? "->" : ".", identifier.c_str());
+    printf("[%s] %s %s\n", GetTypeUnsafe()->GetString().c_str(), dereferenceExpr ? "->" : ".", identifier.c_str());
     indent.pushSingle();
     expr->Print(indent);
 
@@ -6704,7 +6705,7 @@ std::string ConstExpr::GetString() const { return GetValuesAsStr(", "); }
 void ConstExpr::Print(Indent &indent) const {
     indent.Print("ConstExpr", pos);
 
-    printf("[%s] (", GetType()->GetString().c_str());
+    printf("[%s] (", GetTypeUnsafe()->GetString().c_str());
     printf("%s", GetValuesAsStr((char *)", ").c_str());
     printf(")\n");
 
@@ -8033,7 +8034,7 @@ std::string TypeCastExpr::GetString() const {
 
 void TypeCastExpr::Print(Indent &indent) const {
     indent.Print("TypeCastExpr", pos);
-    printf("[%s]\n", GetType()->GetString().c_str());
+    printf("[%s]\n", GetTypeUnsafe()->GetString().c_str());
     indent.pushSingle();
     expr->Print(indent);
     indent.Done();
@@ -8206,7 +8207,7 @@ std::string ReferenceExpr::GetString() const {
 }
 
 void ReferenceExpr::Print(Indent &indent) const {
-    if (expr == nullptr || GetType() == nullptr) {
+    if (expr == nullptr || GetTypeUnsafe() == nullptr) {
         indent.Print("ReferenceExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -8214,7 +8215,7 @@ void ReferenceExpr::Print(Indent &indent) const {
 
     indent.Print("ReferenceExpr", pos);
 
-    printf("[%s]\n", GetType()->GetString().c_str());
+    printf("[%s]\n", GetTypeUnsafe()->GetString().c_str());
     indent.pushSingle();
     expr->Print(indent);
 
@@ -8353,7 +8354,7 @@ std::string PtrDerefExpr::GetString() const {
 }
 
 void PtrDerefExpr::Print(Indent &indent) const {
-    if (expr == nullptr || GetType() == nullptr) {
+    if (expr == nullptr || GetTypeUnsafe() == nullptr) {
         indent.Print("PtrDerefExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -8361,7 +8362,7 @@ void PtrDerefExpr::Print(Indent &indent) const {
 
     indent.Print("PtrDerefExpr", pos);
 
-    printf("[%s]\n", GetType()->GetString().c_str());
+    printf("[%s]\n", GetTypeUnsafe()->GetString().c_str());
     indent.pushSingle();
     expr->Print(indent);
 
@@ -8428,14 +8429,14 @@ std::string RefDerefExpr::GetString() const {
 }
 
 void RefDerefExpr::Print(Indent &indent) const {
-    if (expr == nullptr || GetType() == nullptr) {
+    if (expr == nullptr || GetTypeUnsafe() == nullptr) {
         indent.Print("RefDerefExpr: <NULL EXPR>\n");
         return;
     }
 
     indent.Print("RefDerefExpr", pos);
 
-    printf("[%s]\n", GetType()->GetString().c_str());
+    printf("[%s]\n", GetTypeUnsafe()->GetString().c_str());
     indent.pushSingle();
     expr->Print(indent);
 
@@ -8511,7 +8512,7 @@ std::string AddressOfExpr::GetString() const {
 }
 
 void AddressOfExpr::Print(Indent &indent) const {
-    if (expr == nullptr || GetType() == nullptr) {
+    if (expr == nullptr || GetTypeUnsafe() == nullptr) {
         indent.Print("AddressOfExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -8519,7 +8520,7 @@ void AddressOfExpr::Print(Indent &indent) const {
 
     indent.Print("AddressOfExpr", pos);
 
-    printf("[%s]\n", GetType()->GetString().c_str());
+    printf("[%s]\n", GetTypeUnsafe()->GetString().c_str());
     indent.pushSingle();
     expr->Print(indent);
 
@@ -8879,7 +8880,7 @@ std::string SymbolExpr::GetString() const {
 }
 
 void SymbolExpr::Print(Indent &indent) const {
-    if (symbol == nullptr || GetType() == nullptr) {
+    if (symbol == nullptr || GetTypeUnsafe() == nullptr) {
         indent.Print("SymbolExpr: <NULL EXPR>\n");
         indent.Done();
         return;
@@ -8887,7 +8888,7 @@ void SymbolExpr::Print(Indent &indent) const {
 
     indent.Print("SymbolExpr", pos);
 
-    printf("[%s] symbol name: %s\n", GetType()->GetString().c_str(), symbol->name.c_str());
+    printf("[%s] symbol name: %s\n", GetTypeUnsafe()->GetString().c_str(), symbol->name.c_str());
 
     indent.Done();
 }
@@ -8965,7 +8966,7 @@ std::string FunctionSymbolExpr::GetString() const {
 }
 
 void FunctionSymbolExpr::Print(Indent &indent) const {
-    const Type *type = GetType();
+    const Type *type = GetTypeUnsafe();
 
     indent.Print("FunctionSymbolExpr", pos);
 

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -4322,6 +4322,9 @@ Expr *FunctionCallExpr::TypeCheck() {
             return nullptr;
         }
 
+        if (func->GetType() != nullptr && func->GetType()->IsDependent()) {
+            return this;
+        }
         funcType = CastType<FunctionType>(func->GetType());
         if (funcType == nullptr) {
             const PointerType *pt = CastType<PointerType>(func->GetType());

--- a/src/expr.h
+++ b/src/expr.h
@@ -33,7 +33,7 @@ class Expr : public ASTNode {
     virtual const Type *GetType() const;
 
     /** Returns the Type of the expression.
-        For debugging/AST print, no type-checking guarantee.*/
+        For debugging/AST print, calls from TypeCheck itself, no type-checking guarantee.*/
     virtual const Type *GetTypeUnsafe() const;
 
     /** This is the main method for Expr implementations to implement.  It

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -1268,8 +1268,7 @@ Symbol *TemplateInstantiation::InstantiateSymbol(Symbol *sym) {
         Expr *convertedExpr =
             ::TypeConvertExpr(const_cast<ConstExpr *>(ce), sym->type, "template parameter instantiation");
         if (convertedExpr) {
-            convertedExpr = ::TypeCheck(convertedExpr);
-            convertedExpr = ::Optimize(convertedExpr);
+            convertedExpr = ::TypeCheckAndOptimize(convertedExpr);
             ce = llvm::dyn_cast<ConstExpr>(convertedExpr);
         }
         instSym->constValue = ce ? ce->Instantiate(*this) : nullptr;

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -1265,11 +1265,12 @@ Symbol *TemplateInstantiation::InstantiateSymbol(Symbol *sym) {
         const TemplateArg *arg = argsMap[sym->name];
         Assert(arg != nullptr);
         const ConstExpr *ce = arg->GetAsConstExpr();
-        if (ce != nullptr) {
-            // Do a little type cast to the actual template parameter type here and optimize it
-            Expr *castExpr = new TypeCastExpr(sym->type, const_cast<ConstExpr *>(ce), sym->pos);
-            castExpr = Optimize(castExpr);
-            ce = llvm::dyn_cast<ConstExpr>(castExpr);
+        Expr *convertedExpr =
+            ::TypeConvertExpr(const_cast<ConstExpr *>(ce), sym->type, "template parameter instantiation");
+        if (convertedExpr) {
+            convertedExpr = ::TypeCheck(convertedExpr);
+            convertedExpr = ::Optimize(convertedExpr);
+            ce = llvm::dyn_cast<ConstExpr>(convertedExpr);
         }
         instSym->constValue = ce ? ce->Instantiate(*this) : nullptr;
     } else {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -465,7 +465,7 @@ Expr *lCreateConstExpr(ExprList *exprList, const AtomicType::BasicType basicType
 
     int i = 0;
     for (Expr *expr : exprList->exprs) {
-        const ConstExpr *ce = llvm::dyn_cast<ConstExpr>(Optimize(expr));
+        const ConstExpr *ce = llvm::dyn_cast<ConstExpr>(TypeCheckAndOptimize(expr));
         // ConstExpr of length 1 implies that it contains uniform value
         if (!ce || ce->Count() != 1) {
             canConstructConstExpr = false;
@@ -652,7 +652,11 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
                 }
 
                 if (initExpr != nullptr) {
-                    initExpr = Optimize(initExpr);
+                    initExpr = TypeCheckAndOptimize(initExpr);
+                    if (initExpr == nullptr) {
+                        Error(pos, "Initialization of global variable \"%s\" was unsuccessful.", name.c_str());
+                        return;
+                    }
                     // Fingers crossed, now let's see if we've got a
                     // constant value..
                     std::pair<llvm::Constant *, bool> initPair = initExpr->GetStorageConstant(type);

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -3620,10 +3620,7 @@ static bool
 lGetConstantIntOrSymbol(Expr *expr, std::variant<std::monostate, int, Symbol*> *value, SourcePos pos, const char *usage) {
     if (expr == nullptr)
         return false;
-    expr = TypeCheck(expr);
-    if (expr == nullptr)
-        return false;
-    expr = Optimize(expr);
+    expr = TypeCheckAndOptimize(expr);
     if (expr == nullptr)
         return false;
     const SymbolExpr* se= llvm::dyn_cast<SymbolExpr>(expr);
@@ -3735,7 +3732,11 @@ lFinalizeEnumeratorSymbols(std::vector<Symbol *> &enums,
                us end up with a ConstExpr with the desired EnumType... */
             Expr *castExpr = new TypeCastExpr(constUniformType, enums[i]->constValue,
                                               enums[i]->pos);
-            castExpr = Optimize(castExpr);
+            castExpr = TypeCheckAndOptimize(castExpr);
+            if (castExpr == nullptr) {
+                AssertPos(enums[i]->pos, m->errorCount > 0);
+                continue;
+            }
             enums[i]->constValue = llvm::dyn_cast<ConstExpr>(castExpr);
             AssertPos(enums[i]->pos, enums[i]->constValue != nullptr);
         }

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -215,14 +215,14 @@ void DeclStmt::EmitCode(FunctionEmitContext *ctx) const {
                     // FIXME: and this is only needed to re-establish
                     // constant-ness so that GetConstant below works for
                     // constant artithmetic expressions...
-                    initExpr = ::Optimize(initExpr);
+                    initExpr = ::TypeCheckAndOptimize(initExpr);
                 }
 
                 std::pair<llvm::Constant *, bool> cinitPair = initExpr->GetStorageConstant(sym->type);
                 cinit = cinitPair.first;
                 if (cinit == nullptr) {
                     Error(initExpr->pos,
-                          "Initializer for static variable "
+                          "InitializWer for static variable "
                           "\"%s\" must be a constant.",
                           sym->name.c_str());
                 }


### PR DESCRIPTION
 The primary focus of this PR is adding state tracking for type checking and optimization processes, introducing a unified `TypeCheckAndOptimize` function, and enhancing safety by preventing recursive operations. Additionally, it refactors existing methods to leverage these new mechanisms for better maintainability and robustness.

## Enhancements to `ASTNode` state tracking:
* Added `StateFlags` to `ASTNode` to track optimization and type-checking states (`OPTIMIZED_FLAG`, `TYPECHECKED_FLAG`, etc.). This includes methods to check, set, start, and finish these states, ensuring safe and non-recursive operations.

## Unified type checking and optimization:
* Introduced `TypeCheckAndOptimize` functions for `ASTNode`, `Expr`, and `Stmt`, combining type checking and optimization into a single call. This simplifies code and reduces redundant calls. 

## Refactoring for safety and consistency:
* Replaced direct calls to `TypeCheck` and `Optimize` with `TypeCheckAndOptimize` in various parts of the codebase to ensure the new unified process is used. 
* Introduced a `GetTypeUnsafe` method for cases where type-checking safety checks need to be bypassed, ensuring no infinite recursion occurs. 

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed