### PR TITLE
[LLVM22] Fix LLVM version being checked for LIT test.

### DIFF
--- a/tests/lit-tests/1678_unroll.ispc
+++ b/tests/lit-tests/1678_unroll.ispc
@@ -1,8 +1,8 @@
 // RUN: %{ispc} %s --target=avx2-i32x8 --arch=x86-64 --nostdlib --emit-asm -o - | FileCheck %s
 
-// Test produces different IR/ASM with LLVM_21_0+ due to SROA improvements. Check
-// the LIT test 1678_unroll_llvm_21.ll for more details.
-// REQUIRES: X86_ENABLED && !LLVM_21_0+
+// Test produces different IR/ASM with LLVM_22_0+ due to SROA improvements. Check
+// the LIT test 1678_unroll_llvm_22.ll for more details.
+// REQUIRES: X86_ENABLED && !LLVM_22_0+
 
 // The goal of this test is to check that code generation for both versions is the same.
 

--- a/tests/lit-tests/1678_unroll_llvm_22.ispc
+++ b/tests/lit-tests/1678_unroll_llvm_22.ispc
@@ -1,8 +1,8 @@
 // RUN: %{ispc} %s --target=avx2-i32x8 --arch=x86-64 --nostdlib --emit-asm -o - | FileCheck %s
 
-// Test produces different IR/ASM with LLVM_21_0+ due to SROA improvements. Multiple stores
+// Test produces different IR/ASM with LLVM_22_0+ due to SROA improvements. Multiple stores
 // filling same alloca are tree-optimized - https://github.com/llvm/llvm-project/pull/152793
-// REQUIRES: X86_ENABLED && LLVM_21_0+
+// REQUIRES: X86_ENABLED && LLVM_22_0+
 
 // The goal of this test is to check that code generation for both versions is the same.
 

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -60,6 +60,12 @@ if llvm_version_major >= 21:
 else:
     print("LLVM_21_0+: NO")
 
+if llvm_version_major >= 22:
+    print("LLVM_22_0+: YES")
+    config.available_features.add("LLVM_22_0+")
+else:
+    print("LLVM_22_0+: NO")
+
 # Windows target OS is enabled
 windows_enabled = lit_config.params.get('windows_enabled')
 if windows_enabled == "ON":


### PR DESCRIPTION
LIT test update was targetted for LLVM trunk which is LLVM_22_0. It was
incorrectly updated to use LLVM_21_0 in previous PR - #3609 .

## Description
Brief description of changes

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed