### PR TITLE
Add nanobind option to stability object in alloy.py

### DIFF
--- a/scripts/alloy.py
+++ b/scripts/alloy.py
@@ -599,6 +599,7 @@ def validation_run(only, only_targets, reference_branch, number, update, speed_n
         stability.device = None
         stability.ispc_output = None
         stability.debug_check = False
+        stability.nanobind = False
 # stability varying options
         stability.target = ""
         stability.arch = ""


### PR DESCRIPTION
## Description
This PR adds `nanobind` option to `stability` object in alloy.py which fixes issue like here: 
https://github.com/ispc/ispc/actions/runs/16286474415/job/45987240085

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed