### PR TITLE
CI: add job to build openmoonray

### DIFF
--- a/.github/workflows/openmoonray.yml
+++ b/.github/workflows/openmoonray.yml
@@ -57,8 +57,6 @@ jobs:
       run: |
         pacman -Syu --noconfirm
         pacman -S --needed --noconfirm base-devel git sudo
-        # AUR PKBUILD misses these dependencies for OpenMoonRay
-        pacman -S --noconfirm libmicrohttpd cppunit qt5-base qt5-script openimagedenoise usd
 
     - name: Create build user
       run: |


### PR DESCRIPTION
## Description

This PR adds the openmoonray build job to CI. It can help to prevent regression like this #3545 in future.

At the moment, this job is failing (https://github.com/ispc/ispc/actions/runs/17044829107?pr=3546) and this is expected.


## Related Issue
- [X] Linked to relevant issue: #3545

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)