### PR TITLE
Add the ability to enable SSP (stack smash protection) for ISPC functions.

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -1303,6 +1303,20 @@ compiled with the default ``--addressing=32`` and others were compiled with
 ``--addressing=64``.
 
 
+Stack smash protection (SSP)
+----------------------------
+
+``ispc`` can generate code to guard against stack smashing by enabling
+the LLVM functionality. The ``--stack-protector`` command-line argument
+enables stack protectors for some functions vulnerable to stack smashing.
+This option is equivalent to ``--stack-protector=on``.
+``--stack-protector=strong`` enables stack protectors for functions that
+contain arrays of any size, as well as for functions that take the arguments
+of local variables. ``--stack-protector=all`` enables stack protectors for
+all functions. ``--stack-protector=none`` will not generate any stack protectors,
+which is the default.
+
+
 The Preprocessor
 ----------------
 

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -147,6 +147,13 @@ static ArgsParseResult usage() {
     printf("    [--PIC]\t\t\t\tGenerate position-independent code avoiding any limit on the size of the global offset "
            "table. Ignored for Windows target\n");
     printf("    [--quiet]\t\t\t\tSuppress all output\n");
+    printf("    [--stack-protector]\t\t\tEnable stack protectors for functions with larger stack variables.\n");
+    printf("    [--stack-protector=<option>]\tEnable stack protectors\n");
+    printf("        all\t\t\t\tfor all functions.\n");
+    printf("        none\t\t\t\tfor no functions (default).\n");
+    printf("        on\t\t\t\tfor functions with larger stack variables (same as --stack-protector).\n");
+    printf("        strong\t\t\t\tfor functions with stack variables of any size or taking addresses of local "
+           "variables.\n");
     printf("    [--support-matrix]\t\t\tPrint full matrix of supported targets, architectures and OSes\n");
     printf("    ");
     char targetHelp[2048];
@@ -908,6 +915,21 @@ ArgsParseResult ispc::ParseCommandLineArgs(int argc, char *argv[], std::string &
             g->disableLineWrap = true;
         } else if (!strcmp(argv[i], "--wno-perf") || !strcmp(argv[i], "-wno-perf")) {
             g->emitPerfWarnings = false;
+        } else if (!strcmp(argv[i], "--stack-protector")) {
+            g->SSPLevel = SSPKind::SSPOn;
+        } else if (!strncmp(argv[i], "--stack-protector=", 18)) {
+            const char *level = argv[i] + strlen("--stack-protector=");
+            if (!strcmp(level, "all")) {
+                g->SSPLevel = SSPKind::SSPReq;
+            } else if (!strcmp(level, "on")) {
+                g->SSPLevel = SSPKind::SSPOn;
+            } else if (!strcmp(level, "none")) {
+                g->SSPLevel = SSPKind::SSPNone;
+            } else if (!strcmp(level, "strong")) {
+                g->SSPLevel = SSPKind::SSPStrong;
+            } else {
+                errorHandler.AddError("Unknown --stack-protector= option \"%s\".", level);
+            }
         } else if (!strcmp(argv[i], "-o")) {
             if (++i != argc) {
                 output.out = argv[i];

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2358,6 +2358,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
             fattrBuilder->addAttribute("target-cpu", this->m_cpu);
         }
 #endif
+
         for (auto const &f_attr : m_funcAttributes) {
             fattrBuilder->addAttribute(f_attr.first, f_attr.second);
         }
@@ -3162,6 +3163,7 @@ Globals::Globals() {
     timeTraceGranularity = 500;
     target = nullptr;
     ctx = new llvm::LLVMContext;
+    SSPLevel = SSPKind::SSPNone;
 
 #ifdef ISPC_XE_ENABLED
     stackMemSize = 0;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -137,6 +137,9 @@ class StorageClass {
     Kind m_kind = Kind::NONE;
 };
 
+// Stack smash protection
+enum class SSPKind { SSPNone, SSPOn, SSPStrong, SSPReq };
+
 // Enumerant for address spaces.
 enum class AddressSpace {
     ispc_default,  // 0 = ispc_private
@@ -989,6 +992,9 @@ struct Globals {
 
     /** When true, include float16 conversion functions permanently to the compiled module */
     bool includeFloat16Conversions;
+
+    /* Stores the stack smash protection setting. */
+    SSPKind SSPLevel;
 };
 
 // This is used when empty string is used for "--darwin-version-min"

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -381,6 +381,18 @@ int Module::CompileFile() {
     for (llvm::Function &f : *module) {
         g->target->markFuncWithTargetAttr(&f);
     }
+
+    if (g->SSPLevel != SSPKind::SSPNone) {
+        llvm::Attribute::AttrKind SSPAttrKind = llvm::Attribute::StackProtect;
+        if (g->SSPLevel == SSPKind::SSPStrong) {
+            SSPAttrKind = llvm::Attribute::StackProtectStrong;
+        } else if (g->SSPLevel == SSPKind::SSPReq) {
+            SSPAttrKind = llvm::Attribute::StackProtectReq;
+        }
+        for (llvm::Function &f : *module) {
+            f.addFnAttr(SSPAttrKind);
+        }
+    }
     ast->GenerateIR();
 
     debugDumpModule(module, "GenerateIR", pre_stage++);

--- a/tests/lit-tests/ssp-asm.ispc
+++ b/tests/lit-tests/ssp-asm.ispc
@@ -1,0 +1,22 @@
+// Make sure the backend honors the request to generate code to detect stack smashing.
+// We check for a call to  __security_check_cookie.
+// RUN: %{ispc} -O0 --emit-asm %s --target=host --stack-protector=strong -o - | FileCheck %s
+// RUN: %{ispc} -O1 --emit-asm %s --target=host --stack-protector=strong -o - | FileCheck %s
+// RUN: %{ispc} -O2 --emit-asm %s --target=host --stack-protector=strong -o - | FileCheck %s
+// RUN: %{ispc} -O3 --emit-asm %s --target=host --stack-protector=strong -o - | FileCheck %s
+
+struct S {
+    int arr[20];
+};
+
+//; CHECK-LABEL: test{{.*}}:
+//; CHECK: {{(callq?|bl)}} {{(_+stack_chk_fail|_+security)}}
+
+extern void foo(S *);
+
+int test()
+{
+    uniform S s;
+    foo(&s);
+    return s.arr[14];
+}

--- a/tests/lit-tests/ssp-link.ispc
+++ b/tests/lit-tests/ssp-link.ispc
@@ -1,0 +1,29 @@
+// Check that linking the executable succeeds in the presence of a reference to the function
+// that is called in the event of a stack violation. The symbol is guaranteed to be generated
+// by --stack-protector=all.
+
+// RUN: %{ispc} --target=host --stack-protector=all -h %t.h -o %t.o %s
+// RUN: %{cc} -x c++ -c -o %t-cxx.o --include %t.h %s
+// RUN: %{cc} -o %t.bin %t.o %t-cxx.o
+// On x86 mac hosts clang seems to produce an arm executable, causing this
+// test to fail. Until this is fixed, disable the test on all macs.
+// REQUIRES: !MACOS_HOST
+
+struct S {
+    int arr[20];
+};
+
+#ifdef ISPC
+export uniform int test()
+{
+    uniform S s;
+    return s.arr[14];
+}
+#else
+using namespace ispc;
+
+int main()
+{
+    (void) test();
+}
+#endif /* ISPC */

--- a/tests/lit-tests/ssp.ispc
+++ b/tests/lit-tests/ssp.ispc
@@ -1,0 +1,18 @@
+// Make sure the appropriate ssp function attribute is set.
+
+// RUN: %{ispc} %s --emit-llvm-text -o - | FileCheck %s -check-prefixes=CHECK_ALL,DEFAULT
+// RUN: %{ispc} %s --emit-llvm-text --stack-protector -o - | FileCheck %s -check-prefixes=CHECK_ALL,SSPON
+// RUN: %{ispc} %s --emit-llvm-text --stack-protector=on -o - | FileCheck %s -check-prefixes=CHECK_ALL,SSPON
+// RUN: %{ispc} %s --emit-llvm-text --stack-protector=none -o - | FileCheck %s -check-prefixes=CHECK_ALL,DEFAULT
+// RUN: %{ispc} %s --emit-llvm-text --stack-protector=strong -o - | FileCheck %s -check-prefixes=CHECK_ALL,SSPSTRONG
+// RUN: %{ispc} %s --emit-llvm-text --stack-protector=all -o - | FileCheck %s -check-prefixes=CHECK_ALL,SSPALL
+
+// CHECK_ALL:   define {{.*}}foo{{.*}}#[[ATTRNO:[0-9]+]]
+// DEFAULT-NOT: attributes #[[ATTRNO]] = { {{.* ssp}} }
+// SSPON:       attributes #[[ATTRNO]] = { {{.* ssp .*}} }
+// SSPSTRONG:   attributes #[[ATTRNO]] = { {{.* sspstrong .*}} }
+// SSPALL:      attributes #[[ATTRNO]] = { {{.* sspreq .*}} }
+
+int foo( int val ) {
+    return val;
+}


### PR DESCRIPTION
## Introduction
We at Sony PlayStation are interested in ISPC, and we have been doing some work on ISPC targeting our CPU. Security is a high priority for us, and as a consequence, we have done some work on adding SSP (Stack Smash Protection) to ISPC. We'd like to contribute SSP to the community.

## Description
Make the LLVM SSP functionality available in ISPC by introducing the command line option --stack-protector. By itself it enables SSP for some functions the LLVM backend deems vulnerable. When present with the specifier 'strong' (as in --stack-protector=strong), it enables SSP for functions with any arrays. With --stack-protector=all SSP is enabled for all functions. Details are available in the [LLVM documentation](https://llvm.org/docs/LangRef.html).

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [ssp.ispc](https://github.com/ispc/ispc/compare/main...wolfy1961:ispc:main#diff-7d6b3933fa83af609c3f97e1d1e5dfb07911cebfcc9b42df9dfc081e4092bb98)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [x] [Documentation](https://github.com/ispc/ispc/compare/main...wolfy1961:ispc:main#diff-f014868f1ccd5256b5fa04823a766153c82b0eb98c0b3d9a2b4d154e2ee7275a) updated if needed