### PR TITLE
Fix #3234: sizeof of reference to an array correctly returns the sizeof the referenced array

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -8703,6 +8703,10 @@ llvm::Value *SizeOfExpr::GetValue(FunctionEmitContext *ctx) const {
         return nullptr;
     }
 
+    if (CastType<ReferenceType>(t) != nullptr) {
+        t = t->GetReferenceTarget();
+    }
+
     llvm::Type *llvmType = t->LLVMType(g->ctx);
     if (llvmType == nullptr) {
         return nullptr;

--- a/tests/lit-tests/3234.ispc
+++ b/tests/lit-tests/3234.ispc
@@ -1,0 +1,13 @@
+// This test checks that the sizeof for the reference to an array properly 
+// returns 28 here (size of the array rather than the size of the reference).
+
+// RUN: %{ispc} --target=host --emit-llvm-text --nowrap --nostdlib %s -o - 2>&1 | FileCheck %s
+
+// CHECK: ret i32 28
+// CHECK-NOT: Error:
+// CHECK-NOT: FATAL ERROR:
+
+uniform int foo(uniform int (&a)[7]) {
+    return sizeof(a);
+}
+


### PR DESCRIPTION
## Description

This PR fixes #3234. If the target type is a reference, then the size of the target referenced type is extracted rather than the size of the reference.

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed