### PR TITLE
Fix #2321: reports an error when accessing the component w of a short vector of size 3

### DIFF
--- a/tests/lit-tests/2321.ispc
+++ b/tests/lit-tests/2321.ispc
@@ -1,0 +1,27 @@
+// This test checks that the compiler reports errors when accessing `col.x`
+// and assigning `reduce_col.w` and that this does not cause any crash 
+// (fatal error).
+
+// RUN: not %{ispc} --target=host --emit-llvm-text --nowrap -g %s -o - 2>&1 | FileCheck %s
+
+// CHECK-COUNT-4: Error: Vector element identifier "w" is invalid for type
+// CHECK-NOT: FATAL ERROR:
+
+export void test(uniform int seq_len, uniform int tile_size) {
+    varying float<3> col = {0, 0, 0};
+    uniform float <3>* uniform reduce_col;
+    reduce_col->x = reduce_add(col.x);
+    reduce_col->y = reduce_add(col.y);
+    reduce_col->z = reduce_add(col.z);
+    reduce_col->w = reduce_add(col.w);
+}
+
+export void test2() {
+    varying float<3> col = {0, 0, 0};
+    col.w;
+}
+
+export void test3() {
+    varying float<3> col = {0, 0, 0};
+    sizeof(col.w);
+}


### PR DESCRIPTION
## Description

This PR fix #2321 as pointed out in the name. 
The newly reported errors for the code in the issue are now the following with this PR:

```ispc
/tmp/test.ispc:23:5: Error: Vector element identifier "w" is invalid for type "uniform float<3>" (out of bounds). 
    reduce_col.w = reduce_add(col.w);
    ^^^^^^^^^^^^

/tmp/test.ispc:23:31: Error: Vector element identifier "w" is invalid for type "varying float<3>" (out of bounds). 
    reduce_col.w = reduce_add(col.w);
                              ^^^^^
```

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed