### PR TITLE
Fix or ignore some nightly CI issues

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -399,10 +399,10 @@ jobs:
       fail-fast: false
       matrix:
         llvm: [20]
-        # --math-lib=fast is not tested because of #3442
+        # --math-lib=fast and --opt=fast-math are not tested because of #3442
         extra_flags: ["--opt=disable-zmm", "--addressing=64", "-g",
                       "--math-lib=system", "--mcmodel=large", "--pic",
-                      "--no-wrap-signed-int",  "--opt=disable-fma", "--opt=fast-math"]
+                      "--no-wrap-signed-int",  "--opt=disable-fma"]
     uses: ./.github/workflows/reusable.ispc.test.yml
     with:
       platform: macos

--- a/tests/func-tests/ldexp-float16.ispc
+++ b/tests/func-tests/ldexp-float16.ispc
@@ -1,13 +1,16 @@
 #include "test_static.isph"
 task void f_f(uniform float RET[], uniform float aFOO[]) {
-    float16 a = 1ul << ((programIndex/4) % 28);
+    // Use % 14 to limit input to 2^13 max, ensuring ldexp(a, 2) <= 32768 which
+    // stays within float16's finite range (65504). Using % 28 would allow 2^14
+    // and 2^15 inputs, causing ldexp results to overflow.
+    float16 a = 1ul << ((programIndex/4) % 14);
     if (programIndex & 1)
         a = -a;
     RET[programIndex] = ldexp(a, 2);
 }
 
 task void result(uniform float RET[]) {
-    int pi = (programIndex/4) % 28;
+    int pi = (programIndex/4) % 14;
     #pragma ignore warning(perf)
     RET[programIndex] = (1ul << (pi + 2));
     if (programIndex & 1)

--- a/tests/func-tests/round-float16-uniform.ispc
+++ b/tests/func-tests/round-float16-uniform.ispc
@@ -1,5 +1,8 @@
 #include "test_static.isph"
-// rule: skip on target=generic.*
+
+// See issue #3529
+// rule: skip on OS=windows
+
 task void f_f(uniform float RET[], uniform float aFOO[]) {
     uniform float error = 0;
     RET[programIndex] = 0;

--- a/tests/func-tests/round-float16-varying.ispc
+++ b/tests/func-tests/round-float16-varying.ispc
@@ -1,7 +1,9 @@
 #include "test_static.isph"
 // rule: skip on arch=wasm32
 // rule: skip on arch=wasm64
-// rule: skip on target=generic.*
+
+// See issue #3529
+// rule: skip on OS=windows
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {
     float error = 0;


### PR DESCRIPTION
## Description

- CI: ignore for now --opt=fast-math for macos-test-flags
- func-tests: skip round-float16-*.ispc for all targets on Windows
- ldexp-float16 func-test: reduce input range to avoid float16 overflow (happened for x64 targets).


Full test run: https://github.com/ispc/ispc/actions/runs/16835313082

## Related Issue
- [X] Linked to relevant issue: #3530 

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)