### PR TITLE
ci: skip avx10 targets on x86

### DIFF
--- a/.github/workflows/reusable.ispc.test.yml
+++ b/.github/workflows/reusable.ispc.test.yml
@@ -100,9 +100,9 @@ jobs:
         fi
 
     - name: Running tests on Linux/macOS (alloy mode)
-      # See issue #2818 for more details about skipping avx512 and avx2vnni targets. It's SDE problem running on AMD runner.
+      # See issue #2818 for more details about skipping avx512, avx10 and avx2vnni targets. It's SDE problem running on AMD runner.
       # Unfortunately it's not possible to do this on job level, so we need to do it on step level.
-      if: (inputs.platform == 'linux' || inputs.platform == 'macos') && inputs.architecture != 'aarch64' && inputs.architecture != 'wasm32' && inputs.architecture != 'wasm64' && !(inputs.architecture == 'x86' && (contains(matrix.target, 'avx2vnni') || contains(matrix.target, 'avx512')))
+      if: (inputs.platform == 'linux' || inputs.platform == 'macos') && inputs.architecture != 'aarch64' && inputs.architecture != 'wasm32' && inputs.architecture != 'wasm64' && !(inputs.architecture == 'x86' && (contains(matrix.target, 'avx2vnni') || contains(matrix.target, 'avx512') || contains(matrix.target, 'avx10')))
       shell: bash
       run: |
         echo "PATH=${PATH}"


### PR DESCRIPTION
## Description
Skip avx10 targets on x86 due to SDE problem (same as for avx512).

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed