### PR TITLE
Reuse more generic functions in avx512* targets.

### DIFF
--- a/builtins/target-avx512skx-x16.ll
+++ b/builtins/target-avx512skx-x16.ll
@@ -15,7 +15,7 @@ include(`target-avx512-utils.ll')
 
 ;; Implementation for i8 and i16 types is different across avx512 targets.
 ;; There is no @llvm.x86.avx512.mask.permvar.qi.128 and @llvm.x86.avx512.vpermi2var.qi.128
-;; before icl. 
+;; before icl.
 ;; @llvm.x86.avx512.vpermi2var.hi.256 is not available for KNL.
 ;; Look for definitions in particular target files.
 
@@ -161,7 +161,7 @@ define i16 @__cast_mask_to_i16 (<WIDTH x MASK> %mask) alwaysinline {
 
 define i8 @__extract_mask_low (<WIDTH x MASK> %mask) alwaysinline {
   %mask_i16 = call i16 @__cast_mask_to_i16 (<WIDTH x MASK> %mask)
-  %mask_low = trunc i16 %mask_i16 to i8 
+  %mask_low = trunc i16 %mask_i16 to i8
   ret i8 %mask_low
 }
 
@@ -204,73 +204,6 @@ define <16 x i16> @__float_to_half_varying(<16 x float> %v) nounwind readnone {
   ret <16 x i16> %r
 }
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; rounding floats
-
-declare <16 x float> @llvm.roundeven.v16f32(<16 x float> %p)
-declare <16 x float> @llvm.floor.v16f32(<16 x float> %p)
-declare <16 x float> @llvm.ceil.v16f32(<16 x float> %p)
-
-define <16 x float> @__round_varying_float(<16 x float>) nounwind readonly alwaysinline {
-  %res = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %0)
-  ret <16 x float> %res
-}
-
-define <16 x float> @__floor_varying_float(<16 x float>) nounwind readonly alwaysinline {
-  %res = call <16 x float> @llvm.floor.v16f32(<16 x float> %0)
-  ret <16 x float> %res
-}
-
-define <16 x float> @__ceil_varying_float(<16 x float>) nounwind readonly alwaysinline {
-  %res = call <16 x float> @llvm.ceil.v16f32(<16 x float> %0)
-  ret <16 x float> %res
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; rounding doubles
-
-declare <8 x double> @llvm.roundeven.v8f64(<8 x double> %p)
-declare <8 x double> @llvm.floor.v8f64(<8 x double> %p)
-declare <8 x double> @llvm.ceil.v8f64(<8 x double> %p)
-
-define <16 x double> @__round_varying_double(<16 x double>) nounwind readonly alwaysinline {
-  %v0 = shufflevector <16 x double> %0, <16 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v1 = shufflevector <16 x double> %0, <16 x double> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %r0 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v1)
-  %res = shufflevector <8 x double> %r0, <8 x double> %r1, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-                                                                       i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  ret <16 x double> %res
-}
-
-define <16 x double> @__floor_varying_double(<16 x double>) nounwind readonly alwaysinline {
-  %v0 = shufflevector <16 x double> %0, <16 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v1 = shufflevector <16 x double> %0, <16 x double> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %r0 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v1)
-  %res = shufflevector <8 x double> %r0, <8 x double> %r1, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-                                                                       i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  ret <16 x double> %res
-}
-
-define <16 x double> @__ceil_varying_double(<16 x double>) nounwind readonly alwaysinline {
-  %v0 = shufflevector <16 x double> %0, <16 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v1 = shufflevector <16 x double> %0, <16 x double> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %r0 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v1)
-  %res = shufflevector <8 x double> %r0, <8 x double> %r1, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-                                                                       i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  ret <16 x double> %res
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; trunc float and double
-
-truncate()
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; min/max
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; int64/uint64 min/max
@@ -354,7 +287,7 @@ declare <16 x i32> @llvm.x86.avx512.mask.pmins.d.512(<16 x i32>, <16 x i32>, <16
 declare <16 x i32> @llvm.x86.avx512.mask.pmaxs.d.512(<16 x i32>, <16 x i32>, <16 x i32>, i16)
 
 define <16 x i32> @__min_varying_int32(<16 x i32>, <16 x i32>) nounwind readonly alwaysinline {
-  %ret = call <16 x i32> @llvm.x86.avx512.mask.pmins.d.512(<16 x i32> %0, <16 x i32> %1, 
+  %ret = call <16 x i32> @llvm.x86.avx512.mask.pmins.d.512(<16 x i32> %0, <16 x i32> %1,
                                                            <16 x i32> zeroinitializer, i16 -1)
   ret <16 x i32> %ret
 }
@@ -404,7 +337,7 @@ define <16 x double> @__min_varying_double(<16 x double>, <16 x double>) nounwin
   %res = shufflevector <8 x double> %res_a, <8 x double> %res_b,
                        <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                                    i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  ret <16 x double> %res                       
+  ret <16 x double> %res
 }
 
 define <16 x double> @__max_varying_double(<16 x double>, <16 x double>) nounwind readnone alwaysinline {
@@ -449,13 +382,13 @@ define double @__sqrt_uniform_double(double) nounwind alwaysinline {
 declare <8 x double> @llvm.x86.avx512.mask.sqrt.pd.512(<8 x double>, <8 x double>, i8, i32) nounwind readnone
 
 define <16 x double> @__sqrt_varying_double(<16 x double>) nounwind alwaysinline {
-  %v0 = shufflevector <16 x double> %0, <16 x double> undef, 
+  %v0 = shufflevector <16 x double> %0, <16 x double> undef,
                       <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v1 = shufflevector <16 x double> %0, <16 x double> undef, 
+  %v1 = shufflevector <16 x double> %0, <16 x double> undef,
                       <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %r0 = call <8 x double> @llvm.x86.avx512.mask.sqrt.pd.512(<8 x double> %v0,  <8 x double> zeroinitializer, i8 -1, i32 4)
   %r1 = call <8 x double> @llvm.x86.avx512.mask.sqrt.pd.512(<8 x double> %v1,  <8 x double> zeroinitializer, i8 -1, i32 4)
-  %res = shufflevector <8 x double> %r0, <8 x double> %r1, 
+  %res = shufflevector <8 x double> %r0, <8 x double> %r1,
                        <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                                    i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   ret <16 x double> %res
@@ -680,16 +613,16 @@ define <16 x i32> @__masked_load_i32(i8 * %ptr, <WIDTH x MASK> %mask) nounwind a
 
 declare <8 x i64> @llvm.x86.avx512.mask.loadu.q.512(i8*, <8 x i64>, i8)
 define <16 x i64> @__masked_load_i64(i8 * %ptr, <WIDTH x MASK> %mask) nounwind alwaysinline {
-  %mask_lo_i8 = call i8 @__extract_mask_low (<WIDTH x MASK> %mask) 
+  %mask_lo_i8 = call i8 @__extract_mask_low (<WIDTH x MASK> %mask)
   %mask_hi_i8 = call i8 @__extract_mask_hi (<WIDTH x MASK> %mask)
-  
+
   %ptr_d = bitcast i8* %ptr to <16 x i64>*
   %ptr_hi = getelementptr PTR_OP_ARGS(`<16 x i64>') %ptr_d, i32 0, i32 8
   %ptr_hi_i8 = bitcast i64* %ptr_hi to i8*
 
   %r0 = call <8 x i64> @llvm.x86.avx512.mask.loadu.q.512(i8* %ptr, <8 x i64> zeroinitializer, i8 %mask_lo_i8)
   %r1 = call <8 x i64> @llvm.x86.avx512.mask.loadu.q.512(i8* %ptr_hi_i8, <8 x i64> zeroinitializer, i8 %mask_hi_i8)
-  
+
   %res = shufflevector <8 x i64> %r0, <8 x i64> %r1,
                        <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                                    i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
@@ -715,8 +648,8 @@ define <16 x double> @__masked_load_double(i8 * %ptr, <WIDTH x MASK> %mask) read
 
   %r0 = call <8 x double> @llvm.x86.avx512.mask.loadu.pd.512(i8* %ptr, <8 x double> zeroinitializer, i8 %mask_lo_i8)
   %r1 = call <8 x double> @llvm.x86.avx512.mask.loadu.pd.512(i8* %ptr_hi_i8, <8 x double> zeroinitializer, i8 %mask_hi_i8)
-  
-  %res = shufflevector <8 x double> %r0, <8 x double> %r1, 
+
+  %res = shufflevector <8 x double> %r0, <8 x double> %r1,
                        <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                                    i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   ret <16 x double> %res
@@ -796,61 +729,10 @@ define void @__masked_store_double(<16 x double>* nocapture, <16 x double> %v, <
   ret void
 }
 
-define void @__masked_store_blend_i8(<16 x i8>* nocapture, <16 x i8>, 
-                                     <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<16 x i8> ')  %0
-  %v1 = select <WIDTH x i1> %2, <16 x i8> %1, <16 x i8> %v
-  store <16 x i8> %v1, <16 x i8> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i16(<16 x i16>* nocapture, <16 x i16>, 
-                                      <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<16 x i16> ')  %0
-  %v1 = select <WIDTH x i1> %2, <16 x i16> %1, <16 x i16> %v
-  store <16 x i16> %v1, <16 x i16> * %0
-  ret void
-}
-
-define void @__masked_store_blend_half(<16 x half>* nocapture,
-                            <16 x half>, <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<16 x half> ')  %0
-  %v1 = select <WIDTH x i1> %2, <16 x half> %1, <16 x half> %v
-  store <16 x half> %v1, <16 x half> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i32(<16 x i32>* nocapture, <16 x i32>, 
-                                      <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<16 x i32> ')  %0
-  %v1 = select <WIDTH x i1> %2, <16 x i32> %1, <16 x i32> %v
-  store <16 x i32> %v1, <16 x i32> * %0
-  ret void
-}
-
-define void @__masked_store_blend_float(<16 x float>* nocapture, <16 x float>, 
-                                        <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<16 x float> ')  %0
-  %v1 = select <WIDTH x i1> %2, <16 x float> %1, <16 x float> %v
-  store <16 x float> %v1, <16 x float> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i64(<16 x i64>* nocapture,
-                            <16 x i64>, <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<16 x i64> ')  %0
-  %v1 = select <WIDTH x i1> %2, <16 x i64> %1, <16 x i64> %v
-  store <16 x i64> %v1, <16 x i64> * %0
-  ret void
-}
-
-define void @__masked_store_blend_double(<16 x double>* nocapture,
-                            <16 x double>, <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<16 x double> ')  %0
-  %v1 = select <WIDTH x i1> %2, <16 x double> %1, <16 x double> %v
-  store <16 x double> %v1, <16 x double> * %0
-  ret void
-}
+declare void @__masked_store_blend_i8(<16 x i8>* nocapture, <16 x i8>, <WIDTH x MASK>) nounwind alwaysinline
+declare void @__masked_store_blend_i16(<16 x i16>* nocapture, <16 x i16>, <WIDTH x MASK>) nounwind alwaysinline
+declare void @__masked_store_blend_i32(<16 x i32>* nocapture, <16 x i32>, <WIDTH x MASK>) nounwind alwaysinline
+declare void @__masked_store_blend_i64(<16 x i64>* nocapture, <16 x i64>, <WIDTH x MASK>) nounwind alwaysinline
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; gather/scatter

--- a/builtins/target-avx512skx-x32.ll
+++ b/builtins/target-avx512skx-x32.ll
@@ -238,80 +238,6 @@ define <32 x i16> @__float_to_half_varying(<32 x float> %v) nounwind readnone al
 fastMathFTZDAZ_x86()
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; round/floor/ceil varying float/doubles
-
-declare <16 x float> @llvm.roundeven.v16f32(<16 x float> %p)
-declare <16 x float> @llvm.floor.v16f32(<16 x float> %p)
-declare <16 x float> @llvm.ceil.v16f32(<16 x float> %p)
-
-define <32 x float> @__round_varying_float(<32 x float> %v) nounwind readonly alwaysinline {
-  v32tov16(float, %v, %v0, %v1)
-  %r0 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v0)
-  %r1 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v1)
-  v16tov32(float, %r0, %r1, %r)
-  ret <32 x float> %r
-}
-
-define <32 x float> @__floor_varying_float(<32 x float> %v) nounwind readonly alwaysinline {
-  v32tov16(float, %v, %v0, %v1)
-  %r0 = call <16 x float> @llvm.floor.v16f32(<16 x float> %v0)
-  %r1 = call <16 x float> @llvm.floor.v16f32(<16 x float> %v1)
-  v16tov32(float, %r0, %r1, %r)
-  ret <32 x float> %r
-}
-
-define <32 x float> @__ceil_varying_float(<32 x float> %v) nounwind readonly alwaysinline {
-  v32tov16(float, %v, %v0, %v1)
-  %r0 = call <16 x float> @llvm.ceil.v16f32(<16 x float> %v0)
-  %r1 = call <16 x float> @llvm.ceil.v16f32(<16 x float> %v1)
-  v16tov32(float, %r0, %r1, %r)
-  ret <32 x float> %r
-}
-
-declare <8 x double> @llvm.roundeven.v8f64(<8 x double> %p)
-declare <8 x double> @llvm.floor.v8f64(<8 x double> %p)
-declare <8 x double> @llvm.ceil.v8f64(<8 x double> %p)
-
-define <32 x double> @__round_varying_double(<32 x double> %v) nounwind readonly alwaysinline {
-  v32tov8(double, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v1)
-  %r2 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v2)
-  %r3 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v3)
-  v8tov32(double, %r0, %r1, %r2, %r3, %r)
-  ret <32 x double> %r
-}
-
-define <32 x double> @__floor_varying_double(<32 x double> %v) nounwind readonly alwaysinline {
-  v32tov8(double, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v1)
-  %r2 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v2)
-  %r3 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v3)
-  v8tov32(double, %r0, %r1, %r2, %r3, %r)
-  ret <32 x double> %r
-}
-
-define <32 x double> @__ceil_varying_double(<32 x double> %v) nounwind readonly alwaysinline {
-  v32tov8(double, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v1)
-  %r2 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v2)
-  %r3 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v3)
-  v8tov32(double, %r0, %r1, %r2, %r3, %r)
-  ret <32 x double> %r
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; trunc float and double
-
-truncate()
-
-;; min/max
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; float min/max
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; min/max
 
 declare i64 @__max_uniform_int64(i64, i64) nounwind readonly alwaysinline
@@ -428,11 +354,6 @@ define <WIDTH x float> @__max_varying_float(<WIDTH x float>,
 
 ;; sqrt/rsqrt/rcp
 ;; TODO: need to use intrinsics and N-R approximation.
-
-;; bit ops
-
-popcnt()
-ctlztz()
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; svml
@@ -663,4 +584,4 @@ define_avgs()
 saturation_arithmetic_novec()
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; dot product 
+;; dot product

--- a/builtins/target-avx512skx-x4.ll
+++ b/builtins/target-avx512skx-x4.ll
@@ -218,58 +218,6 @@ define <4 x i16> @__float_to_half_varying(<4 x float> %v) nounwind readnone {
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; rounding floats
-
-declare <4 x float> @llvm.roundeven.v4f32(<4 x float> %p)
-declare <4 x float> @llvm.floor.v4f32(<4 x float> %p)
-declare <4 x float> @llvm.ceil.v4f32(<4 x float> %p)
-
-define <4 x float> @__round_varying_float(<4 x float>) nounwind readonly alwaysinline {
-  %res = call <4 x float> @llvm.roundeven.v4f32(<4 x float> %0)
-  ret <4 x float> %res
-}
-
-define <4 x float> @__floor_varying_float(<4 x float>) nounwind readonly alwaysinline {
-  %res = call <4 x float> @llvm.floor.v4f32(<4 x float> %0)
-  ret <4 x float> %res
-}
-
-define <4 x float> @__ceil_varying_float(<4 x float>) nounwind readonly alwaysinline {
-  %res = call <4 x float> @llvm.ceil.v4f32(<4 x float> %0)
-  ret <4 x float> %res
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; rounding doubles
-
-declare <4 x double> @llvm.roundeven.v4f64(<4 x double> %p)
-declare <4 x double> @llvm.floor.v4f64(<4 x double> %p)
-declare <4 x double> @llvm.ceil.v4f64(<4 x double> %p)
-
-define <4 x double> @__round_varying_double(<4 x double>) nounwind readonly alwaysinline {
-  %res = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %0)
-  ret <4 x double> %res
-}
-
-define <4 x double> @__floor_varying_double(<4 x double>) nounwind readonly alwaysinline {
-  %res = call <4 x double> @llvm.floor.v4f64(<4 x double> %0)
-  ret <4 x double> %res
-}
-
-define <4 x double> @__ceil_varying_double(<4 x double>) nounwind readonly alwaysinline {
-  %res = call <4 x double> @llvm.ceil.v4f64(<4 x double> %0)
-  ret <4 x double> %res
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; trunc float and double
-
-truncate()
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; min/max
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; int64/uint64 min/max
 
 declare <4 x i64> @llvm.x86.avx512.mask.pmaxs.q.256(<4 x i64>, <4 x i64>, <4 x i64>, i8)
@@ -639,61 +587,10 @@ define void @__masked_store_double(<4 x double>* nocapture, <4 x double> %v, <WI
   ret void
 }
 
-define void @__masked_store_blend_i8(<4 x i8>* nocapture, <4 x i8>,
-                                     <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<4 x i8> ')  %0
-  %v1 = select <WIDTH x i1> %2, <4 x i8> %1, <4 x i8> %v
-  store <4 x i8> %v1, <4 x i8> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i16(<4 x i16>* nocapture, <4 x i16>,
-                                      <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<4 x i16> ')  %0
-  %v1 = select <WIDTH x i1> %2, <4 x i16> %1, <4 x i16> %v
-  store <4 x i16> %v1, <4 x i16> * %0
-  ret void
-}
-
-define void @__masked_store_blend_half(<4 x half>* nocapture, <4 x half>,
-                                        <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<4 x half> ')  %0
-  %v1 = select <WIDTH x i1> %2, <4 x half> %1, <4 x half> %v
-  store <4 x half> %v1, <4 x half> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i32(<4 x i32>* nocapture, <4 x i32>,
-                                      <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<4 x i32> ')  %0
-  %v1 = select <WIDTH x i1> %2, <4 x i32> %1, <4 x i32> %v
-  store <4 x i32> %v1, <4 x i32> * %0
-  ret void
-}
-
-define void @__masked_store_blend_float(<4 x float>* nocapture, <4 x float>, 
-                                        <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<4 x float> ')  %0
-  %v1 = select <WIDTH x i1> %2, <4 x float> %1, <4 x float> %v
-  store <4 x float> %v1, <4 x float> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i64(<4 x i64>* nocapture,
-                            <4 x i64>, <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<4 x i64> ')  %0
-  %v1 = select <WIDTH x i1> %2, <4 x i64> %1, <4 x i64> %v
-  store <4 x i64> %v1, <4 x i64> * %0
-  ret void
-}
-
-define void @__masked_store_blend_double(<4 x double>* nocapture,
-                            <4 x double>, <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<4 x double> ')  %0
-  %v1 = select <WIDTH x i1> %2, <4 x double> %1, <4 x double> %v
-  store <4 x double> %v1, <4 x double> * %0
-  ret void
-}
+declare void @__masked_store_blend_i8(<4 x i8>* nocapture, <4 x i8>, <WIDTH x MASK>) nounwind alwaysinline
+declare void @__masked_store_blend_i16(<4 x i16>* nocapture, <4 x i16>, <WIDTH x MASK>) nounwind alwaysinline
+declare void @__masked_store_blend_i32(<4 x i32>* nocapture, <4 x i32>, <WIDTH x MASK>) nounwind alwaysinline
+declare void @__masked_store_blend_i64(<4 x i64>* nocapture, <4 x i64>, <WIDTH x MASK>) nounwind alwaysinline
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; gather/scatter

--- a/builtins/target-avx512skx-x64.ll
+++ b/builtins/target-avx512skx-x64.ll
@@ -216,98 +216,6 @@ define <64 x i16> @__float_to_half_varying(<64 x float> %v) nounwind readnone al
 fastMathFTZDAZ_x86()
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; round/floor/ceil varying float/doubles
-
-declare <16 x float> @llvm.roundeven.v16f32(<16 x float> %p)
-declare <16 x float> @llvm.floor.v16f32(<16 x float> %p)
-declare <16 x float> @llvm.ceil.v16f32(<16 x float> %p)
-
-define <64 x float> @__round_varying_float(<64 x float> %v) nounwind readonly alwaysinline {
-  v64tov16(float, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v0)
-  %r1 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v1)
-  %r2 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v2)
-  %r3 = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %v3)
-  v16tov64(float, %r0, %r1, %r2, %r3, %r)
-  ret <64 x float> %r
-}
-
-define <64 x float> @__floor_varying_float(<64 x float> %v) nounwind readonly alwaysinline {
-  v64tov16(float, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <16 x float> @llvm.floor.v16f32(<16 x float> %v0)
-  %r1 = call <16 x float> @llvm.floor.v16f32(<16 x float> %v1)
-  %r2 = call <16 x float> @llvm.floor.v16f32(<16 x float> %v2)
-  %r3 = call <16 x float> @llvm.floor.v16f32(<16 x float> %v3)
-  v16tov64(float, %r0, %r1, %r2, %r3, %r)
-  ret <64 x float> %r
-}
-
-define <64 x float> @__ceil_varying_float(<64 x float> %v) nounwind readonly alwaysinline {
-  v64tov16(float, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <16 x float> @llvm.ceil.v16f32(<16 x float> %v0)
-  %r1 = call <16 x float> @llvm.ceil.v16f32(<16 x float> %v1)
-  %r2 = call <16 x float> @llvm.ceil.v16f32(<16 x float> %v2)
-  %r3 = call <16 x float> @llvm.ceil.v16f32(<16 x float> %v3)
-  v16tov64(float, %r0, %r1, %r2, %r3, %r)
-  ret <64 x float> %r
-}
-
-declare <8 x double> @llvm.roundeven.v8f64(<8 x double> %p)
-declare <8 x double> @llvm.floor.v8f64(<8 x double> %p)
-declare <8 x double> @llvm.ceil.v8f64(<8 x double> %p)
-
-define <64 x double> @__round_varying_double(<64 x double> %v) nounwind readonly alwaysinline {
-  v64tov8(double, %v, %v0, %v1, %v2, %v3, %v4, %v5, %v6, %v7)
-  %r0 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v1)
-  %r2 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v2)
-  %r3 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v3)
-  %r4 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v4)
-  %r5 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v5)
-  %r6 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v6)
-  %r7 = call <8 x double> @llvm.roundeven.v8f64(<8 x double> %v7)
-  v8tov64(double, %r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7, %r)
-  ret <64 x double> %r
-}
-
-define <64 x double> @__floor_varying_double(<64 x double> %v) nounwind readonly alwaysinline {
-  v64tov8(double, %v, %v0, %v1, %v2, %v3, %v4, %v5, %v6, %v7)
-  %r0 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v1)
-  %r2 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v2)
-  %r3 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v3)
-  %r4 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v4)
-  %r5 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v5)
-  %r6 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v6)
-  %r7 = call <8 x double> @llvm.floor.v8f64(<8 x double> %v7)
-  v8tov64(double, %r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7, %r)
-  ret <64 x double> %r
-}
-
-define <64 x double> @__ceil_varying_double(<64 x double> %v) nounwind readonly alwaysinline {
-  v64tov8(double, %v, %v0, %v1, %v2, %v3, %v4, %v5, %v6, %v7)
-  %r0 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v0)
-  %r1 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v1)
-  %r2 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v2)
-  %r3 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v3)
-  %r4 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v4)
-  %r5 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v5)
-  %r6 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v6)
-  %r7 = call <8 x double> @llvm.ceil.v8f64(<8 x double> %v7)
-  v8tov64(double, %r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7, %r)
-  ret <64 x double> %r
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; trunc float and double
-
-truncate()
-
-;; min/max
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; float min/max
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; min/max
 
 declare i64 @__max_uniform_int64(i64, i64) nounwind readonly alwaysinline
@@ -424,11 +332,6 @@ define <WIDTH x float> @__max_varying_float(<WIDTH x float>,
 
 ;; sqrt/rsqrt/rcp
 ;; TODO: need to use intrinsics and N-R approximation.
-
-;; bit ops
-
-popcnt()
-ctlztz()
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; svml

--- a/builtins/target-avx512skx-x8.ll
+++ b/builtins/target-avx512skx-x8.ll
@@ -192,71 +192,6 @@ define <8 x i16> @__float_to_half_varying(<8 x float> %v) nounwind readnone {
   ret <8 x i16> %r
 }
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; rounding floats
-
-declare <8 x float> @llvm.roundeven.v8f32(<8 x float> %p)
-declare <8 x float> @llvm.floor.v8f32(<8 x float> %p)
-declare <8 x float> @llvm.ceil.v8f32(<8 x float> %p)
-
-define <8 x float> @__round_varying_float(<8 x float>) nounwind readonly alwaysinline {
-  %res = call <8 x float> @llvm.roundeven.v8f32(<8 x float> %0)
-  ret <8 x float> %res
-}
-
-define <8 x float> @__floor_varying_float(<8 x float>) nounwind readonly alwaysinline {
-  %res = call <8 x float> @llvm.floor.v8f32(<8 x float> %0)
-  ret <8 x float> %res
-}
-
-define <8 x float> @__ceil_varying_float(<8 x float>) nounwind readonly alwaysinline {
-  %res = call <8 x float> @llvm.ceil.v8f32(<8 x float> %0)
-  ret <8 x float> %res
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; rounding doubles
-
-declare <4 x double> @llvm.roundeven.v4f64(<4 x double> %p)
-declare <4 x double> @llvm.floor.v4f64(<4 x double> %p)
-declare <4 x double> @llvm.ceil.v4f64(<4 x double> %p)
-
-define <8 x double> @__round_varying_double(<8 x double>) nounwind readonly alwaysinline {
-  %v0 = shufflevector <8 x double> %0, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1 = shufflevector <8 x double> %0, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %r0 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v0)
-  %r1 = call <4 x double> @llvm.roundeven.v4f64(<4 x double> %v1)
-  %res = shufflevector <4 x double> %r0, <4 x double> %r1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  ret <8 x double> %res
-}
-
-define <8 x double> @__floor_varying_double(<8 x double>) nounwind readonly alwaysinline {
-  %v0 = shufflevector <8 x double> %0, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1 = shufflevector <8 x double> %0, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %r0 = call <4 x double> @llvm.floor.v4f64(<4 x double> %v0)
-  %r1 = call <4 x double> @llvm.floor.v4f64(<4 x double> %v1)
-  %res = shufflevector <4 x double> %r0, <4 x double> %r1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  ret <8 x double> %res
-}
-
-define <8 x double> @__ceil_varying_double(<8 x double>) nounwind readonly alwaysinline {
-  %v0 = shufflevector <8 x double> %0, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1 = shufflevector <8 x double> %0, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %r0 = call <4 x double> @llvm.ceil.v4f64(<4 x double> %v0)
-  %r1 = call <4 x double> @llvm.ceil.v4f64(<4 x double> %v1)
-  %res = shufflevector <4 x double> %r0, <4 x double> %r1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  ret <8 x double> %res
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; trunc float and double
-
-truncate()
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; min/max
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; int64/uint64 min/max
 
@@ -335,7 +270,7 @@ declare <8 x i32> @llvm.x86.avx512.mask.pmins.d.256(<8 x i32>, <8 x i32>, <8 x i
 declare <8 x i32> @llvm.x86.avx512.mask.pmaxs.d.256(<8 x i32>, <8 x i32>, <8 x i32>, i8)
 
 define <8 x i32> @__min_varying_int32(<8 x i32>, <8 x i32>) nounwind readonly alwaysinline {
-  %ret = call <8 x i32> @llvm.x86.avx512.mask.pmins.d.256(<8 x i32> %0, <8 x i32> %1, 
+  %ret = call <8 x i32> @llvm.x86.avx512.mask.pmins.d.256(<8 x i32> %0, <8 x i32> %1,
                                                            <8 x i32> zeroinitializer, i8 -1)
   ret <8 x i32> %ret
 }
@@ -384,7 +319,7 @@ define <8 x double> @__min_varying_double(<8 x double>, <8 x double>) nounwind r
                 <4 x double> zeroinitializer, i8 -1)
   %res = shufflevector <4 x double> %res_a, <4 x double> %res_b,
                        <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  ret <8 x double> %res                       
+  ret <8 x double> %res
 }
 
 define <8 x double> @__max_varying_double(<8 x double>, <8 x double>) nounwind readnone alwaysinline {
@@ -402,7 +337,7 @@ define <8 x double> @__max_varying_double(<8 x double>, <8 x double>) nounwind r
                 <4 x double> zeroinitializer, i8 -1)
   %res = shufflevector <4 x double> %res_a, <4 x double> %res_b,
                        <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  ret <8 x double> %res 
+  ret <8 x double> %res
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -428,13 +363,13 @@ define double @__sqrt_uniform_double(double) nounwind alwaysinline {
 declare <4 x double> @llvm.x86.avx512.mask.sqrt.pd.256(<4 x double>, <4 x double>, i8) nounwind readnone
 
 define <8 x double> @__sqrt_varying_double(<8 x double>) nounwind alwaysinline {
-  %v0 = shufflevector <8 x double> %0, <8 x double> undef, 
+  %v0 = shufflevector <8 x double> %0, <8 x double> undef,
                       <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1 = shufflevector <8 x double> %0, <8 x double> undef, 
+  %v1 = shufflevector <8 x double> %0, <8 x double> undef,
                       <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %r0 = call <4 x double> @llvm.x86.avx512.mask.sqrt.pd.256(<4 x double> %v0,  <4 x double> zeroinitializer, i8 -1)
   %r1 = call <4 x double> @llvm.x86.avx512.mask.sqrt.pd.256(<4 x double> %v1,  <4 x double> zeroinitializer, i8 -1)
-  %res = shufflevector <4 x double> %r0, <4 x double> %r1, 
+  %res = shufflevector <4 x double> %r0, <4 x double> %r1,
                        <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x double> %res
 }
@@ -681,7 +616,7 @@ define <8 x double> @__masked_load_double(i8 * %ptr, <WIDTH x MASK> %mask) reado
   %r0 = call <4 x double> @llvm.x86.avx512.mask.loadu.pd.256(i8* %ptr, <4 x double> zeroinitializer, i8 %mask_i8)
   %r1 = call <4 x double> @llvm.x86.avx512.mask.loadu.pd.256(i8* %ptr_hi_i8, <4 x double> zeroinitializer, i8 %mask_shifted)
 
-  %res = shufflevector <4 x double> %r0, <4 x double> %r1, 
+  %res = shufflevector <4 x double> %r0, <4 x double> %r1,
                        <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x double> %res
 }
@@ -753,61 +688,10 @@ define void @__masked_store_double(<8 x double>* nocapture, <8 x double> %v, <WI
   ret void
 }
 
-define void @__masked_store_blend_i8(<8 x i8>* nocapture, <8 x i8>,
-                                     <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<8 x i8> ')  %0
-  %v1 = select <WIDTH x i1> %2, <8 x i8> %1, <8 x i8> %v
-  store <8 x i8> %v1, <8 x i8> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i16(<8 x i16>* nocapture, <8 x i16>,
-                                      <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<8 x i16> ')  %0
-  %v1 = select <WIDTH x i1> %2, <8 x i16> %1, <8 x i16> %v
-  store <8 x i16> %v1, <8 x i16> * %0
-  ret void
-}
-
-define void @__masked_store_blend_half(<8 x half>* nocapture, <8 x half>,
-                                        <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<8 x half> ')  %0
-  %v1 = select <WIDTH x i1> %2, <8 x half> %1, <8 x half> %v
-  store <8 x half> %v1, <8 x half> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i32(<8 x i32>* nocapture, <8 x i32>,
-                                      <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<8 x i32> ')  %0
-  %v1 = select <WIDTH x i1> %2, <8 x i32> %1, <8 x i32> %v
-  store <8 x i32> %v1, <8 x i32> * %0
-  ret void
-}
-
-define void @__masked_store_blend_float(<8 x float>* nocapture, <8 x float>, 
-                                        <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<8 x float> ')  %0
-  %v1 = select <WIDTH x i1> %2, <8 x float> %1, <8 x float> %v
-  store <8 x float> %v1, <8 x float> * %0
-  ret void
-}
-
-define void @__masked_store_blend_i64(<8 x i64>* nocapture,
-                            <8 x i64>, <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<8 x i64> ')  %0
-  %v1 = select <WIDTH x i1> %2, <8 x i64> %1, <8 x i64> %v
-  store <8 x i64> %v1, <8 x i64> * %0
-  ret void
-}
-
-define void @__masked_store_blend_double(<8 x double>* nocapture,
-                            <8 x double>, <WIDTH x MASK>) nounwind alwaysinline {
-  %v = load PTR_OP_ARGS(`<8 x double> ')  %0
-  %v1 = select <WIDTH x i1> %2, <8 x double> %1, <8 x double> %v
-  store <8 x double> %v1, <8 x double> * %0
-  ret void
-}
+declare void @__masked_store_blend_i8(<8 x i8>* nocapture, <8 x i8>, <WIDTH x MASK>) nounwind alwaysinline
+declare void @__masked_store_blend_i16(<8 x i16>* nocapture, <8 x i16>, <WIDTH x MASK>) nounwind alwaysinline
+declare void @__masked_store_blend_i32(<8 x i32>* nocapture, <8 x i32>, <WIDTH x MASK>) nounwind alwaysinline
+declare void @__masked_store_blend_i64(<8 x i64>* nocapture, <8 x i64>, <WIDTH x MASK>) nounwind alwaysinline
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; gather/scatter


### PR DESCRIPTION
## Description
This PR makes further clean up of avx512 targets. It removes the functions that don't use HW-specific intrinsics and fully mimic generic implementation: rounding functions, truncate, masked_store_blend, popcnt, counting zeros.
If on some target you don't see removed masked_store_blend (or other) function, it means that it was already removed earlier.

This change doesn't affect performance but slightly reduces maintainability efforts for these targets.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed