### PR TITLE
Docs fix for bold sections

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -2460,9 +2460,9 @@ changing values in memory with pointers, and so forth is supported as in C.
 As with other basic types, pointers can be both ``uniform`` and
 ``varying``.
 
-**Like other types in ``ispc``, pointers are ``varying`` by default, if an
-explicit ``uniform`` qualifier isn't provided.  However, the default
-variability of the pointed-to type is uniform.** This rule will be
+**Like other types in ispc, pointers are** ``varying`` **by default, if an
+explicit** ``uniform`` **qualifier isn't provided. However, the default
+variability of the pointed-to type is** ``uniform``. This rule will be
 illustrated and explained in examples below.
 
 For example, the ``ptr`` variable in the code below is a varying pointer to

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -2941,7 +2941,7 @@ Unary Operators
 ISPC also supports overloading unary operators: ``++, --, -, !, and ~``. For
 unary operators, the implementation depends on the operator type:
 
-1. **Prefix Increment/Decrement (``++x``, ``--x``)**: Define a function that
+1. **Prefix Increment/Decrement (** ``++x`` **,** ``--x`` **)**: Define a function that
    takes a reference to your struct and returns the modified struct.
 
 ::
@@ -2952,7 +2952,7 @@ unary operators, the implementation depends on the operator type:
         return s;
     }
 
-2. **Postfix Increment/Decrement (``x++``, ``x--``)**: Define a function that
+2. **Postfix Increment/Decrement (** ``x++`` **,** ``x--`` **)**: Define a function that
    takes a reference to your struct and an additional dummy int parameter,
    returning the original value before modification.
 
@@ -2964,7 +2964,7 @@ unary operators, the implementation depends on the operator type:
         return temp;        // Return saved original
     }
 
-3. **Unary Minus, Logical NOT, Bitwise NOT (``-x``, ``!x``, ``~x``)**: Define a
+3. **Unary Minus, Logical NOT, Bitwise NOT (** ``-x`` **,** ``!x`` **,** ``~x`` **)**: Define a
    function that takes your struct by value and returns an appropriate result.
 
 ::
@@ -2986,7 +2986,7 @@ ISPC also supports overloading assignment operators for ``struct`` types. The as
 operators include: ``=, +=, -=, *=, /=, %=, <<=, >>=, &=, |=, and ^=``. This allows for
 more intuitive operations with custom data types.
 
-1. **Basic Assignment (``=``)**: Define a function that takes a reference to your struct
+1. **Basic Assignment (** ``=`` **)**: Define a function that takes a reference to your struct
    as the left-hand side and a value (or reference) of another type as the right-hand side,
    returning a reference to the modified struct.
 
@@ -3004,7 +3004,7 @@ more intuitive operations with custom data types.
         return A;
     }
 
-2. **Compound Assignment (``+=``, ``-=``, etc.)**: Define a function that takes a reference
+2. **Compound Assignment (** ``+=`` **,** ``-=`` **, etc.)**: Define a function that takes a reference
    to your struct as the left-hand side and a value (or reference) as the right-hand side,
    returning a reference to the modified struct.
 


### PR DESCRIPTION
## Description
This PR fixes formatting of code inside bold sections. 
Fixes #3440.
Now it will look like this:
![Screenshot 2025-06-23 203552](https://github.com/user-attachments/assets/f9eb9a63-ba13-4ea7-9db1-326dc13affd4)

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed