### PR TITLE
Add amx example

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -669,7 +669,7 @@ jobs:
     - name: Run examples
       shell: cmd
       run: |
-        ctest --test-dir examples-build -C Release
+        ctest --test-dir examples-build -C Release --output-on-failure
 
   linux-examples:
     needs: [linux-package-examples, linux-build-ispc]
@@ -713,7 +713,7 @@ jobs:
 
     - name: Run examples
       run: |
-        ctest --test-dir examples-build -C Release
+        ctest --test-dir examples-build -C Release --output-on-failure
 
   macos-examples:
     needs: [linux-package-examples, macos-build-ispc]
@@ -752,4 +752,4 @@ jobs:
 
     - name: Run examples
       run: |
-        ctest --test-dir examples-build -C Release
+        ctest --test-dir examples-build -C Release --output-on-failure

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -692,6 +692,7 @@ jobs:
     - name: Install dependencies
       run: |
         .github/workflows/scripts/install-test-deps.sh
+        .github/workflows/scripts/install-build-deps.sh
 
     - name: Unpack examples
       run: |
@@ -703,7 +704,11 @@ jobs:
 
     - name: Build examples
       run: |
-        cmake -DCMAKE_C_FLAGS="-Wall -Werror" -DCMAKE_CXX_FLAGS="-Wall -Werror" examples-package/examples/cpu -B examples-build
+        cmake \
+            -B examples-build \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            examples-package/examples/cpu
         cmake --build examples-build
 
     - name: Run examples

--- a/examples/cpu/CMakeLists.txt
+++ b/examples/cpu/CMakeLists.txt
@@ -57,6 +57,7 @@ add_custom_target(run-cpu-examples
 # Enable ctest support
 enable_testing()
 
+add_subdirectory(amx)
 add_subdirectory(aobench)
 add_subdirectory(aobench_instrumented)
 add_subdirectory(attention)

--- a/examples/cpu/amx/CMakeLists.txt
+++ b/examples/cpu/amx/CMakeLists.txt
@@ -1,0 +1,161 @@
+#
+#  Copyright (c) 2025, Intel Corporation
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+
+#
+# ispc examples: amx
+#
+
+# Check if we're on Linux x86-64 architecture
+if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND (ISPC_ARCH STREQUAL "x86-64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")))
+    message(STATUS "AMX example requires Linux x86-64 architecture. Skipping AMX example.")
+    return()
+endif()
+
+# Test for __fp16 support
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("
+int main() {
+    __fp16 a = 1.0;
+    __fp16 b = 2.0;
+    __fp16 c = a + b;
+    return 0;
+}
+" HAS_FP16_SUPPORT)
+
+if(NOT HAS_FP16_SUPPORT)
+    message(STATUS "AMX example requires __fp16 support, but host compiler doesn't support it. Skipping AMX example.")
+    return()
+endif()
+
+# Check for AMX hardware support on Linux
+set(AMX_SUPPORTED FALSE)
+set(AMX_DETECTION_METHOD "none")
+
+# First check for hardware AMX support via CPUID
+include(CheckCSourceRuns)
+set(CMAKE_REQUIRED_LIBRARIES "")
+
+check_c_source_runs("
+    #include <cpuid.h>
+    #include <stdio.h>
+
+    int check_amx_tile_support() {
+        unsigned int eax, ebx, ecx, edx;
+        // Check CPUID.(EAX=7,ECX=0):EDX[bit 24] for AMX-TILE
+        if (__get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx)) {
+            return (edx & (1 << 24)) != 0;
+        }
+        return 0;
+    }
+
+    int check_amx_fp16_support() {
+        unsigned int eax, ebx, ecx, edx;
+        // Check CPUID.(EAX=7,ECX=1):EAX[bit 21] for AMX-FP16
+        if (__get_cpuid_count(7, 1, &eax, &ebx, &ecx, &edx)) {
+            return (eax & (1 << 21)) != 0;
+        }
+        return 0;
+    }
+
+    int main() {
+        if (check_amx_tile_support() && check_amx_fp16_support()) {
+            return 0; // Success
+        }
+        return 1; // Failure
+    }
+" HAVE_AMX_SUPPORT)
+
+if(HAVE_AMX_SUPPORT)
+    message(STATUS "Detected AMX hardware support via CPUID (AMX-TILE and AMX-FP16)")
+    set(AMX_SUPPORTED TRUE)
+    set(AMX_DETECTION_METHOD "hardware_cpuid")
+else()
+    message(STATUS "AMX hardware support not detected via CPUID")
+    # Fallback to Intel SDE if hardware support is not available
+    find_program(SDE_EXECUTABLE
+        NAMES sde
+        PATHS ENV SDE_PATH
+        PATH_SUFFIXES bin
+        DOC "Intel SDE (Software Development Emulator) for AMX emulation"
+    )
+
+    if(SDE_EXECUTABLE)
+        message(STATUS "Found Intel SDE: ${SDE_EXECUTABLE} - will use for AMX emulation")
+        set(AMX_SUPPORTED TRUE)
+        set(AMX_DETECTION_METHOD "sde")
+    else()
+        set(AMX_SUPPORTED FALSE)
+    endif()
+endif()
+
+if(NOT AMX_SUPPORTED)
+    message(STATUS "Neither AMX hardware nor Intel SDE found. Skipping AMX example.")
+    return()
+endif()
+
+message(STATUS "AMX support detected via: ${AMX_DETECTION_METHOD}")
+
+if(AMX_SUPPORTED)
+    set (ISPC_SRC_NAME "amx_matmul")
+    set (TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/amx_matmul.cpp)
+    set (ISPC_FLAGS -O2 --target=avx512spr-x32 --cpu=gnr --enable-llvm-intrinsics --pic)
+    set (ISPC_IA_TARGETS "avx512spr-x32")
+
+    add_ispc_example(NAME "amx"
+                  ISPC_IA_TARGETS ${ISPC_IA_TARGETS}
+                  ISPC_SRC_NAME ${ISPC_SRC_NAME}
+                  TARGET_SOURCES ${TARGET_SOURCES}
+                  ISPC_FLAGS ${ISPC_FLAGS})
+
+    # Add compile definitions for matrix dimensions
+    target_compile_definitions(amx PRIVATE
+        MAT_SIZE_M=128
+        MAT_SIZE_N=128
+        MAT_SIZE_K=128)
+
+    # Add SDE path if available
+    if(SDE_EXECUTABLE)
+        get_filename_component(SDE_PATH "${SDE_EXECUTABLE}" DIRECTORY)
+        get_filename_component(SDE_PATH "${SDE_PATH}" DIRECTORY)
+        target_compile_definitions(amx PRIVATE SDE_PATH="${SDE_PATH}")
+    endif()
+
+    # Handle testing when SDE emulation is required
+    if(AMX_DETECTION_METHOD STREQUAL "sde")
+        # Disable the default test since it cannot run on non-AMX hardware
+        set_tests_properties(amx PROPERTIES DISABLED TRUE)
+
+        # Add a new test that uses SDE emulation
+        add_test(NAME amx_sde
+                 COMMAND ${SDE_EXECUTABLE} -gnr -- $<TARGET_FILE:amx>
+                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+        set_tests_properties(amx_sde PROPERTIES
+            TIMEOUT 300
+            LABELS "cpu_example"
+        )
+        message(STATUS "Test 'amx' disabled, 'amx_sde' configured to use SDE emulation")
+    endif()
+
+    # Add run target that uses the best available execution method
+    if(AMX_DETECTION_METHOD STREQUAL "sde")
+        # Use SDE emulation if that's how we detected support
+        add_custom_target(run-amx
+            COMMAND ${SDE_EXECUTABLE} -gnr -- $<TARGET_FILE:amx>
+            DEPENDS amx
+            COMMENT "Running AMX example with Intel SDE emulation"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+        message(STATUS "Added run target: 'run-amx' (will use SDE emulation)")
+    else()
+        # Use native execution if we detected hardware support
+        add_custom_target(run-amx
+            COMMAND $<TARGET_FILE:amx>
+            DEPENDS amx
+            COMMENT "Running AMX example on native hardware"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+        message(STATUS "Added run target: 'run-amx' (will use native hardware)")
+    endif()
+endif()

--- a/examples/cpu/amx/amx_matmul.cpp
+++ b/examples/cpu/amx/amx_matmul.cpp
@@ -1,0 +1,168 @@
+/*
+  Copyright (c) 2025, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <chrono>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "amx_matmul_ispc.h"
+using namespace ispc;
+
+// Matrix dimensions
+#ifndef MAT_SIZE_M
+#define MAT_SIZE_M 128 // A rows, C rows
+#endif
+#ifndef MAT_SIZE_N
+#define MAT_SIZE_N 128 // B cols, C cols
+#endif
+#ifndef MAT_SIZE_K
+#define MAT_SIZE_K 128 // A cols, B rows
+#endif
+
+const int A_ELEMENTS = MAT_SIZE_M * MAT_SIZE_K;
+const int B_ELEMENTS = MAT_SIZE_K * MAT_SIZE_N;
+const int C_ELEMENTS = MAT_SIZE_M * MAT_SIZE_N;
+
+// AMX system call constants
+#define ARCH_REQ_XCOMP_PERM 0x1023
+#define XFEATURE_XTILEDATA 18
+
+// Request AMX permissions from kernel
+bool request_amx_permission() {
+  if (syscall(SYS_arch_prctl, ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA)) {
+    std::cout << "Failed to enable XFEATURE_XTILEDATA\n";
+    std::cout << "Note: AMX not available on this system. Use Intel SDE to "
+                 "test AMX functionality.\n";
+    std::cout << "Command: sde -dmr -- ./amx_fp16_test\n";
+    std::cout << "You can use SDE_PATH to point to your SDE installation.\n";
+    return false;
+  } else {
+    std::cout << "TILE DATA USE SET - OK\n\n";
+    return true;
+  }
+}
+
+// High-resolution timer
+double
+get_time_diff(const std::chrono::high_resolution_clock::time_point &start,
+              const std::chrono::high_resolution_clock::time_point &end) {
+  auto duration =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+  return duration.count() / 1e9;
+}
+
+int main() {
+  std::cout << "Intel AMX-FP16 Matrix Multiplication Demo (ISPC)\n";
+  std::cout << "A(" << MAT_SIZE_M << "x" << MAT_SIZE_K << ") * B(" << MAT_SIZE_K
+            << "x" << MAT_SIZE_N << ") = C(" << MAT_SIZE_M << "x" << MAT_SIZE_N
+            << ")\n";
+  std::cout
+      << "===============================================================\n\n";
+
+  // Request AMX permissions
+  if (!request_amx_permission()) {
+    return -1;
+  }
+
+  // Allocate aligned memory for matrices
+  // Matrix A: FP16 elements with padding
+  uint16_t *a = (uint16_t *)aligned_alloc(64, A_ELEMENTS * sizeof(uint16_t));
+  // Matrix B: FP16 elements with padding
+  uint16_t *b = (uint16_t *)aligned_alloc(64, B_ELEMENTS * sizeof(uint16_t));
+  // Matrix C: FP32 elements with padding
+  float *c_amx = (float *)aligned_alloc(64, C_ELEMENTS * sizeof(float));
+  float *c_naive = (float *)aligned_alloc(64, C_ELEMENTS * sizeof(float));
+
+  if (!a || !b || !c_amx || !c_naive) {
+    std::cerr << "Failed to allocate memory\n";
+    return -1;
+  }
+
+  // Initialize matrices using ISPC functions
+  std::cout << "Initializing matrices...\n";
+  init_input_matrices((__fp16 *)a, (__fp16 *)b, MAT_SIZE_M, MAT_SIZE_N,
+                      MAT_SIZE_K);
+  zero_matrix(c_amx, MAT_SIZE_M, MAT_SIZE_N);
+  zero_matrix(c_naive, MAT_SIZE_M, MAT_SIZE_N);
+  std::cout << "Matrix initialization complete.\n\n";
+
+  // Set up AMX tile configuration
+  TileConfig config;
+  init_amx_config(&config);
+
+  // Warm-up run
+  std::cout << "Performing warm-up...\n";
+  amx_matmul_fp16_ispc((__fp16 *)a, (__fp16 *)b, c_amx, MAT_SIZE_M, MAT_SIZE_N,
+                       MAT_SIZE_K, MAT_SIZE_K, MAT_SIZE_N, MAT_SIZE_N);
+  // Reset C matrix for timing
+  zero_matrix(c_amx, MAT_SIZE_M, MAT_SIZE_N);
+
+  // Time both implementations
+  std::cout << "Timing AMX implementation...\n";
+  auto start = std::chrono::high_resolution_clock::now();
+  amx_matmul_fp16_ispc((__fp16 *)a, (__fp16 *)b, c_amx, MAT_SIZE_M, MAT_SIZE_N,
+                       MAT_SIZE_K, MAT_SIZE_K, MAT_SIZE_N, MAT_SIZE_N);
+  auto end = std::chrono::high_resolution_clock::now();
+  double amx_time = get_time_diff(start, end);
+
+  std::cout << "Timing naive implementation...\n";
+  start = std::chrono::high_resolution_clock::now();
+  naive_matmul_fp16_ispc((__fp16 *)a, (__fp16 *)b, c_naive, MAT_SIZE_M,
+                         MAT_SIZE_N, MAT_SIZE_K, MAT_SIZE_K, MAT_SIZE_N,
+                         MAT_SIZE_N);
+  end = std::chrono::high_resolution_clock::now();
+  double naive_time = get_time_diff(start, end);
+
+  // Verify results
+  std::cout << "Verifying...\n";
+  bool results_match = verify_results_fp16(c_amx, c_naive, C_ELEMENTS, 1e-2f);
+
+  // Display matrices only if verification fails
+  if (!results_match) {
+    std::cout << "Verification FAILED. Showing matrices for debugging:\n\n";
+    std::cout << "Input matrices (first 8x8 view):\n";
+    print_matrix_fp16((__fp16 *)a, MAT_SIZE_M, MAT_SIZE_K, MAT_SIZE_K, 8, 8);
+    print_matrix_fp16((__fp16 *)b, MAT_SIZE_K, MAT_SIZE_N, MAT_SIZE_N, 8, 8);
+    std::cout << "Results (first 8x8 view):\n";
+    print_matrix_fp32(c_amx, MAT_SIZE_M, MAT_SIZE_N, MAT_SIZE_N, 8, 8);
+    print_matrix_fp32(c_naive, MAT_SIZE_M, MAT_SIZE_N, MAT_SIZE_N, 8, 8);
+  } else {
+    std::cout << "OK\n";
+  }
+
+  // Results
+  std::cout << "\n====== RESULTS ======\n";
+  std::cout << "Matrix: " << MAT_SIZE_M << "x" << MAT_SIZE_K << " * "
+            << MAT_SIZE_K << "x" << MAT_SIZE_N << "\n";
+  std::cout << "Correctness: " << (results_match ? "PASS" : "FAIL") << "\n";
+  std::cout << std::fixed << std::setprecision(6);
+  std::cout << "AMX time: " << amx_time << "s, Naive time: " << naive_time
+            << "s\n";
+
+  if (amx_time > 0) {
+    double speedup = naive_time / amx_time;
+    double total_ops = 2.0 * MAT_SIZE_M * MAT_SIZE_N * MAT_SIZE_K;
+    std::cout << std::setprecision(2);
+    std::cout << "Speedup: " << speedup << "x\n";
+    std::cout << "Performance: " << (total_ops / amx_time) / 1e9
+              << " GFLOPS (AMX)\n";
+  }
+  std::cout << "======================\n";
+
+  // Release AMX resources
+  release_amx();
+
+  // Cleanup
+  free(a);
+  free(b);
+  free(c_amx);
+  free(c_naive);
+
+  return results_match ? 0 : 1;
+}

--- a/examples/cpu/amx/amx_matmul.ispc
+++ b/examples/cpu/amx/amx_matmul.ispc
@@ -1,0 +1,253 @@
+/*
+  Copyright (c) 2025, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+// ISPC AMX-FP16 Matrix Multiplication using LLVM intrinsics
+// Demonstrates Intel AMX-FP16 usage through ISPC with tiling for 128x128
+// matrices
+
+// AMX tile configuration structure (64 bytes total)
+struct TileConfig {
+  int8 palette_id;   // 0: palette_id
+  int8 start_row;    // 1: startRow
+  int8 reserved[14]; // 2-15: reserved (must be zero)
+  int16 colsb[16];   // 16-47: tile0.colsb through tile15.colsb
+  int8 rows[16];     // 48-63: tile0.rows through tile15.rows
+};
+
+// Constants for AMX-FP16 tile sizes (hardware limits)
+static const uniform int TILE_M = 16; // AMX tile rows
+static const uniform int TILE_N = 16; // AMX tile cols
+static const uniform int TILE_K = 32; // AMX tile inner dimension
+
+// AMX Tile Register Assignments (TMM0-TMM7) with proper cast
+#define TMM_C ((uniform int8)0) // Result tile C (16x16 FP32)
+#define TMM_A ((uniform int8)1) // Matrix A tile (16x32 FP16)
+#define TMM_B ((uniform int8)2) // Matrix B tile (32x16 FP16)
+
+// Matrix dimensions
+#ifndef MAT_SIZE_M
+#define MAT_SIZE_M 128 // A rows, C rows
+#endif
+#ifndef MAT_SIZE_N
+#define MAT_SIZE_N 128 // B cols, C cols
+#endif
+#ifndef MAT_SIZE_K
+#define MAT_SIZE_K 128 // A cols, B rows
+#endif
+
+// Calculate number of tiles needed
+static const uniform int TILES_M = (MAT_SIZE_M + TILE_M - 1) / TILE_M;
+static const uniform int TILES_N = (MAT_SIZE_N + TILE_N - 1) / TILE_N;
+static const uniform int TILES_K = (MAT_SIZE_K + TILE_K - 1) / TILE_K;
+
+// Initialize tile configuration for AMX-FP16
+export void init_amx_config(uniform TileConfig config[]) {
+  // Clear the entire structure
+  for (uniform int i = 0; i < sizeof(uniform TileConfig); ++i) {
+    ((uniform int8 *)config)[i] = 0;
+  }
+
+  config->palette_id = 1;
+  config->start_row = 0;
+
+  // Configure tile 0 (result tile C): TILE_M×TILE_N FP32 values
+  config->colsb[0] = TILE_N * 4; // 4 bytes per FP32
+  config->rows[0] = TILE_M;
+
+  // Configure tile 1 (matrix A): TILE_M×TILE_K FP16 values
+  config->colsb[1] = TILE_K * 2; // 2 bytes per FP16
+  config->rows[1] = TILE_M;
+
+  // Configure tile 2 (matrix B): Special AMX layout for TILE_K×TILE_N
+  config->colsb[2] = TILE_N * 4; // TILE_N * 4 bytes per row
+  config->rows[2] = TILE_K / 2;  // TILE_K/2 rows
+
+  // Load the tile configuration
+  @llvm.x86.ldtilecfg((uniform int8 * uniform) config);
+}
+
+// Release AMX tiles
+export void release_amx() { @llvm.x86.tilerelease(); }
+
+// Simple B tile conversion using direct interleaving
+void convert_b_tile(uniform float16 b_src[], uniform float16 b_amx[],
+                    uniform int b_offset, uniform int stride_b) {
+  // Process pairs of rows with simple interleaving
+  for (uniform int tile_row = 0; tile_row < TILE_K / 2; ++tile_row) {
+    uniform int row0_offset = b_offset + (tile_row * 2) * stride_b;
+    uniform int row1_offset = b_offset + (tile_row * 2 + 1) * stride_b;
+    uniform int amx_row_offset = tile_row * TILE_N * 2;
+
+    // Simple interleaving: row0[0], row1[0], row0[1], row1[1], ...
+    for (uniform int i = 0; i < TILE_N; ++i) {
+      b_amx[amx_row_offset + i * 2] = b_src[row0_offset + i];
+      b_amx[amx_row_offset + i * 2 + 1] = b_src[row1_offset + i];
+    }
+  }
+}
+
+// AMX-FP16 matrix multiplication with tiling
+export void amx_matmul_fp16_ispc(uniform float16 a[], uniform float16 b[],
+                                 uniform float c[], uniform int m,
+                                 uniform int n, uniform int k,
+                                 uniform int stride_a, uniform int stride_b,
+                                 uniform int stride_c) {
+
+  // Allocate temporary buffer for B tile
+  uniform float16 __attribute__((aligned(64))) b_amx[TILE_K * TILE_N];
+
+  // Process matrix in tiles - single tile at a time
+  for (uniform int tile_i = 0; tile_i < TILES_M; ++tile_i) {
+    for (uniform int tile_j = 0; tile_j < TILES_N; ++tile_j) {
+
+      // Zero C tile directly in AMX register
+      @llvm.x86.tilezero(TMM_C);
+
+      // Accumulate across K dimension
+      for (uniform int tile_k = 0; tile_k < TILES_K; ++tile_k) {
+
+        // Calculate positions
+        uniform int a_start_row = tile_i * TILE_M;
+        uniform int a_start_col = tile_k * TILE_K;
+        uniform int a_offset = a_start_row * stride_a + a_start_col;
+        uniform int64 a_byte_stride = stride_a * 2;
+
+        uniform int b_start_row = tile_k * TILE_K;
+        uniform int b_start_col = tile_j * TILE_N;
+        uniform int b_offset = b_start_row * stride_b + b_start_col;
+
+        // Convert B tile from source matrix to AMX format
+        convert_b_tile(b, b_amx, b_offset, stride_b);
+
+        // Load A and B tiles, then perform multiply-accumulate
+        @llvm.x86.tileloadd64(TMM_A, (uniform int8 * uniform) & a[a_offset],
+                              a_byte_stride);
+        @llvm.x86.tileloadd64(TMM_B, (uniform int8 * uniform) & b_amx[0],
+                              (uniform int64)(TILE_N * 4));
+        @llvm.x86.tdpfp16ps(TMM_C, TMM_A, TMM_B);
+      }
+
+      // Store final C tile result to destination matrix
+      uniform int c_offset = (tile_i * TILE_M) * stride_c + (tile_j * TILE_N);
+      uniform int64 c_byte_stride = stride_c * 4;
+      @llvm.x86.tilestored64(TMM_C, (uniform int8 * uniform) & c[c_offset],
+                             c_byte_stride);
+    }
+  }
+}
+
+// Naive matrix multiplication for comparison
+export void naive_matmul_fp16_ispc(uniform float16 a[], uniform float16 b[],
+                                   uniform float c[], uniform int m,
+                                   uniform int n, uniform int k,
+                                   uniform int stride_a, uniform int stride_b,
+                                   uniform int stride_c) {
+  for (uniform int i = 0; i < m; ++i) {
+    for (uniform int j = 0; j < n; ++j) {
+      uniform float sum = 0.0f;
+      for (uniform int kk = 0; kk < k; ++kk) {
+        uniform float a_val = (float)a[i * stride_a + kk];
+        uniform float b_val = (float)b[kk * stride_b + j];
+        sum += a_val * b_val;
+      }
+      c[i * stride_c + j] = sum;
+    }
+  }
+}
+
+// Verify results match between AMX and naive implementations (with tolerance)
+export uniform bool verify_results_fp16(uniform float result_amx[],
+                                        uniform float result_naive[],
+                                        uniform int size,
+                                        uniform float tolerance) {
+  uniform int mismatches = 0;
+  for (uniform int i = 0; i < size; ++i) {
+    uniform float diff = result_amx[i] - result_naive[i];
+    if (diff < 0)
+      diff = -diff; // abs
+    if (diff > tolerance) {
+      if (mismatches < 10) { // Limit output
+        print("Mismatch at position %: AMX=%, Naive=%, diff=%\n", i,
+              result_amx[i], result_naive[i], diff);
+      }
+      mismatches++;
+    }
+  }
+  if (mismatches > 10) {
+    print("... and % more mismatches\n", mismatches - 10);
+  }
+  return mismatches == 0;
+}
+
+// Initialize input matrices A and B with FP16-friendly random values
+export void init_input_matrices(uniform float16 a[], uniform float16 b[],
+                                uniform int m, uniform int n, uniform int k) {
+  // Use simple LCG for deterministic pseudo-random values
+  uniform uint32 seed = 12345;
+
+  // Initialize A with small random values in range [-0.5, 0.5]
+  for (uniform int i = 0; i < m; ++i) {
+    for (uniform int j = 0; j < k; ++j) {
+      seed = seed * 1664525 + 1013904223; // LCG parameters
+      uniform float val =
+          (float)(seed & 0xFFFF) / 65536.0f - 0.5f; // [-0.5, 0.5]
+      a[i * k + j] = (float16)val;
+    }
+  }
+
+  // Initialize B with small random values in range [-0.5, 0.5]
+  for (uniform int i = 0; i < k; ++i) {
+    for (uniform int j = 0; j < n; ++j) {
+      seed = seed * 1664525 + 1013904223; // LCG parameters
+      uniform float val =
+          (float)(seed & 0xFFFF) / 65536.0f - 0.5f; // [-0.5, 0.5]
+      b[i * n + j] = (float16)val;
+    }
+  }
+}
+
+// Zero out matrix C
+export void zero_matrix(uniform float c[], uniform int m, uniform int n) {
+  foreach (i = 0 ... m * n) {
+    c[i] = 0.0f;
+  }
+}
+
+// Print FP16 matrix
+export void print_matrix_fp16(uniform float16 a[], uniform int m, uniform int n,
+                              uniform int stride, uniform int max_print_rows,
+                              uniform int max_print_cols) {
+  print("Matrix (%x%):\n", m, n);
+  for (uniform int i = 0; i < m && i < max_print_rows; ++i) {
+    for (uniform int j = 0; j < n && j < max_print_cols; ++j) {
+      print("% ", (float)a[i * stride + j]);
+    }
+    if (n > max_print_cols)
+      print(" ...");
+    print("\n");
+  }
+  if (m > max_print_rows)
+    print("...\n");
+  print("\n");
+}
+
+// Print FP32 matrix
+export void print_matrix_fp32(uniform float c[], uniform int m, uniform int n,
+                              uniform int stride, uniform int max_print_rows,
+                              uniform int max_print_cols) {
+  print("Matrix (%x%):\n", m, n);
+  for (uniform int i = 0; i < m && i < max_print_rows; ++i) {
+    for (uniform int j = 0; j < n && j < max_print_cols; ++j) {
+      print("% ", c[i * stride + j]);
+    }
+    if (n > max_print_cols)
+      print(" ...");
+    print("\n");
+  }
+  if (m > max_print_rows)
+    print("...\n");
+  print("\n");
+}


### PR DESCRIPTION
## Description

This pull request adds a new Intel AMX-FP16 matrix multiplication example to the CPU examples, including hardware or emulator detection.

* Added `amx` subdirectory to the CPU examples.
* `examples/cpu/amx/CMakeLists.txt`: Implements detection for AMX hardware support via CPUID and falls back to Intel SDE emulation if hardware is not available. Adds a build/run target only when AMX support is detected, and sets up all necessary compile and run configurations.
* `examples/cpu/amx/amx_matmul.ispc`: an ISPC implementation of AMX-FP16 matrix multiplication, including AMX tile configuration, matrix initialization, AMX and naive multiplication kernels, result verification.
* `examples/cpu/amx/amx_matmul.cpp`: C++ code that requests AMX permissions, runs both the AMX and naive implementations, times and verifies results, and prints performance metrics.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)