### PR TITLE
Attach loop.mustprogress metadata to loops

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -886,6 +886,15 @@ New Architecture Support:
   Vector Extension (RVV) ISA. The new ``rvv-x4`` target provides 4-wide
   vectorization for RISC-V processors with vector extensions.
 
+Languages Changes:
+
+The compiler now assumes that all loops with non-constant conditions will make
+forward progress and eventually terminate. This enables optimizations based
+on the assumption that loops will not execute indefinitely. Infinite loops
+with constant conditions like ``for (;;)`` or ``while (1)`` are treated
+specially and do not have this assumption applied.
+
+
 Getting Started with ISPC
 =========================
 
@@ -2126,6 +2135,19 @@ or by jumping to the loop step statement, if all program instances are
 disabled after the ``continue`` has executed.  ``break`` statements are
 handled in a similar fashion.
 
+The compiler assumes that all loops with non-constant conditions will make
+forward progress and eventually terminate. This enables optimizations based
+on the assumption that loops will not execute indefinitely. A loop has a
+non-constant condition when the condition expression depends on runtime values
+(e.g., ``while (i < count)`` or ``for (int i = 0; i < n; i++)``). For such
+loops, the compiler can apply optimizations like loop unrolling and
+vectorization more aggressively, since it knows the loop will eventually exit.
+
+In contrast, infinite loops with constant conditions like ``for (;;)`` or
+``while (1)`` (or ``while (true)``) are treated specially and do not have
+this forward progress assumption applied. These are loops where the condition
+is a compile-time constant that evaluates to true, indicating an intentionally
+infinite loop.
 
 Gang Convergence Guarantees
 ---------------------------

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -566,8 +566,8 @@ class FunctionEmitContext {
         overlapping.) */
     void MemcpyInst(llvm::Value *dest, llvm::Value *src, llvm::Value *count);
 
-    void setLoopUnrollMetadata(llvm::Instruction *inst, std::pair<Globals::pragmaUnrollType, int> loopAttribute,
-                               SourcePos pos);
+    void setLoopMetadata(llvm::Instruction *inst, std::pair<Globals::pragmaUnrollType, int> loopAttribute,
+                         SourcePos pos, bool hasConstantCondition);
     llvm::Instruction *BranchInst(llvm::BasicBlock *block);
     llvm::Instruction *BranchInst(llvm::BasicBlock *trueBlock, llvm::BasicBlock *falseBlock, llvm::Value *test);
 

--- a/tests/lit-tests/assume_uniform_xe.ispc
+++ b/tests/lit-tests/assume_uniform_xe.ispc
@@ -1,8 +1,9 @@
 // RUN: %{ispc} --emit-spirv --target=xehpg-x8 --device=acm-g10 %s -o %t.spv
+// RUN: %{ispc} --emit-llvm-text --target=xehpg-x8 --device=acm-g10 %s -o %t.ll
 // RUN: ocloc compile -file %t.spv -spirv_input -options "-vc-codegen -Xfinalizer -output" -device acm-g10 -output %t.bin -output_no_suffix
 // RUN: FileCheck %s -check-prefix=CHECK_FOO1 -input-file=foo1_kernel.asm
 // RUN: FileCheck %s -check-prefix=CHECK_FOO2 -input-file=foo2_kernel.asm
-// RUN: FileCheck %s -check-prefix=CHECK_FOO3 -input-file=foo3_kernel.asm
+// RUN: FileCheck %s -check-prefix=CHECK_FOO3 -input-file=%t.ll
 
 // REQUIRES: XE_ENABLED
 // REQUIRES: OCLOC_INSTALLED
@@ -39,8 +40,9 @@ task void foo2_kernel(uniform int a[]) {
     bar2(a);
 }
 
-// CHECK_FOO3-COUNT-1: _foo3_kernel
-// CHECK_FOO3-NOT: _foo3_kernel
+// CHECK_FOO3-LABEL: @foo3_kernel
+// CHECK_FOO3: foreach_full_body
+// CHECK_FOO3-NOT: partial_inner_only
 
 // Case 3 : loop : remove remainder loop.
 task void foo3_kernel(uniform int a[], uniform int res[], uniform int count) {

--- a/tests/lit-tests/ind-var-simplify-xe.ispc
+++ b/tests/lit-tests/ind-var-simplify-xe.ispc
@@ -1,16 +1,18 @@
-// This test checks that induction variables are not canonicalized or widened on GPU.
+// This test checks that induction variables are canonicalized or widened on GPU.
 
 // RUN: %{ispc} %s --nostdlib --emit-llvm-text --target=xehpg-x8 --arch=xe64 -o - | FileCheck %s
 
 // REQUIRES: XE_ENABLED
 
-// CHECK-LABEL: for_test:
-// CHECK:           %i{{.*}} = phi i32
+// CHECK-LABEL: for_loop:
+// CHECK:           %i{{.*}} = phi i64
 // CHECK:           %add{{.*}} = add{{.*}} i32 %i{{.*}}
+// CHECK:           %{{.*}} = sext i32 {{.*}} to i64
 
 task void widen(uniform float A[], uniform int64 Num, uniform int64 N) {
     uniform float result = 0;
     for (uniform int i = 0; i < Num; i += N) {
         result += A[i];
     }
+    A[0] = result;
 }

--- a/tests/lit-tests/ind-var-simplify.ispc
+++ b/tests/lit-tests/ind-var-simplify.ispc
@@ -4,13 +4,14 @@
 
 // REQUIRES: X86_ENABLED
 
-// CHECK-LABEL: for_test:
+// CHECK-LABEL: for_loop:
 // CHECK:           %indvars.iv = phi i64
 // CHECK:           %indvars.iv.next = add{{.*}} i64 %indvars.iv
 
-task void widen(uniform float A[], uniform int64 Num, uniform int64 N) {
+void widen(uniform float A[], uniform int64 Num, uniform int64 N) {
     uniform float result = 0;
     for (uniform int i = 0; i < Num; i += N) {
         result += A[i];
     }
+    A[0] = result;
 }

--- a/tests/lit-tests/loop_mustprogress.ispc
+++ b/tests/lit-tests/loop_mustprogress.ispc
@@ -1,0 +1,109 @@
+// Test to check that llvm.loop.mustprogress metadata is added to loops with non-constant conditions.
+
+// RUN: %{ispc} %s --target=host --nowrap -O0 --emit-llvm-text --no-discard-value-names --nostdlib -o - | FileCheck %s
+
+// CHECK-LABEL: define void @test_for_uniform___
+// CHECK: br label %{{[a-zA-Z_][a-zA-Z0-9_]*}}, !llvm.loop [[LOOP_FOR_UNI:![0-9]+]]
+
+// CHECK-LABEL: define void @test_for_varying___
+// CHECK: br label %{{[a-zA-Z_][a-zA-Z0-9_]*}}, !llvm.loop [[LOOP_FOR_VARY:![0-9]+]]
+
+// CHECK-LABEL: define void @test_infinite_for___
+// CHECK-NOT: !llvm.loop
+
+// CHECK-LABEL: define void @test_while_uniform___
+// CHECK: br label %{{[a-zA-Z_][a-zA-Z0-9_]*}}, !llvm.loop [[LOOP_WHILE_UNI:![0-9]+]]
+
+// CHECK-LABEL: define void @test_while_varying___
+// CHECK: br label %{{[a-zA-Z_][a-zA-Z0-9_]*}}, !llvm.loop [[LOOP_WHILE_VARY:![0-9]+]]
+
+// CHECK-LABEL: define void @test_infinite_while___
+// CHECK-NOT: !llvm.loop
+
+// CHECK-LABEL: define void @test_do_while_uniform___
+// CHECK: br i1 %{{[a-zA-Z_][a-zA-Z0-9_]*}}, label %{{[a-zA-Z_][a-zA-Z0-9_]*}}, label %{{[a-zA-Z_][a-zA-Z0-9_]*}}, !llvm.loop [[LOOP_DO_UNI:![0-9]+]]
+
+// CHECK-DAG: br i1 %{{[a-zA-Z_.0-9]+}}, label %do_loop, label %do_exit, !llvm.loop [[LOOP_DO_VARY:![0-9]+]]
+
+// CHECK-DAG: br i1 %{{[a-zA-Z_.0-9]+}}, label %foreach_full_body, label %partial_inner_all_outer, !llvm.loop [[LOOP_FOREACH:![0-9]+]]
+
+// Regular for loop - should have mustprogress
+extern void sink(uniform float);
+extern void sink(float);
+
+void test_for_uniform(uniform int n) {
+    for (uniform int i = 0; i < n; i++) {
+        sink(i);
+    }
+}
+
+void test_for_varying(uniform int n) {
+    for (int i = 0; i < n; i+=programCount) {
+        sink(i);
+    }
+}
+
+// Infinite loop - should NOT have mustprogress (constant condition)
+void test_infinite_for() {
+    uniform int i = 0;
+    for (;;) {
+        sink(i);
+        i++;
+        if (i >= 10) break;
+    }
+}
+
+// Regular while loop - should have mustprogress
+void test_while_uniform(uniform int n) {
+    uniform int i = 0;
+    while (i < n) {
+        sink(i);
+        i++;
+    }
+}
+
+void test_while_varying(uniform int n) {
+    int i = 0;
+    while (i < n) {
+        sink(i);
+        i+=programCount;
+    }
+}
+
+// Infinite while loop - should NOT have mustprogress
+void test_infinite_while(uniform int n) {
+    while(true) {}
+}
+
+// Regular do-while - should have mustprogress
+void test_do_while_uniform(uniform int n) {
+    uniform int i = 0;
+    do {
+        sink(i);
+        i++;
+    } while (i < n);
+}
+
+void test_do_while_varying(uniform int n) {
+    int i = 0;
+    do {
+        sink(i);
+        i+=programCount;
+    } while (i < n);
+}
+
+// Foreach loop - should have mustprogress
+void test_foreach(uniform int n) {
+    foreach (i = 0 ... n) {
+        sink(i);
+    }
+}
+
+// CHECK-DAG: [[LOOP_FOR_UNI]] = distinct !{[[LOOP_FOR_UNI]], [[MUSTPROGRESS:![0-9]+]]}
+// CHECK-DAG: [[LOOP_FOR_VARY]] = distinct !{[[LOOP_FOR_VARY]], [[MUSTPROGRESS]]}
+// CHECK-DAG: [[LOOP_WHILE_UNI]] = distinct !{[[LOOP_WHILE_UNI]], [[MUSTPROGRESS]]}
+// CHECK-DAG: [[LOOP_WHILE_VARY]] = distinct !{[[LOOP_WHILE_VARY]], [[MUSTPROGRESS]]}
+// CHECK-DAG: [[LOOP_DO_UNI]] = distinct !{[[LOOP_DO_UNI]], [[MUSTPROGRESS]]}
+// CHECK-DAG: [[LOOP_DO_VARY]] = distinct !{[[LOOP_DO_VARY]], [[MUSTPROGRESS]]}
+// CHECK-DAG: [[LOOP_FOREACH]] = distinct !{[[LOOP_FOREACH]], [[MUSTPROGRESS]]}
+// CHECK-DAG: [[MUSTPROGRESS]] = !{!"llvm.loop.mustprogress"}


### PR DESCRIPTION
## Description
This PR adds `llvm.mustprogress` metadata to the loops with non-constant conditions as suggested in https://github.com/ispc/ispc/issues/3238. 
We do not add it to loops with constant conditions like `for(;;)` or `while(1)`. It matches C standard behavior.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
- [X] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [X] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed