### PR TITLE
Update default DWARF version

### DIFF
--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -859,6 +859,11 @@ Standard Library Changes:
 * Support for short vector types has been added to the following element-wise
   functions: ``fmod``, ``isnan``, ``rsqrt_fast``, and ``clamp``.
 
+Debugging:
+
+The default DWARF version was updated to DWARF 5. You can still
+specify any supported DWARF version with the ``--dwarf-version=`` switch.
+
 
 Updating ISPC Programs For Changes In ISPC 1.29.0
 -------------------------------------------------
@@ -1549,10 +1554,10 @@ Debugging
 The ``-g`` command-line flag can be supplied to the compiler, which causes
 it to generate debugging symbols.  The debug info is emitted in DWARF format
 on Linux\* and macOS\*.  The version of the DWARF can be controlled by
-command-line switch ``--dwarf-version={2,3,4,5}``.  On Windows\* CodeView format
-is used by default (it's natively supported by Microsoft Visual Studio\*) but
-this switch can force the generation of DWARF format that can be used, e.g.,
-together with MinGW generated code.
+command-line switch ``--dwarf-version={2,3,4,5}``. Default DWARF version is 5.
+On Windows\* CodeView format is used by default (it's natively supported by
+Microsoft Visual Studio\*) but this switch can force the generation of DWARF
+format that can be used, e.g., together with MinGW generated code.
 Running ``ispc`` programs in the debugger, setting breakpoints, printing out
 variables is just the same as debugging C/C++ programs.  Similarly, you can
 directly step up and down the call stack between ``ispc`` code and C/C++

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -3129,7 +3129,7 @@ Globals::Globals() {
     noPragmaOnce = false;
     generateDebuggingSymbols = false;
     debugInfoType = Globals::DebugInfoType::None;
-    generateDWARFVersion = 3;
+    generateDWARFVersion = 5;
     sampleProfilingDebugInfo = false;
     profileSampleUse = "";
     enableLLVMIntrinsics = false;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -849,7 +849,7 @@ struct Globals {
     DebugInfoType debugInfoType;
 
     /** Require generation of DWARF of certain version (2, 3, 4, 5). For
-        default version, this field is set to 3. */
+        default version, this field is set to 5. */
     // Hint: to verify dwarf version in the object file, run on Linux:
     // readelf --debug-dump=info object.o | grep -A 2 'Compilation Unit @'
     // on Mac:

--- a/tests/lit-tests/dwarf_version_default.ispc
+++ b/tests/lit-tests/dwarf_version_default.ispc
@@ -1,0 +1,10 @@
+// Test that the default DWARF version is 5 when -g is specified
+// without an explicit --dwarf-version flag.
+
+// RUN: %{ispc} -g --target=host --target-os=linux --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+
+// REQUIRES: LINUX_ENABLED
+
+// CHECK: Dwarf Version", i32 5
+
+void foo() { return; }


### PR DESCRIPTION
## Description
This PR updates default DWARF version to 5. The same version is used in LLVM since LLVM 14.0

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [x] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed