### PR TITLE
Compute relative error in cbrt-float.ispc

### DIFF
--- a/tests/func-tests/cbrt-float.ispc
+++ b/tests/func-tests/cbrt-float.ispc
@@ -3,13 +3,10 @@
 task void f_f(uniform float RET[], uniform float aFOO[]) {
     varying float f = aFOO[programIndex];
     varying float calc = cbrt(f) * cbrt(f) * cbrt(f);
-    if (calc < 0.) calc = -calc;
-    if (abs(calc - f) < 1e-5)
-    {
+    if (isnan(calc) == isnan(f) && (abs(f) >= 1e-6 && abs((calc - f) / f) < 2e-6 || abs(calc - f) < 2e-12 || isnan(f))) {
         RET[programIndex] = 1;
     }
-    else
-    {
+    else {
         RET[programIndex] = 0;
     }
 }


### PR DESCRIPTION
## Description
Compute relative error in cbrt-float.ispc. Currently the test fails with big inputs (on 64-width targets).

## Related Issue
- [x] Fixes https://github.com/ispc/ispc/issues/3495

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed