### PR TITLE
ISPC as a library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,7 +478,9 @@ list(APPEND FRONTEND_SOURCES
     src/expr.h
     src/func.cpp
     src/func.h
+    src/include/ispc/ispc.h
     src/intrinsics.cpp
+    src/ispc_impl.cpp
     src/module.cpp
     src/module.h
     src/preprocessor.cpp
@@ -642,6 +644,7 @@ list(APPEND INCLUDE_DIRECTORIES
     ${LLVM_INCLUDE_DIRS}
     ${XE_DEPS_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/include
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}
     ${CMAKE_BINARY_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ find_package(Python3 REQUIRED)
     endif()
 
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 find_package(BISON 3.0 REQUIRED)
     if (BISON_FOUND)
@@ -880,7 +881,7 @@ function(configure_ispc_lib TARGET)
         SOVERSION ${ISPC_VERSION_MAJOR})
 endfunction()
 
-# This function creates and configures an ISPC library target (static or shared)
+# This function creates and configures an ISPC library target (shared for now)
 function(add_ispc_library TARGET_NAME LIBRARY_TYPE OUTPUT_NAME_OVERRIDE)
     # Define the common source files and object libraries
     set(ISPC_LIB_SOURCES
@@ -974,6 +975,7 @@ else()
     message(STATUS "ISPC will be built as a composite binary")
 endif()
 
+set(ISPC_SHARED_LIBRARY_AVAILABLE FALSE)
 if (ISPC_LIBRARY AND NOT ISPC_SLIM_BINARY)
     # Add libispc shared library target with default output name "ispc"
     add_ispc_library(libispc_shared SHARED "")
@@ -984,10 +986,42 @@ if (ISPC_LIBRARY AND NOT ISPC_SLIM_BINARY)
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
+
     # Install public headers
     install(DIRECTORY src/include/ispc
         DESTINATION include
         FILES_MATCHING PATTERN "*.h")
+    set(ISPC_SHARED_LIBRARY_AVAILABLE TRUE)
+endif()
+
+# Configure the package config file
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ispcConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/ispcConfig.cmake"
+INSTALL_DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+
+# Configure the version file
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/ispcConfigVersion.cmake"
+    VERSION ${ISPC_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+# Install the package configuration files
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/ispcConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/ispcConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+
+# Install the export set only if library targets exist
+if (ISPC_LIBRARY AND NOT ISPC_SLIM_BINARY)
+    install(EXPORT ${PROJECT_NAME}_Exports
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+        NAMESPACE ${PROJECT_NAME}::
+    )
 endif()
 
 install (TARGETS ispc DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(OUTPUT_DEBUG Debug/bin)
 set(OUTPUT_RELEASE Release/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin )
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib )
 
 if(CMAKE_BUILD_TYPE)
     # Validate build type
@@ -100,6 +101,7 @@ option(ISPC_INCLUDE_BENCHMARKS "Generate build targets for the ISPC tests." OFF)
 option(ISPC_INCLUDE_RT "Generate build targets for ISPC runtime." ON)
 option(ISPC_INCLUDE_UTILS "Generate build targets for the utils." ON)
 option(ISPC_INCLUDE_UTILS_ONLY "Generate build targets only for the utils." OFF)
+option(ISPC_LIBRARY "Build ISPC as a library" ON)
 option(ISPC_PREPARE_PACKAGE "Generate build targets for ispc package" OFF)
 option(ISPC_PACKAGE_EXAMPLES "Pack examples into the ISPC package" ON)
 option(ISPC_SLIM_BINARY "Build ISPC as slim binary" OFF)
@@ -296,10 +298,15 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Version.cmake)
 # Get ispc version
 get_ispc_version("${CMAKE_CURRENT_SOURCE_DIR}/common/version.h")
 
+# Construct full version string
+set(ISPC_VERSION "${ISPC_VERSION_MAJOR}.${ISPC_VERSION_MINOR}.${ISPC_VERSION_PATCH}${ISPC_VERSION_SUFFIX}")
+
 find_package(Python3 REQUIRED)
     if (NOT Python3_Interpreter_FOUND)
         message(FATAL_ERROR "Python interpreter is not found")
     endif()
+
+include(GNUInstallDirs)
 
 find_package(BISON 3.0 REQUIRED)
     if (BISON_FOUND)
@@ -862,6 +869,52 @@ function(configure_ispc_exe TARGET)
     target_link_options(${TARGET} PUBLIC ${LINK_OPTIONS_PUBLIC})
 endfunction()
 
+# This function configures library target.
+function(configure_ispc_lib TARGET)
+    configure_ispc_obj(${TARGET})
+    target_link_options(${TARGET} PRIVATE ${LINK_OPTIONS_PRIVATE})
+    target_link_options(${TARGET} PUBLIC ${LINK_OPTIONS_PUBLIC})
+    set_target_properties(${TARGET} PROPERTIES
+        OUTPUT_NAME "ispc"
+        VERSION ${ISPC_VERSION}
+        SOVERSION ${ISPC_VERSION_MAJOR})
+endfunction()
+
+# This function creates and configures an ISPC library target (static or shared)
+function(add_ispc_library TARGET_NAME LIBRARY_TYPE OUTPUT_NAME_OVERRIDE)
+    # Define the common source files and object libraries
+    set(ISPC_LIB_SOURCES
+        src/binary_composite.cpp
+        $<TARGET_OBJECTS:builtin>
+        $<TARGET_OBJECTS:stdlib>
+        $<TARGET_OBJECTS:optimization>
+        $<TARGET_OBJECTS:common>
+        $<TARGET_OBJECTS:frontend>
+        $<TARGET_OBJECTS:generic-target>
+    )
+
+    # Create the library target
+    add_library(${TARGET_NAME} ${LIBRARY_TYPE} ${ISPC_LIB_SOURCES})
+
+    # Configure the library
+    configure_ispc_lib(${TARGET_NAME})
+
+    # Override output name if provided
+    if(OUTPUT_NAME_OVERRIDE)
+        set_target_properties(${TARGET_NAME} PROPERTIES OUTPUT_NAME "${OUTPUT_NAME_OVERRIDE}")
+    endif()
+
+    # Set interface include directories for consumers
+    target_include_directories(${TARGET_NAME} INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+
+    # Link libraries and set dependencies
+    target_link_libraries(${TARGET_NAME} PRIVATE ${LINK_LIBRARIES})
+    add_dependencies(${TARGET_NAME} ispc-slim)
+endfunction()
+
 # This function creates and configures ispc-slim executable target under the given NAME.
 function(add_ispc_slim NAME)
     # Defines stdlib target
@@ -921,6 +974,22 @@ else()
     message(STATUS "ISPC will be built as a composite binary")
 endif()
 
+if (ISPC_LIBRARY AND NOT ISPC_SLIM_BINARY)
+    # Add libispc shared library target with default output name "ispc"
+    add_ispc_library(libispc_shared SHARED "")
+
+    # Install shared library with export
+    install(TARGETS libispc_shared
+        EXPORT ${PROJECT_NAME}_Exports
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+    # Install public headers
+    install(DIRECTORY src/include/ispc
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.h")
+endif()
+
 install (TARGETS ispc DESTINATION bin)
 if (ISPC_SLIM_BINARY)
     foreach (header ${STDLIB_HEADERS})
@@ -938,7 +1007,6 @@ foreach (header ${INTRINSICS_HEADERS})
 endforeach()
 
 set(ISPC_DEPS generic-target-bc stdlibs-bc stdlib-headers)
-
 
 if (ISPC_INCLUDE_TESTS)
     add_subdirectory(tests)

--- a/cmake/ispcConfig.cmake.in
+++ b/cmake/ispcConfig.cmake.in
@@ -1,0 +1,49 @@
+#
+#  Copyright (c) 2025, Intel Corporation
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+
+# ispcConfig.cmake.in
+
+@PACKAGE_INIT@
+
+# Only include exports if library targets exist
+if(@ISPC_SHARED_LIBRARY_AVAILABLE@ AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@_Exports.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@_Exports.cmake")
+endif()
+
+check_required_components("@PROJECT_NAME@")
+
+# Set up paths
+set(ISPC_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
+set(ISPC_EXECUTABLE "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_BINDIR@/ispc")
+
+# Set variables for backward compatibility
+set(ISPC_LIBRARIES "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
+
+# Check if targets were built
+set(ISPC_SHARED_LIBRARY_AVAILABLE @ISPC_SHARED_LIBRARY_AVAILABLE@)
+
+if(ISPC_SHARED_LIBRARY_AVAILABLE)
+    if(WIN32)
+        set(ISPC_LIBRARY "${ISPC_LIBRARIES}/ispc.dll")
+    else()
+        set(ISPC_LIBRARY "${ISPC_LIBRARIES}/libispc.so")
+    endif()
+endif()
+
+# Create convenience aliases for common naming patterns
+if(ISPC_SHARED_LIBRARY_AVAILABLE AND TARGET @PROJECT_NAME@::libispc_shared)
+    add_library(@PROJECT_NAME@::lib ALIAS @PROJECT_NAME@::libispc_shared)
+endif()
+
+# Set standard variables
+set(ISPC_FOUND TRUE)
+
+# Provide summary
+include(FindPackageMessage)
+if(ISPC_SHARED_LIBRARY_AVAILABLE)
+    find_package_message(@PROJECT_NAME@ "Found ISPC: ${PACKAGE_PREFIX_DIR}" "[${PACKAGE_PREFIX_DIR}]")
+else()
+    find_package_message(@PROJECT_NAME@ "Found ISPC: ${PACKAGE_PREFIX_DIR} (executable only)" "[${PACKAGE_PREFIX_DIR}]")
+endif()

--- a/examples/cpu/CMakeLists.txt
+++ b/examples/cpu/CMakeLists.txt
@@ -60,6 +60,8 @@ add_subdirectory(perfbench)
 add_subdirectory(rt)
 add_subdirectory(sgemm)
 add_subdirectory(simple)
+# This example requires full ISPC installation, it's not supported as part of ISPC build
+# add_subdirectory(simple_lib)
 add_subdirectory(sort)
 add_subdirectory(stencil)
 add_subdirectory(volume_rendering)

--- a/examples/cpu/simple_lib/CMakeLists.txt
+++ b/examples/cpu/simple_lib/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+#  Copyright (c) 2025, Intel Corporation
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.16)
+project(simple_lib VERSION 1.0.0 LANGUAGES CXX)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find ISPC using our package configuration
+find_package(ispc REQUIRED)
+
+# Create the executable
+add_executable(simple_lib simple.cpp)
+
+# Link against ISPC library
+target_link_libraries(simple_lib ispc::lib)
+
+# Copy simple.ispc to build directory so the example can find it
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/simple.ispc ${CMAKE_CURRENT_BINARY_DIR}/simple.ispc COPYONLY)

--- a/examples/cpu/simple_lib/simple.cpp
+++ b/examples/cpu/simple_lib/simple.cpp
@@ -1,0 +1,67 @@
+/*
+  Copyright (c) 2025, Intel Corporation
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <filesystem>
+#include <iostream>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <vector>
+
+#include "ispc/ispc.h"
+
+int main() {
+    // Initialize ISPC
+    std::cout << "Initializing ISPC...\n";
+    if (!ispc::Initialize()) {
+        std::cerr << "Error: Failed to initialize ISPC\n";
+        return 1;
+    }
+
+    std::cout << "Compiling simple.ispc using library mode...\n";
+
+    std::vector<std::string> args1 = {"ispc", "simple.ispc", "--target=host", "-O2", "-o",
+                                      "simple_ispc.o", "-h", "simple_ispc.h"};
+
+    int result = ispc::CompileFromArgs(args1);
+
+    if (result == 0) {
+        std::cout << "ISPC compilation successful!\n";
+    } else {
+        std::cerr << "ISPC compilation failed with code: " << result << "\n";
+        ispc::Shutdown();
+        return result;
+    }
+
+    std::cout << "Compiling simple.ispc using library mode with different options...\n";
+
+    // Set up a second compilation with different options
+    std::vector<std::string> args2 = {"ispc", "simple.ispc", "--target=host",  "-O0", "--emit-asm", "-o",
+                                      "simple_debug.s", "-h", "simple_debug.h", "-g"};
+
+    // Execute second compilation
+    int result2 = ispc::CompileFromArgs(args2);
+
+    if (result2 == 0) {
+        std::cout << "Second compilation successful with different options\n";
+
+        // Verify that files with different extensions were created
+        if (std::filesystem::exists("simple_ispc.o") && std::filesystem::exists("simple_debug.s")) {
+            std::cout << "SUCCESS: Both compilations produced different output files:\n";
+            std::cout << "  - First compilation:  simple_ispc.o\n";
+            std::cout << "  - Second compilation: simple_debug.s\n";
+        } else {
+            std::cout << "Note: Output files may not be visible in current directory\n";
+        }
+    } else {
+        std::cerr << "Second ISPC compilation failed with code: " << result2 << "\n";
+    }
+
+    std::cout << "\nCleaning up...\n";
+    ispc::Shutdown();
+    std::cout << "ISPC shutdown complete\n";
+
+    return 0;
+}

--- a/examples/cpu/simple_lib/simple.ispc
+++ b/examples/cpu/simple_lib/simple.ispc
@@ -1,0 +1,21 @@
+/*
+  Copyright (c) 2025, Intel Corporation
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+export void simple(uniform float vin[], uniform float vout[],
+                   uniform int count) {
+    foreach (index = 0 ... count) {
+        // Load the appropriate input value for this program instance.
+        float v = vin[index];
+
+        // Do an arbitrary little computation, but at least make the
+        // computation dependent on the value being processed
+        if (v < 3.)
+            v = v * v;
+        else
+            v = sqrt(v);
+
+        // And write the result to the output array.
+        vout[index] = v;
+    }
+}

--- a/src/include/ispc/ispc.h
+++ b/src/include/ispc/ispc.h
@@ -1,0 +1,89 @@
+/*
+  Copyright (c) 2025, Intel Corporation
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ispc {
+
+/**
+ * @brief Initializes the ISPC library.
+ * This must be called once before creating any ISPCEngine instances.
+ * Initializes LLVM targets and creates global state.
+ *
+ * @return true on success, false on failure.
+ */
+bool Initialize();
+
+/**
+ * @brief Shuts down the ISPC library and releases global resources.
+ * This should be called once when the consumer is finished using the library.
+ * After calling this, Initialize() must be called again before creating new instances.
+ */
+void Shutdown();
+
+/**
+ * @brief Compiles ISPC code from command-line arguments.
+ * This function parses command-line arguments and executes the appropriate action
+ * (compile, link, or help). Initialize() must be called successfully before using this function.
+ *
+ * @param args Vector of command-line arguments. The first argument should be the program name
+ *             or any dummy string (it will be ignored eventually).
+ * @return 0 on success, non-zero on failure.
+ */
+int CompileFromArgs(const std::vector<std::string> &args);
+
+/**
+ * @brief Compiles ISPC code from command-line arguments.
+ * This function parses command-line arguments and executes the appropriate action
+ * (compile, link, or help). Initialize() must be called successfully before using this function.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector. The first argument should be the program name
+ *             or any dummy string (it will be ignored eventually).
+ * @return 0 on success, non-zero on failure.
+ */
+int CompileFromCArgs(int argc, char *argv[]);
+
+class ISPCEngine {
+  public:
+    /**
+     * @brief Factory method to create a ISPCEngine instance from command-line arguments.
+     * Initialize() must be called successfully before using this method.
+     *
+     * @param args Vector of command-line arguments. The first argument should be the program name
+     *             or any dummy string (it will be ignored eventually).
+     * @return A unique_ptr to a ISPCEngine instance, or nullptr on failure.
+     */
+    static std::unique_ptr<ISPCEngine> CreateFromArgs(const std::vector<std::string> &args);
+
+    /**
+     * @brief Factory method for C-style argc/argv arguments.
+     * @param argc Argument count.
+     * @param argv Argument vector. The first argument should be the program name
+     *             or any dummy string (it will be ignored eventually).
+     * @return A unique_ptr to a ISPCEngine instance, or nullptr on failure.
+     */
+    static std::unique_ptr<ISPCEngine> CreateFromCArgs(int argc, char *argv[]);
+
+    /**
+     * @brief Executes the appropriate action based on the driver state (link, help, or compile).
+     * @return 0 on success, non-zero on failure.
+     */
+    int Execute();
+
+    ~ISPCEngine();
+
+  private:
+    ISPCEngine();
+
+    class Impl;
+    std::unique_ptr<Impl> pImpl;
+};
+
+} // namespace ispc

--- a/src/ispc_impl.cpp
+++ b/src/ispc_impl.cpp
@@ -1,0 +1,232 @@
+/*
+  Copyright (c) 2025, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include "args.h"
+#include "binary_type.h"
+#include "ispc.h"
+#include "ispc/ispc.h"
+#include "target_registry.h"
+#include "type.h"
+#include "util.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/ToolOutputFile.h"
+
+#include <cstring>
+#include <llvm/MC/TargetRegistry.h>
+
+namespace ispc {
+
+class ISPCEngine::Impl {
+  public:
+    Impl() {
+        m_output.type = Module::OutputType::Object; // Default output type
+    }
+
+    // Fields populated by ParseCommandLineArgs
+    char *m_file = nullptr;
+    Arch m_arch{Arch::none};
+    const char *m_cpu{nullptr};
+    std::vector<ISPCTarget> m_targets;
+    Module::Output m_output;
+    std::vector<std::string> m_linkFileNames;
+    bool m_isHelpMode{false};
+    bool m_isLinkMode{false};
+
+    bool IsLinkMode() const { return m_isLinkMode; }
+
+    int Compile() {
+        if (g->enableTimeTrace) {
+            llvm::timeTraceProfilerInitialize(g->timeTraceGranularity, "ispc");
+        }
+
+        int ret = 0;
+        {
+            llvm::TimeTraceScope TimeScope("ExecuteISPCEngine");
+            ret = Module::CompileAndOutput(m_file, m_arch, m_cpu, m_targets, m_output);
+        }
+
+        if (g->enableTimeTrace) {
+            // Write to file only if compilation is successful.
+            if ((ret == 0) && (!m_output.out.empty())) {
+                writeCompileTimeFile(m_output.out.c_str());
+            }
+            llvm::timeTraceProfilerCleanup();
+        }
+        return ret;
+    }
+
+    int Link() {
+        std::string filename = !m_output.out.empty() ? m_output.out : "";
+        return Module::LinkAndOutput(m_linkFileNames, m_output.type, filename);
+    }
+
+    int Execute() {
+        if (m_isLinkMode) {
+            return Link();
+        } else if (m_isHelpMode) {
+            return 0;
+        } else {
+            return Compile();
+        }
+    }
+
+  private:
+    static void writeCompileTimeFile(const char *outFileName) {
+        llvm::SmallString<128> jsonFileName(outFileName);
+        jsonFileName.append(".json");
+        llvm::sys::fs::OpenFlags flags = llvm::sys::fs::OF_Text;
+        std::error_code error;
+        std::unique_ptr<llvm::ToolOutputFile> of(new llvm::ToolOutputFile(jsonFileName.c_str(), error, flags));
+
+        if (error) {
+            Error(SourcePos(), "Cannot open json file \"%s\".\n", jsonFileName.c_str());
+            return;
+        }
+
+        llvm::raw_fd_ostream &fos(of->os());
+        llvm::timeTraceProfilerWrite(fos);
+        of->keep();
+    }
+};
+
+bool Initialize() {
+    // Check if already initialized
+    if (g != nullptr) {
+        return true;
+    }
+
+    // Initialize available LLVM targets
+#ifdef ISPC_X86_ENABLED
+    LLVMInitializeX86TargetInfo();
+    LLVMInitializeX86Target();
+    LLVMInitializeX86AsmPrinter();
+    LLVMInitializeX86AsmParser();
+    LLVMInitializeX86Disassembler();
+    LLVMInitializeX86TargetMC();
+#endif
+
+#ifdef ISPC_ARM_ENABLED
+    LLVMInitializeARMTargetInfo();
+    LLVMInitializeARMTarget();
+    LLVMInitializeARMAsmPrinter();
+    LLVMInitializeARMAsmParser();
+    LLVMInitializeARMDisassembler();
+    LLVMInitializeARMTargetMC();
+
+    LLVMInitializeAArch64TargetInfo();
+    LLVMInitializeAArch64Target();
+    LLVMInitializeAArch64AsmPrinter();
+    LLVMInitializeAArch64AsmParser();
+    LLVMInitializeAArch64Disassembler();
+    LLVMInitializeAArch64TargetMC();
+#endif
+
+#ifdef ISPC_WASM_ENABLED
+    LLVMInitializeWebAssemblyAsmParser();
+    LLVMInitializeWebAssemblyAsmPrinter();
+    LLVMInitializeWebAssemblyDisassembler();
+    LLVMInitializeWebAssemblyTarget();
+    LLVMInitializeWebAssemblyTargetInfo();
+    LLVMInitializeWebAssemblyTargetMC();
+#endif
+
+    // Initialize globals
+    g = new Globals;
+    return true;
+}
+
+std::unique_ptr<ISPCEngine> ISPCEngine::CreateFromCArgs(int argc, char *argv[]) {
+    // Check if library is initialized
+    if (g == nullptr) {
+        return nullptr;
+    }
+
+    auto instance = std::unique_ptr<ISPCEngine>(new ISPCEngine());
+
+    // Parse command line options
+    ArgsParseResult parseResult =
+        ParseCommandLineArgs(argc, argv, instance->pImpl->m_file, instance->pImpl->m_arch, instance->pImpl->m_cpu,
+                             instance->pImpl->m_targets, instance->pImpl->m_output, instance->pImpl->m_linkFileNames,
+                             instance->pImpl->m_isLinkMode);
+
+    if (parseResult == ArgsParseResult::failure) {
+        return nullptr;
+    }
+
+    instance->pImpl->m_isHelpMode = (parseResult == ArgsParseResult::help_requested);
+
+    return instance;
+}
+
+std::unique_ptr<ISPCEngine> ISPCEngine::CreateFromArgs(const std::vector<std::string> &args) {
+    if (args.empty()) {
+        return nullptr;
+    }
+
+    // Convert vector to argc/argv format
+    int argc = args.size();
+    std::vector<std::string> argsCopy(args); // Keep a copy to ensure lifetime
+    std::vector<char *> argv(argc);
+
+    for (int i = 0; i < argc; ++i) {
+        argv[i] = const_cast<char *>(argsCopy[i].c_str());
+    }
+
+    return ISPCEngine::CreateFromCArgs(argc, argv.data());
+}
+
+ISPCEngine::ISPCEngine() : pImpl(std::make_unique<Impl>()) {}
+
+ISPCEngine::~ISPCEngine() {}
+
+void Shutdown() {
+    // Free all bookkept objects.
+    BookKeeper::in().freeAll();
+
+    // Clean up global state
+    if (g != nullptr) {
+        delete g;
+        g = nullptr;
+    }
+}
+
+int ISPCEngine::Execute() { return pImpl->Execute(); }
+
+// Function that uses C-style argc/argv interface
+int CompileFromCArgs(int argc, char *argv[]) {
+    // Check if library is initialized
+    if (g == nullptr) {
+        return 1;
+    }
+
+    auto instance = ISPCEngine::CreateFromCArgs(argc, argv);
+    if (!instance) {
+        return 1;
+    }
+
+    return instance->Execute();
+}
+
+int CompileFromArgs(const std::vector<std::string> &args) {
+    if (args.empty()) {
+        return 1;
+    }
+
+    // Convert vector to argc/argv format
+    int argc = args.size();
+    std::vector<std::string> argsCopy(args); // Keep a copy to ensure lifetime
+    std::vector<char *> argv(argc);
+
+    for (int i = 0; i < argc; ++i) {
+        argv[i] = const_cast<char *>(argsCopy[i].c_str());
+    }
+
+    return CompileFromCArgs(argc, argv.data());
+}
+
+} // namespace ispc


### PR DESCRIPTION
## Description
This pull request enables ISPC to function as a library. The most important changes include adding support for building ISPC as a shared library, creating a new API for programmatic compilation using the `ispc::ISPCEngine` class, and introducing an example (`simple_lib`) that showcases how to use ISPC in library mode.

* Added new header file `ispc.h` defining the API for initializing, shutting down, and compiling ISPC code via library functions 
* Implemented the ISPC library functionality in `ispc_impl.cpp`, including methods for compilation and linking 
* Updated `main.cpp` to include the new library header and removed redundant methods, delegating functionality to the library implementation.
* Added new build target to build shared and static library
* Added `ispcConfig.cmake.in` to provide a package configuration file for consumers of the ISPC library, enabling easy integration via `find_package`
* Added a new example `simple_lib` demonstrating how to use the ISPC library.

Documentation will be updated after the first round of review.

## Related Issue
- [x] Linked to relevant issue(s). Related to https://github.com/ispc/ispc/issues/791 and https://github.com/ispc/ispc/issues/1134

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed