### PR TITLE
Replace undef with poison in @__shuffle2_const_* builtins to eliminate redundant shufflevector instructions

### DIFF
--- a/builtins/util.m4
+++ b/builtins/util.m4
@@ -2213,7 +2213,7 @@ forloop(i, 0, eval(WIDTH-1), `
 forloop(i, 0, eval(WIDTH-1), `
   %v_`'i = extractelement <eval(2*WIDTH) x $1> %v2, i32 %index_`'i')
 
-  %ret_0 = insertelement <WIDTH x $1> undef, $1 %v_0, i32 0
+  %ret_0 = insertelement <WIDTH x $1> poison, $1 %v_0, i32 0
 forloop(i, 1, eval(WIDTH-1), `  %ret_`'i = insertelement <WIDTH x $1> %ret_`'eval(i-1), $1 %v_`'i, i32 i
 ')
   ret <WIDTH x $1> %ret_`'eval(WIDTH-1)

--- a/tests/lit-tests/shuffle.ispc
+++ b/tests/lit-tests/shuffle.ispc
@@ -1,0 +1,26 @@
+// RUN: %{ispc} %s --target=sse4.1-i8x16 --emit-llvm-text -o - | FileCheck %s
+// RUN: %{ispc} %s --target=sse4.2-i8x16 --emit-llvm-text -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx1-i32x16 --emit-llvm-text -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx2-i16x16 --emit-llvm-text -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx2-i32x16 --emit-llvm-text -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx2vnni-i32x16 --emit-llvm-text -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx512icl-x16 --emit-llvm-text -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx512skx-i32x16 --emit-llvm-text -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx512skx-x16 --emit-llvm-text -o - | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// It's expected that the shuffle call will generate a shufflevector
+// instruction in the final LLVM IR after all optimization passes, with
+// the permutation indices preserved exactly as specified in the source code.
+// No undef/poison values should be needed here.
+
+// CHECK: shufflevector <16 x i32> {{%.*}}, <16 x i32> {{%.*}}, <16 x i32> <i32 0, i32 6, i32 1, i32 7, i32 4, i32 0, i32 5, i32 1, i32 8, i32 4, i32 9, i32 25, i32 2, i32 28, i32 3, i32 29>
+
+// CHECK-NOT: poison
+// CHECK-NOT: undef
+
+float foo(int d[]) {
+  const int p = {0, 6, 1, 7, 4, 0, 5, 1, 8, 4, 9, 25, 2, 28, 3, 29};
+  return shuffle(d[0], d[1], p);
+}


### PR DESCRIPTION
A simple `shuffle` in the source code can unexpectedly blow up into a mess of redundant `shufflevector` instructions, killing performance. The culprit is InstCombine's inability to properly optimize `undef` values in certain scenarios, where it prefers `poison` values instead (see this change: https://github.com/llvm/llvm-project/commit/8f1c984325bd679b2634a6173db69548da87ac71). To mitigate this, `undef` value in `@_shuffle2_const*` builtin functions has been replaced with `poison` value. Eventually, other `undef`s should be considered for replacement with `poison`s to prevent similar performance pitfalls.