### PR TITLE
Create explicit target to ensure parser generation completes before compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,8 @@ find_package(BISON 3.0 REQUIRED)
             COMMENT "Generating parse.cc"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
+        # Create explicit target to ensure parser generation completes before compilation
+        add_custom_target(generate-parser DEPENDS ${BISON_CPP_OUTPUT} ${BISON_OUTPUT})
     endif()
 
 find_package(FLEX 2.6 REQUIRED)
@@ -994,11 +996,13 @@ configure_ispc_obj(common)
 
 add_library(frontend OBJECT EXCLUDE_FROM_ALL ${FRONTEND_SOURCES})
 configure_ispc_obj(frontend)
+add_dependencies(frontend generate-parser)
 
 if (ISPC_LIBRARY)
     add_library(frontend-lib OBJECT EXCLUDE_FROM_ALL ${FRONTEND_SOURCES})
     configure_ispc_obj(frontend-lib)
     target_compile_definitions(frontend-lib PRIVATE ISPC_IS_LIBRARY)
+    add_dependencies(frontend-lib generate-parser)
 endif()
 
 # builtin target is created in GenerateBuiltins.cmake


### PR DESCRIPTION
This PR attempts to fix rarely happening issues while building the parser in CI: https://github.com/ispc/ispc/actions/runs/19319277766/job/55257126462?pr=3632
The possible reason is that there is implicit dependency race condition: while CMake should automatically create dependencies from `add_custom_command` OUTPUT to consuming targets, both frontend and frontend-lib can be built in parallel without explicit serialization
    - Bison may still be writing the file
    - The file handle hasn't been closed/flushed
    - The compiler reads a partial file with an unterminated comment
This PR creates an explicit custom target for parser generation. This ensures a proper happens-before relationship and eliminates the race condition.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed