### PR TITLE
Fix typo in superbuild

### DIFF
--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -553,7 +553,7 @@ endif()
 # Targets to build.
 # It is possible to build for stage1 only X86 if we build only on x86 platforms.
 list(APPEND LLVM_COMMON_CMAKE_ARGS
-    -DLLVM_TARGETS_TO_BUILD=X86$<SEMICOLON>AArch64$<SEMICOLON>ARM<SEMICOLON>RISCV
+    -DLLVM_TARGETS_TO_BUILD=X86$<SEMICOLON>AArch64$<SEMICOLON>ARM$<SEMICOLON>RISCV
     -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly
     )
 


### PR DESCRIPTION
## Description
Fix typo in superbuild

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed