### PR TITLE
Fix internal error when casting SOA pointer to opaque pointer (#3591)

### DIFF
--- a/tests/lit-tests/3591.ispc
+++ b/tests/lit-tests/3591.ispc
@@ -1,0 +1,19 @@
+// Test for issue #3591: Internal error casting soa<> pointer to opaque pointer
+// This test verifies that casting from an SOA pointer to a non-SOA pointer type
+// produces a proper error message instead of crashing with "Illegal BitCast".
+//
+// RUN: not %{ispc} %s --target=host --nowrap -o %t.o 2>&1 | FileCheck %s
+
+// CHECK: Error: Can't cast from pointer to SOA type
+// CHECK-NOT: FATAL ERROR
+struct point {
+    int x, y;
+};
+
+struct foo;
+
+__attribute__((external_only))
+export foo* uniform foo_init() {
+    soa<8> point* uniform points = uniform new soa<8> point[123];
+    return (foo* uniform)points;
+}


### PR DESCRIPTION
When casting a slice/SOA pointer (e.g., soa<8> point* uniform) to an opaque pointer type (e.g., foo* uniform), the compiler was attempting to bitcast the entire slice pointer structure ({ptr, i32}) directly to a simple pointer (ptr), which is invalid in LLVM.

The fix extracts the pointer component from the slice structure before performing the bitcast, allowing the cast to succeed.

Fixes #3591

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed