### PR TITLE
Support struct access on function call returns

### DIFF
--- a/tests/func-tests/operators5.ispc
+++ b/tests/func-tests/operators5.ispc
@@ -6,13 +6,13 @@ struct S {
 
 // Prefix increment (++x)
 struct S& operator++(struct S &rs) {
-    rs.a = rs.a + 1;
+    rs.a = rs.a + 2;
     return rs;
 }
 
 // Prefix decrement (--x)
 struct S& operator--(struct S &rs) {
-    rs.a = rs.a - 1;
+    rs.a = rs.a - 4;
     return rs;
 }
 
@@ -39,13 +39,14 @@ task void f_f(uniform float RET[], uniform float aFOO[]) {
     a.a = aFOO[programIndex];
     c.a = aFOO[programIndex];
 
+    // Not using overloaded operator
+    RET[programIndex] = ++a.a;
+
     // Test prefix increment
-    ++a;
-    RET[programIndex] = a.a;
+    RET[programIndex] += (++a).a;
 
     // Test prefix decrement
-    --a;
-    RET[programIndex] += a.a;
+    RET[programIndex] += (--a).a;
 
     // Test postfix increment
     c = a++;
@@ -56,4 +57,4 @@ task void f_f(uniform float RET[], uniform float aFOO[]) {
     RET[programIndex] += c.a - a.a; // 1
 }
 
-task void result(uniform float RET[16]) { RET[programIndex] = programIndex * 2 + 5; }
+task void result(uniform float RET[16]) { RET[programIndex] = programIndex * 3 + 8; }

--- a/tests/func-tests/operators6.ispc
+++ b/tests/func-tests/operators6.ispc
@@ -7,14 +7,14 @@ struct S {
 // Unary minus (-x)
 struct S operator-(struct S rs) {
     struct S result;
-    result.a = -rs.a;
+    result.a = -rs.a - 2;
     return result;
 }
 
 // Unary minus for reference (-x)
 struct S operator-(struct S &rs) {
     struct S result;
-    result.a = -rs.a - 10; // Different behavior for reference to distinguish
+    result.a = -rs.a; // Different behavior for reference to distinguish
     return result;
 }
 
@@ -27,14 +27,14 @@ bool operator!(struct S &rs) { return rs.a <= 0; } // Different behavior for ref
 // Bitwise NOT (~x)
 struct S operator~(struct S rs) {
     struct S result;
-    result.a = ~(rs.a);
+    result.a = ~(rs.a) + 1;
     return result;
 }
 
 // Bitwise NOT for reference (~x)
 struct S operator~(struct S &rs) {
     struct S result;
-    result.a = ~(rs.a) + 5; // Different behavior for reference to distinguish
+    result.a = ~(rs.a); // Different behavior for reference to distinguish
     return result;
 }
 
@@ -46,13 +46,12 @@ task void f_f(uniform float RET[], uniform float aFOO[]) {
     b.a = aFOO[programIndex];
 
     if (!a) {
-        S neg = -b;
-        RET[programIndex] = neg.a;
-        S bitNot = ~b;
-        RET[programIndex] += bitNot.a;
+        RET[programIndex] = -b.a; // -(b.a), not using overloaded operator
+        RET[programIndex] += (-b).a; // Using overloaded - operator
+        RET[programIndex] += (~b).a; // Using overloaded ~ operator
     } else {
         RET[programIndex] = 0;
     }
 }
 
-task void result(uniform float RET[4]) { RET[programIndex] = -3 - (2 * programIndex); }
+task void result(uniform float RET[4]) { RET[programIndex] = -5 - (3 * programIndex); }

--- a/tests/lit-tests/member_access_arrays.ispc
+++ b/tests/lit-tests/member_access_arrays.ispc
@@ -1,0 +1,68 @@
+// Test struct member access with array members on function call returns
+// RUN: %{ispc} --target=host --nowrap --nostdlib %s --emit-asm -o - | FileCheck %s --allow-empty
+// CHECK-NOT: Error
+
+struct Matrix3x3 {
+    float data[9];
+};
+
+struct Vertex {
+    float position[3];
+    float normal[3];
+    float texCoord[2];
+};
+
+Matrix3x3 makeIdentityMatrix() {
+    Matrix3x3 m;
+    for (uniform int i = 0; i < 9; i++) {
+        m.data[i] = (i % 4 == 0) ? 1.0 : 0.0;
+    }
+    return m;
+}
+
+Vertex makeVertex(float px, float py, float pz, float nx, float ny, float nz, float u, float v) {
+    Vertex vert;
+    vert.position[0] = px;
+    vert.position[1] = py;
+    vert.position[2] = pz;
+    vert.normal[0] = nx;
+    vert.normal[1] = ny;
+    vert.normal[2] = nz;
+    vert.texCoord[0] = u;
+    vert.texCoord[1] = v;
+    return vert;
+}
+
+void test_array_member_access() {
+    // Test accessing array members from function call returns
+    float first_element = makeIdentityMatrix().data[0];
+    float diagonal_element = makeIdentityMatrix().data[4];
+    float last_element = makeIdentityMatrix().data[8];
+}
+
+void test_vertex_array_members() {
+    // Test accessing different array members
+    float pos_x = makeVertex(1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 0.5, 0.5).position[0];
+    float pos_y = makeVertex(4.0, 5.0, 6.0, 0.0, 0.0, 1.0, 0.2, 0.8).position[1];
+    float pos_z = makeVertex(7.0, 8.0, 9.0, 1.0, 0.0, 0.0, 0.9, 0.1).position[2];
+
+    float norm_x = makeVertex(10.0, 11.0, 12.0, 0.707, 0.707, 0.0, 0.0, 1.0).normal[0];
+    float norm_y = makeVertex(13.0, 14.0, 15.0, 0.0, 0.707, 0.707, 1.0, 0.0).normal[1];
+    float norm_z = makeVertex(16.0, 17.0, 18.0, 0.707, 0.0, 0.707, 0.3, 0.7).normal[2];
+
+    float tex_u = makeVertex(19.0, 20.0, 21.0, -1.0, 0.0, 0.0, 0.25, 0.75).texCoord[0];
+    float tex_v = makeVertex(22.0, 23.0, 24.0, 0.0, -1.0, 0.0, 0.6, 0.4).texCoord[1];
+}
+
+void test_array_in_expressions() {
+    // Test array member access in arithmetic expressions
+    float dot_product = makeVertex(1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0).position[0] *
+                       makeVertex(1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0).normal[0] +
+                       makeVertex(0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0).position[1] *
+                       makeVertex(0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0).normal[1] +
+                       makeVertex(0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0).position[2] *
+                       makeVertex(0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0).normal[2];
+
+    // Test array indexing with computed indices
+    float matrix_trace = makeIdentityMatrix().data[0] + makeIdentityMatrix().data[4] + makeIdentityMatrix().data[8];
+}

--- a/tests/lit-tests/member_access_comprehensive.ispc
+++ b/tests/lit-tests/member_access_comprehensive.ispc
@@ -1,0 +1,108 @@
+// Comprehensive test for struct member access on function call returns
+// This tests checks different access patterns, no assertion is expected.
+// RUN: %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s --allow-empty
+// CHECK-NOT: Error
+
+struct Point {
+    float x, y;
+};
+
+struct Rectangle {
+    Point topLeft;
+    Point bottomRight;
+};
+
+struct Matrix3x3 {
+    float data[9];
+};
+
+struct Vertex {
+    float position[3];
+    float normal[3];
+};
+
+// Function that returns struct by value
+Point makePoint(float x, float y) {
+    Point p;
+    p.x = x;
+    p.y = y;
+    return p;
+}
+
+Rectangle makeRect(float x1, float y1, float x2, float y2) {
+    Rectangle r;
+    r.topLeft.x = x1;
+    r.topLeft.y = y1;
+    r.bottomRight.x = x2;
+    r.bottomRight.y = y2;
+    return r;
+}
+
+Matrix3x3 makeIdentityMatrix() {
+    Matrix3x3 m;
+    for (uniform int i = 0; i < 9; i++) {
+        m.data[i] = (i % 4 == 0) ? 1.0 : 0.0;
+    }
+    return m;
+}
+
+Vertex makeVertex(float px, float py, float pz, float nx, float ny, float nz) {
+    Vertex v;
+    v.position[0] = px;
+    v.position[1] = py;
+    v.position[2] = pz;
+    v.normal[0] = nx;
+    v.normal[1] = ny;
+    v.normal[2] = nz;
+    return v;
+}
+
+uniform Point makeUniformPoint(uniform float x, uniform float y) {
+    uniform Point p;
+    p.x = x;
+    p.y = y;
+    return p;
+}
+
+void test_comprehensive_member_access() {
+    // ORIGINAL REGRESSION CASE: This caused assertion failure before the fix
+    float x_val = makePoint(1.0, 2.0).x;
+    float y_val = makePoint(3.0, 4.0).y;
+
+    // NESTED STRUCTS: Test nested member access
+    float tl_x = makeRect(0.0, 0.0, 10.0, 10.0).topLeft.x;
+    float br_y = makeRect(1.0, 2.0, 11.0, 12.0).bottomRight.y;
+
+    // ARRAY MEMBERS: Test array member access
+    float m00 = makeIdentityMatrix().data[0];
+    float m11 = makeIdentityMatrix().data[4];
+    float m22 = makeIdentityMatrix().data[8];
+
+    // NESTED ARRAY ACCESS: Test accessing arrays in nested structs
+    float pos_x = makeVertex(1.0, 2.0, 3.0, 0.0, 1.0, 0.0).position[0];
+    float norm_z = makeVertex(4.0, 5.0, 6.0, 0.0, 0.0, 1.0).normal[2];
+
+    // EXPRESSIONS: Test member access in expressions
+    float sum = makePoint(1.0, 2.0).x + makePoint(3.0, 4.0).y;
+    float product = makeRect(0.0, 0.0, 5.0, 3.0).bottomRight.x * makeRect(2.0, 1.0, 7.0, 4.0).bottomRight.y;
+
+    // UNIFORM/VARYING: Test uniform member access
+    uniform float ux = makeUniformPoint(100.0, 200.0).x;
+    uniform float uy = makeUniformPoint(300.0, 400.0).y;
+
+    // VARYING CONTEXT: Test varying member access
+    float vx = makePoint(programIndex, programIndex + 1).x;
+    float vy = makePoint(programIndex * 2, programIndex + 2).y;
+
+    // COMPLEX EXPRESSIONS: Test in complex scenarios
+    float complex_result = makePoint(makeIdentityMatrix().data[0], makeIdentityMatrix().data[4]).x +
+                          makeRect(makePoint(0.0, 0.0).x, makePoint(0.0, 0.0).y,
+                                  makePoint(10.0, 10.0).x, makePoint(10.0, 10.0).y).topLeft.x;
+}
+
+// Test that this compiles without assertion failures
+void test_no_assertion_failure() {
+    // The original bug would cause an assertion failure here
+    // Now it should compile successfully
+    float result = makePoint(42.0, 3.14).x;
+}

--- a/tests/lit-tests/member_access_errors.ispc
+++ b/tests/lit-tests/member_access_errors.ispc
@@ -1,0 +1,109 @@
+// Test that member access errors are properly detected.
+// RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o - 2>&1 | FileCheck %s
+
+struct Point {
+    float x, y;
+};
+
+struct Color {
+    float r, g, b;
+};
+
+struct Rectangle {
+    Point topLeft;
+    Point bottomRight;
+};
+
+struct PointArray {
+    Point points[2];
+};
+
+Point makePoint(float x, float y) {
+    Point p;
+    p.x = x;
+    p.y = y;
+    return p;
+}
+
+Color makeColor(float r, float g, float b) {
+    Color c;
+    c.r = r;
+    c.g = g;
+    c.b = b;
+    return c;
+}
+
+Rectangle makeRectangle(float x1, float y1, float x2, float y2) {
+    Rectangle r;
+    r.topLeft = makePoint(x1, y1);
+    r.bottomRight = makePoint(x2, y2);
+    return r;
+}
+
+PointArray makePointArray() {
+    PointArray pa;
+    pa.points[0] = makePoint(1.0, 2.0);
+    pa.points[1] = makePoint(3.0, 4.0);
+    return pa;
+}
+
+int makeInt() {
+    return 42;
+}
+
+void modifyPoint(Point& p) {
+    p.x = 999.0;
+    p.y = 999.0;
+}
+
+void test_nonexistent_member() {
+    // CHECK: has no member named "z"
+    float bad_z = makePoint(1.0, 2.0).z;
+}
+
+void test_wrong_member_name() {
+    // CHECK: has no member named "red"
+    float bad_red = makeColor(1.0, 0.5, 0.0).red;
+}
+
+void test_member_access_on_non_struct() {
+    // CHECK: Member operator "." can't be used with expression of
+    float bad_access = makeInt().x;
+}
+
+// New tests for lvalue restrictions on function returns
+
+void test_cannot_take_address_of_function_return() {
+    // CHECK: Illegal to take address of non-lvalue or function
+    Point *ptr1 = &makePoint(1.0, 2.0);
+}
+
+void test_cannot_take_address_of_nested_member() {
+    // CHECK: Illegal to take address of non-lvalue or function
+    float *ptr2 = &makeRectangle(0, 0, 10, 10).topLeft.x;
+}
+
+void test_cannot_take_address_of_array_member() {
+    // CHECK: Illegal to take address of non-lvalue or function
+    float *ptr3 = &makePointArray().points[0].x;
+}
+
+void test_cannot_take_address_of_varying_function_return() {
+    // CHECK: Illegal to take address of non-lvalue or function
+    varying float *vptr = &makePoint(programIndex, programIndex).x;
+}
+
+void test_cannot_assign_to_function_return_member() {
+    // CHECK: Left hand side of assignment expression can't be assigned to
+    makePoint(1.0, 2.0).x = 5.0;
+}
+
+void test_cannot_assign_to_nested_member() {
+    // CHECK: Left hand side of assignment expression can't be assigned to
+    makeRectangle(0, 0, 10, 10).topLeft.x = 42.0;
+}
+
+void test_cannot_assign_to_array_member() {
+    // CHECK: Left hand side of assignment expression can't be assigned to
+    makePointArray().points[0].x = 99.0;
+}

--- a/tests/lit-tests/member_access_funcall.ispc
+++ b/tests/lit-tests/member_access_funcall.ispc
@@ -1,0 +1,51 @@
+// Test basic struct member access on function call returns
+// RUN: %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s --allow-empty
+// CHECK-NOT: Error
+
+struct Point {
+    float x, y;
+};
+
+struct Vector3 {
+    float x, y, z;
+};
+
+Point makePoint(float x, float y) {
+    Point p;
+    p.x = x;
+    p.y = y;
+    return p;
+}
+
+Vector3 makeVector3(float x, float y, float z) {
+    Vector3 v;
+    v.x = x;
+    v.y = y;
+    v.z = z;
+    return v;
+}
+
+void test_basic_member_access() {
+    // Basic member access on function call return
+    float x_val = makePoint(1.0, 2.0).x;
+    float y_val = makePoint(3.0, 4.0).y;
+}
+
+void test_multiple_members() {
+    // Access multiple members from same function call
+    Vector3 v = makeVector3(1.0, 2.0, 3.0);
+    float x = v.x;
+    float y = v.y;
+    float z = v.z;
+
+    // Also test direct member access on function call
+    float direct_x = makeVector3(4.0, 5.0, 6.0).x;
+    float direct_y = makeVector3(7.0, 8.0, 9.0).y;
+    float direct_z = makeVector3(10.0, 11.0, 12.0).z;
+}
+
+float test_member_access_in_expressions() {
+    // Test member access in arithmetic expressions
+    return makePoint(1.0, 2.0).x + makePoint(3.0, 4.0).y +
+           makeVector3(2.0, 3.0, 4.0).x * makeVector3(5.0, 6.0, 7.0).y;
+}

--- a/tests/lit-tests/member_access_nested_structs.ispc
+++ b/tests/lit-tests/member_access_nested_structs.ispc
@@ -1,0 +1,61 @@
+// Test nested struct member access on function call returns
+
+// RUN: %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s --allow-empty
+// CHECK-NOT: Error
+
+struct Point {
+    float x, y;
+};
+
+struct Rectangle {
+    Point topLeft;
+    Point bottomRight;
+};
+
+struct Transform {
+    Point translation;
+    float rotation;
+    Point scale;
+};
+
+Rectangle makeRectangle(float x1, float y1, float x2, float y2) {
+    Rectangle rect;
+    rect.topLeft.x = x1;
+    rect.topLeft.y = y1;
+    rect.bottomRight.x = x2;
+    rect.bottomRight.y = y2;
+    return rect;
+}
+
+Transform makeTransform(float tx, float ty, float rot, float sx, float sy) {
+    Transform t;
+    t.translation.x = tx;
+    t.translation.y = ty;
+    t.rotation = rot;
+    t.scale.x = sx;
+    t.scale.y = sy;
+    return t;
+}
+
+void test_nested_member_access() {
+    // Test nested member access on function call returns
+    float top_x = makeRectangle(0.0, 0.0, 10.0, 10.0).topLeft.x;
+    float top_y = makeRectangle(1.0, 2.0, 11.0, 12.0).topLeft.y;
+    float bottom_x = makeRectangle(5.0, 6.0, 15.0, 16.0).bottomRight.x;
+    float bottom_y = makeRectangle(7.0, 8.0, 17.0, 18.0).bottomRight.y;
+}
+
+void test_deep_nested_access() {
+    // Test accessing deeply nested members
+    float trans_x = makeTransform(1.0, 2.0, 45.0, 2.0, 2.0).translation.x;
+    float trans_y = makeTransform(3.0, 4.0, 90.0, 1.5, 1.5).translation.y;
+    float scale_x = makeTransform(5.0, 6.0, 180.0, 3.0, 3.0).scale.x;
+    float scale_y = makeTransform(7.0, 8.0, 270.0, 0.5, 0.5).scale.y;
+    float rot = makeTransform(9.0, 10.0, 360.0, 1.0, 1.0).rotation;
+}
+
+float test_nested_in_expressions() {
+    // Test nested member access in arithmetic expressions
+    return makeRectangle(0.0, 0.0, 10.0, 5.0).bottomRight.x - makeRectangle(0.0, 0.0, 10.0, 5.0).topLeft.x +
+           makeRectangle(2.0, 3.0, 12.0, 8.0).bottomRight.y - makeRectangle(2.0, 3.0, 12.0, 8.0).topLeft.y;
+}

--- a/tests/lit-tests/member_access_regression.ispc
+++ b/tests/lit-tests/member_access_regression.ispc
@@ -1,0 +1,71 @@
+// Regression test for member access on function call returns
+
+// RUN: %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s --allow-empty
+// CHECK-NOT: Error
+
+struct Point {
+    float x, y;
+};
+
+struct Complex {
+    float real, imaginary;
+};
+
+struct Pair {
+    int first, second;
+};
+
+Point makePoint(float x, float y) {
+    Point p;
+    p.x = x;
+    p.y = y;
+    return p;
+}
+
+Complex makeComplex(float r, float i) {
+    Complex c;
+    c.real = r;
+    c.imaginary = i;
+    return c;
+}
+
+Pair makePair(int a, int b) {
+    Pair p;
+    p.first = a;
+    p.second = b;
+    return p;
+}
+
+void test_original_regression_case() {
+    float x_val = makePoint(1.0, 2.0).x;
+    float y_val = makePoint(3.0, 4.0).y;
+}
+
+void test_multiple_struct_types() {
+    // Test with different struct types to ensure the fix is general
+    float real_part = makeComplex(3.14, 2.718).real;
+    float imag_part = makeComplex(1.414, 1.732).imaginary;
+
+    int first_value = makePair(42, 17).first;
+    int second_value = makePair(99, 88).second;
+}
+
+void test_chained_function_calls() {
+    // Test more complex scenarios
+    float sum_x = makePoint(1.0, 2.0).x + makePoint(3.0, 4.0).x;
+    float sum_y = makePoint(5.0, 6.0).y + makePoint(7.0, 8.0).y;
+
+    // Test with function calls as arguments
+    float distance_sq = makePoint(makeComplex(1.0, 0.0).real, makeComplex(0.0, 1.0).imaginary).x *
+                       makePoint(makeComplex(1.0, 0.0).real, makeComplex(0.0, 1.0).imaginary).x +
+                       makePoint(makeComplex(1.0, 0.0).real, makeComplex(0.0, 1.0).imaginary).y *
+                       makePoint(makeComplex(1.0, 0.0).real, makeComplex(0.0, 1.0).imaginary).y;
+}
+
+void test_member_access_with_varying() {
+    float varying_x = makePoint(programIndex, programIndex + 1).x;
+    float varying_y = makePoint(programIndex * 2, programIndex * 3).y;
+
+    Point vp = makePoint(10.0, 20.0);
+    float mixed = vp.x + programIndex;
+}

--- a/tests/lit-tests/member_access_uniform_varying.ispc
+++ b/tests/lit-tests/member_access_uniform_varying.ispc
@@ -1,0 +1,95 @@
+// Test struct member access on function calls with uniform and varying contexts
+
+// RUN: %{ispc} --target=host --nowrap --nostdlib %s -o %t.o 2>&1 | FileCheck %s --allow-empty
+// CHECK-NOT: Error
+
+struct Point {
+    float x, y;
+};
+
+struct Color {
+    float r, g, b, a;
+};
+
+// Uniform function returning struct
+uniform Point makeUniformPoint(uniform float x, uniform float y) {
+    uniform Point p;
+    p.x = x;
+    p.y = y;
+    return p;
+}
+
+// Varying function returning struct
+Point makeVaryingPoint(float x, float y) {
+    Point p;
+    p.x = x;
+    p.y = y;
+    return p;
+}
+
+uniform Color makeUniformColor(uniform float r, uniform float g, uniform float b, uniform float a) {
+    uniform Color c;
+    c.r = r;
+    c.g = g;
+    c.b = b;
+    c.a = a;
+    return c;
+}
+
+Color makeVaryingColor(float r, float g, float b, float a) {
+    Color c;
+    c.r = r;
+    c.g = g;
+    c.b = b;
+    c.a = a;
+    return c;
+}
+
+void test_uniform_member_access() {
+    // Test member access on uniform function call returns
+    uniform float ux = makeUniformPoint(1.0, 2.0).x;
+    uniform float uy = makeUniformPoint(3.0, 4.0).y;
+
+    uniform float ur = makeUniformColor(1.0, 0.5, 0.25, 1.0).r;
+    uniform float ug = makeUniformColor(0.8, 0.6, 0.4, 0.9).g;
+    uniform float ub = makeUniformColor(0.7, 0.3, 0.1, 0.8).b;
+    uniform float ua = makeUniformColor(0.9, 0.8, 0.7, 0.6).a;
+}
+
+void test_varying_member_access() {
+    // Test member access on varying function call returns
+    float vx = makeVaryingPoint(programIndex, programIndex + 1).x;
+    float vy = makeVaryingPoint(programIndex + 2, programIndex + 3).y;
+
+    float vr = makeVaryingColor(programIndex * 0.1, 0.5, 0.25, 1.0).r;
+    float vg = makeVaryingColor(0.8, programIndex * 0.1, 0.4, 0.9).g;
+    float vb = makeVaryingColor(0.7, 0.3, programIndex * 0.1, 0.8).b;
+    float va = makeVaryingColor(0.9, 0.8, 0.7, programIndex * 0.1).a;
+}
+
+void test_mixed_uniform_varying() {
+    // Test mixing uniform and varying member access
+    uniform float uniform_x = makeUniformPoint(5.0, 6.0).x;
+    float varying_y = makeVaryingPoint(uniform_x, programIndex).y;
+
+    // Test using uniform result in varying context
+    float mixed_result = makeUniformColor(1.0, 0.5, 0.0, 1.0).r + programIndex * 0.1;
+
+    // Test using varying result in expressions
+    uniform float base = makeUniformPoint(10.0, 20.0).x;
+    float computed = base + makeVaryingPoint(programIndex, programIndex * 2).y;
+}
+
+void test_conditional_member_access() {
+    // Test member access in conditional contexts
+    if (programIndex % 2 == 0) {
+        float even_x = makeVaryingPoint(programIndex, 0).x;
+        uniform float uniform_y = makeUniformPoint(100.0, 200.0).y;
+    } else {
+        float odd_y = makeVaryingPoint(0, programIndex).y;
+        uniform float uniform_x = makeUniformPoint(300.0, 400.0).x;
+    }
+
+    // Test in varying conditional with uniform access
+    float result = (programIndex > 4) ? makeUniformPoint(1.0, 2.0).x : makeUniformPoint(3.0, 4.0).y;
+}


### PR DESCRIPTION
Support struct access on function call returns (which is especially important when dealing with operators).
Fixes https://github.com/ispc/ispc/issues/3220 and https://github.com/ispc/ispc/issues/2533

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed