### PR TITLE
Extended operators support

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1954,81 +1954,6 @@ BinaryExpr::BinaryExpr(Op o, Expr *a, Expr *b, SourcePos p) : Expr(p, BinaryExpr
     arg1 = b;
 }
 
-bool lCreateBinaryOperatorCall(const BinaryExpr::Op bop, Expr *a0, Expr *a1, Expr *&op, const SourcePos &sp) {
-    bool abort = false;
-    if ((a0 == nullptr) || (a1 == nullptr)) {
-        return abort;
-    }
-    Expr *arg0 = TypeCheck(a0);
-    Expr *arg1 = TypeCheck(a1);
-
-    if ((arg0 == nullptr) || (arg1 == nullptr)) {
-        return false;
-    }
-
-    const Type *type0 = arg0->GetType();
-    const Type *type1 = arg1->GetType();
-
-    // If either operand is a reference, dereference it before we move
-    // forward
-    if (CastType<ReferenceType>(type0) != nullptr) {
-        arg0 = new RefDerefExpr(arg0, arg0->pos);
-        type0 = arg0->GetType();
-    }
-    if (CastType<ReferenceType>(type1) != nullptr) {
-        arg1 = new RefDerefExpr(arg1, arg1->pos);
-        type1 = arg1->GetType();
-    }
-    if ((type0 == nullptr) || (type1 == nullptr)) {
-        return abort;
-    }
-    if (CastType<StructType>(type0) != nullptr || CastType<StructType>(type1) != nullptr) {
-        std::string opName = std::string("operator") + lOpString(bop);
-        std::vector<Symbol *> funcs;
-        bool foundAnyFunction = m->symbolTable->LookupFunction(opName.c_str(), &funcs);
-        std::vector<TemplateSymbol *> funcTempls;
-        bool foundAnyTemplate = m->symbolTable->LookupFunctionTemplate(opName.c_str(), &funcTempls);
-        if (foundAnyFunction || foundAnyTemplate) {
-            FunctionSymbolExpr *functionSymbolExpr =
-                new FunctionSymbolExpr(opName.c_str(), funcs, funcTempls, TemplateArgs(), sp);
-            Assert(functionSymbolExpr != nullptr);
-            ExprList *args = new ExprList(sp);
-            args->exprs.push_back(arg0);
-            args->exprs.push_back(arg1);
-            op = new FunctionCallExpr(functionSymbolExpr, args, sp);
-            return abort;
-        }
-        if (funcs.size() == 0 && funcTempls.size() == 0) {
-            Error(sp, "operator %s(%s, %s) is not defined.", opName.c_str(), (type0->GetString()).c_str(),
-                  (type1->GetString()).c_str());
-            abort = true;
-            return abort;
-        }
-
-        return abort;
-    }
-    return abort;
-}
-
-Expr *ispc::MakeBinaryExpr(BinaryExpr::Op o, Expr *a, Expr *b, SourcePos p) {
-    Expr *op = nullptr;
-    bool abort = lCreateBinaryOperatorCall(o, a, b, op, p);
-    if (op != nullptr) {
-        return op;
-    }
-
-    // lCreateBinaryOperatorCall can return nullptr for 2 cases:
-    // 1. When there is an error.
-    // 2. We have to create a new BinaryExpr.
-    if (abort) {
-        AssertPos(p, m->errorCount > 0);
-        return nullptr;
-    }
-
-    op = new BinaryExpr(o, a, b, p);
-    return op;
-}
-
 /** Emit code for a && or || logical operator.  In particular, the code
     here handles "short-circuit" evaluation, where the second expression
     isn't evaluated if the value of the first one determines the value of
@@ -2863,6 +2788,13 @@ Expr *BinaryExpr::TypeCheck() {
         return this;
     }
 
+    // Resolve expression to operator overload if necessary
+    const std::vector<Expr *> args = {arg0, arg1};
+    Expr *opExpr = PossiblyResolveStructOperatorOverloads(lOpString(op), args, pos, false);
+    if (opExpr != nullptr) {
+        return opExpr;
+    }
+
     // If either operand is a reference, dereference it before we move
     // forward
     if (CastType<ReferenceType>(type0) != nullptr) {
@@ -3201,7 +3133,7 @@ int BinaryExpr::EstimateCost() const {
 Expr *BinaryExpr::Instantiate(TemplateInstantiation &templInst) const {
     Expr *instArg0 = arg0 ? arg0->Instantiate(templInst) : nullptr;
     Expr *instArg1 = arg1 ? arg1->Instantiate(templInst) : nullptr;
-    return MakeBinaryExpr(op, instArg0, instArg1, pos);
+    return new BinaryExpr(op, instArg0, instArg1, pos);
 }
 
 std::string BinaryExpr::GetString() const {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -3550,6 +3550,13 @@ Expr *AssignExpr::TypeCheck() {
         return this;
     }
 
+    // Resolve expression to operator overload if necessary
+    const std::vector<Expr *> args = {lvalue, rvalue};
+    Expr *opExpr = PossiblyResolveStructOperatorOverloads(lOpString(op), args, pos, false);
+    if (opExpr != nullptr) {
+        return opExpr;
+    }
+
     bool lvalueIsReference = CastType<ReferenceType>(lvalue->GetType()) != nullptr;
     if (lvalueIsReference) {
         lvalue = new RefDerefExpr(lvalue, lvalue->pos);

--- a/src/expr.h
+++ b/src/expr.h
@@ -962,4 +962,11 @@ Expr *MakeBinaryExpr(BinaryExpr::Op o, Expr *a, Expr *b, SourcePos p);
 void InitSymbol(AddressInfo *lvalue, const Type *symType, Expr *initExpr, FunctionEmitContext *ctx, SourcePos pos);
 
 bool PossiblyResolveFunctionOverloads(Expr *expr, const Type *type);
+
+/** This function encapsulates the common logic for looking up and calling
+    overloaded operators when at least one of the operands is a struct type.
+    It supports assign, unary and binary operators.
+*/
+Expr *PossiblyResolveStructOperatorOverloads(const char *baseOpName, const std::vector<Expr *> &args, SourcePos pos,
+                                             bool isPostfix = false);
 } // namespace ispc

--- a/src/expr.h
+++ b/src/expr.h
@@ -947,8 +947,6 @@ bool CanConvertTypes(const Type *fromType, const Type *toType, const char *error
  */
 Expr *TypeConvertExpr(Expr *expr, const Type *toType, const char *errorMsgBase);
 
-Expr *MakeBinaryExpr(BinaryExpr::Op o, Expr *a, Expr *b, SourcePos p);
-
 /** Utility routine that emits code to initialize a symbol given an
     initializer expression.
 

--- a/src/lex.ll
+++ b/src/lex.ll
@@ -412,6 +412,12 @@ while { return TOKEN_WHILE; }
 "operator&&" { return lParseOperator(yytext); }
 "operator||" { return lParseOperator(yytext); }
 
+"operator++" { return lParseOperator(yytext); }
+"operator--" { return lParseOperator(yytext); }
+"operator~" { return lParseOperator(yytext); }
+"operator!" { return lParseOperator(yytext); }
+
+
 L?\"(\\.|[^\\"])*\" { lStringConst(&yylval, &yylloc); return TOKEN_STRING_LITERAL; }
 
 {IDENT} {

--- a/src/lex.ll
+++ b/src/lex.ll
@@ -400,6 +400,17 @@ while { return TOKEN_WHILE; }
 "operator>>" { return lParseOperator(yytext); }
 "operator/"  { return lParseOperator(yytext); }
 "operator%"  { return lParseOperator(yytext); }
+"operator==" { return lParseOperator(yytext); }
+"operator!=" { return lParseOperator(yytext); }
+"operator>" { return lParseOperator(yytext); }
+"operator<" { return lParseOperator(yytext); }
+"operator>=" { return lParseOperator(yytext); }
+"operator<=" { return lParseOperator(yytext); }
+"operator&" { return lParseOperator(yytext); }
+"operator^" { return lParseOperator(yytext); }
+"operator|" { return lParseOperator(yytext); }
+"operator&&" { return lParseOperator(yytext); }
+"operator||" { return lParseOperator(yytext); }
 
 L?\"(\\.|[^\\"])*\" { lStringConst(&yylval, &yylloc); return TOKEN_STRING_LITERAL; }
 

--- a/src/lex.ll
+++ b/src/lex.ll
@@ -417,6 +417,18 @@ while { return TOKEN_WHILE; }
 "operator~" { return lParseOperator(yytext); }
 "operator!" { return lParseOperator(yytext); }
 
+"operator*=" { return lParseOperator(yytext); }
+"operator/=" { return lParseOperator(yytext); }
+"operator%=" { return lParseOperator(yytext); }
+"operator+=" { return lParseOperator(yytext); }
+"operator-=" { return lParseOperator(yytext); }
+"operator<<=" { return lParseOperator(yytext); }
+"operator>>=" { return lParseOperator(yytext); }
+"operator&=" { return lParseOperator(yytext); }
+"operator|=" { return lParseOperator(yytext); }
+"operator^=" { return lParseOperator(yytext); }
+"operator=" { return lParseOperator(yytext); }
+
 
 L?\"(\\.|[^\\"])*\" { lStringConst(&yylval, &yylloc); return TOKEN_STRING_LITERAL; }
 

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -863,27 +863,27 @@ cast_expression
 multiplicative_expression
     : cast_expression
     | multiplicative_expression '*' cast_expression
-      { $$ = MakeBinaryExpr(BinaryExpr::Mul, $1, $3, Union(@1, @3)); }
+      { $$ = new BinaryExpr(BinaryExpr::Mul, $1, $3, Union(@1, @3)); }
     | multiplicative_expression '/' cast_expression
-      { $$ = MakeBinaryExpr(BinaryExpr::Div, $1, $3, Union(@1, @3)); }
+      { $$ = new BinaryExpr(BinaryExpr::Div, $1, $3, Union(@1, @3)); }
     | multiplicative_expression '%' cast_expression
-      { $$ = MakeBinaryExpr(BinaryExpr::Mod, $1, $3, Union(@1, @3)); }
+      { $$ = new BinaryExpr(BinaryExpr::Mod, $1, $3, Union(@1, @3)); }
     ;
 
 additive_expression
     : multiplicative_expression
     | additive_expression '+' multiplicative_expression
-      { $$ = MakeBinaryExpr(BinaryExpr::Add, $1, $3, Union(@1, @3)); }
+      { $$ = new BinaryExpr(BinaryExpr::Add, $1, $3, Union(@1, @3)); }
     | additive_expression '-' multiplicative_expression
-      { $$ = MakeBinaryExpr(BinaryExpr::Sub, $1, $3, Union(@1, @3)); }
+      { $$ = new BinaryExpr(BinaryExpr::Sub, $1, $3, Union(@1, @3)); }
     ;
 
 shift_expression
     : additive_expression
     | shift_expression TOKEN_LEFT_OP additive_expression
-      { $$ = MakeBinaryExpr(BinaryExpr::Shl, $1, $3, Union(@1, @3)); }
+      { $$ = new BinaryExpr(BinaryExpr::Shl, $1, $3, Union(@1, @3)); }
     | shift_expression TOKEN_RIGHT_OP additive_expression
-      { $$ = MakeBinaryExpr(BinaryExpr::Shr, $1, $3, Union(@1, @3)); }
+      { $$ = new BinaryExpr(BinaryExpr::Shr, $1, $3, Union(@1, @3)); }
     ;
 
 relational_expression

--- a/tests/func-tests/operators3.ispc
+++ b/tests/func-tests/operators3.ispc
@@ -1,0 +1,43 @@
+#include "test_static.isph"
+
+struct S {
+    uint a;
+};
+
+uint operator==(struct S rr, struct S rv) {
+    return rr.a == rv.a;
+}
+
+uint operator!=(struct S rr, struct S rv) {
+    return rr.a != rv.a;
+}
+
+uint operator>(struct S rr, struct S rv) {
+    return rr.a > rv.a;
+}
+
+uint operator<(struct S rr, struct S rv) {
+    return rr.a < rv.a;
+}
+
+uint operator>=(struct S rr, struct S rv) {
+    return rr.a >= rv.a;
+}
+
+uint operator<=(struct S rr, struct S rv) {
+    return rr.a <= rv.a;
+}
+
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    struct S a;
+    struct S b;
+
+    a.a = aFOO[programIndex];
+    b.a = aFOO[programIndex] + 5;
+
+    RET[programIndex] = (a == b) + (a != b) + (a > b) + (a < b) + (a >= b) + (a <= b);
+}
+
+task void result(uniform float RET[16]) {
+    RET[programIndex] = 3;
+}

--- a/tests/func-tests/operators4.ispc
+++ b/tests/func-tests/operators4.ispc
@@ -1,0 +1,97 @@
+#include "test_static.isph"
+
+struct S {
+    uint a;
+};
+
+struct S operator&(struct S rr, struct S rv) {
+    struct S c;
+    c.a = rr.a & rv.a;
+    return c;
+}
+
+struct S operator|(struct S rr, struct S rv) {
+    struct S c;
+    c.a = rr.a | rv.a;
+    return c;
+}
+
+struct S operator&&(struct S rr, struct S rv) {
+    struct S c;
+    c.a = rr.a && rv.a;
+    return c;
+}
+
+struct S operator||(struct S rr, struct S rv) {
+    struct S c;
+    c.a = rr.a || rv.a;
+    return c;
+}
+
+struct S operator^(struct S rr, struct S rv) {
+    struct S c;
+    c.a = rr.a ^ rv.a;
+    return c;
+}
+
+struct S operator&(struct S &rr, struct S rv) {
+    struct S c;
+    c.a = (rr.a & rv.a) + 1; // Add 1 to distinguish reference version
+    return c;
+}
+
+struct S operator|(struct S rr, struct S &rv) {
+    struct S c;
+    c.a = (rr.a | rv.a) + 1; // Add 1 to distinguish reference version
+    return c;
+}
+
+struct S operator&&(struct S &rr, struct S &rv) {
+    struct S c;
+    c.a = (uint)(rr.a && rv.a) + 1; // Add 1 to distinguish reference version
+    return c;
+}
+
+struct S operator||(struct S &rr, struct S &rv) {
+    struct S c;
+    c.a = (uint)(rr.a || rv.a) + 1; // Add 1 to distinguish reference version
+    return c;
+}
+
+struct S operator^(struct S &rr, struct S &rv) {
+    struct S c;
+    c.a = (rr.a ^ rv.a) + 1; // Add 1 to distinguish reference version
+    return c;
+}
+
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    struct S a;
+    struct S b;
+    struct S c;
+
+    a.a = aFOO[programIndex];
+    b.a = aFOO[programIndex] + 1;
+    c.a = aFOO[programIndex] + 2;
+    struct S d;
+    if (programIndex < 3)
+        d = (a && b) & b | c ^ a;
+    else
+        d = a || b;
+    RET[programIndex] = reduce_add(d.a);
+
+    // Create references
+    struct S &refA = a;
+    struct S &refB = b;
+    struct S &refC = c;
+
+    if (programIndex < 3)
+        d = (refA && refB) & b | refC ^ refA; // Mix of references and values
+    else
+        d = refA || refB;
+
+    RET[programIndex] += reduce_add(d.a);
+}
+
+task void result(uniform float RET[16]) {
+    RET[programIndex] = 23 + programCount*3;
+}

--- a/tests/func-tests/operators5.ispc
+++ b/tests/func-tests/operators5.ispc
@@ -1,0 +1,59 @@
+#include "test_static.isph"
+
+struct S {
+    int a;
+};
+
+// Prefix increment (++x)
+struct S& operator++(struct S &rs) {
+    rs.a = rs.a + 1;
+    return rs;
+}
+
+// Prefix decrement (--x)
+struct S& operator--(struct S &rs) {
+    rs.a = rs.a - 1;
+    return rs;
+}
+
+// Postfix increment (x++)
+struct S operator++(struct S &rs, int) {
+    struct S temp;
+    temp.a = rs.a;
+    rs.a = rs.a + 1;
+    return temp;
+}
+
+// Postfix decrement (x--)
+struct S operator--(struct S &rs, int) {
+    struct S temp;
+    temp.a = rs.a;
+    rs.a = rs.a - 1;
+    return temp;
+}
+
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    struct S a;
+    struct S c;
+
+    a.a = aFOO[programIndex];
+    c.a = aFOO[programIndex];
+
+    // Test prefix increment
+    ++a;
+    RET[programIndex] = a.a;
+
+    // Test prefix decrement
+    --a;
+    RET[programIndex] += a.a;
+
+    // Test postfix increment
+    c = a++;
+    RET[programIndex] += a.a - c.a; // 1
+
+    // Test postfix decrement
+    c = a--;
+    RET[programIndex] += c.a - a.a; // 1
+}
+
+task void result(uniform float RET[16]) { RET[programIndex] = programIndex * 2 + 5; }

--- a/tests/func-tests/operators6.ispc
+++ b/tests/func-tests/operators6.ispc
@@ -1,0 +1,58 @@
+#include "test_static.isph"
+
+struct S {
+    int a;
+};
+
+// Unary minus (-x)
+struct S operator-(struct S rs) {
+    struct S result;
+    result.a = -rs.a;
+    return result;
+}
+
+// Unary minus for reference (-x)
+struct S operator-(struct S &rs) {
+    struct S result;
+    result.a = -rs.a - 10; // Different behavior for reference to distinguish
+    return result;
+}
+
+// Logical NOT (!x)
+bool operator!(struct S rs) { return rs.a == 0; }
+
+// Logical NOT for reference (!x)
+bool operator!(struct S &rs) { return rs.a <= 0; } // Different behavior for reference
+
+// Bitwise NOT (~x)
+struct S operator~(struct S rs) {
+    struct S result;
+    result.a = ~(rs.a);
+    return result;
+}
+
+// Bitwise NOT for reference (~x)
+struct S operator~(struct S &rs) {
+    struct S result;
+    result.a = ~(rs.a) + 5; // Different behavior for reference to distinguish
+    return result;
+}
+
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    struct S a;
+    struct S b;
+
+    a.a = 0;
+    b.a = aFOO[programIndex];
+
+    if (!a) {
+        S neg = -b;
+        RET[programIndex] = neg.a;
+        S bitNot = ~b;
+        RET[programIndex] += bitNot.a;
+    } else {
+        RET[programIndex] = 0;
+    }
+}
+
+task void result(uniform float RET[4]) { RET[programIndex] = -3 - (2 * programIndex); }

--- a/tests/func-tests/operators7.ispc
+++ b/tests/func-tests/operators7.ispc
@@ -1,0 +1,63 @@
+#include "test_static.isph"
+
+struct S {
+    int a;
+};
+
+// Unary minus (-x)
+struct S operator-(struct S rs) {
+    struct S result;
+    result.a = -rs.a;
+    return result;
+}
+
+// Unary minus for reference (-x)
+struct S operator-(struct S &rs) {
+    struct S result;
+    result.a = -rs.a - 10; // Different behavior for reference to distinguish
+    return result;
+}
+
+// Logical NOT (!x)
+bool operator!(struct S rs) { return rs.a == 0; }
+
+// Logical NOT for reference (!x)
+bool operator!(struct S &rs) { return rs.a <= 0; } // Different behavior for reference
+
+// Bitwise NOT (~x)
+struct S operator~(struct S rs) {
+    struct S result;
+    result.a = ~(rs.a);
+    return result;
+}
+
+// Bitwise NOT for reference (~x)
+struct S operator~(struct S &rs) {
+    struct S result;
+    result.a = ~(rs.a) + 5; // Different behavior for reference to distinguish
+    return result;
+}
+
+// New task to test operators with references
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    struct S a;
+    struct S b;
+
+    a.a = -1;
+    b.a = aFOO[programIndex];
+
+    // Create references
+    struct S &refA = a;
+    struct S &refB = b;
+
+    if (!refA) {       // Using overloaded ! operator for reference
+        S neg = -refB; // Using overloaded - operator for reference
+        RET[programIndex] = neg.a;
+        S bitNot = ~refB; // Using overloaded ~ operator for reference
+        RET[programIndex] += bitNot.a;
+    } else {
+        RET[programIndex] = 0;
+    }
+}
+
+task void result(uniform float RET[4]) { RET[programIndex] = -8 - 2 * programIndex; }

--- a/tests/func-tests/operators8.ispc
+++ b/tests/func-tests/operators8.ispc
@@ -1,0 +1,243 @@
+#include "test_static.isph"
+struct S {
+    unsigned int32 value;
+};
+
+// Assignment operator
+inline S &operator=(S &a, S b) {
+    a.value = b.value + 1; // Adding 1 to the value for demonstration
+    return a;
+}
+
+// Multiplication assignment operator
+inline S &operator*=(S &a, S b) {
+    a.value *= b.value;
+    return a;
+}
+
+// Division assignment operator
+inline S &operator/=(S &a, S b) {
+    a.value /= b.value;
+    return a;
+}
+
+// Modulo assignment operator
+inline S &operator%=(S &a, S b) {
+    a.value %= b.value;
+    return a;
+}
+
+// Addition assignment operator
+inline S &operator+=(S &a, S b) {
+    a.value += b.value;
+    return a;
+}
+
+// Subtraction assignment operator
+inline S &operator-=(S &a, S b) {
+    a.value -= b.value;
+    return a;
+}
+
+// Left shift assignment operator
+inline S &operator<<=(S &a, S b) {
+    a.value <<= b.value;
+    return a;
+}
+
+// Right shift assignment operator
+inline S &operator>>=(S &a, S b) {
+    a.value >>= b.value;
+    return a;
+}
+
+// Bitwise AND assignment operator
+inline S &operator&=(S &a, S b) {
+    a.value &= b.value;
+    return a;
+}
+
+// Bitwise XOR assignment operator
+inline S &operator^=(S &a, S b) {
+    a.value ^= b.value;
+    return a;
+}
+
+// Bitwise OR assignment operator
+inline S &operator|=(S &a, S b) {
+    a.value |= b.value;
+    return a;
+}
+
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    RET[programIndex] = 0;
+    S x, y, z;
+    x.value = 100;
+    y.value = 5;
+
+    // Assignment
+    // Using standard assignment
+    S t = x; // t.value = 100
+    // Using assignment operator
+    z = x; // z.value = 101
+
+    // Multiplication assignment
+    z *= y; // z.value = 505 (101 * 5)
+
+    // Division assignment
+    S div = z;
+    div /= y; // div.value = 101 (505 / 5)
+
+    // Modulo assignment
+    S mod;
+    mod.value = 17;
+    mod %= y; // mod.value = 2 (17 % 5)
+
+    // Addition assignment
+    S sum = x;
+    sum += y; // sum.value = 105 (100 + 5)
+
+    // Subtraction assignment
+    S diff = x;
+    diff -= y; // diff.value = 95 (100 - 5)
+
+    // Left shift assignment
+    S lshift = x;
+    S shift_amount;
+    shift_amount.value = 3;
+    lshift <<= shift_amount; // lshift.value = 800 (100 << 3)
+
+    // Right shift assignment
+    S rshift;
+    rshift.value = 64;
+    rshift >>= shift_amount; // rshift.value = 8 (64 >> 3)
+
+    // Bitwise AND assignment
+    S band;
+    band.value = 0xFF;
+    S mask;
+    mask.value = 0x0F;
+    band &= mask; // band.value = 15 (0xFF & 0x0F = 0x0F = 15)
+
+    // Bitwise XOR assignment
+    S bxor;
+    bxor.value = 0xAA; // 10101010 in binary
+    S xmask;
+    xmask.value = 0x55; // 01010101 in binary
+    bxor ^= xmask;      // bxor.value = 255 (0xAA ^ 0x55 = 0xFF = 255)
+
+    // Bitwise OR assignment
+    S bor;
+    bor.value = 0xF0; // 11110000 in binary
+    S ormask;
+    ormask.value = 0x0F; // 00001111 in binary
+    bor |= ormask;       // bor.value = 255 (0xF0 | 0x0F = 0xFF = 255)
+
+    // Chaining operations
+    S chain;
+    chain.value = 10;
+    chain += y; // chain.value = 15
+    chain *= y; // chain.value = 75
+    chain /= y; // chain.value = 15
+
+    RET[0] = extract(z.value, 0);     // Multiplication result
+    RET[1] = extract(sum.value, 0);   // Addition result
+    RET[2] = extract(diff.value, 0);  // Subtraction result
+    RET[3] = extract(bor.value, 0);   // Bitwise OR result
+    RET[4] = extract(chain.value, 0); // Bitwise OR result
+
+    // NEW: Test with references as lvalues
+    print("Starting reference tests\n");
+
+    // Creating reference variables to test with
+    S ref_base, ref_op;
+    ref_base.value = 50;
+    ref_op.value = 10;
+
+    // References to structures
+    S &ref_x = ref_base;
+    S &ref_y = ref_op;
+
+    // Assignment with reference as lvalue
+    ref_x = x; // ref_x.value = 101 (100 + 1)
+
+    // Multiplication assignment with reference
+    ref_x *= y; // ref_x.value = 505 (101 * 5)
+
+    // Division assignment with reference
+    S &ref_div = ref_x; // ref pointing to ref_x (value = 505)
+    ref_div /= ref_y;   // ref_div.value = 50 (505 / 10)
+
+    // Modulo assignment with reference
+    S mod_ref;
+    mod_ref.value = 27;
+    S &ref_mod = mod_ref;
+    ref_mod %= ref_y; // ref_mod.value = 7 (27 % 10)
+
+    // Addition assignment with reference
+    S &ref_sum = ref_x; // ref pointing to ref_x (value = 50)
+    ref_sum += ref_y;   // ref_sum.value = 60 (50 + 10)
+
+    // Subtraction assignment with reference
+    S &ref_diff = ref_x; // ref pointing to ref_x (value = 60)
+    ref_diff -= ref_y;   // ref_diff.value = 50 (60 - 10)
+
+    // Left shift assignment with reference
+    S lshift_ref;
+    lshift_ref.value = 8;
+    S shift_ref;
+    shift_ref.value = 2;
+    S &ref_lshift = lshift_ref;
+    S &ref_shift = shift_ref;
+    ref_lshift <<= ref_shift; // ref_lshift.value = 32 (8 << 2)
+
+    // Right shift assignment with reference
+    S rshift_ref;
+    rshift_ref.value = 32;
+    S &ref_rshift = rshift_ref;
+    ref_rshift >>= ref_shift; // ref_rshift.value = 8 (32 >> 2)
+
+    // Bitwise AND assignment with reference
+    S band_ref, mask_ref;
+    band_ref.value = 0xCC; // 11001100 in binary
+    mask_ref.value = 0xAA; // 10101010 in binary
+    S &ref_band = band_ref;
+    S &ref_mask = mask_ref;
+    ref_band &= ref_mask; // ref_band.value = 136 (0xCC & 0xAA = 0x88 = 136)
+
+    // Bitwise XOR assignment with reference
+    S bxor_ref;
+    bxor_ref.value = 0x33; // 00110011 in binary
+    S &ref_bxor = bxor_ref;
+    ref_bxor ^= ref_mask; // ref_bxor.value = 153 (0x33 ^ 0xAA = 0x99 = 153)
+
+    // Bitwise OR assignment with reference
+    S bor_ref;
+    bor_ref.value = 0x33; // 00110011 in binary
+    S &ref_bor = bor_ref;
+    ref_bor |= ref_mask; // ref_bor.value = 187 (0x33 | 0xAA = 0xBB = 187)
+
+    // Chain of operations with references
+    S chain_ref;
+    chain_ref.value = 20;
+    S &ref_chain = chain_ref;
+    ref_chain += ref_y; // ref_chain.value = 30 (20 + 10)
+    ref_chain *= ref_y; // ref_chain.value = 300 (30 * 10)
+    ref_chain /= ref_y; // ref_chain.value = 30 (300 / 10)
+
+    // Store results from reference operations
+    RET[0] += extract(ref_x.value, 0);      // 50
+    RET[1] += extract(ref_mod.value, 0);    // 7
+    RET[2] += extract(ref_lshift.value, 0); // 32
+    RET[3] += extract(ref_band.value, 0);   // 136
+    RET[4] += extract(ref_chain.value, 0);  // 30
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 0;
+    RET[0] = 555;
+    RET[1] = 112;
+    RET[2] = 127;
+    RET[3] = 391;
+    RET[4] = 45;
+}

--- a/tests/lit-tests/func_template_operator_1.ispc
+++ b/tests/lit-tests/func_template_operator_1.ispc
@@ -1,14 +1,25 @@
 // Basic check of template operators (issue #2634)
 // RUN: %{ispc}  %s --emit-llvm-text --target=host --nostdlib -o - | FileCheck %s
 
-// CHECK: define %v{{[0-9]*}}_varying_FMatrix @"operator*___s_5B_vyFMatrixF_5D____REFs_5B__c_vyFMatrix_5D_REFs_5B__c_vyFMatrixF_5D_"({{.*}} %A, {{.*}} %B, <{{[0-9]*}} x {{.*}}> %__mask)
-// CHECK: define weak_odr %v{{[0-9]*}}_varying_FMatrix @"operator*___s_5B_vyFMatrixI_5D____REFs_5B__c_vyFMatrix_5D_REFs_5B__c_vyFMatrixI_5D_"({{.*}} %A, {{.*}} %B, <{{[0-9]*}} x {{.*}}> %__mask)
+// Multiplication operator checks
+// CHECK: define %v{{[0-9]*}}_varying_FMatrix @"operator*___s_5B_vyFMatrixF_5D____REFs_5B__c_vyFMatrix_5D_REFs_5B__c_vyFMatrixF_5D_"({{.*}} %A, {{.*}} %B, <{{[0-9]*}} x i32> %__mask)
+
+// Prefix increment operator checks
+// CHECK: define %v{{[0-9]*}}_varying_FMatrixF @"operator++___s_5B_vyFMatrixF_5D____REFs_5B_vyFMatrixF_5D_"({{.*}} %A, <{{[0-9]*}} x i32> %__mask)
+
+// Postfix increment operator checks
+// CHECK: define %v{{[0-9]*}}_varying_FMatrixF @"operator++___s_5B_vyFMatrixF_5D____REFs_5B_vyFMatrixF_5D_vyi"({{.*}} %A, <{{[0-9]*}} x i32> %__anon_parameter_1, <{{[0-9]*}} x i32> %__mask)
+
+// Assignment operator checks
+// CHECK: define %v{{[0-9]*}}_varying_FMatrix @"operator=___s_5B_vyFMatrixF_5D____REFs_5B_vyFMatrix_5D_REFs_5B__c_vyFMatrixF_5D_"({{.*}} %A, {{.*}} %B, <{{[0-9]*}} x i32> %__mask)
 
 // CHECK-LABEL: define <{{[0-9]*}} x double> @DoMath___
-// CHECK: call %v{{[0-9]*}}_varying_FMatrix @"operator*___{{.*}}"({{.*}} %A, {{.*}} %B, <{{[0-9]*}} x {{.*}}> %__mask)
+// CHECK: call %v{{[0-9]*}}_varying_FMatrix @"operator*___{{.*}}"({{.*}} %A, {{.*}} %B, <{{[0-9]*}} x i32> %__mask)
 
-// CHECK-LABEL: define linkonce_odr %v{{[0-9]*}}_varying_FMatrix @"operator*___{{.*}}"({{.*}} %A, {{.*}} %B, <{{[0-9]*}} x {{.*}}> %__mask)
-
+// CHECK-LABEL: define <{{[0-9]*}} x double> @TestIncrementOperators___
+// CHECK: call %v{{[0-9]*}}_varying_FMatrixF @"operator++___s_5B_vyFMatrixF_5D____REFs_5B_vyFMatrixF_5D_"({{.*}} %A, <{{[0-9]*}} x i32>
+// CHECK: call %v{{[0-9]*}}_varying_FMatrixF @"operator++___s_5B_vyFMatrixF_5D____REFs_5B_vyFMatrixF_5D_vyi"({{.*}} %A, <{{[0-9]*}} x i32> poison, <{{[0-9]*}} x i32>
+// CHECK: call %v{{[0-9]*}}_varying_FMatrix @"operator=___s_5B_vyFMatrixF_5D____REFs_5B_vyFMatrix_5D_REFs_5B__c_vyFMatrixF_5D_"({{.*}} %D, {{.*}} %A, <{{[0-9]*}} x i32>
 
 struct FMatrix {
     double M[16];
@@ -16,10 +27,6 @@ struct FMatrix {
 
 struct FMatrixF {
     float M[16];
-};
-
-struct FMatrixI {
-    int M[16];
 };
 
 template <typename T> noinline FMatrix operator*(const FMatrix &A, const T &B) {
@@ -45,11 +52,78 @@ noinline FMatrix operator*<FMatrixF>(const FMatrix &A, const FMatrixF &B) {
     return A;
 }
 
-template FMatrix noinline operator*<FMatrixI>(const FMatrix &A, const FMatrixI &B);
+// Prefix increment operator (++) template
+template <typename T> noinline T operator++(T &A) {
+    // Simple implementation that increments all elements by 1
+    for (uniform unsigned int i = 0; i < 16; i++) {
+        A.M[i] += 1;
+    }
+    return A;
+}
+
+template <>
+noinline FMatrixF operator++<FMatrixF>(FMatrixF &A) {
+    for (uniform unsigned int i = 0; i < 16; i++) {
+        A.M[i] += 1.0f;
+    }
+    return A;
+}
+
+// Postfix increment operator (i++) template
+template <typename T> noinline T operator++(T &A, int) {
+    T temp = A;
+    ++A; // Reuse prefix increment
+    return temp;
+}
+
+template <>
+noinline FMatrixF operator++<FMatrixF>(FMatrixF &A, int) {
+    FMatrixF temp = A;
+    for (uniform unsigned int i = 0; i < 16; i++) {
+        A.M[i] += 1.0f;
+    }
+    return temp;
+}
+
+// Assignment operator template
+template <typename T> noinline FMatrix operator=(FMatrix &A, const T &B) {
+    // Copy elements with type conversion if needed
+    for (uniform unsigned int i = 0; i < 16; i++) {
+        A.M[i] = B.M[i];
+    }
+    return A;
+}
+
+template <>
+noinline FMatrix operator=<FMatrixF>(FMatrix &A, const FMatrixF &B) {
+    for (uniform unsigned int i = 0; i < 16; i++) {
+        A.M[i] = B.M[i];
+    }
+    return A;
+}
 
 double DoMath() {
     FMatrix A;
     FMatrix B;
     FMatrix result = A * B;
     return result.M[0];
+}
+
+double TestIncrementOperators() {
+    FMatrixF A;
+    for (uniform unsigned int i = 0; i < 16; i++) {
+        A.M[i] = i;
+    }
+
+    // Test prefix increment
+    FMatrixF B = ++A;
+
+    // Test postfix increment
+    FMatrixF C = A++;
+
+    // Test assignment
+    FMatrix D;
+    D = A;
+
+    return B.M[0] + C.M[0] + D.M[0];
 }

--- a/tests/lit-tests/operators-err.ispc
+++ b/tests/lit-tests/operators-err.ispc
@@ -1,0 +1,119 @@
+// RUN: not %{ispc} --target=host --nowrap %s -o - 2>&1 | FileCheck %s
+
+struct MyStruct {
+    int value;
+};
+
+struct AnotherStruct {
+    float value;
+};
+
+struct ComplexStruct {
+    MyStruct s1;
+    AnotherStruct s2;
+};
+
+noinline MyStruct operator-(MyStruct a, MyStruct b) {
+    MyStruct result;
+    result.value = a.value - b.value;
+    return result;
+}
+
+// Partial implementation - only implements == for int comparison
+bool operator==(MyStruct a, int b) {
+    return a.value == b;
+}
+
+bool operator==(MyStruct a, MyStruct b) {
+    return a.value == b.value;
+}
+
+// Define compound assignment operator
+noinline MyStruct operator+=(MyStruct &a, MyStruct b) {
+    a.value += b.value;
+    return a;
+}
+
+// Incorrect signature - parameter should be a reference for compound assignment
+noinline AnotherStruct operator-=(AnotherStruct a, AnotherStruct b) {
+    a.value -= b.value;
+    return a;
+}
+
+// Define unary operator - correct
+noinline MyStruct operator++(MyStruct &a) {
+    a.value++;
+    return a;
+}
+
+// Define postfix operator - incorrect (missing int parameter)
+noinline AnotherStruct operator++(AnotherStruct &a) {
+    AnotherStruct temp = a;
+    a.value += 1.0f;
+    return temp;
+}
+
+// Define postfix operator correctly (with int parameter)
+noinline AnotherStruct operator++(AnotherStruct &a, int) {
+    AnotherStruct temp = a;
+    a.value += 1.0f;
+    return temp;
+}
+
+// CHECK: 80:18: Error: operator operator+(varying struct MyStruct, varying struct MyStruct) is not defined.
+// CHECK: 80:18: Error: First operand to binary operator "+" is of invalid type "varying struct MyStruct".
+// CHECK: 81:18: Error: Unable to find any matching overload for call to function "operator-".
+// CHECK: 81:18: Error: First operand to binary operator "-" is of invalid type "varying struct MyStruct".
+// CHECK: 105:20: Error: Unable to find any matching overload for call to function "operator-".
+// CHECK: 105:21: Error: Negate not allowed for non-numeric type "varying struct MyStruct"
+// CHECK: 108:25: Error: operator operator+(varying struct MyStruct, varying struct AnotherStruct) is not defined.
+// CHECK: 108:25: Error: First operand to binary operator "+" is of invalid type "varying struct MyStruct".
+// CHECK: 118:18: Error: Unable to find any matching overload for call to function "operator==".
+// CHECK: 118:18: Error: First operand to operator "==" is of non-comparable type "varying struct ComplexStruct".
+// CHECK: 115:26: Error: Can't convert between different struct types "varying struct ComplexStruct" and "varying struct MyStruct" for initializer.
+// CHECK-NOT: Error
+int test_missing_operator() {
+    MyStruct a, b;
+    a.value = 10;
+    b.value = 20;
+
+    MyStruct c = a + b;
+    MyStruct d = a - 4;
+
+    if (c == d) {
+        return 0;
+    }
+    if (c == 4) {
+        return 1;
+    }
+
+    return 2;
+}
+
+void test_additional_errors() {
+    MyStruct ms1, ms2;
+    ms1.value = 5;
+    ms2.value = 10;
+
+    AnotherStruct as1, as2;
+    as1.value = 2.5f;
+    as2.value = 1.5f;
+
+    ms1 += ms2;  // This should work fine
+
+    // Missing unary minus operator
+    MyStruct neg = -ms1;
+
+    // Type mismatch in operator usage
+    MyStruct combined = ms1 + as1;  // Type mismatch
+
+    ComplexStruct cs;
+    cs.s1.value = 42;
+    cs.s2.value = 3.14f;
+
+    // Implicit conversion not available for struct types
+    MyStruct converted = cs;
+
+    // Using unrelated struct type with comparison operator
+    bool comp = (cs == ms1);
+}

--- a/tests/lit-tests/operators.ispc
+++ b/tests/lit-tests/operators.ispc
@@ -1,0 +1,409 @@
+// RUN: %{ispc} --target=host --nowrap -O0 --emit-llvm-text -o - %s | FileCheck %s
+
+struct Complex {
+    float real;
+    float imag;
+};
+
+// Binary arithmetic operators
+noinline Complex operator*(Complex a, Complex b) {
+    Complex result;
+    result.real = a.real * b.real - a.imag * b.imag;
+    result.imag = a.real * b.imag + a.imag * b.real;
+    return result;
+}
+
+noinline Complex operator+(Complex a, Complex b) {
+    Complex result;
+    result.real = a.real + b.real;
+    result.imag = a.imag + b.imag;
+    return result;
+}
+
+noinline Complex operator-(Complex a, Complex b) {
+    Complex result;
+    result.real = a.real - b.real;
+    result.imag = a.imag - b.imag;
+    return result;
+}
+
+noinline Complex operator/(Complex a, Complex b) {
+    float denom = b.real * b.real + b.imag * b.imag;
+    Complex result;
+    result.real = (a.real * b.real + a.imag * b.imag) / denom;
+    result.imag = (a.imag * b.real - a.real * b.imag) / denom;
+    return result;
+}
+
+noinline Complex operator%(Complex a, Complex b) {
+    // Simple example - just perform modulo on real parts
+    Complex result;
+    result.real = a.real - (int)(a.real / b.real) * b.real;
+    result.imag = a.imag;
+    return result;
+}
+
+// Bitshift operators (treating real part as an integer)
+noinline Complex operator<<(Complex a, Complex b) {
+    Complex result;
+    result.real = (int)a.real << (int)b.real;
+    result.imag = a.imag;
+    return result;
+}
+
+noinline Complex operator>>(Complex a, Complex b) {
+    Complex result;
+    result.real = (int)a.real >> (int)b.real;
+    result.imag = a.imag;
+    return result;
+}
+
+// Comparison operators
+noinline bool operator==(Complex a, Complex b) {
+    return (a.real == b.real && a.imag == b.imag);
+}
+
+noinline bool operator!=(Complex a, Complex b) {
+    return (a.real != b.real || a.imag != b.imag);
+}
+
+noinline bool operator>(Complex a, Complex b) {
+    // Compare magnitude
+    float mag_a = a.real * a.real + a.imag * a.imag;
+    float mag_b = b.real * b.real + b.imag * b.imag;
+    return mag_a > mag_b;
+}
+
+noinline bool operator<(Complex a, Complex b) {
+    float mag_a = a.real * a.real + a.imag * a.imag;
+    float mag_b = b.real * b.real + b.imag * b.imag;
+    return mag_a < mag_b;
+}
+
+noinline bool operator>=(Complex a, Complex b) {
+    float mag_a = a.real * a.real + a.imag * a.imag;
+    float mag_b = b.real * b.real + b.imag * b.imag;
+    return mag_a >= mag_b;
+}
+
+noinline bool operator<=(Complex a, Complex b) {
+    float mag_a = a.real * a.real + a.imag * a.imag;
+    float mag_b = b.real * b.real + b.imag * b.imag;
+    return mag_a <= mag_b;
+}
+
+// Bitwise operators (treating real parts as integers)
+noinline Complex operator&(Complex a, Complex b) {
+    Complex result;
+    result.real = (int)a.real & (int)b.real;
+    result.imag = (int)a.imag & (int)b.imag;
+    return result;
+}
+
+noinline Complex operator^(Complex a, Complex b) {
+    Complex result;
+    result.real = (int)a.real ^ (int)b.real;
+    result.imag = (int)a.imag ^ (int)b.imag;
+    return result;
+}
+
+noinline Complex operator|(Complex a, Complex b) {
+    Complex result;
+    result.real = (int)a.real | (int)b.real;
+    result.imag = (int)a.imag | (int)b.imag;
+    return result;
+}
+
+// Logical operators
+noinline bool operator&&(Complex a, Complex b) {
+    return (a.real != 0.0f || a.imag != 0.0f) &&
+           (b.real != 0.0f || b.imag != 0.0f);
+}
+
+noinline bool operator||(Complex a, Complex b) {
+    return (a.real != 0.0f || a.imag != 0.0f) ||
+           (b.real != 0.0f || b.imag != 0.0f);
+}
+
+// Unary operators
+noinline Complex operator++(Complex &a) {
+    a.real += 1.0f;
+    return a;
+}
+
+noinline Complex operator--(Complex &a) {
+    a.real -= 1.0f;
+    return a;
+}
+
+noinline Complex operator++(Complex &a, int) {
+    Complex temp = a;
+    a.real += 1.0f;
+    return temp;
+}
+
+noinline Complex operator--(Complex &a, int) {
+    Complex temp = a;
+    a.real -= 1.0f;
+    return temp;
+}
+
+noinline Complex operator~(Complex a) {
+    Complex result;
+    result.real = ~(int)a.real;
+    result.imag = ~(int)a.imag;
+    return result;
+}
+
+noinline bool operator!(Complex a) {
+    return (a.real == 0.0f && a.imag == 0.0f);
+}
+
+// Assignment operators
+noinline Complex operator=(Complex &a, Complex b) {
+    a.real = b.real;
+    a.imag = b.imag;
+    return a;
+}
+
+noinline Complex operator*=(Complex &a, Complex b) {
+    float temp_real = a.real * b.real - a.imag * b.imag;
+    a.imag = a.real * b.imag + a.imag * b.real;
+    a.real = temp_real;
+    return a;
+}
+
+noinline Complex operator/=(Complex &a, Complex b) {
+    float denom = b.real * b.real + b.imag * b.imag;
+    float temp_real = (a.real * b.real + a.imag * b.imag) / denom;
+    a.imag = (a.imag * b.real - a.real * b.imag) / denom;
+    a.real = temp_real;
+    return a;
+}
+
+noinline Complex operator%=(Complex &a, Complex b) {
+    a.real = a.real - (int)(a.real / b.real) * b.real;
+    return a;
+}
+
+noinline Complex operator+=(Complex &a, Complex b) {
+    a.real += b.real;
+    a.imag += b.imag;
+    return a;
+}
+
+noinline Complex operator-=(Complex &a, Complex b) {
+    a.real -= b.real;
+    a.imag -= b.imag;
+    return a;
+}
+
+noinline Complex operator<<=(Complex &a, Complex b) {
+    a.real = (int)a.real << (int)b.real;
+    return a;
+}
+
+noinline Complex operator>>=(Complex &a, Complex b) {
+    a.real = (int)a.real >> (int)b.real;
+    return a;
+}
+
+noinline Complex operator&=(Complex &a, Complex b) {
+    a.real = (int)a.real & (int)b.real;
+    a.imag = (int)a.imag & (int)b.imag;
+    return a;
+}
+
+noinline Complex operator|=(Complex &a, Complex b) {
+    a.real = (int)a.real | (int)b.real;
+    a.imag = (int)a.imag | (int)b.imag;
+    return a;
+}
+
+noinline Complex operator^=(Complex &a, Complex b) {
+    a.real = (int)a.real ^ (int)b.real;
+    a.imag = (int)a.imag ^ (int)b.imag;
+    return a;
+}
+
+// CHECK-LABEL: @test_binary_ops
+unmasked void test_binary_ops(uniform float* uniform out) {
+    Complex c1, c2;
+    c1.real = 5.0f; c1.imag = 2.0f;
+    c2.real = 3.0f; c2.imag = 4.0f;
+    float res;
+    // Arithmetic operators
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator*___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex mul = c1 * c2;
+    res = mul.real + mul.imag;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator+___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex sum = c1 + c2;
+    res += sum.real + sum.imag;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @operator-___s_5B_vyComplex_5D_s_5B_vyComplex_5D_
+    Complex diff = c1 - c2;
+    res += diff.real + diff.imag;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator/___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex div = c1 / c2;
+    res += div.real + div.imag;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator%___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex mod = c1 % c2;
+    res += mod.real + mod.imag;
+
+    // Bitshift operators
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator<<___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex lshift = c1 << c2;
+    res += lshift.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator>>___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex rshift = c1 >> c2;
+    res += rshift.real;
+
+    // Comparison operators
+    // CHECK: call <{{[0-9]*}} x {{.*}}> @"operator==___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    bool equal = (c1 == c2);
+    res += equal ? 1.0f : 0.0f;
+
+    // CHECK: call <{{[0-9]*}} x {{.*}}> @"operator!=___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    bool notEqual = (c1 != c2);
+    res += notEqual ? 1.0f : 0.0f;
+
+    // CHECK: call <{{[0-9]*}} x {{.*}}> @"operator>___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    bool greater = (c1 > c2);
+    res += greater ? 1.0f : 0.0f;
+
+    // CHECK: call <{{[0-9]*}} x {{.*}}> @"operator<___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    bool less = (c1 < c2);
+    res += less ? 1.0f : 0.0f;
+
+    // CHECK: call <{{[0-9]*}} x {{.*}}> @"operator>=___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    bool greaterOrEqual = (c1 >= c2);
+    res += greaterOrEqual ? 1.0f : 0.0f;
+
+    // CHECK: call <{{[0-9]*}} x {{.*}}> @"operator<=___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    bool lessOrEqual = (c1 <= c2);
+    res += lessOrEqual ? 1.0f : 0.0f;
+
+    // Bitwise operators
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator&___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex bitAnd = c1 & c2;
+    res += bitAnd.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator^___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex bitXor = c1 ^ c2;
+    res += bitXor.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator|___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex bitOr = c1 | c2;
+    res += bitOr.real;
+
+    // Logical operators
+    // CHECK: call <{{[0-9]*}} x {{.*}}> @"operator&&___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    bool logicalAnd = (c1 && c2);
+    res += logicalAnd ? 1.0f : 0.0f;
+
+    // CHECK: call <{{[0-9]*}} x {{.*}}> @"operator||___s_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    bool logicalOr = (c1 || c2);
+    res += logicalOr ? 1.0f : 0.0f;
+    out[programIndex] = res;
+}
+
+// CHECK-LABEL: @test_unary_ops
+unmasked void test_unary_ops(uniform float* uniform out) {
+    Complex c;
+    c.real = 5.0f; c.imag = 2.0f;
+    float res;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator++___REFs_5B_vyComplex_5D_"
+    Complex preinc = ++c;
+    res += preinc.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @operator--___REFs_5B_vyComplex_5D_
+    Complex predec = --c;
+    res += predec.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator++___REFs_5B_vyComplex_5D_vyi"
+    Complex postinc = c++;
+    res += postinc.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @operator--___REFs_5B_vyComplex_5D_vyi
+    Complex postdec = c--;
+    res += postdec.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator~___s_5B_vyComplex_5D_"
+    Complex bitnot = ~c;
+    res += bitnot.real;
+
+    // CHECK: call <{{[0-9]*}} x {{.*}}> @"operator!___s_5B_vyComplex_5D_"
+    bool lognot = !c;
+    res += lognot ? 1.0f : 0.0f;
+    out[programIndex] = res;
+}
+
+// CHECK-LABEL: @test_assignment_ops
+unmasked void test_assignment_ops(float* uniform out) {
+    Complex c1, c2;
+    c1.real = 5.0f; c1.imag = 2.0f;
+    c2.real = 3.0f; c2.imag = 4.0f;
+
+    float res;
+    // Assignment operators
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator=___REFs_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex assign;
+    assign = c1;
+    res += assign.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator*=___REFs_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex c3 = c1;
+    c3 *= c2;
+    res += c3.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator/=___REFs_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex c4 = c1;
+    c4 /= c2;
+    res += c4.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator%=___REFs_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex c5 = c1;
+    c5 %= c2;
+    res += c5.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator+=___REFs_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex c6 = c1;
+    c6 += c2;
+    res += c6.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator-=___REFs_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex c7 = c1;
+    c7 -= c2;
+    res += c7.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator<<=___REFs_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex c8 = c1;
+    c8 <<= c2;
+    res += c8.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator>>=___REFs_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex c9 = c1;
+    c9 >>= c2;
+    res += c9.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator&=___REFs_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex c10 = c1;
+    c10 &= c2;
+    res += c10.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator|=___REFs_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex c11 = c1;
+    c11 |= c2;
+    res += c11.real;
+
+    // CHECK: call %v{{[0-9]*}}_varying_Complex @"operator^=___REFs_5B_vyComplex_5D_s_5B_vyComplex_5D_"
+    Complex c12 = c1;
+    c12 ^= c2;
+    res += c12.real;
+    out[programIndex] = res;
+}


### PR DESCRIPTION
This pull request extends operator overloading capabilities for `struct` types. 

## Operator Overloading Enhancements:

* Extended support for overloading unary (`++, --, -, !, ~`), binary (`*, /, %, +, -, >>, <<, ==, !=, <, >, <=, >=, &, |, ^, &&, ||`), and assignment (`=, +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=`) operators for `struct` types. 
* Added a new helper function, `PossiblyResolveStructOperatorOverloads`, to centralize the logic for resolving operator overloads for `struct` types.
* Removed the now-obsolete `MakeBinaryExpr` function, simplifying the codebase by directly constructing `BinaryExpr` instances where needed.

## Related Issue
- [x] Linked to relevant issue(s): fixes #1587 and #732 

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [x] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [x] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed