### PR TITLE
Fix the list of reserved keywords in the doc

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -2076,12 +2076,13 @@ The following reserved words from C89 are also reserved in ``ispc``:
 
 ``ispc`` additionally reserves the following words:
 
-``bool``, ``delete``, ``export``, ``cdo``, ``cfor``, ``cif``, ``cwhile``,
+``bool``, ``cdo``, ``cfor``, ``cif``, ``cwhile``, ``delete``, ``export``,
 ``false``, ``float16``, ``foreach``, ``foreach_active``, ``foreach_tiled``,
-``foreach_unique``, ``in``, ``inline``, ``noinline``, ``__regcall``,
-``__vectorcall``, ``int8``, ``int16``, ``int32``, ``int64``, ``launch``,
-``new``, ``print``, ``uint8``, ``uint16``, ``uint32``, ``uint64``, ``soa``,
-``__attribute__``, ``sync``, ``task``, ``true``, ``uniform``, and ``varying``.
+``foreach_unique``, ``in``, ``inline``, ``int8``, ``int16``, ``int32``,
+``int64``, ``invoke_sycl``, ``launch``, ``new``, ``noinline``, ``print``,
+``soa``, ``sync``, ``task``, ``template``, ``true``, ``typename``, ``uint8``,
+``uint16``, ``uint32``, ``uint64``, ``uint``, ``uniform``, ``unmasked``,
+``varying``, ``__attribute__``, ``__regcall``, ``__vectorcall``.
 
 
 Lexical Structure
@@ -2236,17 +2237,17 @@ as the first argument to the ``print()`` statement, however.  ``ispc`` also
 doesn't support character constants.
 
 The following identifiers are reserved as language keywords: ``bool``,
-``break``, ``case``, ``cdo``, ``cfor``, ``char``, ``cif``, ``cwhile``,
-``const``, ``continue``, ``default``, ``do``, ``double``, ``else``,
-``enum``, ``export``, ``extern``, ``false``, ``float``, ``float16``, ``for``,
+``break``, ``case``, ``cdo``, ``cfor``, ``cif``, ``const``, ``continue``,
+``cwhile``, ``default``, ``delete``, ``do``, ``double``, ``else``, ``enum``,
+``export``, ``extern``, ``false``, ``float16``, ``float``, ``for``,
 ``foreach``, ``foreach_active``, ``foreach_tiled``, ``foreach_unique``,
-``goto``, ``if``, ``in``, ``inline``, ``noinline``, ``int``, ``int8``,
-``int16``, ``int32``, ``int64``, ``invoke_sycl``, ``launch``, ``NULL``,
-``print``, ``return``, ``signed``, ``sizeof``, ``soa``, ``static``, ``struct``,
-``switch``, ``sync``, ``task``, ``template``, ``true``, ``typedef``,
-``typename``, ``uint``, ``uint8``, ``uint16``, ``uint32``, ``uint64``,
-``uniform``, ``union``, ``unsigned``, ``varying``, ``__regcall``,
-``__vectorcall``, ``__attribute__``, ``void``, ``volatile``, ``while``.
+``goto``, ``if``, ``in``, ``inline``, ``int8``, ``int16``, ``int32``,
+``int64``, ``int``, ``invoke_sycl``, ``launch``, ``new``, ``noinline``,
+``NULL``, ``print``, ``return``, ``signed``, ``sizeof``, ``soa``, ``static``,
+``struct``, ``switch``, ``sync``, ``task``, ``template``, ``true``,
+``typedef``, ``typename``, ``uint8``, ``uint16``, ``uint32``, ``uint64``,
+``uint``, ``uniform``, ``unmasked``, ``unsigned``, ``varying``, ``void``,
+``while``, ``__attribute__``, ``__regcall``, ``__vectorcall``.
 
 ``ispc`` defines the following operators and punctuation:
 


### PR DESCRIPTION
## Description

Everything is in the name.
The list of keywords was not up to date and also incorrect. For example, `char` was in the list while it is not a reserved keyword (explicitly mentioned earlier in the doc so it was inconsistent and confusing). Moreover, `template` and `typename` were missing in the first list while they was inconsistently added in the second one. For `NULL`, it is the opposite. Additionally, `alloca` was missing in both. There are few other issues like this in these two lists.

Interestingly, while `assert` is mentioned [here](https://github.com/ispc/ispc/blob/31b620ac6a8220333880a1272ccd7e27a4526da6/src/lex.ll#L50) as a reserved token, it does not seems to actually be one : https://ispc.godbolt.org/z/Ebdd9cdMe . This looks like a bug to me.
Thus, I did not add `assert` yet to the list.

By the way, I wonder how relevant it is to keep the first list in the doc. Keeping simultaneously the two lists in the doc is prone to mistakes. What do you think about this?

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [x] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed