### PR TITLE
Make dispatcher thread-safe

### DIFF
--- a/benchmarks/01_trivial/16_dispatcher_overhead.cpp
+++ b/benchmarks/01_trivial/16_dispatcher_overhead.cpp
@@ -4,6 +4,7 @@
 #include <benchmark/benchmark.h>
 #include <cstdint>
 #include <stdio.h>
+#include <thread>
 
 #include "../common.h"
 #include "16_dispatcher_overhead_ispc.h"
@@ -54,6 +55,23 @@ static void dispatcher_overhead_test(benchmark::State &state) {
     state.SetComplexityN(state.range(0));
 }
 
+static void dispatcher_overhead_test_multithread(benchmark::State &state) {
+
+    int count = static_cast<int>(state.range(0));
+    for (auto _ : state) {
+
+        std::vector<std::thread> v;
+        for (int i = 0; i < count; i++)
+            v.emplace_back(ispc::dispatcher_overhead_test);
+
+        for (auto &t : v)
+            t.join();
+    }
+
+    state.SetComplexityN(state.range(0));
+}
+
 BENCHMARK(dispatcher_overhead_test)->ARGS;
+BENCHMARK(dispatcher_overhead_test_multithread)->Arg(100)->Arg(1000)->Arg(10000);
 
 BENCHMARK_MAIN();

--- a/builtins/dispatch.c
+++ b/builtins/dispatch.c
@@ -27,8 +27,9 @@
 // via llvm-link. However, this approach requires llvm-link as a dependency
 // during ISPC build time.
 #include "isa.h"
+#include <stdatomic.h>
 
-static int __system_best_isa = -1;
+static atomic_int __system_best_isa = -1;
 
 // For function definitions, we need to use static keyword. This is because
 // because users can compile several translation units in multi-target mode and
@@ -64,8 +65,12 @@ static int __get_system_isa() {
 }
 
 int __get_system_best_isa() {
-    if (__system_best_isa == -1) {
-        __system_best_isa = __get_system_isa();
+
+    int isa = atomic_load(&__system_best_isa);
+    if (isa == -1) {
+        isa = __get_system_isa();
+        atomic_store(&__system_best_isa, isa);
     }
-    return __system_best_isa;
+
+    return isa;
 }

--- a/tests/lit-tests/3587.ispc
+++ b/tests/lit-tests/3587.ispc
@@ -9,14 +9,16 @@
 // CHECK: @__system_func_ptr_cache_foo = internal global ptr null
 
 // CHECK: define internal i32 @__get_system_best_isa()
+// CHECK: load atomic i32, ptr @__system_best_isa seq_cst, align 4
+// CHECK: store atomic i32 {{.*}}, ptr @__system_best_isa seq_cst, align 4
 
 // CHECK:      define i32 @bar(i32 %0)
 // CHECK-NEXT: entry:
-// CHECK-NEXT:   %1 = load ptr, ptr @__system_func_ptr_cache_bar, align 8
+// CHECK-NEXT:   %1 = load atomic ptr, ptr @__system_func_ptr_cache_bar unordered, align 8
 // CHECK-NEXT:   %2 = icmp ne ptr %1, null
 // CHECK-NEXT:   br i1 %2, label %skip_init, label %do_init
 // CHECK:      skip_init:
-// CHECK-NEXT:   %3 = load ptr, ptr @__system_func_ptr_cache_bar, align 8
+// CHECK-NEXT:   %3 = load atomic ptr, ptr @__system_func_ptr_cache_bar unordered, align 8
 // CHECK-NEXT:   %4 = call i32 %3(i32 %0)
 // CHECK-NEXT:   ret i32 %4
 // CHECK:      do_init:
@@ -24,19 +26,19 @@
 // CHECK-NEXT:   %isa_ok = icmp sge i32 %system_isa, 5
 // CHECK-NEXT:   br i1 %isa_ok, label %do_call, label %next_try
 // CHECK:      do_call:
-// CHECK-NEXT:   store ptr @bar_avx2, ptr @__system_func_ptr_cache_bar, align 8
+// CHECK-NEXT:   store atomic ptr @bar_avx2, ptr @__system_func_ptr_cache_bar unordered, align 8
 // CHECK-NEXT:   br label %skip_init
 // CHECK:      next_try:
 // CHECK-NEXT:   %isa_ok1 = icmp sge i32 %system_isa, 3
 // CHECK-NEXT:   br i1 %isa_ok1, label %do_call2, label %next_try3
 // CHECK:      do_call2:
-// CHECK-NEXT:   store ptr @bar_avx, ptr @__system_func_ptr_cache_bar, align 8
+// CHECK-NEXT:   store atomic ptr @bar_avx, ptr @__system_func_ptr_cache_bar unordered, align 8
 // CHECK-NEXT:   br label %skip_init
 // CHECK:        next_try3:
 // SSE4-NEXT:     %isa_ok4 = icmp sge i32 %system_isa, 2
 // SSE4-NEXT:     br i1 %isa_ok4, label %do_call5, label %next_try6
 // SSE4:        do_call5:
-// SSE4-NEXT:     store ptr @bar_sse4, ptr @__system_func_ptr_cache_bar, align 8
+// SSE4-NEXT:     store atomic ptr @bar_sse4, ptr @__system_func_ptr_cache_bar unordered, align 8
 // SSE4-NEXT:     br label %skip_init
 // SSE4:        next_try6:
 // CHECK-NEXT:   call void asm sideeffect "ud2", "~{dirflag},~{fpsr},~{flags}"()
@@ -44,11 +46,11 @@
 
 // CHECK:      define void @foo()
 // CHECK-NEXT: entry:
-// CHECK-NEXT:   %0 = load ptr, ptr @__system_func_ptr_cache_foo, align 8
+// CHECK-NEXT:   %0 = load atomic ptr, ptr @__system_func_ptr_cache_foo unordered, align 8
 // CHECK-NEXT:   %1 = icmp ne ptr %0, null
 // CHECK-NEXT:   br i1 %1, label %skip_init, label %do_init
 // CHECK:      skip_init:
-// CHECK-NEXT:   %2 = load ptr, ptr @__system_func_ptr_cache_foo, align 8
+// CHECK-NEXT:   %2 = load atomic ptr, ptr @__system_func_ptr_cache_foo unordered, align 8
 // CHECK-NEXT:   call void %2()
 // CHECK-NEXT:   ret void
 // CHECK:      do_init:
@@ -56,19 +58,19 @@
 // CHECK-NEXT:   %isa_ok = icmp sge i32 %system_isa, 5
 // CHECK-NEXT:   br i1 %isa_ok, label %do_call, label %next_try
 // CHECK:      do_call:
-// CHECK-NEXT:   store ptr @foo_avx2, ptr @__system_func_ptr_cache_foo, align 8
+// CHECK-NEXT:   store atomic ptr @foo_avx2, ptr @__system_func_ptr_cache_foo unordered, align 8
 // CHECK-NEXT:   br label %skip_init
 // CHECK:      next_try:
 // CHECK-NEXT:   %isa_ok1 = icmp sge i32 %system_isa, 3
 // CHECK-NEXT:   br i1 %isa_ok1, label %do_call2, label %next_try3
 // CHECK:      do_call2:
-// CHECK-NEXT:   store ptr @foo_avx, ptr @__system_func_ptr_cache_foo, align 8
+// CHECK-NEXT:   store atomic ptr @foo_avx, ptr @__system_func_ptr_cache_foo unordered, align 8
 // CHECK-NEXT:   br label %skip_init
 // CHECK:      next_try3:
 // SSE4-NEXT:     %isa_ok4 = icmp sge i32 %system_isa, 2
 // SSE4-NEXT:     br i1 %isa_ok4, label %do_call5, label %next_try6
 // SSE4:        do_call5:
-// SSE4-NEXT:     store ptr @foo_sse4, ptr @__system_func_ptr_cache_foo, align 8
+// SSE4-NEXT:     store atomic ptr @foo_sse4, ptr @__system_func_ptr_cache_foo unordered, align 8
 // SSE4-NEXT:     br label %skip_init
 // SSE4:        next_try6:
 // CHECK-NEXT:   call void asm sideeffect "ud2", "~{dirflag},~{fpsr},~{flags}"()


### PR DESCRIPTION
This is a follow-up change addressing feedback from the #3587 code review. The patch marks loads and stores to variables that may be shared across threads as atomic operations. While multiple threads may still execute code for selecting the optimal ISA or function variant, this change eliminates data races when accessing the corresponding shared variables. The patch is not expected to impact dispatcher performance.