### PR TITLE
Fix #1964: add srgb8_to_float to the stdlib

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -214,7 +214,7 @@ Contents:
 
     * `Converting Between Array-of-Structures and Structure-of-Arrays Layout`_
     * `Conversions To and From Half-Precision Floats`_
-    * `Converting to sRGB8`_
+    * `Converting from/to sRGB8`_
 
   + `Systems Programming Support`_
 
@@ -6414,13 +6414,14 @@ precise.
     uniform int16 float_to_half_fast(uniform float f)
 
 
-Converting to sRGB8
--------------------
+Converting from/to sRGB8
+------------------------
 
 The sRGB color space is used in many applications in graphics and imaging;
 see the `Wikipedia page on sRGB`_ for more information.  The ``ispc``
-standard library provides two functions for converting floating-point color
-values to 8-bit values in the sRGB space.
+standard library provides four conversions functions: two for converting
+floating-point color values to 8-bit values in the sRGB space, and 2 for the
+reverse operation.
 
 .. _Wikipedia page on sRGB: http://en.wikipedia.org/wiki/SRGB
 
@@ -6428,6 +6429,11 @@ values to 8-bit values in the sRGB space.
 
     int float_to_srgb8(float v)
     uniform int float_to_srgb8(uniform float v)
+
+::
+
+    float srgb8_to_float(int v)
+    uniform float srgb8_to_float(uniform int v)
 
 
 Systems Programming Support

--- a/stdlib/include/stdlib.isph
+++ b/stdlib/include/stdlib.isph
@@ -1101,33 +1101,14 @@ __declspec(safe) inline int16 float_to_half_fast(float f);
 ///////////////////////////////////////////////////////////////////////////
 // float -> srgb8
 
-// https://gist.github.com/2246678, from Fabian "rygorous" Giesen.
-//
-// The basic ideas are still the same, only this time, we squeeze
-// everything into the table, even the linear part of the range; since we
-// are approximating the function as piecewise linear anyway, this is
-// fairly easy.
-//
-// In the exact version of the conversion, any value that produces an
-// output float less than 0.5 will be rounded to an integer of
-// zero. Inverting the linear part of the transform, we get:
-//
-//   log2(0.5 / (255 * 12.92)) =~ -12.686
-//
-// which in turn means that any value smaller than about 2^(-12.687) will
-// return 0.  What this means is that we can adapt the clamping code to
-// just clamp to [2^(-13), 1-eps] and we're covered. This means our table
-// needs to cover a range of 13 different exponents from -13 to -1.
-//
-// The table lookup, storage and interpolation works exactly the same way
-// as in the code above.
-//
-// Max error for the whole function (integer-rounded result minus "exact"
-// value, as computed in floats using the official formula): 0.544403 at
-// 0x3e9f8000
-
 __declspec(safe) inline int float_to_srgb8(float inval);
 __declspec(safe) inline uniform int float_to_srgb8(uniform float inval);
+
+///////////////////////////////////////////////////////////////////////////
+// srgb8 -> float
+
+__declspec(safe) inline float srgb8_to_float(int inval);
+__declspec(safe) inline uniform float srgb8_to_float(uniform int inval);
 
 ///////////////////////////////////////////////////////////////////////////
 // RNG stuff

--- a/stdlib/stdlib.ispc
+++ b/stdlib/stdlib.ispc
@@ -5613,6 +5613,42 @@ __declspec(safe) static inline uniform int float_to_srgb8(uniform float inval) {
 }
 
 ///////////////////////////////////////////////////////////////////////////
+// srgb8 -> float
+//
+// It uses a polynomial approximation of (x/255+0.055)/1.055)^2.4 for the range
+// [9.384;265.71]. The relative error is 5e-4.
+// This should be enough since the input is a 8-bit integer anyway.
+// Coefficients are from sollya (with some fine-tunning so 0 <= r <= 1.0).
+//
+// For more precise results a (1KiB) LUT can be used instead.
+// Using a LUT is generally (1~2 times) slower on AVX2/AVX-512 targets.
+// However, using a LUT might be faster on SSE/Neon with a warm cache.
+
+__declspec(safe) static inline float srgb8_to_float(int inval) {
+    const float x = clamp(inval, (uniform int)0, (uniform int)255);
+    float r = 1.0489326014e-13;
+    r = r * x - 8.6331650162e-11;
+    r = r * x + 4.2816203915e-8;
+    r = r * x + 7.7981030699e-6;
+    r = r * x + 1.3343113823e-4;
+    r = r * x + 8.7884825188e-4;
+    const float scale = 1.0 / 255 / 12.92;
+    return select(x < 10.31475, x * scale, r);
+}
+
+__declspec(safe) static inline uniform float srgb8_to_float(uniform int inval) {
+    const uniform float x = clamp(inval, (uniform int)0, (uniform int)255);
+    uniform float r = 1.0489326014e-13;
+    r = r * x - 8.6331650162e-11;
+    r = r * x + 4.2816203915e-8;
+    r = r * x + 7.7981030699e-6;
+    r = r * x + 1.3343113823e-4;
+    r = r * x + 8.7884825188e-4;
+    const uniform float scale = 1.0 / 255 / 12.92;
+    return select(x < 10.31475, x * scale, r);
+}
+
+///////////////////////////////////////////////////////////////////////////
 // RNG stuff
 
 static inline unsigned int random(varying RNGState *uniform state) {

--- a/tests/func-tests/srgb8.ispc
+++ b/tests/func-tests/srgb8.ispc
@@ -1,0 +1,41 @@
+#include "test_static.isph"
+
+template <typename T>
+int clamp_test() {
+    int errorCount = 0;
+
+    // The implementation must perform a clamp and is expected to be 
+    // precise for values <= 0.
+    if(abs(srgb8_to_float((T)-30)) != 0.0)
+        errorCount++;
+
+    // The actual implementation might not be very precise 
+    // for values >=255. That being said a clamp is required.
+    if(abs(srgb8_to_float((T)300) - 1.0) > 1.0 / 254.0)
+        errorCount++;
+
+    return errorCount;
+}
+
+task void f_v(uniform float RET[]) {
+    int errorCount = 0;
+
+    foreach(i = 0...256)
+        if(float_to_srgb8(srgb8_to_float(i)) != i)
+            errorCount++;
+
+    errorCount += clamp_test<int>();
+
+    for(uniform int i = 0; i < 256; ++i)
+        if(float_to_srgb8(srgb8_to_float(i)) != i)
+            errorCount++;
+
+    errorCount += clamp_test<uniform int>();
+
+    RET[programIndex] = errorCount;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 0;
+}
+


### PR DESCRIPTION
## Description

This PR fixes #1964 (add `srgb8_to_float` to ISPC standard library).
Everything is said in the issue and comments in the codes ;) .
Here is the 2 new functions:

```ispc
float srgb8_to_float(int inval)
uniform float srgb8_to_float(uniform int inval)
```

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [x] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [x] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed