### PR TITLE
Use std::move() to avoid unnecessary copying

### DIFF
--- a/src/args.cpp
+++ b/src/args.cpp
@@ -252,16 +252,6 @@ static ArgsParseResult devUsage() {
  */
 class ArgFactory {
   private:
-    char *AllocateString(std::string string) {
-        int len = string.length();
-        // We use malloc here because of strdup in lAddSingleArg
-        char *ptr = (char *)malloc(len + 1);
-        memset(ptr, 0, len + 1);
-        strncpy(ptr, string.c_str(), len);
-        ptr[len] = '\0';
-        return ptr;
-    }
-
     /** Method provided by the derived classes to retrieve the next character from the stream.
      */
     virtual char GetNextChar() = 0;
@@ -302,7 +292,7 @@ class ArgFactory {
             c = GetNextChar();
         }
 
-        return AllocateString(arg);
+        return strdup(arg.c_str());
     }
 };
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -37,7 +37,7 @@ void Indent::pushList(int i) {
     }
 }
 
-void Indent::setNextLabel(std::string s) { label = s; }
+void Indent::setNextLabel(std::string s) { label = std::move(s); }
 
 // Print indent and an optional string
 void Indent::Print(const char *title) {

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -229,7 +229,7 @@ void AttrArgument::Print() const {
 }
 
 Attribute::Attribute(const std::string &n) : name(n), arg() {}
-Attribute::Attribute(const std::string &n, AttrArgument a) : name(n), arg(a) {}
+Attribute::Attribute(const std::string &n, AttrArgument a) : name(n), arg(std::move(a)) {}
 Attribute::Attribute(const Attribute &a) : name(a.name), arg(a.arg) {}
 
 bool Attribute::IsKnownAttribute() const {

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -1120,7 +1120,7 @@ void FunctionTemplate::Print(Indent &indent) const {
             }
         }
         argsStr = "instantiation <" + argsStr + ">";
-        indent.setNextLabel(argsStr);
+        indent.setNextLabel(std::move(argsStr));
         symbol->parentFunction->Print(indent);
     }
 

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -960,7 +960,7 @@ bool Module::DispatchHeaderInfo::initialize(std::string headerFileName) {
     Emit4 = true;
     Emit8 = true;
     Emit16 = true;
-    header = headerFileName;
+    header = std::move(headerFileName);
     fn = header.c_str();
 
     if (!header.empty()) {

--- a/src/ispc_impl.cpp
+++ b/src/ispc_impl.cpp
@@ -62,7 +62,7 @@ class ISPCEngine::Impl {
 
     int Link() {
         std::string filename = !m_output.out.empty() ? m_output.out : "";
-        return Module::LinkAndOutput(m_linkFileNames, m_output.type, filename);
+        return Module::LinkAndOutput(m_linkFileNames, m_output.type, std::move(filename));
     }
 
     int Execute() {

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -340,7 +340,7 @@ llvm::Constant *LLVMUInt32Vector(const uint32_t *ivec) {
 }
 
 llvm::Constant *LLVMFloat16Vector(llvm::APFloat fval) {
-    llvm::Constant *v = LLVMFloat16(fval);
+    llvm::Constant *v = LLVMFloat16(std::move(fval));
     std::vector<llvm::Constant *> vals;
     for (int i = 0; i < g->target->getVectorWidth(); ++i) {
         vals.push_back(v);
@@ -357,7 +357,7 @@ llvm::Constant *LLVMFloat16Vector(const std::vector<llvm::APFloat> &fvec) {
 }
 
 llvm::Constant *LLVMFloatVector(llvm::APFloat fval) {
-    llvm::Constant *v = LLVMFloat(fval);
+    llvm::Constant *v = LLVMFloat(std::move(fval));
     std::vector<llvm::Constant *> vals;
     for (int i = 0; i < g->target->getVectorWidth(); ++i) {
         vals.push_back(v);
@@ -374,7 +374,7 @@ llvm::Constant *LLVMFloatVector(const std::vector<llvm::APFloat> &fvec) {
 }
 
 llvm::Constant *LLVMDoubleVector(llvm::APFloat dval) {
-    llvm::Constant *v = LLVMDouble(dval);
+    llvm::Constant *v = LLVMDouble(std::move(dval));
     std::vector<llvm::Constant *> vals;
     for (int i = 0; i < g->target->getVectorWidth(); ++i) {
         vals.push_back(v);

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -184,7 +184,7 @@ DebugModulePassManager::DebugModulePassManager(llvm::Module &M, int optLevel) : 
         if (targetMachine) {
             targetMachine->registerDefaultAliasAnalyses(aam);
         }
-        fam.registerPass([aam] { return std::move(aam); });
+        fam.registerPass([aam = std::move(aam)] { return std::move(aam); });
     }
 }
 

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -767,7 +767,7 @@ llvm::DIType *AtomicType::GetDIType(llvm::DIScope *scope) const {
 // TemplateTypeParmType
 
 TemplateTypeParmType::TemplateTypeParmType(std::string n, Variability v, bool ic, SourcePos p)
-    : Type(TEMPLATE_TYPE_PARM_TYPE, v, ic, p), name(n) {
+    : Type(TEMPLATE_TYPE_PARM_TYPE, v, ic, p), name(std::move(n)) {
     asOtherConstType = nullptr;
     asUniformType = asVaryingType = nullptr;
 }
@@ -3064,7 +3064,7 @@ llvm::FunctionType *FunctionType::LLVMFunctionType(llvm::LLVMContext *ctx, bool 
         callTypes.push_back(LLVMTypes::Int32Type); // taskCount2
     } else {
         // Otherwise we already have the types of the arguments
-        callTypes = llvmArgTypes;
+        callTypes = std::move(llvmArgTypes);
     }
 
     if (returnType == nullptr) {


### PR DESCRIPTION
## Description
This PR fixes minor Coverity issues related to using `std::move` instead of object copying.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed