### PR TITLE
func-tests: skip round-float16-*.ispc for all targets on x86_64 mac

### DIFF
--- a/tests/func-tests/round-float16-uniform.ispc
+++ b/tests/func-tests/round-float16-uniform.ispc
@@ -1,6 +1,8 @@
 #include "test_static.isph"
 
 // See issue #3529
+// rule: run on OS=!darwin
+// rule: run on arch!=x86_64
 // rule: skip on OS=windows
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/func-tests/round-float16-varying.ispc
+++ b/tests/func-tests/round-float16-varying.ispc
@@ -1,9 +1,12 @@
 #include "test_static.isph"
-// rule: skip on arch=wasm32
-// rule: skip on arch=wasm64
 
 // See issue #3529
+// rule: run on OS=!darwin
+// rule: run on arch!=x86_64
 // rule: skip on OS=windows
+
+// rule: skip on arch=wasm32
+// rule: skip on arch=wasm64
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {
     float error = 0;


### PR DESCRIPTION
## Description

I attempted to replicate https://github.com/ispc/ispc/pull/3531/commits/3d052870b3dc3c7553329cd6b9ccc4db2228e030 for x86_64-darwin to get around https://github.com/ispc/ispc/issues/3529, but couldn't find a way to match against arch/os in one go. Tried De Morgan's laws via multiple `run on` but that also doesn't seem to work?

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed