### PR TITLE
CI: enable testing in OpenMoonRay workflow

### DIFF
--- a/.github/workflows/openmoonray.yml
+++ b/.github/workflows/openmoonray.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Build and install random123
       run: |
         su - builder -c "
-          git clone https://aur.archlinux.org/random123.git
+          git clone --branch random123 --single-branch https://github.com/archlinux/aur.git random123
           cd random123
           makepkg -si --noconfirm
         "
@@ -89,7 +89,7 @@ jobs:
     - name: Build OpenMoonRay
       run: |
         su - builder -c "
-          git clone https://aur.archlinux.org/openmoonray.git
+          git clone --branch openmoonray --single-branch https://github.com/archlinux/aur.git openmoonray
           cd openmoonray
 
           # Remove ispc dependency since we have fresh build

--- a/.github/workflows/openmoonray.yml
+++ b/.github/workflows/openmoonray.yml
@@ -95,6 +95,14 @@ jobs:
           # Remove ispc dependency since we have fresh build
           sed -i '/ispc/d' PKGBUILD
 
+          # Enable testing in CMAKE configuration
+          sed -i 's/-DMOONRAY_BUILD_TESTING=OFF/-DMOONRAY_BUILD_TESTING=ON/' PKGBUILD
+          sed -i 's/-DBUILD_TESTING=OFF/-DBUILD_TESTING=ON/' PKGBUILD
+
           # Build with automatic dependency resolution
           makepkg -s --noconfirm
+
+          # Run tests
+          cd src/build
+          ctest -L unit -E scenerdl2_render_util_tests --output-on-failure
         "

--- a/.github/workflows/opensource-projects.yml
+++ b/.github/workflows/opensource-projects.yml
@@ -137,7 +137,7 @@ jobs:
             extra_packages: gtest
             build_cmd: |
               su - builder -c "
-                git clone https://aur.archlinux.org/lc0.git
+                git clone --branch lc0 --single-branch https://github.com/archlinux/aur.git lc0
                 cd lc0
                 makepkg -s --noconfirm
               "


### PR DESCRIPTION
## Description

This pull request updates the build workflow for OpenMoonRay to improve testing coverage. The main changes focus on enabling and running tests during the build process.

**Testing improvements:**

* Updated `PKGBUILD` configuration to enable testing by switching `MOONRAY_BUILD_TESTING` and `BUILD_TESTING` from `OFF` to `ON`.
* Added steps to run tests after building by navigating to the `build` directory and executing `ctest -L unit`.
