### PR TITLE
Zen4/Zen5 support

### DIFF
--- a/tests/lit-tests/cpus_x86.ispc
+++ b/tests/lit-tests/cpus_x86.ispc
@@ -22,6 +22,7 @@
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=znver1
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=znver2
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=znver3
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=znver4
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=ps5
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=skx
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=icelake-client

--- a/tests/lit-tests/cpus_x86_llvm20.ispc
+++ b/tests/lit-tests/cpus_x86_llvm20.ispc
@@ -2,6 +2,7 @@
 
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=dmr
 //; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=diamondrapids
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=sse2-i32x4 --cpu=znver5
 
 // REQUIRES: X86_ENABLED && LLVM_20_0+
 


### PR DESCRIPTION
## Description

This PR add the support of Zen4 and Zen5.
Zen4 is apparently [supported since LLVM 16](https://www.phoronix.com/news/AMD-Zen-4-Znver4-LLVM-Added), while Zen5 is [supported since LLVM 19~20](https://www.phoronix.com/news/LLVM-Clang-Znver5-Merged). Since the minimum [LLVM version supported by ISPC](https://github.com/ispc/ispc/wiki/ISPC-Development-Guide) is supposed to be the 18.1 I only guarded Zen5 changes with preprocessor's conditions. I used [this Wikipedia page](https://fr.wikipedia.org/wiki/Advanced_Vector_Extensions) as a reference to add the new support.

I got some questions though:
- Why `CPU_ICL` references `avx512skx_x16` and not `avx512icl_x16` [here](https://github.com/ispc/ispc/blob/b8b8bf8b685852f6719abbc2d47e9d11651730c9/src/ispc.cpp#L982)?
- I guess "avx_vnni" means VNNI for AVX2 only, so without a 512-bit support (only 256-bit), while "avx512_vnni" means VNNI for AVX-512 only, so without a 256-bit support (only 512-bit); is this right here?
- Why `compat[CPU_ZNVER2]` don't include `CPU_ZNVER1` [here](https://github.com/ispc/ispc/blob/b8b8bf8b685852f6719abbc2d47e9d11651730c9/src/ispc.cpp#L657)? Same question with `compat[CPU_ZNVER3]` and `CPU_ZNVER2`.
- Out of curiosity, is this OK to remove the ISPC_LLVM_18_1 conditionals since the minimum LLVM version required by ISPC is the 18.1?

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed