### PR TITLE
Remove alloca from reserved keywords

### DIFF
--- a/src/lex.ll
+++ b/src/lex.ll
@@ -373,7 +373,7 @@ return { return TOKEN_RETURN; }
 soa { return TOKEN_SOA; }
 signed { return TOKEN_SIGNED; }
 sizeof { return TOKEN_SIZEOF; }
-alloca { return TOKEN_ALLOCA; }
+__alloca { return TOKEN_ALLOCA; }
 static { return TOKEN_STATIC; }
 struct { return TOKEN_STRUCT; }
 switch { return TOKEN_SWITCH; }

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -156,7 +156,7 @@ static void lFinalizeEnumeratorSymbols(std::vector<Symbol *> &enums,
                                        const EnumType *enumType);
 
 static const char *lBuiltinTokens[] = {
-    "assert", "bool", "break", "case", "cdo",
+    "assert", "alloca", "bool", "break", "case", "cdo",
     "cfor", "cif", "cwhile", "const", "continue", "default",
     "do", "delete", "double", "else", "enum", "export", "extern", "false",
     "float16", "float", "for", "foreach", "foreach_active", "foreach_tiled",

--- a/stdlib/include/core.isph
+++ b/stdlib/include/core.isph
@@ -39,6 +39,8 @@
 #define assert(x) __assert(#x, x)
 #endif
 
+#define alloca(x) __alloca(x)
+
 static const uniform int32 programCount = TARGET_WIDTH;
 
 #if TARGET_WIDTH == 2

--- a/tests/lit-tests/3454.ispc
+++ b/tests/lit-tests/3454.ispc
@@ -1,0 +1,15 @@
+// This test checks that alloca is not a reserved keyword of the language.
+
+// RUN: %{ispc} --target=host --emit-llvm-text --nowrap -g %s -o - 2>&1 | FileCheck %s
+
+// CHECK-NOT: Error:
+// CHECK-NOT: FATAL ERROR:
+
+int test1() {
+    int alloca = 42;
+    return alloca;
+}
+
+int test2() {
+    void* addr = alloca(1000);
+}


### PR DESCRIPTION
## Description

As discussed in #3448, this PR removes alloca from the list of reserved keywords so we can now use it as a variable name.
Note alloca is already covered by existing lit-tests like in `tests/lit-tests/alloca.ispc` but I added a new one to check this is not a reserved anymore and we can still use it just to be on the safe side.

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed