### PR TITLE
Fix NaN to bool conversion to match C/C++ behavior

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -7519,17 +7519,17 @@ static llvm::Value *lTypeConvAtomicOrUniformVector(FunctionEmitContext *ctx, llv
         }
         case AtomicType::TYPE_FLOAT16: {
             llvm::Value *zero = LLVMFPZeroAsType(fromType->LLVMType(g->ctx));
-            cast = ctx->CmpInst(llvm::Instruction::FCmp, llvm::CmpInst::FCMP_ONE, exprVal, zero, cOpName);
+            cast = ctx->CmpInst(llvm::Instruction::FCmp, llvm::CmpInst::FCMP_UNE, exprVal, zero, cOpName);
             break;
         }
         case AtomicType::TYPE_FLOAT: {
             llvm::Value *zero = LLVMFPZeroAsType(fromType->LLVMType(g->ctx));
-            cast = ctx->CmpInst(llvm::Instruction::FCmp, llvm::CmpInst::FCMP_ONE, exprVal, zero, cOpName);
+            cast = ctx->CmpInst(llvm::Instruction::FCmp, llvm::CmpInst::FCMP_UNE, exprVal, zero, cOpName);
             break;
         }
         case AtomicType::TYPE_DOUBLE: {
             llvm::Value *zero = LLVMFPZeroAsType(fromType->LLVMType(g->ctx));
-            cast = ctx->CmpInst(llvm::Instruction::FCmp, llvm::CmpInst::FCMP_ONE, exprVal, zero, cOpName);
+            cast = ctx->CmpInst(llvm::Instruction::FCmp, llvm::CmpInst::FCMP_UNE, exprVal, zero, cOpName);
             break;
         }
         default:

--- a/tests/lit-tests/3474.ispc
+++ b/tests/lit-tests/3474.ispc
@@ -13,7 +13,7 @@
 // CHECK: icmp ne <4 x i32> %cond, zeroinitializer
 
 // CHECK-LABEL: @test_float_cond___unf_3C_4_3E_uni_3C_4_3E_uni_3C_4_3E_(
-// CHECK: fcmp one <4 x float> %cond, zeroinitializer
+// CHECK: fcmp une <4 x float> %cond, zeroinitializer
 
 // CHECK-LABEL: @test_int8_cond___unt_3C_4_3E_uni_3C_4_3E_uni_3C_4_3E_(
 // CHECK: icmp ne <4 x i8> %cond, zeroinitializer

--- a/tests/lit-tests/3514.ispc
+++ b/tests/lit-tests/3514.ispc
@@ -1,0 +1,40 @@
+// This test checks that NaN to bool conversion returns true (consistent with C/C++)
+
+// RUN: %{ispc} --pic --target=host -h %t-host.h %s -o %t-host.o
+// RUN: %{cc} -O2 -x c -c %s -o %t-host.c.o --include %t-host.h
+// RUN: %{cc} %t-host.o %t-host.c.o -o %t-host.c.bin
+// RUN: %t-host.c.bin | FileCheck %s
+// RUN: %{cc} -O2 -x c++ -c %s -o %t-host.cpp.o --include %t-host.h
+// RUN: %{cc} %t-host.o %t-host.cpp.o -o %t-host.cpp.bin
+// RUN: %t-host.cpp.bin | FileCheck %s
+
+// REQUIRES: !MACOS_HOST
+
+// CHECK: true true false false false true true
+
+#ifdef ISPC
+export void test_nan_to_bool() {
+    uniform float a = 0.0;
+    uniform int* uniform ptr = 0;
+    uniform bool b1 = 0.5;              // b1 == 1 (0.5 converted to int would be zero)
+    uniform bool b4 = a / 0.0;          // b4 == 1 (NaN does not compare equal to zero)
+    uniform bool b5 = ptr;              // b5 == 0 (nullptr is converted to false)
+    uniform bool b6 = (uniform int)0.5; // b6 == 0 (see b1)
+    uniform bool b7 = 0.0;              // b7 == 0 (see b4)
+    uniform bool b8 = -1;               // b8 == 1
+    uniform bool b9 = 2;                // b9 == 1
+
+    print("% % % % % % %\n", b1, b4, b5, b6, b7, b8, b9);
+}
+#else
+#include <stdio.h>
+
+#if defined(__cplusplus)
+using namespace ispc;
+#endif
+
+int main() {
+    test_nan_to_bool();
+    return 0;
+}
+#endif // ISPC


### PR DESCRIPTION
## Description

Change float/double to bool conversion from using FCMP_ONE (ordered and not equal) to FCMP_UNE (unordered and not equal) to handle NaN values correctly.

In C/C++, NaN converts to bool true because it does not compare equal to zero. The previous implementation incorrectly returned false for NaN values.

Fixes #3514

## Related Issue
- [X] Linked to relevant issue

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
- [X] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)