### PR TITLE
Fix 3358: Support structures in lIsSafeToBlend

### DIFF
--- a/tests/lit-tests/3358.ispc
+++ b/tests/lit-tests/3358.ispc
@@ -1,0 +1,90 @@
+// This test checks that masked store is promoted to blend stores for structures
+// RUN: %{ispc} --target=host --nowrap --debug-phase=280:280 %s -o %t 2>&1 | FileCheck %s
+
+// Original issue
+struct Compound {
+    int a;
+    float<16> value;
+};
+
+// CHECK-LABEL: @test
+// CHECK-COUNT-16: call void @__masked_store_blend_float
+unmasked void test(Compound& data, float test) {
+    Compound copy = data;
+    if (test <= 0) {
+        copy.value += 0.01;
+    }
+    data = copy;
+}
+
+// Deeply nested struct with vector fields
+struct InnerStruct {
+    uniform int padding;
+    int<4> data;
+};
+
+struct MiddleStruct {
+    float<4> additional_data;
+    InnerStruct inner;
+    int more_padding;
+};
+
+struct OuterStruct {
+    MiddleStruct middle;
+    double<4> outer_data;
+    uniform int final_padding;
+};
+
+// CHECK-LABEL: @test_deeply_nested
+// CHECK-COUNT-4: call void @__masked_store_blend_i32
+// CHECK-COUNT-4: call void @__masked_store_blend_float
+// CHECK-COUNT-4: call void @__masked_store_blend_double
+unmasked void test_deeply_nested(OuterStruct & compound, float test) {
+    OuterStruct copy = compound;
+    if (test <= 0) {
+        copy.middle.inner.data += 0.01;
+        copy.middle.additional_data += 0.02;
+        copy.outer_data += 0.03;
+    }
+    compound = copy;
+}
+
+// Struct with multiple vector fields
+struct MultiVectorStruct {
+    float<4> vector1;
+    int<4> vector2;
+    int padding1;
+    float<4> vector4;
+    int padding2;
+};
+
+// CHECK-LABEL: @test_multi_vector
+// CHECK-COUNT-4: call void @__masked_store_blend_float
+// CHECK-COUNT-4: call void @__masked_store_blend_i32
+// CHECK-COUNT-4: call void @__masked_store_blend_float
+unmasked void test_multi_vector(MultiVectorStruct & data, float test) {
+    MultiVectorStruct copy = data;
+    if (test > 0) {
+        copy.vector1 *= 2.0;
+        copy.vector2 += 1;
+        copy.vector4 -= 0.5;
+    }
+    data = copy;
+}
+
+// Global structure (should not blend)
+// CHECK-LABEL: @test_multi_vector_global
+// CHECK-COUNT-4: call void @__masked_store_float
+// CHECK-COUNT-4: call void @__masked_store_i32
+// CHECK-COUNT-4: call void @__masked_store_float
+MultiVectorStruct global_struct;
+unmasked void test_multi_vector_global(MultiVectorStruct & data, float test) {
+    if (test > 0) {
+        global_struct.vector1 *= 2.0;
+        global_struct.vector2 += 1;
+        global_struct.vector4 -= 0.5;
+    }
+}
+
+
+


### PR DESCRIPTION
## Description
This PR supports structures in analysis allowing to promote masked store to blend store. It's especially beneficial on the targets without HW masked stores (like neon, sse4) where emulating of masked store results in multiple branches.
No regressions were observed. One improvement of 53% is present on one GameDev benchmark.

## Related Issue
- [x] Fixes #3358 

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
- [X] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed