### PR TITLE
Generic permutations for avx512

### DIFF
--- a/builtins/generic.ispc
+++ b/builtins/generic.ispc
@@ -1003,17 +1003,11 @@ EXT READNONE varying double __rotate_double(varying double v, uniform int32 i) {
 
 // shift
 template <typename T> unmasked varying T __shift(varying T v, uniform int32 i) {
-    uniform T<DOUBLE_WIDTH> dbl;
-    uniform T zero = 0;
-    uniform int32 start_pos = i;
-    if (i < 0) {
-        start_pos = TARGET_WIDTH + i;
-        dbl = __concat(zero, v);
-    } else {
-        dbl = __concat(v, zero);
-    }
-    varying T *uniform ptr = (varying T * uniform) & dbl[start_pos];
-    return *ptr;
+    varying T<3> trp = {0, v, 0};
+    uniform int32 start_pos = i + TARGET_WIDTH;
+    uniform T *uniform ptr = (uniform T * uniform) & trp;
+    varying T *uniform res_ptr = (varying T * uniform) & ptr[start_pos];
+    return *res_ptr;
 }
 EXT READNONE varying int8 __shift_i8(varying int8 v, uniform int32 i) { return __shift<int8>(v, i); }
 EXT READNONE varying int16 __shift_i16(varying int16 v, uniform int32 i) { return __shift<int16>(v, i); }

--- a/builtins/target-avx512-utils.ll
+++ b/builtins/target-avx512-utils.ll
@@ -15,7 +15,6 @@ rdrand_definition()
 popcnt()
 ctlztz()
 halfTypeGenericImplementation()
-define_vector_permutations()
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; aos/soa


### PR DESCRIPTION
## Description

This PR removes permutation definitions from AVX512 builtins. rotate and shift have been unused since versions #3464 and #3441. For broadcasts, the same code is produced. It also changes the generic shift implementation to a similar one in `utils.m4` that avoids branching. It also removes the dependency of `__reduce_equal` from `__rotate`. The call to `__rotate(x, 1)` is changed to an equivalent `__shuffle` call.

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)