### PR TITLE
Use the avx512icl_x16 target on IceLake CPUs instead of avx512skx_x16

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -1003,6 +1003,9 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         case CPU_TGL:
         case CPU_ICX:
         case CPU_ICL:
+            m_ispc_target = ISPCTarget::avx512icl_x16;
+            break;
+
         case CPU_SKX:
             m_ispc_target = ISPCTarget::avx512skx_x16;
             break;


### PR DESCRIPTION
## Description

Everything is in the name. 
This is a follow up of the discussion about the IceLake issue found during the PR #3426 .

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed