### PR TITLE
Fix missing IRBuilder.h include

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -35,6 +35,7 @@
 #include <llvm/Bitcode/BitcodeWriter.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Type.h>


### PR DESCRIPTION
Add missing IRBuilder.h include to fix compilation error with LLVM 21:
```
/home/runner/work/ispc/ispc/src/module.cpp:2017:11: error: no member named 'IRBuilder' in namespace 'llvm'; did you mean 'DIBuilder'?
 2017 |     llvm::IRBuilder builder(bblock);
      |           ^~~~~~~~~
```