### PR TITLE
Make fast-math optimizations more aggressive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,6 +594,8 @@ list(APPEND OPT_SOURCES
     src/opt/ReplaceStdlibShiftPass.h
     src/opt/ScalarizePass.cpp
     src/opt/ScalarizePass.h
+    src/opt/FastMath.cpp
+    src/opt/FastMath.h
     src/opt/XeGatherCoalescePass.cpp
     src/opt/XeGatherCoalescePass.h
     src/opt/XeReplaceLLVMIntrinsics.cpp

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -1685,17 +1685,18 @@ Available options:
   Perform non-IEEE-compliant optimizations of numeric expressions. These
   optimizations may improve performance but can result in less precise results
   or different behavior compared to IEEE-compliant math. Various fast-math
-  modes are available. The default one is the ``legacy`` mode.
+  modes are available.
 
   Available modes:
 
-  - ``legacy``
+  - ``legacy`` (default)
 
     Replace divisions by constants (i.e., ``x / const``) to multiplications by
     the inverse (i.e., ``x * (1/const)``), and perform reciprocal approximations
     (i.e., ``x / y`` is replaced with ``x * rcp(y)``). Please read the
     documentation about ``rcp()`` for more information about its precision.
-    This mode was used in version 1.30 and earlier.
+    This was the unique implicit mode available in version 1.30 and earlier. 
+    Its behavior is the same in newer versions.
 
   - ``balanced``
 

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -142,7 +142,14 @@ static ArgsParseResult usage() {
     printf("        enable-xe-foreach-varying\t\tEnable experimental foreach support inside varying control flow\n");
 #endif
     printf("        fast-masked-vload\t\tFaster masked vector loads on SSE (may go past end of array)\n");
-    printf("        fast-math\t\t\tPerform non-IEEE-compliant optimizations of numeric expressions\n");
+    printf("        fast-math[:<mode>]\t\tPerform non-IEEE-compliant optimizations of numeric expressions. Default "
+           "mode is legacy\n");
+    printf("            legacy\t\t\tReplace divisions by constants to multiplications and perform reciprocal "
+           "approximations\n");
+    printf("            balanced\t\t\tEnable imprecise optimizations (i.e. algebraically-equivalent transformations, "
+           "contractions, a/b treated as a*(1/b), a/(b/c) as a*c/b, -0 as +0, and vice versa)\n");
+    printf("            aggressive\t\t\tEnable unsafe optimizations (i.e. assume there is neither NaN nor +/- Inf) and "
+           "even more imprecise ones (e.g. reciprocal approximations)\n");
     printf("        force-aligned-memory\t\tAlways issue \"aligned\" vector load and store instructions\n");
     printf("        reset-ftz-daz\t\t\tReset FTZ/DAZ flags on ISPC extern function entrance / restore on return\n");
     printf("    [--pic]\t\t\t\tGenerate position-independent code.  Ignored for Windows target\n");

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -837,7 +837,7 @@ ArgsParseResult ispc::ParseCommandLineArgs(int argc, char *argv[], std::string &
             const char *opt = argv[i] + 6;
             if (!strncmp(opt, "fast-math", 9)) {
                 const char *fastMathOpt = opt + 9;
-                if(*fastMathOpt == 0) {
+                if (*fastMathOpt == 0) {
                     // Default value if the mode is unspecified
                     g->opt.fastMath = Opt::FastMathMode::Legacy;
                 } else if (*fastMathOpt == ':') {

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -844,10 +844,10 @@ ArgsParseResult ispc::ParseCommandLineArgs(int argc, char *argv[], std::string &
                     fastMathOpt += 1;
                     if (!strcmp(fastMathOpt, "legacy")) {
                         g->opt.fastMath = Opt::FastMathMode::Legacy;
-                    } else if (!strcmp(fastMathOpt, "safe")) {
-                        g->opt.fastMath = Opt::FastMathMode::Safe;
-                    } else if (!strcmp(fastMathOpt, "unsafe")) {
-                        g->opt.fastMath = Opt::FastMathMode::Unsafe;
+                    } else if (!strcmp(fastMathOpt, "balanced")) {
+                        g->opt.fastMath = Opt::FastMathMode::Balanced;
+                    } else if (!strcmp(fastMathOpt, "aggressive")) {
+                        g->opt.fastMath = Opt::FastMathMode::Aggressive;
                     } else {
                         errorHandler.AddError("Unknown fast-math mode \"%s\".", fastMathOpt);
                     }

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -835,8 +835,25 @@ ArgsParseResult ispc::ParseCommandLineArgs(int argc, char *argv[], std::string &
             }
         } else if (!strncmp(argv[i], "--opt=", 6)) {
             const char *opt = argv[i] + 6;
-            if (!strcmp(opt, "fast-math")) {
-                g->opt.fastMath = true;
+            if (!strncmp(opt, "fast-math", 9)) {
+                const char *fastMathOpt = opt + 9;
+                if(*fastMathOpt == 0) {
+                    // Default value if the mode is unspecified
+                    g->opt.fastMath = Opt::FastMathMode::Legacy;
+                } else if (*fastMathOpt == ':') {
+                    fastMathOpt += 1;
+                    if (!strcmp(fastMathOpt, "legacy")) {
+                        g->opt.fastMath = Opt::FastMathMode::Legacy;
+                    } else if (!strcmp(fastMathOpt, "safe")) {
+                        g->opt.fastMath = Opt::FastMathMode::Safe;
+                    } else if (!strcmp(fastMathOpt, "unsafe")) {
+                        g->opt.fastMath = Opt::FastMathMode::Unsafe;
+                    } else {
+                        errorHandler.AddError("Unknown fast-math mode \"%s\".", fastMathOpt);
+                    }
+                } else {
+                    errorHandler.AddError("Unknown --opt= option \"%s\".", opt);
+                }
             } else if (!strcmp(opt, "fast-masked-vload")) {
                 g->opt.fastMaskedVload = true;
             } else if (!strcmp(opt, "disable-assertions")) {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -2710,7 +2710,7 @@ Expr *BinaryExpr::Optimize() {
     ConstExpr *constArg0 = llvm::dyn_cast<ConstExpr>(arg0);
     ConstExpr *constArg1 = llvm::dyn_cast<ConstExpr>(arg1);
 
-    if (g->opt.fastMath) {
+    if (g->opt.fastMath == Opt::FastMathMode::Legacy) {
         // TODO: consider moving fast-math optimizations to backend
 
         // optimizations related to division by floats..

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -3252,7 +3252,7 @@ bool Target::hasXePrefetch() const {
 
 Opt::Opt() {
     level = 2;
-    fastMath = false;
+    fastMath = FastMathMode::None;
     fastMaskedVload = false;
     force32BitAddressing = true;
     unrollLoops = true;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -547,7 +547,7 @@ struct Opt {
 
     /** Indicates whether "fast and loose" numerically unsafe optimizations
         should be performed.  This is None by default. */
-    enum class FastMathMode { None, Legacy, Safe, Unsafe };
+    enum class FastMathMode { None, Legacy, Balanced, Aggressive };
     FastMathMode fastMath;
 
     /** Indicates whether an vector load should be issued for masked loads

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -546,8 +546,9 @@ struct Opt {
     int level;
 
     /** Indicates whether "fast and loose" numerically unsafe optimizations
-        should be performed.  This is false by default. */
-    bool fastMath;
+        should be performed.  This is None by default. */
+    enum class FastMathMode { None, Legacy, Safe, Unsafe };
+    FastMathMode fastMath;
 
     /** Indicates whether an vector load should be issued for masked loads
         on platforms that don't have a native masked vector load.  (This may

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -403,7 +403,7 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
 
         // This should be early (before the InstCombinePass and 
         // InstructionSimplifyPass to actually be effective).
-        if (g->opt.fastMath) {
+        if (g->opt.fastMath != Opt::FastMathMode::None) {
             optPM.addFunctionPass(FastMathPass());
         }
 

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -401,7 +401,7 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         }
         optPM.addFunctionPass(llvm::DCEPass(), 220);
 
-        // This should be early (before the InstCombinePass and 
+        // This should be early (before the InstCombinePass and
         // InstructionSimplifyPass to actually be effective).
         if (g->opt.fastMath != Opt::FastMathMode::None) {
             optPM.addFunctionPass(FastMathPass());

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -401,6 +401,12 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         }
         optPM.addFunctionPass(llvm::DCEPass(), 220);
 
+        // This should be early (before the InstCombinePass and 
+        // InstructionSimplifyPass to actually be effective).
+        if (g->opt.fastMath) {
+            optPM.addFunctionPass(FastMathPass());
+        }
+
         // On to more serious optimizations
         optPM.addFunctionPass(llvm::SROAPass(llvm::SROAOptions::ModifyCFG));
         optPM.addFunctionPass(llvm::InferAlignmentPass());

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -403,7 +403,7 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
 
         // This should be early (before the InstCombinePass and
         // InstructionSimplifyPass to actually be effective).
-        if (g->opt.fastMath != Opt::FastMathMode::None) {
+        if (g->opt.fastMath != Opt::FastMathMode::None && g->opt.fastMath != Opt::FastMathMode::Legacy) {
             optPM.addFunctionPass(FastMathPass());
         }
 

--- a/src/opt/FastMath.cpp
+++ b/src/opt/FastMath.cpp
@@ -11,9 +11,13 @@ bool FastMathPass::optimizeFpInstructions(llvm::BasicBlock &bb) {
     llvm::FastMathFlags fmFlags;
 
     if (g->opt.fastMath == Opt::FastMathMode::Balanced) {
+        // Note that imprecise rcp instructions are apparently only generated
+        // when at least both math function approximations and reciprocal are
+        // allowed.
         fmFlags.setAllowContract(true);
         fmFlags.setAllowReassoc(true);
         fmFlags.setNoSignedZeros(true);
+        fmFlags.setAllowReciprocal(true);
     } else if (g->opt.fastMath == Opt::FastMathMode::Aggressive) {
         // This improves the performance of generated codes in some cases but
         // it is much more dangerous. Indeed, it assumes there are no NaN,

--- a/src/opt/FastMath.cpp
+++ b/src/opt/FastMath.cpp
@@ -13,11 +13,11 @@ bool FastMathPass::optimizeFpInstructions(llvm::BasicBlock &bb) {
 
     llvm::FastMathFlags fmFlags;
 
-    if (g->opt.fastMath == Opt::FastMathMode::Safe) {
+    if (g->opt.fastMath == Opt::FastMathMode::Balanced) {
         fmFlags.setAllowContract(true);
         fmFlags.setAllowReassoc(true);
         fmFlags.setNoSignedZeros(true);
-    } else if (g->opt.fastMath == Opt::FastMathMode::Unsafe) {
+    } else if (g->opt.fastMath == Opt::FastMathMode::Aggressive) {
         // This improves the performance of generated codes in some cases but
         // it is much more dangerous. Indeed, it assumes there are no NaN,
         // infinities, negative zeros or subnormal values computed by the
@@ -27,8 +27,6 @@ bool FastMathPass::optimizeFpInstructions(llvm::BasicBlock &bb) {
         // for ISPC users). For more information, please read:
         // https://github.com/iree-org/iree/issues/19743
         fmFlags.setFast(true);
-
-        // TODO: alternative solution: only enable SafeMode + ISPC reciprocals
     }
 
     // Note: we do modify instruction list during the traversal, so the iterator

--- a/src/opt/FastMath.cpp
+++ b/src/opt/FastMath.cpp
@@ -1,9 +1,6 @@
 #include "FastMath.h"
 #include "builtins-decl.h"
 
-
-//#define AGGRESSIVE_FAST_MATH_OPT
-
 namespace ispc {
 
 bool FastMathPass::optimizeFpInstructions(llvm::BasicBlock &bb) {

--- a/src/opt/FastMath.cpp
+++ b/src/opt/FastMath.cpp
@@ -1,0 +1,68 @@
+#include "FastMath.h"
+#include "builtins-decl.h"
+
+// Enable all fast math flags. This improves the performance of generated
+// codes in some cases but it is much more dangerous. Indeed, it assumes there
+// are no NaN, Inf, negative zeros or subnormal values computed by the target 
+// code. If this assumption is broken, then LLVM store poison values in the 
+// output so the target code basically has an undefined behaviour and may do
+// completely crazy things (very hard to debug for ISPC users).
+// See https://github.com/iree-org/iree/issues/19743 for more information.
+//#define AGGRESSIVE_FAST_MATH_OPT
+
+namespace ispc {
+
+bool FastMathPass::optimizeFpInstructions(llvm::BasicBlock &bb) {
+    DEBUG_START_BB("FastMath");
+
+    bool modifiedAny = false;
+
+    llvm::FastMathFlags fmFlags;
+
+#ifdef AGGRESSIVE_FAST_MATH_OPT
+    fmFlags.setFast(true);
+#else
+    // The three first are required to perform basic FP math reassociation.
+    fmFlags.setAllowContract(true);
+    fmFlags.setAllowReassoc(true);
+    fmFlags.setNoSignedZeros(true);
+    fmFlags.setAllowReciprocal(true);
+#endif
+
+    // Note: we do modify instruction list during the traversal, so the iterator
+    // is moved forward before the instruction is processed.
+    for (llvm::BasicBlock::iterator iter = bb.begin(), e = bb.end(); iter != e;) {
+        llvm::BasicBlock::iterator curIter = iter++;
+        llvm::Instruction *inst = &*curIter;
+        llvm::BinaryOperator *binOpInst = llvm::dyn_cast<llvm::BinaryOperator>(inst);
+        llvm::FPMathOperator *fpMathInst = llvm::dyn_cast<llvm::FPMathOperator>(inst);
+        if (binOpInst && fpMathInst) {
+            binOpInst->setFastMathFlags(fmFlags);
+            modifiedAny = true;
+        }
+    }
+
+    DEBUG_END_BB("FastMath");
+
+    return modifiedAny;
+}
+
+llvm::PreservedAnalyses FastMathPass::run(llvm::Function &F, llvm::FunctionAnalysisManager &FAM) {
+    llvm::TimeTraceScope FuncScope("FastMathPass::run", F.getName());
+    bool modifiedAny = false;
+
+    for (llvm::BasicBlock &BB : F) {
+        modifiedAny |= optimizeFpInstructions(BB);
+    }
+
+    if (!modifiedAny) {
+        // No changes, all analyses are preserved.
+        return llvm::PreservedAnalyses::all();
+    }
+
+    llvm::PreservedAnalyses PA;
+    PA.preserveSet<llvm::CFGAnalyses>();
+    return PA;
+}
+
+} // namespace ispc

--- a/src/opt/FastMath.cpp
+++ b/src/opt/FastMath.cpp
@@ -1,3 +1,9 @@
+/*
+  Copyright (c) 2026, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
 #include "FastMath.h"
 #include "builtins-decl.h"
 
@@ -35,10 +41,8 @@ bool FastMathPass::optimizeFpInstructions(llvm::BasicBlock &bb) {
     for (llvm::BasicBlock::iterator iter = bb.begin(), e = bb.end(); iter != e;) {
         llvm::BasicBlock::iterator curIter = iter++;
         llvm::Instruction *inst = &*curIter;
-        llvm::BinaryOperator *binOpInst = llvm::dyn_cast<llvm::BinaryOperator>(inst);
-        llvm::FPMathOperator *fpMathInst = llvm::dyn_cast<llvm::FPMathOperator>(inst);
-        if (binOpInst && fpMathInst) {
-            binOpInst->setFastMathFlags(fmFlags);
+        if (llvm::dyn_cast<llvm::FPMathOperator>(inst)) {
+            inst->setFastMathFlags(fmFlags);
             modifiedAny = true;
         }
     }

--- a/src/opt/FastMath.h
+++ b/src/opt/FastMath.h
@@ -4,7 +4,7 @@
 
 namespace ispc {
 
-/** This optimization pass add flags to FP instructions so to enable 
+/** This optimization pass add flags to FP instructions so to enable
     fast-math-related optimizations in the subsequent passes */
 struct FastMathPass : public llvm::PassInfoMixin<FastMathPass> {
 

--- a/src/opt/FastMath.h
+++ b/src/opt/FastMath.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "ISPCPass.h"
+
+namespace ispc {
+
+/** This optimization pass add flags to FP instructions so to enable 
+    fast-math-related optimizations in the subsequent passes */
+struct FastMathPass : public llvm::PassInfoMixin<FastMathPass> {
+
+    llvm::PreservedAnalyses run(llvm::Function &F, llvm::FunctionAnalysisManager &FAM);
+
+  private:
+    bool optimizeFpInstructions(llvm::BasicBlock &BB);
+};
+
+} // namespace ispc

--- a/src/opt/FastMath.h
+++ b/src/opt/FastMath.h
@@ -1,3 +1,9 @@
+/*
+  Copyright (c) 2026, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
 #pragma once
 
 #include "ISPCPass.h"

--- a/src/opt/ISPCPassRegistry.def
+++ b/src/opt/ISPCPassRegistry.def
@@ -19,6 +19,7 @@ FUNCTION_PASS("replace-masked-memory-ops", ReplaceMaskedMemOpsPass())
 FUNCTION_PASS("replace-pseudo-memory-ops", ReplacePseudoMemoryOpsPass())
 FUNCTION_PASS("replace-stdlib-shift", ReplaceStdlibShiftPass())
 FUNCTION_PASS("scalarize", ScalarizePass())
+FUNCTION_PASS("fast-math", FastMathPass())
 #ifdef ISPC_XE_ENABLED
 FUNCTION_PASS("check-ir-for-xe-target", CheckIRForXeTarget())
 FUNCTION_PASS("mangle-opencl-builtins", MangleOpenCLBuiltins())

--- a/src/opt/ISPCPasses.h
+++ b/src/opt/ISPCPasses.h
@@ -25,5 +25,6 @@
 #include "ReplacePseudoMemoryOps.h"
 #include "ReplaceStdlibShiftPass.h"
 #include "ScalarizePass.h"
+#include "FastMath.h"
 #include "XeGatherCoalescePass.h"
 #include "XeReplaceLLVMIntrinsics.h"

--- a/src/opt/ISPCPasses.h
+++ b/src/opt/ISPCPasses.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "CheckIRForXeTarget.h"
+#include "FastMath.h"
 #include "GatherCoalescePass.h"
 #include "ImproveMemoryOps.h"
 #include "InstructionSimplify.h"
@@ -25,6 +26,5 @@
 #include "ReplacePseudoMemoryOps.h"
 #include "ReplaceStdlibShiftPass.h"
 #include "ScalarizePass.h"
-#include "FastMath.h"
 #include "XeGatherCoalescePass.h"
 #include "XeReplaceLLVMIntrinsics.h"

--- a/tests/lit-tests/3402.ispc
+++ b/tests/lit-tests/3402.ispc
@@ -1,0 +1,33 @@
+// RUN: %{ispc} %s --target=host --opt=fast-math -O2 --emit-llvm-text -o -| FileCheck %s
+
+// CHECK-COUNT-4: fmul
+
+static inline varying float square(const varying float value)
+{
+    return value * value;
+}
+
+template<int N>
+static inline varying float power(const varying float value)
+{
+    varying float accum = value;
+
+    #pragma unroll
+    for (uniform int i = 1; i < N; i++) {
+        accum *= value;
+    }
+
+    return accum;
+}
+
+void power_9(uniform float values[], const uniform int count)
+{
+    assume(((uniform uint64)((void*)values) & (32 * TARGET_WIDTH)-1) == 0);
+    assume(count % TARGET_WIDTH == 0);
+
+    #pragma nounroll
+    foreach(index = 0...count) {
+        values[index] = power<9>(values[index]);
+        // values[index] = square(square(square(values[index]))) * values[index];
+    }
+}

--- a/tests/lit-tests/constant_folding_double.ispc
+++ b/tests/lit-tests/constant_folding_double.ispc
@@ -31,7 +31,7 @@ uniform double retNegD() {
 }
 
 // CHECK: @retFastMathD
-// CHECK: fmul double %{{[a-zA-Z_][a-zA-Z0-9_]*}}, 5.000000e-01
+// CHECK: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )*}}double %{{[a-zA-Z_][a-zA-Z0-9_]*}}, 5.000000e-01
 uniform double retFastMathD(uniform double arg) {
     return arg / 2.d;
 }

--- a/tests/lit-tests/constant_folding_float.ispc
+++ b/tests/lit-tests/constant_folding_float.ispc
@@ -31,7 +31,7 @@ uniform float retNegF() {
 }
 
 // CHECK: @retFastMathF
-// CHECK: fmul float %{{[a-zA-Z_][a-zA-Z0-9_]*}}, 5.000000e-01
+// CHECK: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )*}}float %{{[a-zA-Z_][a-zA-Z0-9_]*}}, 5.000000e-01
 uniform float retFastMathF(uniform float arg) {
     return arg / 2.f;
 }

--- a/tests/lit-tests/constant_folding_float16.ispc
+++ b/tests/lit-tests/constant_folding_float16.ispc
@@ -31,7 +31,7 @@ uniform float16 retNegF16() {
 }
 
 // CHECK: @retFastMathF16
-// CHECK: fmul half %{{[a-zA-Z_][a-zA-Z0-9_]*}}, 0xH3800
+// CHECK: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )*}}half %{{[a-zA-Z_][a-zA-Z0-9_]*}}, 0xH3800
 uniform float16 retFastMathF16(uniform float16 arg) {
     return arg / 2.f16;
 }

--- a/tests/lit-tests/fast_math_opt-2.ispc
+++ b/tests/lit-tests/fast_math_opt-2.ispc
@@ -1,0 +1,84 @@
+// RUN: %{ispc} %s --target=host --opt=fast-math -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_IR
+// RUN: %{ispc} %s --target=avx2-i32x8 --opt=fast-math -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM
+// RUN: %{ispc} %s --target=avx2-i32x8 --opt=fast-math -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_V2
+
+// Must return the input
+// CHECK_IR: @test1
+// CHECK_IR: ret <8 x float> %v1
+float test1(float v1) {
+    return v1 + 1.0 - 1.0;
+}
+
+// Must return the input
+// CHECK_IR: @test2
+// CHECK_IR: ret <8 x float> %v2
+float test2(float v2) {
+    float t = v2 * 0.5;
+    return t * 2;
+}
+
+// Must return the input
+// CHECK_IR: @test3
+// CHECK_IR: ret <8 x float> %v3
+float test3(float v3) {
+    float t = v3 * 0.5 + 2.5;
+    return (t - 2.5) * 2.0;
+}
+
+// Must return the input
+// CHECK_IR: @test4
+// CHECK_IR: ret <8 x float> %v4
+float test4(float v4) {
+    float t = v4 * 0.5 + 2.5;
+    return (t - 0.5) * 2.0 - 4.0;
+}
+
+// CHECK_X64_ASM_V2-COUNT-3: vfmadd{{[1-3][1-3][1-3]}}ps
+
+// Must just generate a single FMA
+// CHECK_X64_ASM: 0x40600000
+// CHECK_X64_ASM: 0x40200000
+// CHECK_X64_ASM: @test5
+float test5(float v5) {
+    return v5 * 3.5 + 2.5;
+}
+
+// Must just generate a single FMA
+// CHECK_X64_ASM: 0xc1408000
+// CHECK_X64_ASM: 0xc19f4000
+// CHECK_X64_ASM: @test6
+float test6(float v6) {
+    v6 *= 2.5;
+    v6 += 1.5;
+    v6 *= 1.75;
+    v6 += 3.25;
+    v6 *= -2.75;
+    v6 -= 3.75;
+    return v6;
+}
+
+// Must just generate a single FMA (certainly only with the full fast-math)
+// CHECK_X64_ASM: 0xc08f5076
+// CHECK_X64_ASM: 0xc116f8b0
+// CHECK_X64_ASM: @test7
+float test7(float v7) {
+    v7 *= 2.75;
+    v7 += 1.25;
+    v7 *= 1.5;
+    v7 += 3.0;
+    v7 /= -1.25;
+    v7 -= 3.5;
+    v7 += -0.0;
+    v7 *= 9.5;
+    v7 += 4.25;
+    v7 /= 7;
+    return v7;
+}
+
+// Must return 0 with an aggressive fast-math, but it must only generate a
+// basic vsubps instruction due possible to NaN/Inf values in `v8`
+// CHECK_X64_ASM: @test8
+// CHECK_X64_ASM: vsubps
+float test8(float v8) {
+    return v8 - v8;
+}

--- a/tests/lit-tests/fast_math_opt-2.ispc
+++ b/tests/lit-tests/fast_math_opt-2.ispc
@@ -1,4 +1,8 @@
-// RUN: %{ispc} %s --target=host --opt=fast-math:balanced -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_IR_BALANCED
+// This test checks the optimizations performed by the different fast-math modes on basic operations.
+
+// REQUIRES: X86_ENABLED
+
+// RUN: %{ispc} %s --target=avx2-i32x8 --opt=fast-math:balanced -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_IR_BALANCED
 // RUN: %{ispc} %s --target=avx2-i32x8 --opt=fast-math:balanced -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_BALANCED
 // RUN: %{ispc} %s --target=avx2-i32x8 --opt=fast-math:aggressive -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_AGGRESSIVE
 

--- a/tests/lit-tests/fast_math_opt-2.ispc
+++ b/tests/lit-tests/fast_math_opt-2.ispc
@@ -2,49 +2,63 @@
 // RUN: %{ispc} %s --target=avx2-i32x8 --opt=fast-math:balanced -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_BALANCED
 // RUN: %{ispc} %s --target=avx2-i32x8 --opt=fast-math:aggressive -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_AGGRESSIVE
 
-// Must return the input
+// Shall return the input
 // CHECK_IR_BALANCED: @test1
 // CHECK_IR_BALANCED: ret <8 x float> %v1
+// CHECK_IR_AGGRESSIVE: @test1
+// CHECK_IR_AGGRESSIVE: ret <8 x float> %v1
 float test1(float v1) {
     return v1 + 1.0 - 1.0;
 }
 
-// Must return the input
+// Shall return the input
 // CHECK_IR_BALANCED: @test2
 // CHECK_IR_BALANCED: ret <8 x float> %v2
+// CHECK_IR_AGGRESSIVE: @test2
+// CHECK_IR_AGGRESSIVE: ret <8 x float> %v2
 float test2(float v2) {
     float t = v2 * 0.5;
     return t * 2;
 }
 
-// Must return the input
+// Shall return the input
 // CHECK_IR_BALANCED: @test3
 // CHECK_IR_BALANCED: ret <8 x float> %v3
+// CHECK_IR_AGGRESSIVE: @test3
+// CHECK_IR_AGGRESSIVE: ret <8 x float> %v3
 float test3(float v3) {
     float t = v3 * 0.5 + 2.5;
     return (t - 2.5) * 2.0;
 }
 
-// Must return the input
+// Shall return the input
 // CHECK_IR_BALANCED: @test4
 // CHECK_IR_BALANCED: ret <8 x float> %v4
+// CHECK_IR_AGGRESSIVE: @test4
+// CHECK_IR_AGGRESSIVE: ret <8 x float> %v4
 float test4(float v4) {
     float t = v4 * 0.5 + 2.5;
     return (t - 0.5) * 2.0 - 4.0;
 }
 
-// Must just generate a single FMA
+// Shall just generate a single FMA
 // CHECK_X64_ASM_BALANCED: 0x40600000
 // CHECK_X64_ASM_BALANCED: 0x40200000
 // CHECK_X64_ASM_BALANCED: @test5
+// CHECK_X64_ASM_AGGRESSIVE: 0x40600000
+// CHECK_X64_ASM_AGGRESSIVE: 0x40200000
+// CHECK_X64_ASM_AGGRESSIVE: @test5
 float test5(float v5) {
     return v5 * 3.5 + 2.5;
 }
 
-// Must just generate a single FMA
+// Shall just generate a single FMA
 // CHECK_X64_ASM_BALANCED: 0xc1408000
 // CHECK_X64_ASM_BALANCED: 0xc19f4000
 // CHECK_X64_ASM_BALANCED: @test6
+// CHECK_X64_ASM_AGGRESSIVE: 0xc1408000
+// CHECK_X64_ASM_AGGRESSIVE: 0xc19f4000
+// CHECK_X64_ASM_AGGRESSIVE: @test6
 float test6(float v6) {
     v6 *= 2.5;
     v6 += 1.5;
@@ -55,13 +69,13 @@ float test6(float v6) {
     return v6;
 }
 
-// Must just generate a single FMA in aggressive mode.
-// The same should be true in balanced mode, but LLVM 20 does not currently
-// do that yet (a single fma + div are surprizingly generated).
-// The balanced version should at least uses FMA instructions instead of 
-// mul+add instructions.
+// Shall just generate a single FMA in both balanced and aggressive modes.
+// Without arcp, LLVM 20 does not currently do that yet.
+// Indeed, one fma + one div intructions are generated.
+// CHECK_X64_ASM_BALANCED: 0xc08f5076
+// CHECK_X64_ASM_BALANCED: 0xc116f8b0
 // CHECK_X64_ASM_BALANCED: @test7
-// CHECK_X64_ASM_BALANCED: {{fmadd|fmsub}}
+// CHECK_X64_ASM_BALANCED-NOT: vdivps
 // CHECK_X64_ASM_AGGRESSIVE: 0xc08f5076
 // CHECK_X64_ASM_AGGRESSIVE: 0xc116f8b0
 // CHECK_X64_ASM_AGGRESSIVE: @test7
@@ -80,8 +94,8 @@ float test7(float v7) {
     return v7;
 }
 
-// Must return 0 with an aggressive fast-math, but it must only generate a
-// basic vsubps instruction due possible to NaN/Inf values in `v8`.
+// Shall return 0 with an aggressive mode. 
+// Shall only generate a basic vsubps instruction in balanced mode (due to a possible NaN/Inf value in `v8`).
 // CHECK_X64_ASM_BALANCED: @test8
 // CHECK_X64_ASM_BALANCED: vsubps
 // CHECK_X64_ASM_AGGRESSIVE: @test8

--- a/tests/lit-tests/fast_math_opt-2.ispc
+++ b/tests/lit-tests/fast_math_opt-2.ispc
@@ -1,52 +1,50 @@
-// RUN: %{ispc} %s --target=host --opt=fast-math -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_IR
-// RUN: %{ispc} %s --target=avx2-i32x8 --opt=fast-math -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM
-// RUN: %{ispc} %s --target=avx2-i32x8 --opt=fast-math -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_V2
+// RUN: %{ispc} %s --target=host --opt=fast-math:balanced -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_IR_BALANCED
+// RUN: %{ispc} %s --target=avx2-i32x8 --opt=fast-math:balanced -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_BALANCED
+// RUN: %{ispc} %s --target=avx2-i32x8 --opt=fast-math:aggressive -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_AGGRESSIVE
 
 // Must return the input
-// CHECK_IR: @test1
-// CHECK_IR: ret <8 x float> %v1
+// CHECK_IR_BALANCED: @test1
+// CHECK_IR_BALANCED: ret <8 x float> %v1
 float test1(float v1) {
     return v1 + 1.0 - 1.0;
 }
 
 // Must return the input
-// CHECK_IR: @test2
-// CHECK_IR: ret <8 x float> %v2
+// CHECK_IR_BALANCED: @test2
+// CHECK_IR_BALANCED: ret <8 x float> %v2
 float test2(float v2) {
     float t = v2 * 0.5;
     return t * 2;
 }
 
 // Must return the input
-// CHECK_IR: @test3
-// CHECK_IR: ret <8 x float> %v3
+// CHECK_IR_BALANCED: @test3
+// CHECK_IR_BALANCED: ret <8 x float> %v3
 float test3(float v3) {
     float t = v3 * 0.5 + 2.5;
     return (t - 2.5) * 2.0;
 }
 
 // Must return the input
-// CHECK_IR: @test4
-// CHECK_IR: ret <8 x float> %v4
+// CHECK_IR_BALANCED: @test4
+// CHECK_IR_BALANCED: ret <8 x float> %v4
 float test4(float v4) {
     float t = v4 * 0.5 + 2.5;
     return (t - 0.5) * 2.0 - 4.0;
 }
 
-// CHECK_X64_ASM_V2-COUNT-3: vfmadd{{[1-3][1-3][1-3]}}ps
-
 // Must just generate a single FMA
-// CHECK_X64_ASM: 0x40600000
-// CHECK_X64_ASM: 0x40200000
-// CHECK_X64_ASM: @test5
+// CHECK_X64_ASM_BALANCED: 0x40600000
+// CHECK_X64_ASM_BALANCED: 0x40200000
+// CHECK_X64_ASM_BALANCED: @test5
 float test5(float v5) {
     return v5 * 3.5 + 2.5;
 }
 
 // Must just generate a single FMA
-// CHECK_X64_ASM: 0xc1408000
-// CHECK_X64_ASM: 0xc19f4000
-// CHECK_X64_ASM: @test6
+// CHECK_X64_ASM_BALANCED: 0xc1408000
+// CHECK_X64_ASM_BALANCED: 0xc19f4000
+// CHECK_X64_ASM_BALANCED: @test6
 float test6(float v6) {
     v6 *= 2.5;
     v6 += 1.5;
@@ -57,10 +55,17 @@ float test6(float v6) {
     return v6;
 }
 
-// Must just generate a single FMA (certainly only with the full fast-math)
-// CHECK_X64_ASM: 0xc08f5076
-// CHECK_X64_ASM: 0xc116f8b0
-// CHECK_X64_ASM: @test7
+// Must just generate a single FMA in aggressive mode.
+// The same should be true in balanced mode, but LLVM 20 does not currently
+// do that yet (a single fma + div are surprizingly generated).
+// The balanced version should at least uses FMA instructions instead of 
+// mul+add instructions.
+// CHECK_X64_ASM_BALANCED: @test7
+// CHECK_X64_ASM_BALANCED: {{fmadd|fmsub}}
+// CHECK_X64_ASM_AGGRESSIVE: 0xc08f5076
+// CHECK_X64_ASM_AGGRESSIVE: 0xc116f8b0
+// CHECK_X64_ASM_AGGRESSIVE: @test7
+// CHECK_X64_ASM_AGGRESSIVE-NOT: vdivps
 float test7(float v7) {
     v7 *= 2.75;
     v7 += 1.25;
@@ -76,9 +81,12 @@ float test7(float v7) {
 }
 
 // Must return 0 with an aggressive fast-math, but it must only generate a
-// basic vsubps instruction due possible to NaN/Inf values in `v8`
-// CHECK_X64_ASM: @test8
-// CHECK_X64_ASM: vsubps
+// basic vsubps instruction due possible to NaN/Inf values in `v8`.
+// CHECK_X64_ASM_BALANCED: @test8
+// CHECK_X64_ASM_BALANCED: vsubps
+// CHECK_X64_ASM_AGGRESSIVE: @test8
+// CHECK_X64_ASM_AGGRESSIVE: vxorps
+// CHECK_X64_ASM_AGGRESSIVE-NOT: vsubps
 float test8(float v8) {
     return v8 - v8;
 }

--- a/tests/lit-tests/fast_math_opt-asm.ispc
+++ b/tests/lit-tests/fast_math_opt-asm.ispc
@@ -1,11 +1,7 @@
-// This test checks the optimizations performed by the different fast-math modes on divisions.
+// This test checks the optimizations performed by the different fast-math modes on divisions at the assembly level.
+// The IR/ASM tests are split because MacOS does not support avx512spr targets required for native float16 support.
 
-// REQUIRES: X86_ENABLED
-
-// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_DEFAULT
-// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:legacy -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_LEGACY
-// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:balanced -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_BALANCED
-// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:aggressive -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_AGGRESSIVE
+// REQUIRES: X86_ENABLED && !MACOS_HOST
 
 // RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_DEFAULT
 // RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:legacy -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_LEGACY
@@ -17,31 +13,17 @@
 // XFAIL: PPC64LE_HOST
 
 // The default mode is the legacy one
-// CHECK_X64_IR_DEFAULT-NOT: fdiv <16 x {{(half|float|double)}}>
-// CHECK_X64_IR_DEFAULT-COUNT-2: fmul <16 x half> %a
-// CHECK_X64_IR_DEFAULT-COUNT-2: fmul <16 x float> %a
-// CHECK_X64_IR_DEFAULT-COUNT-2: fmul <16 x double> %a
 // CHECK_X64_ASM_DEFAULT: vrcpph
 // CHECK_X64_ASM_DEFAULT: vrcp{{12|14}}ps
 // CHECK_X64_ASM_DEFAULT: vrcp{{12|14}}pd
 
 // In legacy mode, rcp+fmul shall be performed systematically instead of basic divisions
-// CHECK_X64_IR_LEGACY-NOT: fdiv <16 x {{(half|float|double)}}>
-// CHECK_X64_IR_LEGACY-COUNT-2: fmul <16 x half> %a
-// CHECK_X64_IR_LEGACY-COUNT-2: fmul <16 x float> %a
-// CHECK_X64_IR_LEGACY-COUNT-2: fmul <16 x double> %a
 // CHECK_X64_ASM_LEGACY: vrcpph
 // CHECK_X64_ASM_LEGACY: vrcp{{12|14}}ps
 // CHECK_X64_ASM_LEGACY: vrcp{{12|14}}pd
 
 // In balanced mode, math operations shall be tagged and divisions shall not be approximated.
 // Divisions can be replace by a multiplication for constants here.
-// CHECK_X64_IR_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz|arcp) )+}}<16 x half> %a
-// CHECK_X64_IR_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz|arcp) )+}}<16 x half> %a
-// CHECK_X64_IR_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz|arcp) )+}}<16 x float> %a
-// CHECK_X64_IR_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz|arcp) )+}}<16 x float> %a
-// CHECK_X64_IR_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz|arcp) )+}}<16 x double> %a
-// CHECK_X64_IR_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz|arcp) )+}}<16 x double> %a
 // CHECK_X64_ASM_BALANCED-NOT: vrcpph
 // CHECK_X64_ASM_BALANCED-NOT: vrcp{{12|14}}ps
 // CHECK_X64_ASM_BALANCED-NOT: vrcp{{12|14}}pd
@@ -49,9 +31,6 @@
 // In aggressive mode, math operations shall be tagged, divisions can be optimized out and may even be aproximated.
 // That being said, approximations are typically done in the generated assembly and not the in the IR.
 // It shall at least optimize divisions by constants in the IR.
-// CHECK_X64_IR_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x half> %a
-// CHECK_X64_IR_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x float> %a
-// CHECK_X64_IR_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x double> %a
 // CHECK_X64_ASM_AGGRESSIVE: vrcpph
 // CHECK_X64_ASM_AGGRESSIVE: vrcp{{12|14}}ps
 // CHECK_X64_ASM_AGGRESSIVE: {{vrcp(12|14)pd|vdivpd}}

--- a/tests/lit-tests/fast_math_opt-asm.ispc
+++ b/tests/lit-tests/fast_math_opt-asm.ispc
@@ -1,5 +1,7 @@
 // This test checks the optimizations performed by the different fast-math modes on divisions at the assembly level.
 // The IR/ASM tests are split because MacOS does not support avx512spr targets required for native float16 support.
+// Besides, generic target stdlib's rcp implementation uses 1.0/x (fdiv) rather than a hardware rcp instruction
+// so it will fail on ppc64le for example.
 
 // REQUIRES: X86_ENABLED && !MACOS_HOST
 
@@ -7,10 +9,6 @@
 // RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:legacy -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_LEGACY
 // RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:balanced -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_BALANCED
 // RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:aggressive -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_AGGRESSIVE
-
-// Generic target stdlib's rcp implementation uses 1.0/x (fdiv) rather than
-// a hardware rcp instruction, so the CHECK_NOFDIV check fails on ppc64le.
-// XFAIL: PPC64LE_HOST
 
 // The default mode is the legacy one
 // CHECK_X64_ASM_DEFAULT: vrcpph

--- a/tests/lit-tests/fast_math_opt-ir.ispc
+++ b/tests/lit-tests/fast_math_opt-ir.ispc
@@ -1,0 +1,60 @@
+// This test checks the optimizations performed by the different fast-math modes on divisions at the IR level.
+
+// REQUIRES: X86_ENABLED
+
+// RUN: %{ispc} %s --target=avx512skx-x16 --opt=fast-math -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_DEFAULT
+// RUN: %{ispc} %s --target=avx512skx-x16 --opt=fast-math:legacy -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_LEGACY
+// RUN: %{ispc} %s --target=avx512skx-x16 --opt=fast-math:balanced -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_BALANCED
+// RUN: %{ispc} %s --target=avx512skx-x16 --opt=fast-math:aggressive -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_AGGRESSIVE
+
+// The default mode is the legacy one
+// CHECK_X64_IR_DEFAULT-NOT: fdiv <16 x {{(half|float|double)}}>
+// CHECK_X64_IR_DEFAULT-COUNT-2: fmul <16 x half> {{%a|.*, %a}}
+// CHECK_X64_IR_DEFAULT-COUNT-2: fmul <16 x float> {{%a|.*, %a}}
+// CHECK_X64_IR_DEFAULT-COUNT-2: fmul <16 x double> {{%a|.*, %a}}
+
+// In legacy mode, rcp+fmul shall be performed systematically instead of basic divisions
+// CHECK_X64_IR_LEGACY-NOT: fdiv <16 x {{(half|float|double)}}>
+// CHECK_X64_IR_LEGACY-COUNT-2: fmul <16 x half> {{%a|.*, %a}}
+// CHECK_X64_IR_LEGACY-COUNT-2: fmul <16 x float> {{%a|.*, %a}}
+// CHECK_X64_IR_LEGACY-COUNT-2: fmul <16 x double> {{%a|.*, %a}}
+
+// In balanced mode, math operations shall be tagged and divisions shall not be approximated.
+// Divisions can be replace by a multiplication for constants here.
+// CHECK_X64_IR_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz|arcp) )+}}<16 x half> {{%a|.*, %a}}
+// CHECK_X64_IR_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz|arcp) )+}}<16 x half> {{%a|.*, %a}}
+// CHECK_X64_IR_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz|arcp) )+}}<16 x float> {{%a|.*, %a}}
+// CHECK_X64_IR_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz|arcp) )+}}<16 x float> {{%a|.*, %a}}
+// CHECK_X64_IR_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz|arcp) )+}}<16 x double> {{%a|.*, %a}}
+// CHECK_X64_IR_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz|arcp) )+}}<16 x double> {{%a|.*, %a}}
+
+// In aggressive mode, math operations shall be tagged, divisions can be optimized out and may even be aproximated.
+// That being said, approximations are typically done in the generated assembly and not the in the IR.
+// It shall at least optimize divisions by constants in the IR.
+// CHECK_X64_IR_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x half> {{%a|.*, %a}}
+// CHECK_X64_IR_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x float> {{%a|.*, %a}}
+// CHECK_X64_IR_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x double> {{%a|.*, %a}}
+
+float16 f1(float16 a) {
+  return a/2.f16;
+}
+
+float16 f2(float16 a, float16 b) {
+  return a/b;
+}
+
+float f3(float a) {
+  return a/2.f;
+}
+
+float f4(float a, float b) {
+  return a/b;
+}
+
+double f5(double a) {
+  return a/2.d;
+}
+
+double f6(double a, double b) {
+  return a/b;
+}

--- a/tests/lit-tests/fast_math_opt.ispc
+++ b/tests/lit-tests/fast_math_opt.ispc
@@ -1,11 +1,37 @@
-// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_ASM
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_DEFAULT
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:legacy -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_LEGACY
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:balanced -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_BALANCED
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:aggressive -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_AGGRESSIVE
 
 // Generic target stdlib's rcp implementation uses 1.0/x (fdiv) rather than
 // a hardware rcp instruction, so the CHECK_NOFDIV check fails on ppc64le.
 // XFAIL: PPC64LE_HOST
 
-// CHECK_X64_ASM-COUNT-1: fdiv {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )*}}<8 x double> %a, %b
+// The default mode is the legacy one
+// CHECK_X64_ASM_DEFAULT-NOT: fdiv <16 x {{(half|float|double)}}>
+// CHECK_X64_ASM_DEFAULT-COUNT-2: fmul <16 x half> %a
+// CHECK_X64_ASM_DEFAULT-COUNT-2: fmul <16 x float> %a
+// CHECK_X64_ASM_DEFAULT-COUNT-2: fmul <16 x double> %a
 
+// In legacy mode, rcp+fmul should be performed systematically instead of plain divisions
+// CHECK_X64_ASM_LEGACY-NOT: fdiv <16 x {{(half|float|double)}}>
+// CHECK_X64_ASM_LEGACY-COUNT-2: fmul <16 x half> %a
+// CHECK_X64_ASM_LEGACY-COUNT-2: fmul <16 x float> %a
+// CHECK_X64_ASM_LEGACY-COUNT-2: fmul <16 x double> %a
+
+// In balanced mode, math operations should be tagged and divisions should not be optimized out, except for constants.
+// CHECK_X64_ASM_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz) )+}}<16 x half> %a
+// CHECK_X64_ASM_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz) )+}}<16 x half> %a
+// CHECK_X64_ASM_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz) )+}}<16 x float> %a
+// CHECK_X64_ASM_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz) )+}}<16 x float> %a
+// CHECK_X64_ASM_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz) )+}}<16 x double> %a
+// CHECK_X64_ASM_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz) )+}}<16 x double> %a
+
+// In aggressive mode, math operations should be tagged and division can be optimized out (but may not always be).
+// It should at least optimize divisions by constants.
+// CHECK_X64_ASM_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x half> %a
+// CHECK_X64_ASM_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x float> %a
+// CHECK_X64_ASM_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x double> %a
 
 float16 f1(float16 a) {
   return a/2.f16;

--- a/tests/lit-tests/fast_math_opt.ispc
+++ b/tests/lit-tests/fast_math_opt.ispc
@@ -1,3 +1,7 @@
+// This test checks the optimizations performed by the different fast-math modes on divisions.
+
+// REQUIRES: X86_ENABLED
+
 // RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_DEFAULT
 // RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:legacy -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_LEGACY
 // RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:balanced -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_BALANCED

--- a/tests/lit-tests/fast_math_opt.ispc
+++ b/tests/lit-tests/fast_math_opt.ispc
@@ -1,18 +1,16 @@
-// RUN: %{ispc} %s --target=host --opt=fast-math --nostdlib --nowrap 2>&1 | FileCheck %s -check-prefix=CHECK_WARN
-// RUN: %{ispc} %s --target=host --opt=fast-math -O0 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_NOFDIV
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_ASM
 
 // Generic target stdlib's rcp implementation uses 1.0/x (fdiv) rather than
 // a hardware rcp instruction, so the CHECK_NOFDIV check fails on ppc64le.
 // XFAIL: PPC64LE_HOST
 
-// CHECK_NOFDIV-NOT: fdiv
+// CHECK_X64_ASM-COUNT-1: fdiv {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )*}}<8 x double> %a, %b
 
 
 float16 f1(float16 a) {
   return a/2.f16;
 }
 
-// CHECK_WARN: Warning: rcp(varying float16) not found from stdlib. Can't apply fast-math rcp optimization.
 float16 f2(float16 a, float16 b) {
   return a/b;
 }
@@ -21,7 +19,6 @@ float f3(float a) {
   return a/2.f;
 }
 
-// CHECK_WARN: Warning: rcp(varying float) not found from stdlib. Can't apply fast-math rcp optimization.
 float f4(float a, float b) {
   return a/b;
 }
@@ -30,7 +27,6 @@ double f5(double a) {
   return a/2.d;
 }
 
-// CHECK_WARN: Warning: rcp(varying double) not found from stdlib. Can't apply fast-math rcp optimization.
 double f6(double a, double b) {
   return a/b;
 }

--- a/tests/lit-tests/fast_math_opt.ispc
+++ b/tests/lit-tests/fast_math_opt.ispc
@@ -1,37 +1,56 @@
-// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_DEFAULT
-// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:legacy -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_LEGACY
-// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:balanced -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_BALANCED
-// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:aggressive -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_AGGRESSIVE
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_DEFAULT
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:legacy -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_LEGACY
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:balanced -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_BALANCED
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:aggressive -O2 --emit-llvm-text -o -| FileCheck %s -check-prefix=CHECK_X64_IR_AGGRESSIVE
+
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_DEFAULT
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:legacy -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_LEGACY
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:balanced -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_BALANCED
+// RUN: %{ispc} %s --target=avx512spr-x16 --opt=fast-math:aggressive -O2 --emit-asm -o -| FileCheck %s -check-prefix=CHECK_X64_ASM_AGGRESSIVE
 
 // Generic target stdlib's rcp implementation uses 1.0/x (fdiv) rather than
 // a hardware rcp instruction, so the CHECK_NOFDIV check fails on ppc64le.
 // XFAIL: PPC64LE_HOST
 
 // The default mode is the legacy one
-// CHECK_X64_ASM_DEFAULT-NOT: fdiv <16 x {{(half|float|double)}}>
-// CHECK_X64_ASM_DEFAULT-COUNT-2: fmul <16 x half> %a
-// CHECK_X64_ASM_DEFAULT-COUNT-2: fmul <16 x float> %a
-// CHECK_X64_ASM_DEFAULT-COUNT-2: fmul <16 x double> %a
+// CHECK_X64_IR_DEFAULT-NOT: fdiv <16 x {{(half|float|double)}}>
+// CHECK_X64_IR_DEFAULT-COUNT-2: fmul <16 x half> %a
+// CHECK_X64_IR_DEFAULT-COUNT-2: fmul <16 x float> %a
+// CHECK_X64_IR_DEFAULT-COUNT-2: fmul <16 x double> %a
+// CHECK_X64_ASM_DEFAULT: vrcpph
+// CHECK_X64_ASM_DEFAULT: vrcp{{12|14}}ps
+// CHECK_X64_ASM_DEFAULT: vrcp{{12|14}}pd
 
-// In legacy mode, rcp+fmul should be performed systematically instead of plain divisions
-// CHECK_X64_ASM_LEGACY-NOT: fdiv <16 x {{(half|float|double)}}>
-// CHECK_X64_ASM_LEGACY-COUNT-2: fmul <16 x half> %a
-// CHECK_X64_ASM_LEGACY-COUNT-2: fmul <16 x float> %a
-// CHECK_X64_ASM_LEGACY-COUNT-2: fmul <16 x double> %a
+// In legacy mode, rcp+fmul shall be performed systematically instead of basic divisions
+// CHECK_X64_IR_LEGACY-NOT: fdiv <16 x {{(half|float|double)}}>
+// CHECK_X64_IR_LEGACY-COUNT-2: fmul <16 x half> %a
+// CHECK_X64_IR_LEGACY-COUNT-2: fmul <16 x float> %a
+// CHECK_X64_IR_LEGACY-COUNT-2: fmul <16 x double> %a
+// CHECK_X64_ASM_LEGACY: vrcpph
+// CHECK_X64_ASM_LEGACY: vrcp{{12|14}}ps
+// CHECK_X64_ASM_LEGACY: vrcp{{12|14}}pd
 
-// In balanced mode, math operations should be tagged and divisions should not be optimized out, except for constants.
-// CHECK_X64_ASM_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz) )+}}<16 x half> %a
-// CHECK_X64_ASM_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz) )+}}<16 x half> %a
-// CHECK_X64_ASM_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz) )+}}<16 x float> %a
-// CHECK_X64_ASM_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz) )+}}<16 x float> %a
-// CHECK_X64_ASM_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz) )+}}<16 x double> %a
-// CHECK_X64_ASM_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz) )+}}<16 x double> %a
+// In balanced mode, math operations shall be tagged and divisions shall not be approximated.
+// Divisions can be replace by a multiplication for constants here.
+// CHECK_X64_IR_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz|arcp) )+}}<16 x half> %a
+// CHECK_X64_IR_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz|arcp) )+}}<16 x half> %a
+// CHECK_X64_IR_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz|arcp) )+}}<16 x float> %a
+// CHECK_X64_IR_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz|arcp) )+}}<16 x float> %a
+// CHECK_X64_IR_BALANCED-COUNT-1: fmul {{((contract|reassoc|nsz|arcp) )+}}<16 x double> %a
+// CHECK_X64_IR_BALANCED-COUNT-1: fdiv {{((contract|reassoc|nsz|arcp) )+}}<16 x double> %a
+// CHECK_X64_ASM_BALANCED-NOT: vrcpph
+// CHECK_X64_ASM_BALANCED-NOT: vrcp{{12|14}}ps
+// CHECK_X64_ASM_BALANCED-NOT: vrcp{{12|14}}pd
 
-// In aggressive mode, math operations should be tagged and division can be optimized out (but may not always be).
-// It should at least optimize divisions by constants.
-// CHECK_X64_ASM_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x half> %a
-// CHECK_X64_ASM_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x float> %a
-// CHECK_X64_ASM_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x double> %a
+// In aggressive mode, math operations shall be tagged, divisions can be optimized out and may even be aproximated.
+// That being said, approximations are typically done in the generated assembly and not the in the IR.
+// It shall at least optimize divisions by constants in the IR.
+// CHECK_X64_IR_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x half> %a
+// CHECK_X64_IR_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x float> %a
+// CHECK_X64_IR_AGGRESSIVE: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )+}}<16 x double> %a
+// CHECK_X64_ASM_AGGRESSIVE: vrcpph
+// CHECK_X64_ASM_AGGRESSIVE: vrcp{{12|14}}ps
+// CHECK_X64_ASM_AGGRESSIVE: {{vrcp(12|14)pd|vdivpd}}
 
 float16 f1(float16 a) {
   return a/2.f16;


### PR DESCRIPTION
## Description

This PR implements an LLVM pass so to optimize floating-point math operations. It currently also removes the frond-end AST transformation (regarding divisions to reciprocals) since it is meant to be done in the back-end.
It fixes the issue #3402 when fast-math is enabled (i.e. using compilation flags `--opt=fast-math -O2`).
However, there are many things to consider and discuss.

One major issue with the current LLVM IR `fast` flag on FP math instructions is that is can cause *crazy transformations* during optimizations if the fast-math assumptions are broken. This a known issue and it also happens in C and C++ code compiled with `--fast-math`. This is described further [here](https://github.com/iree-org/iree/issues/19743). See https://llvm.org/docs/LangRef.html#fast-math-flags for more information about LLVM fast-math/rewrite-based flags.

IMHO, this is like opening the Pandora's box. Indeed, it is very easy to generate Inf, NaN, negative zeros values (e.g. from subnormal which are also quite common in pathological cases) and so to break codes compiled with this optimization. While this happens in C/C++, the benefit in C/C++ is higher because this optimization generally enables loops to be auto-vectorized (strongly improving performance in many cases), while in ISPC there is no need of this for loops to be efficiently vectorized (which is great since `--fast-math` is pretty dangerous and its effect are often underestimated). That being said, it would be nice to benefit from `contract` (i.e. `mul`+`add` to `fma`), and `reassoc` (i.e. associative FP math) to improve a bit further ISPC code without the dangerous impact of a full fast-math. #3402 is a good example for that (NaN and Inf could still be supported with twice less `mul` -- so a possibly twice faster code). In some cases, enabling reciprocal optimization can be also beneficial for performance though it is generally less precise and more dangerous. For users wanting performance at all costs, it would be good to provide a full fast-math optimization. The later is particularly dangerous because it should impact all our math functions and I have no idea of whether they still work well in this case (I just run some functional-tests to quickly evaluate this and it was surprisingly not that bad but I think some important test on math functions are disabled).

Based on this, I started to support one experimental version fully enabling fast-math optimization (enabled with the define `AGGRESSIVE_FAST_MATH_OPT`. It works well regarding optimizations: LLVM performs FP math operation re-association, reciprocal optimization (certainly better than we do so far), etc. Then I tried to support a less dangerous fast-math as aforementioned. On one hand, It turns out that re-association requires the `nsz` (i.e. "no signed zeros") flag to be actually effective. Fortunately, it *"does not imply that -0.0 is poison and/or guaranteed to not exist in the operation"* so this is a rather-"safe" assumption. Please note that *"the reassociation does lose both some infinites and some NaNs"* (aforementioned [here](https://github.com/iree-org/iree/issues/19743)), but IMHO I consider this is rather normal considering one plays with fire in such a case. Still, there is no poison values in this case. On the other hand, reciprocal optimizations requires the `ninf` flag (or apparently `nnan` for some non-trivial optimizations) to be enabled to be actually effective and this one is dangerous due to the aforementioned possibly-broken assumption during optimizations. It (kind of) makes sense since reciprocal operation (like the optimization we currently do in ISPC when fast-math is enabled) can sometimes generate infinities from subnormal values or even `-nan` values from infinities ([see on Godbolt](https://ispc.godbolt.org/z/qvdbn5b8v)).

Currently, in this PR, the fast-math optimizations are rather-safe and the reciprocal optimizations are not done anymore in the AST. The later should either be done by LLVM if we accept to perform a full fast-math optimization, or done manually in this new fast-math optimization pass (and consider the fact that it can wrongly produce NaN/Inf values in pathological cases). Indeed, the early transformation of the divisions in the AST apparently prevent [some checks](https://ispc.godbolt.org/z/z1jqWx1d8) to be reported so moving this to the back-end should solve this issue. I personally prefer the work to be done by LLVM since the optimization do not need the stdlib (as opposed to our current solution) and the code is better in some cases (e.g. more accurate for double-precision in AVX2 targets while being at least as fast). Our ISPC solution does not generate poison values when assumptions are broken but it can generate Inf/NaN values that will break assumption if the `nnan`, `ninf` or `fast` math-flags are used anyway...

At this point, here is the **list of questions we should answer**:
 - Should `--opt=fast-math` be equivalent to `--fast-math` in Clang?
 - Should we provide fine-grained fast-math optimizations like in Clang? Or alternatively, should we provide multiple level of fast-math optimizations? (IMHO the later help a LOT easily track issues in our math functions since there is far less combination to tests and it makes things simpler from the user PoV).
 - Should we use our own reciprocal function or let LLVM do the optimizations?

Last but not least, some other points needs to be considered like the fact fast-math will certainly have a different behavior, the documentation this and ways to avoid users to encounter issues from such an update (i.e. reduce surprising results after updating ISPC). One way to do that is by removing the current `--opt=fast-math` flag so to force users to switch to the new one. We could also just still support the old one and warn users temporary (i.e. deprecation warning) and remove this later (but this certainly make things a bit more complicated).

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed