### PR TITLE
Workaround #3491

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -611,6 +611,9 @@ def run_test(testname, host, target):
 
                 cc_cmd = "%s /Itests /Zi /nologo /DTEST_SIG=%d /DTEST_WIDTH=%d %s %s /Fe%s" % \
                          (options.compiler_exe, match, width, add_prefix("tests\\test_static.cpp", host, target), obj_name, exe_name)
+                # Increase the stack size for Windows up to 8MB because some
+                # tests for -O0/x86 can generate quite large stack frames.
+                cc_cmd += " /F8388608"
                 if target.is_xe():
                     cc_cmd = "%s /Itests /I%s\\include /nologo /DTEST_SIG=%d /DTEST_WIDTH=%d %s %s /Fe%s ze_loader.lib /link /LIBPATH:%s\\lib" % \
                          (options.compiler_exe, options.l0loader, match, width, " /DTEST_ZEBIN" if options.ispc_output == "ze" else " /DTEST_SPV", \

--- a/stdlib/include/short_vec.isph
+++ b/stdlib/include/short_vec.isph
@@ -166,7 +166,7 @@ template <typename T, uint N> inline uniform T<N> select(uniform bool cond, unif
     uniform T<N> result;
 
     foreach (i = 0 ... N) {
-        result[i] = select(cond, t[i], f[i]);
+        result[i] = select((UIntMaskType)cond, t[i], f[i]);
     }
 
     return result;
@@ -176,7 +176,7 @@ template <typename T, uint N> inline uniform T<N> select(uniform bool<N> cond, u
     uniform T<N> result;
 
     foreach (i = 0 ... N) {
-        result[i] = select(cond[i], t[i], f[i]);
+        result[i] = select((UIntMaskType)cond[i], t[i], f[i]);
     }
 
     return result;


### PR DESCRIPTION
## Description

* `run_tests.py`: Increased the stack size to 8MB for Windows builds to accommodate large stack frames generated by certain tests, especially for `-O0` optimizations on x86.

* `stdlib/include/short_vec.isph`: updated the `select` function to cast `cond` to `UIntMaskType` as workaround for #3491 

## Related Issue
- [X] Linked to relevant issue: #3491

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
