### PR TITLE
Repair build for LLVM 21

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -228,7 +228,7 @@ Module::Module(const char *fn) : srcFile(fn) {
     lSetCodeModel(module);
     lSetPICLevel(module);
 
-#if ISPC_LLVM_VERSION >= ISPC_LLVM_19_0
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_19_0 && ISPC_LLVM_VERSION < ISPC_LLVM_21_0
     // LLVM is transitioning to new debug info representation, use "old" style for now.
     module->setIsNewDbgInfoFormat(false);
 #endif
@@ -2075,7 +2075,7 @@ static llvm::Module *lInitDispatchModule() {
     lSetCodeModel(module);
     lSetPICLevel(module);
 
-#if ISPC_LLVM_VERSION >= ISPC_LLVM_19_0
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_19_0 && ISPC_LLVM_VERSION < ISPC_LLVM_21_0
     // LLVM is transitioning to new debug info representation, use "old" style for now.
     module->setIsNewDbgInfoFormat(false);
 #endif


### PR DESCRIPTION
## Description

They are transitioning to using debug records only. Debug info format flag was removed in
https://github.com/llvm/llvm-project/commit/97ac6483aaead89897d9bda8a12f1f4c11fad621

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed