### PR TITLE
Add the isinf and isfinite standard functions

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -4945,6 +4945,36 @@ The ``isnan()`` functions test whether the given value is a floating-point
     bool isnan(double v)
     uniform bool isnan(uniform double v)
 
+The ``isinf()`` and ``isfinite()`` functions test whether the given value is
+a floating-point infinity (please note that a "not a number" value is neither 
+considered finite nor infinite):
+
+::
+
+    bool isinf(float16 v)
+    uniform bool isinf(uniform float16 v)
+    bool isinf(float v)
+    uniform bool isinf(uniform float v)
+    bool isinf(double v)
+    uniform bool isinf(uniform double v)
+
+::
+
+    bool isfinite(float16 v)
+    uniform bool isfinite(uniform float16 v)
+    bool isfinite(float v)
+    uniform bool isfinite(uniform float v)
+    bool isfinite(double v)
+    uniform bool isfinite(uniform double v)
+
+The isinf and isfinite functions also support short vector types with the
+basic types listed above.
+
+::
+
+    template <typename T, uint N> T<N> isinf(T<N> v)
+    template <typename T, uint N> T<N> isfinite(T<N> v)
+
 
 A number of functions are also available for performing operations on 8- and
 16-bit quantities; these map to specialized instructions that perform these

--- a/stdlib/include/stdlib.isph
+++ b/stdlib/include/stdlib.isph
@@ -527,6 +527,20 @@ __declspec(safe, cost1) inline bool isnan(float v);
 __declspec(safe, cost1) inline uniform bool isnan(uniform double v);
 __declspec(safe, cost1) inline bool isnan(double v);
 
+__declspec(safe, cost1) inline uniform bool isinf(uniform float16 v);
+__declspec(safe, cost1) inline bool isinf(float16 v);
+__declspec(safe, cost1) inline uniform bool isinf(uniform float v);
+__declspec(safe, cost1) inline bool isinf(float v);
+__declspec(safe, cost1) inline uniform bool isinf(uniform double v);
+__declspec(safe, cost1) inline bool isinf(double v);
+
+__declspec(safe, cost1) inline uniform bool isfinite(uniform float16 v);
+__declspec(safe, cost1) inline bool isfinite(float16 v);
+__declspec(safe, cost1) inline uniform bool isfinite(uniform float v);
+__declspec(safe, cost1) inline bool isfinite(float v);
+__declspec(safe, cost1) inline uniform bool isfinite(uniform double v);
+__declspec(safe, cost1) inline bool isfinite(double v);
+
 __declspec(safe, cost1) inline int8 abs(int8 a);
 __declspec(safe, cost1) inline uniform int8 abs(uniform int8 a);
 __declspec(safe, cost1) inline int16 abs(int16 a);
@@ -1337,9 +1351,13 @@ __declspec(safe) static inline varying int32 dot2add_u16i16packed_sat(varying ui
     SHORT_VEC_VARYING_ARG2(FUNC)
 
 // Generate the template functions for short vectors
+
 SHORT_VEC_ARG1(abs)
 SHORT_VEC_ARG2(max)
 SHORT_VEC_ARG2(min)
+
+SHORT_VEC_ARG1(isinf)
+SHORT_VEC_ARG1(isfinite)
 
 SHORT_VEC_ARG1(round)
 SHORT_VEC_ARG1(floor)

--- a/stdlib/stdlib.ispc
+++ b/stdlib/stdlib.ispc
@@ -1728,6 +1728,40 @@ __declspec(safe, cost1) static inline uniform bool isnan(uniform double v) { ret
 
 __declspec(safe, cost1) static inline bool isnan(double v) { return v != v; }
 
+__declspec(safe, cost1) static inline uniform bool isinf(uniform float16 v) { return intbits(abs(v)) == 0x7C00; }
+
+__declspec(safe, cost1) static inline bool isinf(float16 v) { return intbits(abs(v)) == 0x7C00; }
+
+__declspec(safe, cost1) static inline uniform bool isinf(uniform float v) { return intbits(abs(v)) == 0x7F800000; }
+
+__declspec(safe, cost1) static inline bool isinf(float v) { return intbits(abs(v)) == 0x7F800000; }
+
+__declspec(safe, cost1) static inline uniform bool isinf(uniform double v) {
+    return intbits(abs(v)) == 0x7FF0000000000000;
+}
+
+__declspec(safe, cost1) static inline bool isinf(double v) { return intbits(abs(v)) == 0x7FF0000000000000; }
+
+__declspec(safe, cost1) static inline uniform bool isfinite(uniform float16 v) {
+    return (intbits(v) & 0x7C00) != 0x7C00;
+}
+
+__declspec(safe, cost1) static inline bool isfinite(float16 v) { return (intbits(v) & 0x7C00) != 0x7C00; }
+
+__declspec(safe, cost1) static inline uniform bool isfinite(uniform float v) {
+    return (intbits(v) & 0x7F800000) != 0x7F800000;
+}
+
+__declspec(safe, cost1) static inline bool isfinite(float v) { return (intbits(v) & 0x7F800000) != 0x7F800000; }
+
+__declspec(safe, cost1) static inline uniform bool isfinite(uniform double v) {
+    return (intbits(v) & 0x7FF0000000000000) != 0x7FF0000000000000;
+}
+
+__declspec(safe, cost1) static inline bool isfinite(double v) {
+    return (intbits(v) & 0x7FF0000000000000) != 0x7FF0000000000000;
+}
+
 __declspec(safe, cost1) static inline int8 abs(int8 a) { return a > 0 ? a : -a; }
 
 __declspec(safe, cost1) static inline uniform int8 abs(uniform int8 a) { return a > 0 ? a : -a; }

--- a/tests/func-tests/isfinite.ispc
+++ b/tests/func-tests/isfinite.ispc
@@ -1,0 +1,38 @@
+#include "test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
+
+template <typename T>
+int test_isfinite()
+{
+    // Constants assumed to be converted to the right type and variability
+    const uniform double neg_inf = doublebits(0xFFF0000000000000);
+    const uniform double pos_inf = doublebits(0x7FF0000000000000);
+    const uniform double nan_val1 = doublebits(0xFFF8000000000000);
+    const uniform double nan_val2 = doublebits(0xFFF8000000000001);
+    const uniform double nan_val3 = doublebits(0x7FF8000000000000);
+
+    int errors = 0;
+    if (isfinite((T)neg_inf)) errors++;
+    if (isfinite((T)pos_inf)) errors++;
+    if (isfinite((T)nan_val1)) errors++;
+    if (isfinite((T)nan_val2)) errors++;
+    if (isfinite((T)nan_val3)) errors++;
+    if (!isfinite((T)0)) errors++;
+    if (!isfinite((T)-0)) errors++;
+    if (!isfinite((T)42)) errors++;
+    if (!isfinite((T)-42)) errors++;
+    return errors;
+}
+
+task void f_v(uniform float RET[]) {
+    int errors = 0;
+    errors += test_isfinite<uniform float16>() + test_isfinite<float16>();
+    errors += test_isfinite<uniform float>() + test_isfinite<float>();
+    errors += test_isfinite<uniform double>() + test_isfinite<double>();
+    RET[programIndex] = errors;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 0;
+}

--- a/tests/func-tests/isinf.ispc
+++ b/tests/func-tests/isinf.ispc
@@ -1,0 +1,38 @@
+#include "test_static.isph"
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
+
+template <typename T>
+int test_isinf()
+{
+    // Constants assumed to be converted to the right type and variability
+    const uniform double neg_inf = doublebits(0xFFF0000000000000);
+    const uniform double pos_inf = doublebits(0x7FF0000000000000);
+    const uniform double nan_val1 = doublebits(0xFFF8000000000000);
+    const uniform double nan_val2 = doublebits(0xFFF8000000000001);
+    const uniform double nan_val3 = doublebits(0x7FF8000000000000);
+
+    int errors = 0;
+    if (!isinf((T)neg_inf)) errors++;
+    if (!isinf((T)pos_inf)) errors++;
+    if (isinf((T)nan_val1)) errors++;
+    if (isinf((T)nan_val2)) errors++;
+    if (isinf((T)nan_val3)) errors++;
+    if (isinf((T)0)) errors++;
+    if (isinf((T)-0)) errors++;
+    if (isinf((T)42)) errors++;
+    if (isinf((T)-42)) errors++;
+    return errors;
+}
+
+task void f_v(uniform float RET[]) {
+    int errors = 0;
+    errors += test_isinf<uniform float16>() + test_isinf<float16>();
+    errors += test_isinf<uniform float>() + test_isinf<float>();
+    errors += test_isinf<uniform double>() + test_isinf<double>();
+    RET[programIndex] = errors;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 0;
+}


### PR DESCRIPTION
## Description
This add the two basic `isinf` and `isfinite` math functions requested in #2168. They behave like in C/C++.

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [x] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [x] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed