### PR TITLE
Fix #2291 about extracting the address of const variables set to compile-time constants

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -124,6 +124,7 @@ class ASTNode : public Traceable {
         AssignExprID,
         BinaryExprID,
         ConstExprID,
+        ConstSymbolExprID,
         DerefExprID,
         PtrDerefExprID,
         RefDerefExprID,

--- a/tests/lit-tests/2291.ispc
+++ b/tests/lit-tests/2291.ispc
@@ -1,0 +1,16 @@
+// This test checks that this code does not cause any crash (fatal error) 
+// due to the address of the `dummy_error` being requested, even though this 
+// variable is `const` and also set to a compile-time constant.
+
+// RUN: %{ispc} %s --emit-llvm-text --nowrap --nostdlib --target=host -g -o - 2>&1 | FileCheck %s
+
+// CHECK-NOT: Error:
+// CHECK-NOT: FATAL ERROR:
+
+uniform int foo(uniform const int8 * uniform bar);
+
+void crash() {
+  const uniform int8 dummy_error = 0;
+  uniform int err = 0;
+  err = foo(&dummy_error);
+}

--- a/tests/lit-tests/2552.ispc
+++ b/tests/lit-tests/2552.ispc
@@ -1,0 +1,17 @@
+// This test checks that this code produces neither any unreachable code nor
+// causes any crash one functions requesting the addresses of variables that 
+// are `const` and also set to a compile-time constant (even when the later
+// address is dereferenced).
+
+// RUN: %{ispc} %s --emit-llvm-text --nowrap --nostdlib --target=host -g -o - 2>&1 | FileCheck %s
+
+// CHECK-NOT: unreachable
+// CHECK-NOT: Error:
+// CHECK-NOT: FATAL ERROR:
+
+uniform int boo() {
+    const uniform int a = 2;
+    uniform const int * uniform const p = &a;
+    uniform int x = a + *p;
+    return x;
+}


### PR DESCRIPTION
## Description

As the name suggest, this PR fix #2291 . 
Details are provided in the linked issue. It implements the new class `ConstSymbolExpr` meant to replace `ConstExpr` for node representing (optimized) `const` symbols set to compile-time constant. Overall, It behaves like `ConstExpr` except regarding lvalues.

I wonder if the `ConstSymbolExpr::Instantiate` member function is correct. I wrote it based on `SymbolExpr::Instantiate`. I am not sure of what this function is meant to do. It looks like it is not called in practice.

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed
