### PR TITLE
Restrict permissions for Codex workflow

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -13,9 +13,11 @@ name: Codex PR Review
 
 # zizmor is not wrong, but we need to access token in the target repo for the PR to make it work.
 # The token is created with minimal scope possible.
+
+# Temporary disable pull_requst_target due to unclear security policies.
 on:
-  pull_request_target:  # zizmor: ignore[dangerous-triggers]
-    types: [opened, reopened]
+  #pull_requst_target:  # zizmor: ignore[dangerous-triggers]
+  #  types: [opened, reopened]
   workflow_dispatch:  # Manual trigger
     inputs:
       pr_number:


### PR DESCRIPTION
## Description
Restrict the permissions for Coder PR Review workflow to minimally required.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed