### PR TITLE
Replace trunc i8 to i1 with icmp ne i8 in bool conversion

### DIFF
--- a/tests/lit-tests/3491.ispc
+++ b/tests/lit-tests/3491.ispc
@@ -6,7 +6,15 @@
 
 // REQUIRES: X86_ENABLED
 
-// CHECK: sext
+// CHECK-LABEL: define <16 x i8> @embedded_select___unb_3C_3_3E_unT_3C_3_3E_unT_3C_3_3E_(
+// CHECK-NEXT: allocas:
+// CHECK-NEXT:   [[COND_STORAGE:%.*]] = zext <16 x i1> %cond to <16 x i8>
+// CHECK-NEXT:   [[SHUFFLE1:%.*]] = shufflevector <16 x i8> [[COND_STORAGE]], <16 x i8> {{.*}}, <16 x i32> {{.*}}
+// CHECK-NEXT:   [[CMP:%.*]] = icmp eq <16 x i8> [[SHUFFLE1]], zeroinitializer
+// CHECK-NEXT:   [[SELECT:%.*]] = select <16 x i1> [[CMP]], <16 x i8> %f, <16 x i8> %t
+// CHECK-NEXT:   [[RESULT:%.*]] = shufflevector <16 x i8> [[SELECT]], <16 x i8> {{.*}}, <16 x i32> {{.*}}
+// CHECK-NEXT:   ret <16 x i8> [[RESULT]]
+// CHECK-NEXT: }
 
 #define N 3
 

--- a/tests/lit-tests/3571.ispc
+++ b/tests/lit-tests/3571.ispc
@@ -1,0 +1,73 @@
+// Test for correct boolean return value representation in exported functions
+// Regression test for issue where uniform bool return values could be 255 instead of 1
+
+// RUN: %{ispc} -O2 --pic --target=avx2-i32x8 -h %t.h %s -o %t.o
+// RUN: %{cc} -O2 -x c++ -c %s -o %t.cpp.o --include %t.h
+// RUN: %{cc} %t.o %t.cpp.o -o %t.cpp.bin -lstdc++
+// RUN: %t.cpp.bin | FileCheck %s
+
+// CHECK: Raw ISPC result: 1 (as int)
+// CHECK: Raw ISPC result: 1 (as bool)
+// CHECK: asCppBool result: 1 (as int)
+// CHECK: asCppBool result: 1 (as bool)
+
+// REQUIRES: X86_ENABLED && !MACOS_HOST
+
+// FAIL: LLVM_20_0+
+
+#ifdef ISPC
+export uniform bool foo(uniform float scl, uniform uint32 &isectsEqual) {
+    uniform bool success = true;
+    uint32 localIsectsEqual = 0;
+
+    for (uniform uint32 y = 0; y < 2; y++) {
+        float testValue = (float)y * scl;
+
+        bool passed = true;
+        bool asserted = false;
+
+        if (!asserted) {
+            if (testValue > 1.0f) {
+                passed = false;
+                if (testValue > 0.1f) {
+                    asserted = true;
+                }
+            }
+        }
+
+        if (asserted) {
+            success = false;
+        }
+
+        localIsectsEqual += passed ? 1 : 0;
+    }
+
+    isectsEqual = reduce_add(localIsectsEqual);
+
+    return success;
+}
+#else
+#include <iostream>
+using namespace ispc;
+
+inline bool asCppBool(bool ispcBool) {
+    int i = ispcBool ? 1 : 0;
+    return (bool)i;
+}
+
+int main() {
+    float scl = 0.001f;
+    uint32_t isectsEqual = 0;
+
+    bool rawResult = foo(scl, isectsEqual);
+
+    bool convertedResult = asCppBool(rawResult);
+
+    std::cout << "Raw ISPC result: " << (int)rawResult << " (as int)" << std::endl;
+    std::cout << "Raw ISPC result: " << rawResult << " (as bool)" << std::endl;
+    std::cout << "asCppBool result: " << (int)convertedResult << " (as int)" << std::endl;
+    std::cout << "asCppBool result: " << convertedResult << " (as bool)" << std::endl;
+
+    return 0;
+}
+#endif

--- a/tests/lit-tests/bool-store-varying.ispc
+++ b/tests/lit-tests/bool-store-varying.ispc
@@ -36,8 +36,8 @@ void foo(uint8 a, uint8 b)
 // src/llvmutil.cpp BoolVectoType).
 // AVX2: define void @boo___vyb(<[[WIDTH]] x [[RTYPE:i[0-9]+]]> %a, <[[WIDTH]] x [[RTYPE]]> %__mask)
 // AVX2-NEXT: allocas:
-// AVX2-NEXT: [[TRUNC:%.*]] = trunc <[[WIDTH]] x [[RTYPE]]> %a to <[[WIDTH]] x i8>
-// AVX2-NEXT: [[CAST:%.*]] = and <[[WIDTH]] x i8> [[TRUNC]], {{(splat \(i8 1\)|<i8 1, i8 1, i8 1, i8 1>)}}
+// AVX2-NEXT: [[CMP:%.*]] = icmp ne <[[WIDTH]] x [[RTYPE]]> %a, zeroinitializer
+// AVX2-NEXT: [[CAST:%.*]] = zext <[[WIDTH]] x i1> [[CMP]] to <[[WIDTH]] x i8>
 // AVX2-NEXT: store <[[WIDTH]] x i8> [[CAST]], {{.*}} @y
 // AVX2-NEXT: ret void
 


### PR DESCRIPTION
## Description

Replace trunc i8 to i1 with icmp ne i8, 0 for proper bool conversion. LLVM 19+ removed the InstCombine canonicalization that converted trunc i8 to i1 to icmp ne i8, 0. This caused uniform bool return values to potentially be 255 instead of the expected 1.

The fix updates lSwitchBoolSize_2() in ctx.cpp to generate proper comparison instructions instead of relying on removed LLVM InstCombine canonicalization. This canonicalization for trunc to `i1` in LLVM was removed in https://github.com/llvm/llvm-project/pull/84628 that caused regression in #3571. 

## Related Issue
- [X] Linked to relevant issue: #3571

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
- [X] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)