### PR TITLE
Fix variable scoping within single-statement blocks

### DIFF
--- a/src/parse.yy
+++ b/src/parse.yy
@@ -2461,6 +2461,22 @@ for_init_statement
     | declaration_statement
     ;
 
+while_scope
+    : TOKEN_WHILE { m->symbolTable->PushScope(); }
+    ;
+
+cwhile_scope
+    : TOKEN_CWHILE { m->symbolTable->PushScope(); }
+    ;
+
+do_scope
+    : TOKEN_DO { m->symbolTable->PushScope(); }
+    ;
+
+cdo_scope
+    : TOKEN_CDO { m->symbolTable->PushScope(); }
+    ;
+
 for_scope
     : TOKEN_FOR { m->symbolTable->PushScope(); }
     ;
@@ -2559,14 +2575,22 @@ foreach_unique_identifier
     ;
 
 iteration_statement
-    : TOKEN_WHILE '(' expression ')' attributed_statement
-      { $$ = new ForStmt(nullptr, $3, nullptr, $5, false, @1); }
-    | TOKEN_CWHILE '(' expression ')' attributed_statement
-      { $$ = new ForStmt(nullptr, $3, nullptr, $5, true, @1); }
-    | TOKEN_DO attributed_statement TOKEN_WHILE '(' expression ')' ';'
-      { $$ = new DoStmt($5, $2, false, @1); }
-    | TOKEN_CDO attributed_statement TOKEN_WHILE '(' expression ')' ';'
-      { $$ = new DoStmt($5, $2, true, @1); }
+    : while_scope '(' expression ')' attributed_statement
+      { $$ = new ForStmt(nullptr, $3, nullptr, $5, false, @1);
+        m->symbolTable->PopScope();
+      }
+    | cwhile_scope '(' expression ')' attributed_statement
+      { $$ = new ForStmt(nullptr, $3, nullptr, $5, true, @1);
+        m->symbolTable->PopScope();
+      }
+    | do_scope attributed_statement TOKEN_WHILE '(' expression ')' ';'
+      { $$ = new DoStmt($5, $2, false, @1);
+        m->symbolTable->PopScope();
+      }
+    | cdo_scope attributed_statement TOKEN_WHILE '(' expression ')' ';'
+      { $$ = new DoStmt($5, $2, true, @1);
+        m->symbolTable->PopScope();
+      }
     | for_scope '(' for_init_statement for_test ')' attributed_statement
       { $$ = new ForStmt($3, $4, nullptr, $6, false, @1);
         m->symbolTable->PopScope();

--- a/tests/lit-tests/3386.ispc
+++ b/tests/lit-tests/3386.ispc
@@ -1,5 +1,5 @@
-// This tests that variables declared in if statements are properly scoped
-// RUN: not %{ispc} %s --nostdlib --nowrap --target=host -o %t.o | FileCheck %s
+// This tests that variables declared in statements without braces are properly scoped
+// RUN: not %{ispc} %s --nostdlib --nowrap --target=host -o %t.o 2>&1 | FileCheck %s
 
 // CHECK: 8:16: Error: Undeclared symbol "y". Did you mean "x"?
 int32 Test1(int32 x) {
@@ -17,7 +17,7 @@ int32 Test2(int32 x) {
 }
 
 // CHECK: 29:16: Error: Undeclared symbol "y". Did you mean "x"?
-// CHECK: 29:16: Error: Undeclared symbol "z". Did you mean "x"?
+// CHECK: 29:20: Error: Undeclared symbol "z". Did you mean "x"?
 // Test with else branch
 int32 Test3(int32 x) {
     if (x == 0)
@@ -27,4 +27,21 @@ int32 Test3(int32 x) {
 
     // Neither y nor z should be visible here
     return x + y + z;
+}
+
+// CHECK: 37:16: Error: Undeclared symbol "w". Did you mean "x"?
+// Test with while loop - single statement without braces
+int32 Test4(int32 x) {
+    while (x < 5)
+        varying int32 w = 4;
+    return x + w;  // w should not be visible here
+}
+
+// CHECK: 46:16: Error: Undeclared symbol "v". Did you mean "x"?
+// Test with do-while loop - single statement without braces
+int32 Test5(int32 x) {
+    do
+        varying int32 v = 5;
+    while (x < 10);
+    return x + v;  // v should not be visible here
 }


### PR DESCRIPTION
This pull request introduces changes to improve variable scoping in control flow statements, ensuring proper scope handling for variables declared within single-statement blocks without braces.

### Improvements to Variable Scoping:

* **Control Flow Statements (`if`, `while`, `do-while`, etc.):**
  - Introduced dedicated scope rules (`if_scope`, `cif_scope`, `while_scope`, `cwhile_scope`, `do_scope`, and `cdo_scope`) to manage symbol table operations during parsing. These changes ensure that variables declared in control flow statements are correctly scoped and not accessible outside their intended blocks.

## Related Issue
- [x] Linked to relevant issue(s). Fixes #3386 

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed