### PR TITLE
Fix #2207: make integer suffix definition stricter

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -799,6 +799,15 @@ existing code from intrinsics to ISPC, you can use these headers as a reference.
 The standard library ``select`` functions now support unsigned integer types
 ``uint8``, ``uint16``, ``uint32``, and ``uint64``.
 
+Integer literals are now stricter:
+
+* It now limits the number of occurrences of [uUlL] symbols (i.e. "ulll", 
+  "uul" and "lulu" are not valid anymore).
+* The value modification suffix (i.e. [kMG]) must preceed the type 
+  modification suffix (i.e. [uUlL] symbols).
+* Like C/C++, "lL" and "Ll" suffixes is not allowed anymore (i.e. the mix of 
+  lower and upper case "L" to form a "LL" suffix).
+
 
 Getting Started with ISPC
 =========================
@@ -2122,15 +2131,22 @@ Here are three ways of specifying the integer value "15":
 
 A number of suffixes can be provided with integer numeric constants.
 First, "u" denotes that the constant is unsigned, and "ll" denotes a 64-bit
-integer constant (while "l" denotes a 32-bit integer constant).  It is also
-possible to denote units of 1024, 1024*1024, or 1024*1024*1024 with the
-SI-inspired suffixes "k", "M", and "G" respectively:
+integer constant (while "l" denotes a 32-bit integer constant). The 
+aforementioned suffixes can also be written in uppercase. However, like in C, 
+you cannot mix uppercase and lowercase in a given suffix (e.g. uLl or ulL).
+It is also possible to denote units of 1024, 1024*1024, or 1024*1024*1024 with
+the SI-inspired suffixes "k", "M", and "G" respectively. Note that the later 
+suffixes must preceed the type-related suffixes. Here is an example:
 
 ::
 
-   int two_kb = 2k;   // 2048
-   int two_megs = 2M; // 2 * 1024 * 1024
-   int one_gig = 1G;  // 1024 * 1024 * 1024
+   uint three = 3ul;
+   int two_kb = 2k;         // 2048
+   int two_megs = 2M;       // 2 * 1024 * 1024
+   int one_gig = 1G;        // 1024 * 1024 * 1024
+   uint three_gig = 3Gu;    // 3 * 1024 * 1024 * 1024
+   uint64 six_gig = 6GuLL;  // 6 * 1024 * 1024 * 1024
+   int64 ten_gig = 10Gll;   // 10 * 1024 * 1024 * 1024
 
 Floating Point Literals
 -----------------------

--- a/src/lex.ll
+++ b/src/lex.ll
@@ -290,8 +290,8 @@ void ParserInit() {
 %option nounistd
 
 WHITESPACE [ \t\r]+
-INT_NUMBER (([0-9]+)|(0[xX][0-9a-fA-F]+)|(0b[01]+))[uUlL]*[kMG]?[uUlL]*
-INT_NUMBER_DOTDOTDOT (([0-9]+)|(0[xX][0-9a-fA-F]+)|(0b[01]+))[uUlL]*[kMG]?[uUlL]*\.\.\.
+INT_NUMBER (([0-9]+)|(0[xX][0-9a-fA-F]+)|(0b[01]+))[kMG]?([uU][lL]{0,2}|[lL]{1,2}[uU]?)?
+INT_NUMBER_DOTDOTDOT (([0-9]+)|(0[xX][0-9a-fA-F]+)|(0b[01]+))[kMG]?([uU][lL]{0,2}|[lL]{1,2}[uU]?)?\.\.\.
 FLOAT_NUMBER_DECIMAL ((([0-9]+\.[0-9]*)|(\.[0-9]+))([dD]|[fF]|[fF]16)?)
 FLOAT_NUMBER_DECIMAL_DEPRECATED ([0-9]+[fF])
 FLOAT_NUMBER_DECIMAL_ILLEGAL ([0-9]+([dD]|[fF]16))

--- a/tests/lit-tests/2207-1.ispc
+++ b/tests/lit-tests/2207-1.ispc
@@ -1,0 +1,58 @@
+// This test checks that the compiler correctly parses integer suffixes.
+
+// RUN: %{ispc} --target=host --emit-llvm-text --nostdlib --nowrap -g %s -o - 2>&1 | FileCheck %s
+
+// CHECK-NOT: Error:
+// CHECK-NOT: FATAL ERROR:
+
+uniform int test()
+{
+    uniform int arr[] = {
+        15,
+        15u,
+        15l,
+        15ul,
+        15uL,
+        15Ul,
+        15UL,
+        15ull,
+        15Ull,
+        15ULL,
+        15uLL,
+        15llu,
+        15llU,
+        15LLU,
+        15LLu,
+        15G,
+        15k,
+        15G,
+        15Gu,
+        15Gl,
+        15Mull,
+        15MUll,
+        15MULL,
+        15MuLL,
+        15Mllu,
+        15MllU,
+        15MLLU,
+        15MLLu,
+        15kull,
+        15kUll,
+        15kULL,
+        15kuLL,
+        15kllu,
+        15kllU,
+        15kLLU,
+        15kLLu,
+        15Gull,
+        15GUll,
+        15GULL,
+        15GuLL,
+        15Gllu,
+        15GllU,
+        15GLLU,
+        15GLLu
+    };
+    return arr[0];
+}
+

--- a/tests/lit-tests/2207-2.ispc
+++ b/tests/lit-tests/2207-2.ispc
@@ -1,0 +1,13 @@
+// This test checks that the compiler limit the number of occurrences of
+// [uUlL] symbols in integer suffixes.
+
+// RUN: not %{ispc} --target=host --emit-llvm-text --nostdlib --nowrap -g %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error:
+// CHECK-NOT: FATAL ERROR:
+
+uniform int test()
+{
+    return 1ulll;
+}
+

--- a/tests/lit-tests/2207-3.ispc
+++ b/tests/lit-tests/2207-3.ispc
@@ -1,0 +1,13 @@
+// This test checks that the compiler limit the number of occurrences of
+// [uUlL] symbols in integer suffixes.
+
+// RUN: not %{ispc} --target=host --emit-llvm-text --nostdlib --nowrap -g %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error:
+// CHECK-NOT: FATAL ERROR:
+
+uniform int test()
+{
+    return 1uul;
+}
+

--- a/tests/lit-tests/2207-4.ispc
+++ b/tests/lit-tests/2207-4.ispc
@@ -1,0 +1,13 @@
+// This test checks that the compiler limit the number of occurrences of
+// [uUlL] symbols in integer suffixes.
+
+// RUN: not %{ispc} --target=host --emit-llvm-text --nostdlib --nowrap -g %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error:
+// CHECK-NOT: FATAL ERROR:
+
+uniform int test()
+{
+    return 1ulu;
+}
+

--- a/tests/lit-tests/2207-5.ispc
+++ b/tests/lit-tests/2207-5.ispc
@@ -1,0 +1,13 @@
+// This test checks that the compiler limit the number of occurrences of
+// [uUlL] symbols in integer suffixes.
+
+// RUN: not %{ispc} --target=host --emit-llvm-text --nostdlib --nowrap -g %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error:
+// CHECK-NOT: FATAL ERROR:
+
+uniform int test()
+{
+    return 1lul;
+}
+

--- a/tests/lit-tests/2207-6.ispc
+++ b/tests/lit-tests/2207-6.ispc
@@ -1,0 +1,13 @@
+// This test checks that the compiler does not accept value modification
+// suffixes after type modification suffixes.
+
+// RUN: not %{ispc} --target=host --emit-llvm-text --nostdlib --nowrap -g %s -o - 2>&1 | FileCheck %s
+
+// CHECK: Error:
+// CHECK-NOT: FATAL ERROR:
+
+uniform int test()
+{
+    return 1llG;
+}
+


### PR DESCRIPTION
## Description

This PR fixes #2207 (i.e. it makes the integer suffix definition stricter).

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed