### PR TITLE
Restrict the canonicalization of extractelement(cast)

### DIFF
--- a/llvm_patches/20_1_21_1_limit-canonicalization.patch
+++ b/llvm_patches/20_1_21_1_limit-canonicalization.patch
@@ -1,0 +1,22 @@
+# This patch is backport of the https://github.com/llvm/llvm-project/pull/166227
+diff --git a/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp b/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
+index 98e2d9ebe4fc2..cf973cd449f15 100644
+--- a/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
++++ b/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
+@@ -593,7 +593,15 @@ Instruction *InstCombinerImpl::visitExtractElementInst(ExtractElementInst &EI) {
+       // Canonicalize extractelement(cast) -> cast(extractelement).
+       // Bitcasts can change the number of vector elements, and they cost
+       // nothing.
+-      if (CI->hasOneUse() && (CI->getOpcode() != Instruction::BitCast)) {
++      // If the CI has only one use, but that use is inside a loop, this
++      // canonicalization is not profitable because it would turn a vector
++      // operation into scalar operations inside the loop. Apply the transform
++      // when:
++      //  - the index is constant and CI has one use, or
++      //  - the CI and EI are in the same basic block, so the cast won't be sunk
++      //    into a loop.
++      if (CI->hasOneUse() && (CI->getOpcode() != Instruction::BitCast) &&
++          (EI.getParent() == CI->getParent() || isa<ConstantInt>(Index))) {
+         Value *EE = Builder.CreateExtractElement(CI->getOperand(0), Index);
+         return CastInst::Create(CI->getOpcode(), EE, EI.getType());
+       }


### PR DESCRIPTION
## Description
Add an LLVM patch to restrict the canonicalization of extractelement(cast) to cases where the index is constant or both instructions are in the same basic block. 

Lit test to the issue: 

There is also a opensource LLVM PR under the review: https://github.com/llvm/llvm-project/pull/166227

## Related Issue
This is fix for [Sub-par code generation when using extract issue](https://github.com/ispc/ispc/issues/3081)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed