### PR TITLE
Header generation, ordering of the struct in __ISPC_ALIGNED_STRUCT__ MSVC

### DIFF
--- a/src/header.cpp
+++ b/src/header.cpp
@@ -207,13 +207,13 @@ static void lEmitStructDecls(std::vector<const StructType *> &structTypes, FILE 
                   "#warning \"Alignment not supported on this compiler\"\n"
                   "#endif // defined(__cplusplus) && __cplusplus >= 201103L\n"
                   "#ifndef __ISPC_ALIGNED_STRUCT__\n"
-                  "#if defined(__clang__) || !defined(_MSC_VER)\n"
-                  "// Clang, GCC, ICC\n"
+                  "#if defined(__clang__) || !defined(_MSC_VER) || _MSC_VER > 1943\n"
+                  "// Clang, GCC, ICC, Visual Studio\n"
                   "#define __ISPC_ALIGNED_STRUCT__(s) struct __ISPC_ALIGN__(s)\n"
                   "#else\n"
-                  "// Visual Studio\n"
+                  "// Older Visual Studio\n"
                   "#define __ISPC_ALIGNED_STRUCT__(s) __ISPC_ALIGN__(s) struct\n"
-                  "#endif // defined(__clang__) || !defined(_MSC_VER)\n"
+                  "#endif // defined(__clang__) || !defined(_MSC_VER) || _MSC_VER > 1943\n"
                   "#endif // __ISPC_ALIGNED_STRUCT__\n\n");
 
     for (unsigned int i = 0; i < structTypes.size(); ++i) {


### PR DESCRIPTION
Ordering of the struct in __ISPC_ALIGNED_STRUCT__ changed in recent MSVC compilers that matches similarly to other compilers.

## Description
Building OpenMoonray on Windows with an updated ISPC 1.28.1 and MSVC compiler, it seems as though alignas ordering has changed to match other compilers. The error gets flagged at least in MSVC 14.44.x: `moonray\scene_rdl2\include\scene_rdl2\common\math\ispc\Types_ispc_stubs.h(55,2): error C3837: attributes are not allowed in this context` from a generated header from ISPC.

I'm not sure which compiler starts to match the others as I couldn't find release notes for this, maybe others can find out. I put in `_MSC_VER > 1943` as a placeholder to the one I'm using.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed