### PR TITLE
Fix select-short-vec.ispc for targets with i8 mask

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -3178,7 +3178,10 @@ void FunctionEmitContext::maskedStore(llvm::Value *value, llvm::Value *ptr, cons
         maskedStoreFunc = m->module->getFunction(builtin::__pseudo_masked_store_i16);
     } else if (llvmValueStorageType == LLVMTypes::Int8VectorType) {
         maskedStoreFunc = m->module->getFunction(builtin::__pseudo_masked_store_i8);
-        value = SwitchBoolToStorageType(value, llvmValueStorageType);
+        // Do not mix i8 types with bool type, only bool type requires the special handling.
+        if (valueType->IsBoolType()) {
+            value = SwitchBoolToStorageType(value, llvmValueStorageType);
+        }
     }
     AssertPos(currentPos, maskedStoreFunc != nullptr);
 

--- a/stdlib/include/short_vec.isph
+++ b/stdlib/include/short_vec.isph
@@ -166,7 +166,7 @@ template <typename T, uint N> inline uniform T<N> select(uniform bool cond, unif
     uniform T<N> result;
 
     foreach (i = 0 ... N) {
-        result[i] = select((UIntMaskType)cond, t[i], f[i]);
+        result[i] = select(cond, t[i], f[i]);
     }
 
     return result;
@@ -176,7 +176,7 @@ template <typename T, uint N> inline uniform T<N> select(uniform bool<N> cond, u
     uniform T<N> result;
 
     foreach (i = 0 ... N) {
-        result[i] = select((UIntMaskType)cond[i], t[i], f[i]);
+        result[i] = select(cond[i], t[i], f[i]);
     }
 
     return result;

--- a/tests/func-tests/select-short-vec-func.ispc
+++ b/tests/func-tests/select-short-vec-func.ispc
@@ -1,0 +1,98 @@
+#include "test_static.isph"
+#include "short_vec.isph"
+
+// On macOS, this test triggers crash in the system linker:
+// ld: Assertion failed: (slot < _sideTableBuffer.size(), function addAtom, file AtomFileConsolidator.cpp, line 2278)
+// rule: skip on OS=mac
+
+template <typename T, int N>
+noinline uniform bool<N> test_cond(uniform T<N> dummy) {
+    uniform bool<N> cond;
+    foreach(i = 0...N) {
+        cond[i] = i % 2 == 0 || i % 5 == 3;
+    }
+    return cond;
+}
+
+template <typename T, int N>
+int test_select() {
+    int errors = 0;
+
+    uniform T<N> t;
+    uniform T<N> f;
+
+    foreach(i = 0...N) {
+        t[i] = 42 + i;
+        f[i] = 815 + i;
+    }
+
+    uniform T<N> rt = select<T, N>(true, t, f);
+    uniform T<N> rf = select<T, N>(false, t, f);
+    uniform T<N> rc1 = select<T, N>(test_cond(t), t, f);
+    uniform T<N> rc2 = select<T, N>(test_cond(t), f, t);
+
+    foreach(i = 0...N) {
+        errors += rt[i] != t[i] ? 1 : 0;
+        errors += rf[i] != f[i] ? 1 : 0;
+        errors += (test_cond(t)[i] == true && rc1[i] != t[i] || test_cond(t)[i] == false && rc1[i] != f[i]) ? 1 : 0;
+        errors += (test_cond(t)[i] == true && rc2[i] != f[i] || test_cond(t)[i] == false && rc2[i] != t[i]) ? 1 : 0;
+    }
+
+    return errors;
+}
+
+task void f_v(uniform float RET[]) {
+    int errors = 0;
+
+    errors += test_select<int32, 1>();
+    errors += test_select<int32, 2>();
+    errors += test_select<int32, 3>();
+    errors += test_select<int32, 4>();
+    errors += test_select<int32, 5>();
+    errors += test_select<int32, 6>();
+    errors += test_select<int32, 7>();
+    errors += test_select<int32, 8>();
+    errors += test_select<int32, 9>();
+    errors += test_select<int32, 11>();
+    errors += test_select<int32, 15>();
+    errors += test_select<int32, 16>();
+    errors += test_select<int32, 17>();
+
+    errors += test_select<uint32, 1>();
+    errors += test_select<uint32, 3>();
+    errors += test_select<uint32, 4>();
+    errors += test_select<uint32, 7>();
+
+    errors += test_select<int8, 3>();
+    errors += test_select<uint8, 3>();
+    errors += test_select<int16, 3>();
+    errors += test_select<uint16, 3>();
+    errors += test_select<int64, 3>();
+    errors += test_select<uint64, 3>();
+
+    errors += test_select<float, 1>();
+    errors += test_select<float, 2>();
+    errors += test_select<float, 3>();
+    errors += test_select<float, 4>();
+    errors += test_select<float, 5>();
+    errors += test_select<float, 6>();
+    errors += test_select<float, 7>();
+    errors += test_select<float, 8>();
+    errors += test_select<float, 9>();
+
+    errors += test_select<double, 1>();
+    errors += test_select<double, 2>();
+    errors += test_select<double, 3>();
+    errors += test_select<double, 4>();
+    errors += test_select<double, 5>();
+    errors += test_select<double, 6>();
+    errors += test_select<double, 7>();
+    errors += test_select<double, 8>();
+    errors += test_select<double, 9>();
+
+    RET[programIndex] = errors;
+}
+
+task void result(uniform float RET[]) {
+    RET[programIndex] = 0;
+}

--- a/tests/lit-tests/3491.ispc
+++ b/tests/lit-tests/3491.ispc
@@ -1,0 +1,21 @@
+// This test checks that ISPC generates the correct code for selects with bool
+// condition for targets with i8 masks.
+
+// RUN: %{ispc} --target=sse4.1-i8x16 --emit-llvm-text -O2 -o - %s 2>&1 | FileCheck %s
+// RUN: %{ispc} --target=sse4.2-i8x16 --emit-llvm-text -O2 -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK: sext
+
+#define N 3
+
+uniform uint8<N> embedded_select(uniform bool<N> cond, uniform uint8<N> t, uniform uint8<N> f) {
+    uniform uint8<N> result;
+
+    foreach (i = 0 ... N) {
+        result[i] = select(cond[i], t[i], f[i]);
+    }
+
+    return result;
+}

--- a/tests/lit-tests/3513.ispc
+++ b/tests/lit-tests/3513.ispc
@@ -1,0 +1,41 @@
+// This test checks whether ISPC produces correct representation of bool type
+// on ABI boundary for targets with i8 masks.
+
+// RUN: %{ispc} --pic --target=sse4.1-i8x16 -h %t.h %s -o %t.o
+// RUN: %{cc} -O2 -x c -c %s -o %t.c.o --include %t.h
+// RUN: %{cc} %t.o %t.c.o -o %t.c.bin
+// RUN: %t.c.bin | FileCheck %s
+// RUN: %{cc} -O2 -x c++ -c %s -o %t.cpp.o --include %t.h
+// RUN: %{cc} %t.o %t.cpp.o -o %t.cpp.bin
+// RUN: %t.cpp.bin | FileCheck %s
+
+// REQUIRES: !MACOS_HOST && X86_ENABLED && X86_64_HOST
+
+// CHECK: dst = true, bit representation: 0x01
+
+#ifdef ISPC
+export void test_bool_bug(uniform bool *uniform dst) {
+    foreach (i = 0...1) {
+        dst[i] = true;
+    }
+}
+#else
+#include <stdio.h>
+
+#if defined(__cplusplus)
+using namespace ispc;
+#endif
+
+int main() {
+    bool dst;
+
+    // Call ISPC function that sets dst[0] = true
+    test_bool_bug(&dst);
+
+    // Check the bool representation
+    printf("dst = %s, bit representation: 0x%02x\n",
+           dst ? "true" : "false", (unsigned char)dst);
+
+    return 0;
+}
+#endif // ISPC

--- a/tests/lit-tests/3513.ispc
+++ b/tests/lit-tests/3513.ispc
@@ -1,13 +1,89 @@
 // This test checks whether ISPC produces correct representation of bool type
 // on ABI boundary for targets with i8 masks.
 
-// RUN: %{ispc} --pic --target=sse4.1-i8x16 -h %t.h %s -o %t.o
-// RUN: %{cc} -O2 -x c -c %s -o %t.c.o --include %t.h
-// RUN: %{cc} %t.o %t.c.o -o %t.c.bin
-// RUN: %t.c.bin | FileCheck %s
-// RUN: %{cc} -O2 -x c++ -c %s -o %t.cpp.o --include %t.h
-// RUN: %{cc} %t.o %t.cpp.o -o %t.cpp.bin
-// RUN: %t.cpp.bin | FileCheck %s
+// RUN: %{ispc} --pic --target=avx2-i16x16 -h %t-avx2-i16x16.h %s -o %t-avx2-i16x16.o
+// RUN: %{cc} -O2 -x c -c %s -o %t-avx2-i16x16.c.o --include %t-avx2-i16x16.h
+// RUN: %{cc} %t-avx2-i16x16.o %t-avx2-i16x16.c.o -o %t-avx2-i16x16.c.bin
+// RUN: %t-avx2-i16x16.c.bin | FileCheck %s
+// RUN: %{cc} -O2 -x c++ -c %s -o %t-avx2-i16x16.cpp.o --include %t-avx2-i16x16.h
+// RUN: %{cc} %t-avx2-i16x16.o %t-avx2-i16x16.cpp.o -o %t-avx2-i16x16.cpp.bin
+// RUN: %t-avx2-i16x16.cpp.bin | FileCheck %s
+
+// RUN: %{ispc} --pic --target=avx2-i32x16 -h %t-avx2-i32x16.h %s -o %t-avx2-i32x16.o
+// RUN: %{cc} -O2 -x c -c %s -o %t-avx2-i32x16.c.o --include %t-avx2-i32x16.h
+// RUN: %{cc} %t-avx2-i32x16.o %t-avx2-i32x16.c.o -o %t-avx2-i32x16.c.bin
+// RUN: %t-avx2-i32x16.c.bin | FileCheck %s
+// RUN: %{cc} -O2 -x c++ -c %s -o %t-avx2-i32x16.cpp.o --include %t-avx2-i32x16.h
+// RUN: %{cc} %t-avx2-i32x16.o %t-avx2-i32x16.cpp.o -o %t-avx2-i32x16.cpp.bin
+// RUN: %t-avx2-i32x16.cpp.bin | FileCheck %s
+
+// RUN: %{ispc} --pic --target=avx2-i32x4 -h %t-avx2-i32x4.h %s -o %t-avx2-i32x4.o
+// RUN: %{cc} -O2 -x c -c %s -o %t-avx2-i32x4.c.o --include %t-avx2-i32x4.h
+// RUN: %{cc} %t-avx2-i32x4.o %t-avx2-i32x4.c.o -o %t-avx2-i32x4.c.bin
+// RUN: %t-avx2-i32x4.c.bin | FileCheck %s
+// RUN: %{cc} -O2 -x c++ -c %s -o %t-avx2-i32x4.cpp.o --include %t-avx2-i32x4.h
+// RUN: %{cc} %t-avx2-i32x4.o %t-avx2-i32x4.cpp.o -o %t-avx2-i32x4.cpp.bin
+// RUN: %t-avx2-i32x4.cpp.bin | FileCheck %s
+
+// RUN: %{ispc} --pic --target=avx2-i32x8 -h %t-avx2-i32x8.h %s -o %t-avx2-i32x8.o
+// RUN: %{cc} -O2 -x c -c %s -o %t-avx2-i32x8.c.o --include %t-avx2-i32x8.h
+// RUN: %{cc} %t-avx2-i32x8.o %t-avx2-i32x8.c.o -o %t-avx2-i32x8.c.bin
+// RUN: %t-avx2-i32x8.c.bin | FileCheck %s
+// RUN: %{cc} -O2 -x c++ -c %s -o %t-avx2-i32x8.cpp.o --include %t-avx2-i32x8.h
+// RUN: %{cc} %t-avx2-i32x8.o %t-avx2-i32x8.cpp.o -o %t-avx2-i32x8.cpp.bin
+// RUN: %t-avx2-i32x8.cpp.bin | FileCheck %s
+
+// RUN: %{ispc} --pic --target=avx2-i64x4 -h %t-avx2-i64x4.h %s -o %t-avx2-i64x4.o
+// RUN: %{cc} -O2 -x c -c %s -o %t-avx2-i64x4.c.o --include %t-avx2-i64x4.h
+// RUN: %{cc} %t-avx2-i64x4.o %t-avx2-i64x4.c.o -o %t-avx2-i64x4.c.bin
+// RUN: %t-avx2-i64x4.c.bin | FileCheck %s
+// RUN: %{cc} -O2 -x c++ -c %s -o %t-avx2-i64x4.cpp.o --include %t-avx2-i64x4.h
+// RUN: %{cc} %t-avx2-i64x4.o %t-avx2-i64x4.cpp.o -o %t-avx2-i64x4.cpp.bin
+// RUN: %t-avx2-i64x4.cpp.bin | FileCheck %s
+
+// RUN: %{ispc} --pic --target=avx2-i8x32 -h %t-avx2-i8x32.h %s -o %t-avx2-i8x32.o
+// RUN: %{cc} -O2 -x c -c %s -o %t-avx2-i8x32.c.o --include %t-avx2-i8x32.h
+// RUN: %{cc} %t-avx2-i8x32.o %t-avx2-i8x32.c.o -o %t-avx2-i8x32.c.bin
+// RUN: %t-avx2-i8x32.c.bin | FileCheck %s
+// RUN: %{cc} -O2 -x c++ -c %s -o %t-avx2-i8x32.cpp.o --include %t-avx2-i8x32.h
+// RUN: %{cc} %t-avx2-i8x32.o %t-avx2-i8x32.cpp.o -o %t-avx2-i8x32.cpp.bin
+// RUN: %t-avx2-i8x32.cpp.bin | FileCheck %s
+
+// RUN: %{ispc} --pic --target=sse4.1-i16x8 -h %t-sse4.1-i16x8.h %s -o %t-sse4.1-i16x8.o
+// RUN: %{cc} -O2 -x c -c %s -o %t-sse4.1-i16x8.c.o --include %t-sse4.1-i16x8.h
+// RUN: %{cc} %t-sse4.1-i16x8.o %t-sse4.1-i16x8.c.o -o %t-sse4.1-i16x8.c.bin
+// RUN: %t-sse4.1-i16x8.c.bin | FileCheck %s
+// RUN: %{cc} -O2 -x c++ -c %s -o %t-sse4.1-i16x8.cpp.o --include %t-sse4.1-i16x8.h
+// RUN: %{cc} %t-sse4.1-i16x8.o %t-sse4.1-i16x8.cpp.o -o %t-sse4.1-i16x8.cpp.bin
+// RUN: %t-sse4.1-i16x8.cpp.bin | FileCheck %s
+
+// RUN: %{ispc} --pic --target=sse4.1-i32x4 -h %t-sse4.1-i32x4.h %s -o %t-sse4.1-i32x4.o
+// RUN: %{cc} -O2 -x c -c %s -o %t-sse4.1-i32x4.c.o --include %t-sse4.1-i32x4.h
+// RUN: %{cc} %t-sse4.1-i32x4.o %t-sse4.1-i32x4.c.o -o %t-sse4.1-i32x4.c.bin
+// RUN: %t-sse4.1-i32x4.c.bin | FileCheck %s
+// RUN: %{cc} -O2 -x c++ -c %s -o %t-sse4.1-i32x4.cpp.o --include %t-sse4.1-i32x4.h
+// RUN: %{cc} %t-sse4.1-i32x4.o %t-sse4.1-i32x4.cpp.o -o %t-sse4.1-i32x4.cpp.bin
+// RUN: %t-sse4.1-i32x4.cpp.bin | FileCheck %s
+
+// RUN: %{ispc} --pic --target=sse4.1-i32x8 -h %t-sse4.1-i32x8.h %s -o %t-sse4.1-i32x8.o
+// RUN: %{cc} -O2 -x c -c %s -o %t-sse4.1-i32x8.c.o --include %t-sse4.1-i32x8.h
+// RUN: %{cc} %t-sse4.1-i32x8.o %t-sse4.1-i32x8.c.o -o %t-sse4.1-i32x8.c.bin
+// RUN: %t-sse4.1-i32x8.c.bin | FileCheck %s
+// RUN: %{cc} -O2 -x c++ -c %s -o %t-sse4.1-i32x8.cpp.o --include %t-sse4.1-i32x8.h
+// RUN: %{cc} %t-sse4.1-i32x8.o %t-sse4.1-i32x8.cpp.o -o %t-sse4.1-i32x8.cpp.bin
+// RUN: %t-sse4.1-i32x8.cpp.bin | FileCheck %s
+
+// RUN: %{ispc} --pic --target=sse4.1-i8x16 -h %t-sse4.1-i8x16.h %s -o %t-sse4.1-i8x16.o
+// RUN: %{cc} -O2 -x c -c %s -o %t-sse4.1-i8x16.c.o --include %t-sse4.1-i8x16.h
+// RUN: %{cc} %t-sse4.1-i8x16.o %t-sse4.1-i8x16.c.o -o %t-sse4.1-i8x16.c.bin
+// RUN: %t-sse4.1-i8x16.c.bin | FileCheck %s
+// RUN: %{cc} -O2 -x c++ -c %s -o %t-sse4.1-i8x16.cpp.o --include %t-sse4.1-i8x16.h
+// RUN: %{cc} %t-sse4.1-i8x16.o %t-sse4.1-i8x16.cpp.o -o %t-sse4.1-i8x16.cpp.bin
+// RUN: %t-sse4.1-i8x16.cpp.bin | FileCheck %s
+
+// TODO: ideally we need to introduce AVX2_HOST and similar features to
+// reliably test tests like this but for now assume that AVX2 is always
+// available practically on any x86_64 hosts
 
 // REQUIRES: !MACOS_HOST && X86_ENABLED && X86_64_HOST
 

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -189,6 +189,18 @@ elif platform.system() == "Darwin":
 else:
     print("HOST OS: UNKNOWN")
 
+# detect host arch
+host_arch = platform.machine()
+if host_arch == "x86_64":
+    print("HOST ARCH: X86_64")
+    config.available_features.add("X86_64_HOST")
+elif host_arch == "aarch64":
+    print("HOST ARCH: AARCH64")
+    config.available_features.add("AARCH64_HOST")
+else:
+    print(f"HOST ARCH: {host_arch} (unknown)")
+    config.available_features.add("UNKNOWN_HOST_ARCH")
+
 # Detect that lit-tests run under ASAN.
 # This checks kind of requires us to run ASAN tests always with some ASAN_OPTIONS
 asan_mode = os.environ.get("ASAN_OPTIONS", False)


### PR DESCRIPTION
## Description

This PR fixes #3491 properly. With this fix nightly tests should pass [link](https://github.com/ispc/ispc/actions/runs/16624470651). However in full testing, there are still failed jobs with, e.g, avx1-i32x16 for -O1 for LLVM <= 19 [link](https://github.com/ispc/ispc/actions/runs/16624474802).

This PR changes:

* Gather missed conversion of bool to storage type for targets with i8 mask.

* This also fixes FunctionEmitContext::lSwitchBoolSize_2 to be able to cast bool <-> mask of equal length to each other, i.e., performing either 0x01 -> 0xff or 0xff -> 0x01 conversion.

* maskedStore: convert only bool to bool storage representation. Plain int8 or uint8 do not to be represented or converted like bool types.

### Debugging utilities:
* Added debug wrapper functions (`dv` and `dt`) for dumping LLVM values and types in debug builds, aiding GDB/LLDB debugging.

### Reverted workaround:
* https://github.com/ispc/ispc/commit/d22999b8cc152af7edf685bc86acd748405add2e

## Related Issue
- [X] Linked to relevant issue: #3491 and #3513

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
