### PR TITLE
Fix reusable test workflow

### DIFF
--- a/.github/workflows/reusable.ispc.test.yml
+++ b/.github/workflows/reusable.ispc.test.yml
@@ -170,10 +170,11 @@ jobs:
       id: set-artifact-name
       shell: bash
       run: |
+        TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
         if [ "${{ inputs.enable_debug }}" == "true" ]; then
-          echo "name_prefix=${{ inputs.artifact_name }}.debug.${{ inputs.architecture }}.${{ matrix.target }}" >> "$GITHUB_ENV"
+          echo "name_prefix=${{ inputs.artifact_name }}.debug.${{ inputs.architecture }}.${{ matrix.target }}.${TIMESTAMP}" >> "$GITHUB_ENV"
         else
-          echo "name_prefix=${{ inputs.artifact_name }}.${{ inputs.architecture }}.${{ matrix.target }}" >> "$GITHUB_OUTPUT"
+          echo "name_prefix=${{ inputs.artifact_name }}.${{ inputs.architecture }}.${{ matrix.target }}.${TIMESTAMP}" >> "$GITHUB_OUTPUT"
         fi
     - name: Check
       run: |

--- a/.github/workflows/reusable.ispc.test.yml
+++ b/.github/workflows/reusable.ispc.test.yml
@@ -175,7 +175,10 @@ jobs:
         else
           echo "name_prefix=${{ inputs.artifact_name }}.${{ inputs.architecture }}.${{ matrix.target }}" >> "$GITHUB_OUTPUT"
         fi
-
+    - name: Check
+      run: |
+        # Print fails to the log.
+        git diff --exit-code
     - name: Upload fail_db.txt
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       if: failure()


### PR DESCRIPTION
## Description
The `alloy.py` doesn't return error code in case if there were any test failures. This PR adds a check that `git diff` is not empty which means that `alloy.py` updated fail_db with new failures.

The CI was broken for quite a while and there is a bunch of test failures. 
Full run is here: https://github.com/ispc/ispc/actions/runs/16325104505

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed