### PR TITLE
Deprecate sse2 targets

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -935,6 +935,8 @@ functions from ISPC code will result in a **compilation error**.
 Note: The compiler can only detect calls to exported functions within the same
 compilation unit. Cross-module calls to exported functions cannot be detected.
 
+``sse2-i32x4`` and ``sse2-i32x8`` targets are deprecated and will be removed in
+future releases.
 
 Getting Started with ISPC
 =========================

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -1234,6 +1234,14 @@ ArgsParseResult ispc::ParseCommandLineArgs(int argc, char *argv[], std::string &
         }
     }
 
+    // Check for deprecated targets
+    for (auto target : targets) {
+        if (target == ISPCTarget::sse2_i32x4 || target == ISPCTarget::sse2_i32x8) {
+            Warning(SourcePos(), "The target %s is deprecated and will be removed in the future.",
+                    ISPCTargetToString(target).c_str());
+        }
+    }
+
     if ((output.type == Module::Asm) && (intelAsmSyntax != nullptr)) {
         std::vector<const char *> Args(3);
         Args[0] = "ispc (LLVM option parsing)";

--- a/tests/lit-tests/sse2-deprecation.ispc
+++ b/tests/lit-tests/sse2-deprecation.ispc
@@ -1,0 +1,12 @@
+// RUN: %{ispc} --nowrap --target=sse2 --emit-asm -o %t.s %s 2>&1 | FileCheck %s --check-prefix=CHECK-X4
+// RUN: %{ispc} --nowrap --target=sse2-i32x4 --emit-asm -o %t.s %s 2>&1 | FileCheck %s --check-prefix=CHECK-X4
+// RUN: %{ispc} --nowrap --target=sse2-x2 --emit-asm -o %t.s %s 2>&1 | FileCheck %s --check-prefix=CHECK-X8
+// RUN: %{ispc} --nowrap --target=sse2-i32x8 --emit-asm -o %t.s %s 2>&1 | FileCheck %s --check-prefix=CHECK-X8
+// RUN: %{ispc} --nowrap --target=sse2-i32x8,avx2-i32x4 --emit-asm -o %t.s %s 2>&1 | FileCheck %s --check-prefix=CHECK-X8
+
+// REQUIRES: X86_ENABLED
+
+// CHECK-X4: Warning: The target sse2-i32x4 is deprecated and will be removed in the future.
+// CHECK-X8: Warning: The target sse2-i32x8 is deprecated and will be removed in the future.
+
+void foo() {}


### PR DESCRIPTION
## Description
Deprecate `sse2-i32x4` and `sse2-i32x8` targets.

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed