### PR TITLE
Fix issue 3616

### DIFF
--- a/src/ctx.h
+++ b/src/ctx.h
@@ -468,6 +468,10 @@ class FunctionEmitContext {
         and an integer offset to a slice within that type. */
     llvm::Value *MakeSlicePointer(llvm::Value *ptr, llvm::Value *offset);
 
+    /** Given a slice pointer to soa'd data, apply the slice offset to compute
+        the actual pointer. Updates ptrType to reflect the resulting pointer type. */
+    llvm::Value *ApplySliceOffset(llvm::Value *ptr, const PointerType **ptrType);
+
     /* Regularize to a standard pointer type.
        May return nullptr if type is not PointerType or ReferenceType */
     const PointerType *RegularizePointer(const Type *ptrRefType);

--- a/tests/lit-tests/3616.ispc
+++ b/tests/lit-tests/3616.ispc
@@ -1,0 +1,47 @@
+// Verifies that casting a SOA element address to integer doesn't crash the compiler.
+
+// RUN: %{ispc} %s --target=host --nostdlib --nowrap --emit-llvm-text -o - | FileCheck %s
+
+struct Point { uint64 x; float y; float z; };
+
+// Test uniform slice pointer to uniform integer
+// CHECK-LABEL: define i64 @"gp___
+// CHECK: extractvalue { ptr, i32 }
+// CHECK: extractvalue { ptr, i32 }
+// CHECK: getelementptr
+// CHECK: getelementptr
+// CHECK: ptrtoint ptr
+// CHECK: ret i64
+
+uniform uint64 gp(soa<16> Point v[]) {
+    return (uniform uint64)&v[0].x;
+}
+
+// Test uniform slice pointer to varying integer
+// CHECK-LABEL: define <{{[0-9]+}} x i64> @"vp___
+// CHECK: extractvalue { ptr, i32 }
+// CHECK: extractvalue { ptr, i32 }
+// CHECK: getelementptr
+// CHECK: getelementptr
+// CHECK: ptrtoint ptr
+// CHECK: insertelement <{{[0-9]+}} x i64> poison, i64
+// CHECK: shufflevector <{{[0-9]+}} x i64>
+// CHECK: ret <{{[0-9]+}} x i64>
+
+varying uint64 vp(soa<16> Point v[]) {
+    return (varying uint64)&v[0].x;
+}
+
+// Test uniform slice pointer to uniform 16-bit integer
+// CHECK-LABEL: define i16 @"gp16___
+// CHECK: extractvalue { ptr, i32 }
+// CHECK: extractvalue { ptr, i32 }
+// CHECK: getelementptr
+// CHECK: getelementptr
+// CHECK: ptrtoint ptr
+// CHECK: trunc
+// CHECK: ret i16
+
+uniform uint16 gp16(soa<16> Point v[]) {
+    return (uniform uint16)&v[0].x;
+}


### PR DESCRIPTION
## Description
This PR fixes compiler crash when casting SOA element address to integer

## Related Issue
Fixes #3616 

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed