### PR TITLE
CI: update macos-13 runner to macos-15-intel

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -326,7 +326,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [macos-13, macos-14]
+        runner: [macos-15-intel, macos-14]
         llvm:
           - version: "18.1"
             full_version: "18.1.8"
@@ -351,7 +351,7 @@ jobs:
     with:
       platform: macos
       artifact_name: ispc_llvm20_lto_macos
-      runner: macos-13
+      runner: macos-15-intel
       llvm_version: 20.1
       llvm_tar: llvm-20.1.8-macos-Release-lto-universal-x86.arm.wasm.tar.xz
       enable_lto: true
@@ -366,7 +366,7 @@ jobs:
     with:
       platform: macos
       architecture: x86-64
-      artifact_name: ispc_llvm${{matrix.llvm}}_macos-13
+      artifact_name: ispc_llvm${{matrix.llvm}}_macos-15-intel
       targets: '["sse4-i32x4"]'
       optsets: -O0 -O2
 

--- a/.github/workflows/reusable.ispc.build.yml
+++ b/.github/workflows/reusable.ispc.build.yml
@@ -17,7 +17,7 @@ on:
          required: true
          type: string
       runner:
-         description: 'Github runner (ubuntu-22.04, ubuntu-22.04-arm, macos-13, windows-2019)'
+         description: 'Github runner (ubuntu-22.04, ubuntu-22.04-arm, macos-15-intel, windows-2019)'
          required: true
          type: string
       llvm_version:

--- a/.github/workflows/reusable.ispc.test.yml
+++ b/.github/workflows/reusable.ispc.test.yml
@@ -65,7 +65,7 @@ env:
 jobs:
   test:
     name: ${{ inputs.platform }} (${{ inputs.architecture }}, ${{ matrix.target }}, ${{ inputs.optsets }})
-    runs-on: ${{ inputs.platform == 'macos' && (inputs.architecture == 'aarch64' && 'macos-14' || 'macos-13') || (inputs.platform == 'windows' && (inputs.architecture == 'aarch64' && 'windows-11-arm' || 'windows-2022')) || (inputs.architecture == 'aarch64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.platform == 'macos' && (inputs.architecture == 'aarch64' && 'macos-14' || 'macos-15-intel') || (inputs.platform == 'windows' && (inputs.architecture == 'aarch64' && 'windows-11-arm' || 'windows-2022')) || (inputs.architecture == 'aarch64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
     continue-on-error: false
     strategy:
       fail-fast: false

--- a/.github/workflows/scripts/install-build-deps.sh
+++ b/.github/workflows/scripts/install-build-deps.sh
@@ -6,7 +6,7 @@ source "${SCRIPT_DIR}/init-env.sh"
 OS=$(uname -s)
 case "$OS" in
   Darwin*)
-    RUNNER=${1:-"macos-13"}
+    RUNNER=${1:-"macos-15-intel"}
     ls -al /Library/Developer/CommandLineTools/SDKs/
     xcrun --show-sdk-path
     [ -n "$LLVM_REPO" ] && wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 --no-verbose "$LLVM_REPO/releases/download/llvm-${LLVM_VERSION}-ispc-dev/${LLVM_TAR}"

--- a/.github/workflows/slim-binary.yml
+++ b/.github/workflows/slim-binary.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-13
+          - runner: macos-15-intel
             target: avx2-i32x8
             arch: x86-64
           - runner: macos-14


### PR DESCRIPTION
## Description
According to Github notification macos-13 runner will be removed soon so I'm switching our pipeline to macos-15-intel.

## Related Issue
- [ ] Fixes https://github.com/ispc/ispc/issues/3583

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed