### PR TITLE
Disable failed <os>-test-flags jobs

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -211,6 +211,14 @@ jobs:
         exclude:
           - arch: x86
             extra_flags: "--mcmodel=large"
+          - arch: x86
+            extra_flags: "--opt=fast-math"
+          - arch: x86
+            extra_flags: "--math-lib=fast"
+          - arch: x86-64
+            extra_flags: "--opt=fast-math"
+          - arch: x86-64
+            extra_flags: "--math-lib=fast"
     uses: ./.github/workflows/reusable.ispc.test.yml
     with:
       platform: linux
@@ -501,6 +509,16 @@ jobs:
         exclude:
           - arch: x86
             extra_flags: "--mcmodel=large"
+          - arch: x86
+            extra_flags: "--opt=fast-math"
+          - arch: x86
+            extra_flags: "--math-lib=fast"
+          - arch: x86
+            extra_flags: "--math-lib=system"
+          - arch: x86-64
+            extra_flags: "--opt=fast-math"
+          - arch: x86-64
+            extra_flags: "--math-lib=fast"
     uses: ./.github/workflows/reusable.ispc.test.yml
     with:
       platform: windows


### PR DESCRIPTION
## Description
Brief description of changes

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed