### PR TITLE
Fix ispc#3145: enable void functions to return expression of void type

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -1283,7 +1283,15 @@ void FunctionEmitContext::CurrentLanesReturned(Expr *expr, bool doCoherenceCheck
         if (expr != nullptr) {
             const Type *exprType = expr->GetType();
             Assert(exprType);
-            Error(expr->pos, "Can't return non-void type \"%s\" from void function.", exprType->GetString().c_str());
+
+            if (exprType->IsVoidType()) {
+                // Force function calls instructions to be emitted even though
+                // the llvm::Value result is unused.
+                expr->GetValue(this);
+            } else {
+                Error(expr->pos, "Can't return an expression of type \"%s\" in a function returning void.",
+                      exprType->GetString().c_str());
+            }
         }
     } else {
         if (expr == nullptr) {

--- a/tests/lit-tests/3145-1.ispc
+++ b/tests/lit-tests/3145-1.ispc
@@ -1,0 +1,26 @@
+// This test checks there is no error produced when calling void function in 
+// return statements of void functions and that the call is correctly evaluated.
+// Note that this is valid for a function to call itself in the return statement.
+
+// RUN: %{ispc} --target=host --emit-llvm-text --nowrap --nostdlib %s -O3 -o - 2>&1 | FileCheck %s
+
+// CHECK-COUNT-3: tail call void @unoptimized_call()
+// CHECK: br label %tailrecurse
+
+extern "C" void unoptimized_call();
+
+void bar_v1() {
+    unoptimized_call();
+}
+
+void bar_v2() {
+    return unoptimized_call();
+}
+
+void foo() {
+    return bar_v1();
+}
+
+void loop_fun() {
+    return loop_fun();
+}

--- a/tests/lit-tests/3145-2.ispc
+++ b/tests/lit-tests/3145-2.ispc
@@ -1,0 +1,16 @@
+// This test checks an error is produced when returning a non-void value from 
+// a function returning a void type.
+
+// RUN: not %{ispc} --target=host --emit-llvm-text --nowrap --nostdlib %s -O3 -o - 2>&1 | FileCheck %s
+
+// CHECK-COUNT-2: Error: Can't return an expression of type
+
+extern "C" int unoptimized_call();
+
+void bar() {
+    return 3;
+}
+
+void loop_fun() {
+    return unoptimized_call();
+}


### PR DESCRIPTION
## Description

This PR fixes #3145.
I do not think there is a need for lit-tests here since I just made the error clearer and it appears in the same exact case anyway (only the content of the message changes -- and it is specialized regarding the use-case). Do you agree?

## Related Issue
- [X] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed