### PR TITLE
nanobind: fix a potential null-deref

### DIFF
--- a/src/header.cpp
+++ b/src/header.cpp
@@ -1159,8 +1159,12 @@ std::string lGetCallArguments(const FunctionType *ftype) {
 void lEmitNanobindWrapper(FILE *f, const Symbol *sym) {
     std::string fname = sym->name;
     const FunctionType *ftype = CastType<FunctionType>(sym->type);
-    const Type *returnType = ftype->GetReturnType();
+    if (!ftype) {
+        Error(sym->pos, "Symbol %s is not a function type", fname.c_str());
+        return;
+    }
 
+    const Type *returnType = ftype->GetReturnType();
     std::string nbWrapper = lGetNanobindType(returnType) + " " + fname + "(" + lGetParameters(ftype) + ")";
     std::string callArgs = lGetCallArguments(ftype);
     fprintf(f, "%s {\n", nbWrapper.c_str());


### PR DESCRIPTION
## Description

Added a null check for the `ftype` parameter in `lEmitNanobindWrapper` to ensure it is a valid function type. If `ftype` is null, an error message is logged and the function returns early, preventing further processing.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed