### PR TITLE
Fix clang warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,7 +690,6 @@ else()
         -Wall
         -Wextra
         -Wno-unused-parameter
-        -Wno-sign-compare
         ${LLVM_CPP_FLAGS}
     )
     # Disable warnings coming from LLVM headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,7 +691,6 @@ else()
         -Wextra
         -Wno-unused-parameter
         -Wno-sign-compare
-        -Wno-unused-function
         ${LLVM_CPP_FLAGS}
     )
     # Disable warnings coming from LLVM headers

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -46,7 +46,7 @@ void Indent::Print(const char *title) {
     int &top = stack.back();
     Assert(top > 0);
 
-    for (int i = 0; i < (stack.size() - 1); i++) {
+    for (size_t i = 0; i < (stack.size() - 1); i++) {
         if (stack[i] == 0) {
             printf("  ");
         } else {

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -242,7 +242,7 @@ FunctionEmitContext::FunctionEmitContext(const Function *func, Symbol *funSym, l
     // If the function doesn't have __mask in parameters, there is no need to
     // have function mask
     if (((func->GetType()->IsExported() || func->GetType()->IsISPCExternal()) &&
-         (lf->getFunctionType()->getNumParams() == func->GetType()->GetNumParameters())) ||
+         (lf->getFunctionType()->getNumParams() == static_cast<unsigned int>(func->GetType()->GetNumParameters()))) ||
         (func->GetType()->IsUnmasked()) || func->GetType()->IsTask()) {
         functionMaskValue = nullptr;
         fullMaskAddressInfo = nullptr;
@@ -348,7 +348,7 @@ FunctionEmitContext::FunctionEmitContext(const Function *func, Symbol *funSym, l
         // The condition below checks that the function doesn't have additional `__mask` parameter.
         // If it has `__mask`, it's an internal version of export function and we don't need to set
         // FTZ/DAZ flags there.
-        (lf->getFunctionType()->getNumParams() == func->GetType()->GetNumParameters())) {
+        (lf->getFunctionType()->getNumParams() == static_cast<unsigned int>(func->GetType()->GetNumParameters()))) {
         // On ARM the size of register with FTZ/DAZ flags is platform dependent,
         // on other platforms it's always i32.
         functionFTZ_DAZValue = AllocaInst(
@@ -4293,7 +4293,7 @@ llvm::Value *FunctionEmitContext::InvokeSyclInst(llvm::Value *func, const Functi
     // Broadcast uniform function arguments to varying to match IGC signature by vISA level
     // for extern "SYCL" functions on Xe targets
     std::vector<llvm::Value *> argsFinal;
-    for (int i = 0; i < args.size(); i++) {
+    for (size_t i = 0; i < args.size(); i++) {
         llvm::Value *argCast = args[i];
         if (g->target->isXeTarget() && funcType->IsExternSYCL() && funcType->GetParameterType(i)->IsUniformType()) {
             if (!llvm::isa<llvm::VectorType>(argCast->getType())) {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -104,13 +104,6 @@ bool Expr::HasAmbiguousVariability(std::vector<const Expr *> &warn) const { retu
 
 ///////////////////////////////////////////////////////////////////////////
 
-static llvm::APFloat lCreateAPFloat(llvm::APFloat f, llvm::Type *type) {
-    const llvm::fltSemantics &FS = type->getFltSemantics();
-    bool ignored = false;
-    f.convert(FS, llvm::APFloat::rmNearestTiesToEven, &ignored);
-    return f;
-}
-
 static llvm::APFloat lCreateAPFloat(double value, llvm::Type *type) {
     llvm::APFloat f(value);
     const llvm::fltSemantics &FS = type->getFltSemantics();

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -4815,7 +4815,7 @@ bool ExprList::HasAtomicInitializerList(std::map<AtomicType::BasicType, std::vec
     bool isAtomicInit = true;
 
     // Go through all initializer expressions and check if they are atomic
-    for (int i = 0; i < exprs.size(); ++i) {
+    for (size_t i = 0; i < exprs.size(); ++i) {
         // Check for null expressions in the list. This can occur if the list contains
         // invalid or uninitialized expressions due to errors in earlier processing.
         if (exprs[i] == nullptr) {
@@ -4824,7 +4824,7 @@ bool ExprList::HasAtomicInitializerList(std::map<AtomicType::BasicType, std::vec
         }
         const AtomicType *at = CastType<AtomicType>(exprs[i]->GetType());
         if (at) {
-            map[at->basicType].push_back({exprs[i], i});
+            map[at->basicType].push_back({exprs[i], static_cast<int>(i)});
         } else {
             isAtomicInit = false;
             break;
@@ -9493,12 +9493,13 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
 
         // There's no way to match if the caller is passing more arguments
         // than this function instance takes.
-        if (argTypes.size() > ft->GetNumParameters()) {
+        if (argTypes.size() > static_cast<size_t>(ft->GetNumParameters())) {
             continue;
         }
 
         // Not enough arguments, and no default argument value to save us
-        if (argTypes.size() < ft->GetNumParameters() && ft->GetParameterDefault(argTypes.size()) == nullptr) {
+        if (argTypes.size() < static_cast<size_t>(ft->GetNumParameters()) &&
+            ft->GetParameterDefault(argTypes.size()) == nullptr) {
             continue;
         }
 
@@ -9539,7 +9540,7 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
             // First, check types of non-type parameters (non-type parameters can't be used in partially specified
             // template instantiations)
             bool argsMatchingPassed = true;
-            for (int i = 0; i < templateParms->GetCount(); ++i) {
+            for (size_t i = 0; i < templateParms->GetCount(); ++i) {
                 if ((*templateParms)[i]->IsNonTypeParam()) {
                     const Type *argType = templateArgs[i].GetAsType();
                     const Type *paramType = (*templateParms)[i]->GetNonTypeParam()->type;
@@ -9579,7 +9580,7 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
 
         // Deduce template parameters from function arguments. Trying to follow C++ template argument deduction
         // algorithm.
-        for (int i = 0; i < substitutedParamTypes.size(); ++i) {
+        for (size_t i = 0; i < substitutedParamTypes.size(); ++i) {
             const Type *paramType = substitutedParamTypes[i];
             if (paramType->IsDependent()) {
                 // Try to deduce
@@ -9651,7 +9652,7 @@ FunctionSymbolExpr::getCandidateTemplateFunctions(const std::vector<const Type *
 
         // Build a complete vector of deduced template arguments.
         TemplateArgs deducedArgs;
-        for (int i = 0; i < templateParms->GetCount(); ++i) {
+        for (size_t i = 0; i < templateParms->GetCount(); ++i) {
             if (i < templateArgs.size()) {
                 deducedArgs.push_back(templateArgs[i]);
             } else {
@@ -9892,7 +9893,7 @@ int FunctionSymbolExpr::FindBestMatchCost(const std::vector<Symbol *> &actualCan
     for (int i = 0; i < (int)candidateCosts.size(); ++i) {
         if (candidateCosts[i] == bestMatchCost) {
             for (int j = 0; j < (int)candidateCosts.size(); ++j) {
-                for (int k = 0; k < argTypes.size(); k++) {
+                for (size_t k = 0; k < argTypes.size(); k++) {
                     if (candidateCosts[j] != -1 && candidateExpandCosts[j][k] < candidateExpandCosts[i][k]) {
                         std::vector<Symbol *> temp;
                         temp.push_back(actualCandidates[i]);

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -111,10 +111,10 @@ void Function::Print(Indent &indent) const {
     }
 
     indent.pushList(args.size() + 1);
-    for (int i = 0; i < args.size(); i++) {
+    for (size_t i = 0; i < args.size(); i++) {
         static constexpr std::size_t BUFSIZE{15};
         char buffer[BUFSIZE];
-        snprintf(buffer, BUFSIZE, "param %d", i);
+        snprintf(buffer, BUFSIZE, "param %zu", i);
         indent.setNextLabel(buffer);
         if (args[i]) {
             indent.Print();
@@ -761,7 +761,7 @@ void Function::GenerateIR() const {
             }
 
             if (function->getFunctionType()->getNumParams() > 0) {
-                for (int i = 0; i < function->getFunctionType()->getNumParams() - 1; i++) {
+                for (unsigned i = 0; i < function->getFunctionType()->getNumParams() - 1; i++) {
                     if (function->hasParamAttribute(i, llvm::Attribute::NoAlias)) {
                         appFunction->addParamAttr(i, llvm::Attribute::NoAlias);
                     }
@@ -1086,10 +1086,10 @@ void FunctionTemplate::Print(Indent &indent) const {
 
     indent.pushList(itemsToPrint);
     if (typenames->GetCount() > 0) {
-        for (int i = 0; i < typenames->GetCount(); i++) {
+        for (size_t i = 0; i < typenames->GetCount(); i++) {
             static constexpr std::size_t BUFSIZE{25};
             char buffer[BUFSIZE];
-            snprintf(buffer, BUFSIZE, "template param %d", i);
+            snprintf(buffer, BUFSIZE, "template param %zu", i);
             indent.setNextLabel(buffer);
             if ((*typenames)[i]) {
                 indent.Print((*typenames)[i]->IsTypeParam()
@@ -1208,7 +1208,7 @@ TemplateInstantiation::TemplateInstantiation(const TemplateParms &typeParms, con
     // Note we do that for all specified templates arguments, which number may be less than a number of template
     // parameters. In this case the rest of template parameters will be deduced later during template argumnet
     // deduction.
-    for (int i = 0; i < tArgs.size(); i++) {
+    for (size_t i = 0; i < tArgs.size(); i++) {
         std::string name = typeParms[i]->GetName();
         const TemplateArg *arg = new TemplateArg(tArgs[i]);
         argsMap[name] = arg;

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -112,10 +112,7 @@ void Function::Print(Indent &indent) const {
 
     indent.pushList(args.size() + 1);
     for (size_t i = 0; i < args.size(); i++) {
-        static constexpr std::size_t BUFSIZE{15};
-        char buffer[BUFSIZE];
-        snprintf(buffer, BUFSIZE, "param %zu", i);
-        indent.setNextLabel(buffer);
+        indent.setNextLabel("param " + std::to_string(i));
         if (args[i]) {
             indent.Print();
             if (args[i]->type != nullptr) {
@@ -1087,10 +1084,7 @@ void FunctionTemplate::Print(Indent &indent) const {
     indent.pushList(itemsToPrint);
     if (typenames->GetCount() > 0) {
         for (size_t i = 0; i < typenames->GetCount(); i++) {
-            static constexpr std::size_t BUFSIZE{25};
-            char buffer[BUFSIZE];
-            snprintf(buffer, BUFSIZE, "template param %zu", i);
-            indent.setNextLabel(buffer);
+            indent.setNextLabel("template param " + std::to_string(i));
             if ((*typenames)[i]) {
                 indent.Print((*typenames)[i]->IsTypeParam()
                                  ? "TemplateTypeParmType"

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -248,7 +248,7 @@ static const Type *lLLVMTypeToISPCType(const llvm::Type *t, bool intAsUnsigned) 
     else if (const llvm::VectorType *vt = llvm::dyn_cast<llvm::VectorType>(t)) {
         // check if vector length is equal to TARGET_WIDTH
         unsigned int vectorWidth = vt->getElementCount().getKnownMinValue();
-        if (vectorWidth == g->target->getVectorWidth()) {
+        if (vectorWidth == static_cast<unsigned int>(g->target->getVectorWidth())) {
             // we should never hit this case, because it should be handled by the cases above
             return nullptr;
         } else {
@@ -468,7 +468,7 @@ size_t lNextIITDescs(const IITDesc &D) {
 // The function analyzes an LLVM intrinsic (identified by its ID) and finds
 // which argument positions can accept any type. It returns these
 // positions in the provided result vector.
-void lGetOverloadedArgumentIndices(llvm::Intrinsic::ID ID, std::vector<unsigned> &result, SourcePos pos) {
+void lGetOverloadedArgumentIndices(llvm::Intrinsic::ID ID, std::vector<size_t> &result, SourcePos pos) {
     // The LLVM Intrinsic Information Table (IIT) is a data structure that
     // describes the type system and constraints for LLVM's built-in functions
     // (intrinsics). The table contains a series of descriptors, where the
@@ -494,7 +494,7 @@ void lGetOverloadedArgumentIndices(llvm::Intrinsic::ID ID, std::vector<unsigned>
     // The trick part is that return type often is any. However in ISPC, we
     // have no return type information, so we need to find the argument with
     // the same type as return value.
-    unsigned argIndex = 0;
+    size_t argIndex = 0;
     size_t i = lNextIITDescs(Table[0]);
     if (lIsAnyArgumentKind(Table[0])) {
         while (i < Table.size()) {
@@ -534,11 +534,11 @@ static std::vector<llvm::Type *> lDeductArgTypes(llvm::Module *module, llvm::Int
     if (llvm::Intrinsic::isOverloaded(ID)) {
         Assert(args);
 
-        std::vector<unsigned> nInits;
+        std::vector<size_t> nInits;
         lGetOverloadedArgumentIndices(ID, nInits, pos);
 
         Assert(nInits.size() > 0);
-        for (int i : nInits) {
+        for (size_t i : nInits) {
             Assert(i < args->exprs.size());
             const Type *argType = (args->exprs[i])->GetType();
             Assert(argType);

--- a/src/isa.h
+++ b/src/isa.h
@@ -102,7 +102,7 @@ static int __os_has_avx512_support() {
 
 // Return of the x86 ISA enumerant values that gives the most capable ISA that
 // the current system can run.
-static enum ISA get_x86_isa() {
+UNUSED_ATTR static enum ISA get_x86_isa() {
     int info[4];
     __cpuid(info, 1);
     UNUSED_ATTR int max_level = info[0];
@@ -262,7 +262,7 @@ static enum ISA get_x86_isa() {
 #else
 
 // For non-x86 platforms, define a function with trivial implementation.
-static enum ISA get_x86_isa() { return INVALID; }
+UNUSED_ATTR static enum ISA get_x86_isa() { return INVALID; }
 
 #endif // defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
 

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -147,9 +147,11 @@ enum class AddressSpace {
 };
 
 namespace dispatch {
-// This would create an unnecessary unused copies of functions defined in isa.h
+// This would create unnecessary unused copies of functions defined in isa.h
 // in each translation unit that includes the current header (ispc.h). However,
-// all unused ones will be removed by the compiler, because they are static.
+// all unused ones will be removed by the compiler because they are static.
+// We need to include this header here because we use the `dispatch::ISA` enum
+// later in the current header.
 #include "isa.h"
 } // namespace dispatch
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -433,7 +433,7 @@ Expr *lCreateConstExpr(ExprList *exprList, const AtomicType::BasicType basicType
     const int N = g->target->getVectorWidth();
     bool canConstructConstExpr = true;
     // Exit early if the number of initializers is more than N
-    if (exprList->exprs.size() > N) {
+    if (exprList->exprs.size() > static_cast<size_t>(N)) {
         return nullptr;
     }
     using ManagedType =
@@ -1157,7 +1157,7 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
             function->addParamAttr(i, llvm::Attribute::NoAlias);
         }
 
-        Assert(decl && decl->functionParams.size() == nArgs);
+        Assert(decl && decl->functionParams.size() == static_cast<size_t>(nArgs));
         DeclSpecs *declSpecs = decl->functionParams[i]->declSpecs;
         AttributeList *attrList = declSpecs ? declSpecs->attributeList : nullptr;
         if (attrList) {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -105,9 +105,11 @@ static bool lIsLlvmBitcode(std::ifstream &is) {
     return lHasSameMagic(llvmBcMagic, is) || lHasSameMagic(llvmBcMagicWrapper, is);
 }
 
+#ifdef ISPC_XE_ENABLED
 static bool lIsSpirVBitcode(std::ifstream &is) {
     return lHasSameMagic(spirvMagic, is) || lHasSameMagic(spirvMagicInv, is);
 }
+#endif
 
 static bool lIsStdlibPseudoFile(const std::string &name) {
     // This needs to correspond to lAddImplicitInclude

--- a/src/opt/ReplaceMaskedMemOps.cpp
+++ b/src/opt/ReplaceMaskedMemOps.cpp
@@ -29,7 +29,7 @@ bool lCheckMask(llvm::Value *mask, unsigned &TrueSubmaskLength) {
         }
 
         unsigned TruePrefixLength = 0;
-        for (auto i = 0; i < N; i++) {
+        for (unsigned i = 0; i < N; i++) {
             llvm::Constant *E = CV->getAggregateElement(i);
             if (auto *C = llvm::dyn_cast<llvm::ConstantInt>(E)) {
                 if (C->isOne()) {

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -342,8 +342,10 @@ static bool lCheckInit(const Type *type, Expr **init, const std::string &name) {
     } else if (CastType<StructType>(type) != nullptr && llvm::dyn_cast<ExprList>(*init) != nullptr) {
         const StructType *st = CastType<StructType>(type);
         ExprList *el = llvm::dyn_cast<ExprList>(*init);
-        int elt_count = st->GetElementCount() < el->exprs.size() ? st->GetElementCount() : el->exprs.size();
-        for (int i = 0; i < elt_count; i++) {
+        size_t elt_count = static_cast<size_t>(st->GetElementCount()) < el->exprs.size()
+                               ? static_cast<size_t>(st->GetElementCount())
+                               : el->exprs.size();
+        for (size_t i = 0; i < elt_count; i++) {
             encounteredError |= lCheckInit(st->GetElementType(i), &(el->exprs[i]), name);
         }
     } else if (CastType<UndefinedStructType>(type)) {

--- a/src/target_registry.cpp
+++ b/src/target_registry.cpp
@@ -282,18 +282,18 @@ void TargetLibRegistry::printSupportMatrix() const {
     }
 
     // Collect maximum sizes for all columns
-    std::vector<int> column_sizes(table[0].size(), 7);
+    std::vector<size_t> column_sizes(table[0].size(), 7);
     for (auto &row : table) {
-        for (int i = 0; i < row.size(); i++) {
+        for (size_t i = 0; i < row.size(); i++) {
             column_sizes[i] = column_sizes[i] > row[i].size() ? column_sizes[i] : row[i].size();
         }
     }
-    int width = std::accumulate(column_sizes.begin(), column_sizes.end(), 0) + (column_sizes.size() - 1) * 3;
+    size_t width = std::accumulate(column_sizes.begin(), column_sizes.end(), (column_sizes.size() - 1) * 3);
 
     // Print the table
-    for (int i = 0; i < table.size(); i++) {
+    for (size_t i = 0; i < table.size(); i++) {
         auto row = table[i];
-        for (int j = 0; j < row.size(); j++) {
+        for (size_t j = 0; j < row.size(); j++) {
             auto align = std::string(column_sizes[j] - row[j].size(), ' ');
             printf("%s%s", row[j].c_str(), align.c_str());
             if (j + 1 != row.size()) {


### PR DESCRIPTION
## Description

This PR fixes unused function warnings (the most annoying one was about get_x86_isa). Moreover, a few sign-compare warnings were also fixed. This PR enables these two diagnostics for non-Windows builds.

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)