### PR TITLE
Report an error when mcmodel large and x86 are used

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -208,6 +208,9 @@ jobs:
         extra_flags: ["--opt=disable-zmm", "--addressing=64", "-g", "--math-lib=fast",
                       "--math-lib=system", "--mcmodel=large", "--pic",
                       "--no-wrap-signed-int",  "--opt=disable-fma", "--opt=fast-math"]
+        exclude:
+          - arch: x86
+            extra_flags: "--mcmodel=large"
     uses: ./.github/workflows/reusable.ispc.test.yml
     with:
       platform: linux
@@ -494,6 +497,9 @@ jobs:
         extra_flags: ["--opt=disable-zmm", "--addressing=64", "-g", "--math-lib=fast",
                       "--math-lib=system", "--mcmodel=large", "--pic",
                       "--no-wrap-signed-int",  "--opt=disable-fma", "--opt=fast-math"]
+        exclude:
+          - arch: x86
+            extra_flags: "--mcmodel=large"
     uses: ./.github/workflows/reusable.ispc.test.yml
     with:
       platform: windows

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -1163,6 +1163,13 @@ ArgsParseResult ispc::ParseCommandLineArgs(int argc, char *argv[], char *&file, 
     }
 #endif
 
+    // Validate mcmodel and architecture combination
+    if (output.flags.getMCModel() == MCModel::Large && arch == Arch::x86) {
+        Error(SourcePos(), "--mcmodel=large is not supported for x86 architecture. "
+                           "Use x86-64 architecture instead.");
+        return ArgsParseResult::failure;
+    }
+
     if (!output.deps.empty()) {
         output.flags.setDepsToStdout(false);
     }

--- a/tests/lit-tests/mcmodel_x86_error.ispc
+++ b/tests/lit-tests/mcmodel_x86_error.ispc
@@ -1,0 +1,16 @@
+
+// This test verifies that ISPC correctly reports an error when --mcmodel=large
+// is used with --arch=x86, as the large code model is not supported on 32-bit x86.
+// It also verifies that compiler doesn't crash.
+
+// RUN: not %{ispc} %s --nowrap --target=avx2-i32x8 --arch=x86 --mcmodel=large -o %t.o 2>&1 | FileCheck %s -check-prefix=CHECK_ERROR_1
+// RUN: %{ispc} %s --nowrap --target=avx2-i32x8 --arch=x86 --mcmodel=small -o %t.o
+// RUN: %{ispc} %s --nowrap --target=avx2-i32x8 --arch=x86-64 --mcmodel=large -o %t.o
+// RUN: %{ispc} %s --nowrap --target=avx2-i32x8 --arch=x86-64 --mcmodel=small -o %t.o
+
+// REQUIRES: X86_ENABLED && !MACOS_HOST
+
+// CHECK_ERROR_1: Error: --mcmodel=large is not supported for x86 architecture. Use x86-64 architecture instead.
+// CHECK_ERROR_1-NOT: FATAL ERROR
+
+uniform int i;


### PR DESCRIPTION
## Description
Report an error when mcmodel large and x86 are used. Also exclude this options combination from testing

## Related Issue
- [x] Fixes https://github.com/ispc/ispc/issues/3497

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed