### PR TITLE
Split fmod-double-varying-2.ispc

### DIFF
--- a/tests/func-tests/fmod-double-varying-2.ispc
+++ b/tests/func-tests/fmod-double-varying-2.ispc
@@ -4,12 +4,11 @@
 // rule: skip on cpu=dg2
 // rule: skip on target=generic.*
 
-// TODO: consider further splitting/simplification of this test to reduce stack usage with O0.
 task void f_f(uniform float RET[], uniform float aFOO[]) {
     RET[programIndex] = 0;
 
     // Continuation of the test from fmod-double-varying.ispc.
-    // It's split into two files to reduce stack usage with O0.
+    // It's split into there files to reduce stack usage with O0.
     // Case 5.1: x is +inf, y is positive
     double x = aFOO[programCount / 2] / 0.0;
     double y = 0.8;
@@ -24,42 +23,6 @@ task void f_f(uniform float RET[], uniform float aFOO[]) {
 
     // Case 6: x is positive, y is 0.0
     x = aFOO[programCount / 2];
-    y = 0.0;
-    testVal = fmod(x, y);
-    RET[programIndex] += (isnan(testVal) && (signbits(testVal) == signbits(x))) ? 0 : 1;
-
-    // Case 7.1: x is positive, y is inf
-    x = aFOO[programCount / 2];
-    y = 0.8 / 0.0;
-    testVal = fmod(x, y);
-    RET[programIndex] += (testVal == x) ? 0 : 1;
-
-    // Case 7.1: x is negative, y is inf
-    x = -aFOO[programCount / 2];
-    y = 0.8 / 0.0;
-    testVal = fmod(x, y);
-    RET[programIndex] += (testVal == x) ? 0 : 1;
-
-    // Case 8.1: x is +0.0, y is positive
-    x = 0.0;
-    y = 0.8;
-    testVal = fmod(x, y);
-    RET[programIndex] += (testVal == x) ? 0 : 1;
-
-    // Case 8.2: x is -0.0, y is positive
-    x = -0.0;
-    y = 0.8;
-    testVal = fmod(x, y);
-    RET[programIndex] += (testVal == x) ? 0 : 1;
-
-    // Case 9.1: x is +0.0, y is 0.0
-    x = 0.0;
-    y = 0.0;
-    testVal = fmod(x, y);
-    RET[programIndex] += (isnan(testVal) && (signbits(testVal) == signbits(x))) ? 0 : 1;
-
-    // Case 9.2: x is -0.0, y is 0.0
-    x = -0.0;
     y = 0.0;
     testVal = fmod(x, y);
     RET[programIndex] += (isnan(testVal) && (signbits(testVal) == signbits(x))) ? 0 : 1;

--- a/tests/func-tests/fmod-double-varying-3.ispc
+++ b/tests/func-tests/fmod-double-varying-3.ispc
@@ -1,0 +1,49 @@
+#include "test_static.isph"
+// rule: run on OS=!windows
+// rule: skip on cpu=tgllp
+// rule: skip on cpu=dg2
+// rule: skip on target=generic.*
+
+task void f_f(uniform float RET[], uniform float aFOO[]) {
+    RET[programIndex] = 0;
+
+    // Continuation of the test from fmod-double-varying.ispc.
+    // It's split into three files to reduce stack usage with O0.
+    // Case 7.1: x is positive, y is inf
+    double x = aFOO[programCount / 2];
+    double y = 0.8 / 0.0;
+    double testVal = fmod(x, y);
+    RET[programIndex] += (testVal == x) ? 0 : 1;
+
+    // Case 7.1: x is negative, y is inf
+    x = -aFOO[programCount / 2];
+    y = 0.8 / 0.0;
+    testVal = fmod(x, y);
+    RET[programIndex] += (testVal == x) ? 0 : 1;
+
+    // Case 8.1: x is +0.0, y is positive
+    x = 0.0;
+    y = 0.8;
+    testVal = fmod(x, y);
+    RET[programIndex] += (testVal == x) ? 0 : 1;
+
+    // Case 8.2: x is -0.0, y is positive
+    x = -0.0;
+    y = 0.8;
+    testVal = fmod(x, y);
+    RET[programIndex] += (testVal == x) ? 0 : 1;
+
+    // Case 9.1: x is +0.0, y is 0.0
+    x = 0.0;
+    y = 0.0;
+    testVal = fmod(x, y);
+    RET[programIndex] += (isnan(testVal) && (signbits(testVal) == signbits(x))) ? 0 : 1;
+
+    // Case 9.2: x is -0.0, y is 0.0
+    x = -0.0;
+    y = 0.0;
+    testVal = fmod(x, y);
+    RET[programIndex] += (isnan(testVal) && (signbits(testVal) == signbits(x))) ? 0 : 1;
+}
+
+task void result(uniform float RET[]) { RET[0] = 0; }


### PR DESCRIPTION
## Description
One more split of fmod-double-varying-2.ispc to reduce stack usage on x86 with `-O2`

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed