### PR TITLE
Fix #3471: fix a crash when using the signed keyword

### DIFF
--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1687,7 +1687,10 @@ specifier_qualifier_list
             else if ($1 == TYPEQUAL_CONST)
                 $$ = $2->GetAsConstType();
             else if ($1 == TYPEQUAL_SIGNED) {
-                if ($2->IsIntType() == false) {
+                const Type *t = $2->GetAsSignedType();
+                if (t)
+                    $$ = t;
+                else {
                     Error(@1, "Can't apply \"signed\" qualifier to \"%s\" type.",
                           $2->ResolveUnboundVariability(Variability::Varying)->GetString().c_str());
                     $$ = $2;

--- a/tests/lit-tests/3471.ispc
+++ b/tests/lit-tests/3471.ispc
@@ -1,0 +1,10 @@
+// This test checks that the compiler does not crash (fatal error) when using
+// the `signed` keyword in types (like in casts or in function return types).
+
+// RUN: %{ispc} --target=host --emit-llvm-text --nostdlib --nowrap -g %s -o - 2>&1 | FileCheck %s
+
+// CHECK-NOT: FATAL ERROR:
+
+export uniform signed int test() {
+    return (const uniform signed int)0;
+}


### PR DESCRIPTION
## Description

This PR fixes #3471 .

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed