### PR TITLE
Fix enum fields missing from generated headers

### DIFF
--- a/src/parse.yy
+++ b/src/parse.yy
@@ -3761,10 +3761,10 @@ lCreateEnumType(const char *name, std::vector<Symbol *> *enums, SourcePos pos) {
     if (name != nullptr)
         m->symbolTable->AddType(name, enumType, pos);
 
+    enumType->SetEnumerators(*enums);
     lFinalizeEnumeratorSymbols(*enums, enumType);
     for (unsigned int i = 0; i < enums->size(); ++i)
         m->symbolTable->AddVariable((*enums)[i]);
-    enumType->SetEnumerators(*enums);
     return enumType;
 }
 

--- a/tests/lit-tests/3563.ispc
+++ b/tests/lit-tests/3563.ispc
@@ -1,0 +1,11 @@
+// This test ensures that enum fields are correctly included in generated headers.
+// Regression test for issue where enum fields were missing from generated headers
+
+// RUN: %{ispc} %s --target=host --nostdlib -h %t.h
+// RUN: FileCheck --input-file=%t.h %s
+
+// CHECK: enum E {
+// CHECK-NEXT: A = 0 
+// CHECK-NEXT: };
+enum E { A };
+export void foo(const uniform E x) {}


### PR DESCRIPTION
This commit fixes a bug introduced by the Type system refactoring in commit fdb994e64 where enum fields were not included in generated C/C++ header files.

The issue was caused by a change in caching behavior during type transformations:
- Old system: EnumType had its own GetAsConstType()/GetAsUniformType() methods that created new copies without caching
- New system: EnumType uses base Type class methods that cache the results

The parsing order in lCreateEnumType() called lFinalizeEnumeratorSymbols() before SetEnumerators(), causing cached const/uniform type copies to be created with empty enumerator lists. When SetEnumerators() was later called, it only updated the original EnumType, not the cached copies used for header generation.

## Related Issue
- [X] Linked to relevant issue: #3563

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
- [X] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
