### PR TITLE
Fix of several crashes related to short vector initialization/indexing

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -4996,7 +4996,12 @@ llvm::Value *IndexExpr::GetValue(FunctionEmitContext *ctx) const {
             Assert(m->errorCount > 0);
             return nullptr;
         }
-        lvType = PointerType::GetUniform(st->GetElementType());
+        // Use varying pointer type if the index is varying, uniform otherwise
+        if (indexType->IsVaryingType()) {
+            lvType = PointerType::GetVarying(st->GetElementType());
+        } else {
+            lvType = PointerType::GetUniform(st->GetElementType());
+        }
 
         // And do the indexing calculation into the temporary array in memory
         ptr = ctx->GetElementPtrInst(tmpPtrInfo->getPointer(), LLVMInt32(0), index->GetValue(ctx),

--- a/tests/lit-tests/2376.ispc
+++ b/tests/lit-tests/2376.ispc
@@ -2,12 +2,10 @@
 // error when varying index is used with short vectors
 // Currently fails (https://github.com/ispc/ispc/issues/2376).
 
-// RUN: not %{ispc} %s --target=host --nostdlib 2>&1 | FileCheck %s
+// RUN: %{ispc} %s --target=host --nostdlib 2>&1 | FileCheck %s --allow-empty
 // Error when LLVM built with no assertions
 // CHECK-NOT: FATAL ERROR
-// Error when LLVM built with assertions
-// CHECK-NOT: Assertion failed
-// XFAIL: *
+
 typedef int<3> int3;
 
 export void test(uniform float ret[], uniform float b) {

--- a/tests/lit-tests/3484-1.ispc
+++ b/tests/lit-tests/3484-1.ispc
@@ -1,0 +1,15 @@
+// This test ensures that the compiler doesn't crash when trying to initialize
+// a uniform vector with varying values, but instead produces an appropriate error message.
+// Previously this would cause an LLVM assertion failure in FixedVectorType::get().
+
+// RUN: not %{ispc} %s --target=host --nowrap 2>&1 | FileCheck %s
+
+// CHECK: Error: Can't convert from type "varying float" to type "uniform float" for initializer list
+
+static varying float load(const uniform float *values) { return 0.0f; }
+
+export void func(uniform float values[][programCount]) {
+    uniform float<3> col_xyz = {load(&values[0][0]),
+                                load(&values[0][0]),
+                                load(&values[0][0])};
+}

--- a/tests/lit-tests/3484-2.ispc
+++ b/tests/lit-tests/3484-2.ispc
@@ -1,0 +1,9 @@
+// This test ensures that the compiler doesn't crash with a segmentation fault
+// when trying to use an invalid function call in an initializer list.
+// Previously this would cause a null pointer dereference in HasAtomicInitializerList.
+
+// RUN: not %{ispc} %s --target=host --nowrap 2>&1 | FileCheck %s
+// CHECK: Error: Must provide function name or function pointer for function call expression
+export void func(uniform float values[][programCount]) {
+    uniform float<3> col_xyz = {values(&values[0][0])};
+}


### PR DESCRIPTION
## Description
Fixed three separate compiler crashes that occurred when processing invalid or edge-case ISPC code related to short vectors.
1. Use ISPC's `symVectorType->LLVMType(g->ctx)` instead of manually constructing `llvm::FixedVectorType::get()`
2. Null pointer check (src/expr.cpp:4831)
3. Use PointerType::GetVarying() when indexType->IsVaryingType()
4. Early exit if we can't construct short vector from initializer list due to different variability.

## Related Issue
- [x] Fixes #3484, #2376 

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed