### PR TITLE
Fix #707: support signed/unsigned/const in 'new' expressions and template arguments

### DIFF
--- a/src/parse.yy
+++ b/src/parse.yy
@@ -1000,30 +1000,19 @@ rate_qualified_new
     ;
 
 rate_qualified_type_specifier
-    : type_specifier { $$ = $1; }
-    | TOKEN_UNIFORM type_specifier
+    : specifier_qualifier_list
     {
-        if ($2 == nullptr)
-            $$ = nullptr;
-        else if ($2->IsVoidType()) {
-            Error(@1, "\"uniform\" qualifier is illegal with \"void\" type.");
+        const VectorType *vt = CastType<VectorType>($1);
+        if (vt != nullptr) {
+            Error(@1, "\"%s\" vector type not supported here yet.",
+                  $1->GetString().c_str());
             $$ = nullptr;
         }
-        else
-            $$ = $2->GetAsUniformType();
-    }
-    | TOKEN_VARYING type_specifier
-    {
-        if ($2 == nullptr)
-            $$ = nullptr;
-        else if ($2->IsVoidType()) {
-            Error(@1, "\"varying\" qualifier is illegal with \"void\" type.");
-            $$ = nullptr;
+        else {
+            $$ = $1;
         }
-        else
-            $$ = $2->GetAsVaryingType();
     }
-    | soa_width_specifier type_specifier
+    | soa_width_specifier specifier_qualifier_list
     {
         if ($2 == nullptr)
             $$ = nullptr;

--- a/tests/lit-tests/707.ispc
+++ b/tests/lit-tests/707.ispc
@@ -1,0 +1,37 @@
+// This test checks that the compiler supports `signed`, `unsigned` and `const`
+// quialifiers in `new` expressions and template arguments. 
+// It also check the compiler does not crash (fatal error).
+
+// RUN: %{ispc} --target=host --emit-llvm-text --nostdlib --nowrap -g %s -o - 2>&1 | FileCheck %s
+
+// CHECK-NOT: FATAL ERROR:
+
+uniform uint* uniform test_uint() {
+    return uniform new uniform unsigned int;
+}
+
+uniform int* uniform test_sint() {
+    return uniform new uniform signed int; 
+}
+
+uniform const int* uniform test_const() {
+    return uniform new uniform const int(815);
+}
+
+const unsigned uniform int* uniform test_mixed_unordered() {
+    return uniform new unsigned const uniform int(815);
+}
+
+template <typename T> void test_template() {}
+
+void test_template_instantiation()
+{
+    test_template<int>();
+    test_template<uniform int>();
+    test_template<varying int>();
+    test_template<const int>();
+    test_template<const signed int>();
+    test_template<const unsigned int>();
+    test_template<const unsigned uniform int>();
+    test_template<uniform const unsigned int>();
+}


### PR DESCRIPTION
## Description

This PR fixes #707 (and the duplicate issue #1272).
The modification also impacts template arguments (but not template parameters).

Short vectors can now be syntactically supported but they do not seems to be fully supported by the rest of the ISPC code. Thus, I explicitly disabled them so far. I put some examples in the lit-test code showing what could be easily supported and what breaks (or is ambiguous) if we enable them. I think supporting short vectors in `new` expression can be a good idea though it is certainly a low-priority feature since I do not expect much people to use it. I am not sure it make sense in template parameters (nor if this is already supported in the rest of the code, and otherwise if this is simple to do). What do you think about this?
Anyway, note that this can be implemented in another independent  PR if needed (and discussed in a separate issue).

Note that this PR is dependent of the PR #3472 for the lit-tests to pass when they will be complete. I will correct the lit-test once #3472 will be merged.

Note that `new const soa<4> Struct` is not supported yet, but `new soa<4> const Struct` is. I am not just we want the first to be supported though.

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed