### PR TITLE
Backport LLVM FullUnroll fix and add LIT test

### DIFF
--- a/llvm_patches/20_1_21_1_full-unroll-fix.patch
+++ b/llvm_patches/20_1_21_1_full-unroll-fix.patch
@@ -1,0 +1,14 @@
+diff --git a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+index 2bda9d83236e8..802ae4e9c28e3 100644
+--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
++++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+@@ -1327,7 +1327,8 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
+   }
+ 
+   // Do not attempt partial/runtime unrolling in FullLoopUnrolling
+-  if (OnlyFullUnroll && (UP.Count < TripCount || UP.Count < MaxTripCount)) {
++  if (OnlyFullUnroll && ((!TripCount && !MaxTripCount) ||
++                         UP.Count < TripCount || UP.Count < MaxTripCount)) {
+     LLVM_DEBUG(
+         dbgs() << "Not attempting partial/runtime unroll in FullLoopUnroll.\n");
+     return LoopUnrollResult::Unmodified;

--- a/tests/lit-tests/2334_unroll.ispc
+++ b/tests/lit-tests/2334_unroll.ispc
@@ -1,0 +1,30 @@
+// RUN: %{ispc} %s --target=avx2-i32x8 --arch=x86-64 --addressing=64 --emit-asm -o - | FileCheck %s
+
+// XFAIL: *
+
+// UNSUPPORTED: !LLVM_20_0+
+
+// REQUIRES: X86_ENABLED
+
+// CHECK:      vmovups (
+// CHECK-NEXT: vmovups 32(
+// CHECK-NEXT: vmovups 64(
+// CHECK-NEXT: vmovups 96(
+// CHECK-NEXT: vfmadd132ps (
+// CHECK-NEXT: vfmadd231ps 32(
+// CHECK-NEXT: vfmadd231ps 64(
+// CHECK-NEXT: vfmadd231ps 96(
+
+unmasked uniform float dotProductSoA_Unroll(uniform float a[], uniform float b[], uniform size_t N)
+{
+    varying float dot = 0;
+    
+    #pragma unroll 4
+    for(uniform size_t c = 0; c < N; c += programCount)
+    {
+        varying int i = c + programIndex;
+        dot += a[i] * b[i];
+    }
+
+    return reduce_add(dot);
+}


### PR DESCRIPTION
This patch fixes issue #2334 for LLVM 20.1 and 21.1 compilers. For newer versions, the fix has been upstreamed in https://github.com/llvm/llvm-project/pull/165013.