### PR TITLE
Fix IndexExpr::GetLValueType() for function calls returning pointers

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -5223,10 +5223,21 @@ const Type *IndexExpr::GetLValueType() const {
         return lvalueType;
     }
 
-    const Type *baseExprType = nullptr, *baseExprLValueType = nullptr, *indexType = nullptr;
+    const Type *baseExprType = nullptr, *indexType = nullptr;
     if (baseExpr == nullptr || index == nullptr || ((baseExprType = baseExpr->GetType()) == nullptr) ||
-        ((baseExprLValueType = baseExpr->GetLValueType()) == nullptr) || ((indexType = index->GetType()) == nullptr)) {
+        ((indexType = index->GetType()) == nullptr)) {
         return nullptr;
+    }
+
+    // If baseExpr->GetLValueType() is null but baseExpr->GetType() is a pointer,
+    // use the pointer type directly (e.g., function calls returning pointers)
+    const Type *baseExprLValueType = baseExpr->GetLValueType();
+    if (baseExprLValueType == nullptr) {
+        if (baseExprType->IsPointerType()) {
+            baseExprLValueType = baseExprType;
+        } else {
+            return nullptr;
+        }
     }
 
     // regularize to a PointerType

--- a/tests/lit-tests/3549.ispc
+++ b/tests/lit-tests/3549.ispc
@@ -1,0 +1,26 @@
+// This test checks that the ISPC compiler does not crash when compiling
+// IndexExpr with FunctionCallExpr returning pointer type.
+
+// RUN: %{ispc} --target=host --emit-llvm-text --nostdlib --nowrap %s -o - 2>&1 | FileCheck %s
+// RUN: %{ispc} --target=avx512icl-x16 -O2 --emit-asm --x86-asm-syntax=intel --nostdlib --nowrap %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-AVX512
+
+// REQUIRES: X86_ENABLED
+
+// CHECK-NOT: .*expr.cpp:.*: Assertion failed: "ptrType != nullptr".
+
+// CHECK-AVX512-LABEL: foo___{{.*}}:
+// CHECK-AVX512-NEXT: # %bb.0:
+// CHECK-AVX512-NEXT:  movsxd  [[REG:r[a-z]+]], {{.*}}
+// CHECK-AVX512-NEXT:  shl     [[REG]], 6
+// CHECK-AVX512-NEXT:  vmovups zmm0, zmmword ptr [r{{.*}} + [[REG]]]
+// CHECK-AVX512-NEXT:  ret
+
+struct S {
+    float b[100];
+};
+varying float *uniform func(const varying struct S &t) {
+    return (varying float *uniform) & t;
+};
+varying float foo(const varying struct S &x, uniform int c) {
+    return (func(x))[c];
+}


### PR DESCRIPTION
## Description

Fixes assertion failure in lAddVaryingOffsetsIfNeeded() when compiling expressions like `(func(x))[c]` where func returns a pointer type.

When indexing into the result of a function call that returns a pointer (e.g., `func()[index]`), IndexExpr::GetLValueType() would incorrectly require baseExpr->GetLValueType() to be non-null. However, function calls returning pointers are rvalues, so FunctionCallExpr::GetLValueType() correctly returns null for non-reference return types.

The fix allows IndexExpr to fall back to using the pointer type directly when GetLValueType() returns null but GetType() returns a pointer type. This enables indexing operations on function call results that return pointers, which should create valid lvalues.


## Related Issue
- [X] Linked to relevant issue: #3549 

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
- [X] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
