### PR TITLE
Fix issue #3335: assertion failed on nested foreach

### DIFF
--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -1620,6 +1620,7 @@ void ForeachStmt::EmitCode(FunctionEmitContext *ctx) const {
         llvm::Value *sv = startExprs[i]->GetValue(ctx);
         llvm::Value *ev = endExprs[i]->GetValue(ctx);
         if (sv == nullptr || ev == nullptr) {
+            ctx->EndScope();
             return;
         }
         startVals.push_back(sv);
@@ -2068,8 +2069,10 @@ void ForeachStmt::EmitCodeForXe(FunctionEmitContext *ctx) const {
 
         llvm::Value *sv = startExprs[i]->GetValue(ctx);
         llvm::Value *ev = endExprs[i]->GetValue(ctx);
-        if (sv == nullptr || ev == nullptr)
+        if (sv == nullptr || ev == nullptr) {
+            ctx->EndScope();
             return;
+        }
 
         // Store varying start
         sv = ctx->BroadcastValue(sv, LLVMTypes::Int32VectorType, "start_broadcast");
@@ -2641,6 +2644,8 @@ void ForeachUniqueStmt::EmitCode(FunctionEmitContext *ctx) const {
     if (exprValue == nullptr || (exprType = expr->GetType()) == nullptr ||
         llvm::dyn_cast<llvm::VectorType>(exprValue->getType()) == nullptr) {
         Assert(m->errorCount > 0);
+        ctx->EndForeach();
+        ctx->EndScope();
         return;
     }
     ctx->SetDebugPos(pos);

--- a/tests/lit-tests/3335.ispc
+++ b/tests/lit-tests/3335.ispc
@@ -1,0 +1,20 @@
+// This test checks that the compiler reports an error (on `tile_q * tile_size`)
+// in a foreach section and that this does not cause any crash (fatal error) 
+// due to scoping issue when debugging is enabled.
+
+// RUN: not %{ispc} --target=host --nowrap -g %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error: Can't convert from type "varying int32" to type "uniform int32" for initializer.
+// CHECK-NOT: FATAL ERROR:
+
+export void kernel(uniform int seq_len, uniform int tile_size) {
+    uniform int num_tiles = (seq_len + tile_size - 1) / tile_size;
+    foreach (tile_q = 0 ... num_tiles) {
+        uniform int q_start = tile_q * tile_size;
+        uniform int q_end = min(q_start + tile_size, seq_len);
+
+        foreach (q_idx = q_start ... q_end) {
+            float max_score = -1e20f;
+        }
+    }
+}


### PR DESCRIPTION
Fix the issue #3335 (details about the PR are mentioned in the issue).
Put it shortly: I added the missing `EndScope` and there is no assertion anymore. It just reports:

```ispc
tests/lit-tests/3335.ispc:13:31: Error: Can't convert from type "varying int32" to type "uniform int32" for initializer. 
        uniform int q_start = tile_q * tile_size;
                              ^^^^^^^^^^^^^^^^^^
```

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed