### PR TITLE
Fix 2334_unroll.ispc for LLVM trunk

### DIFF
--- a/tests/lit-tests/2334_unroll.ispc
+++ b/tests/lit-tests/2334_unroll.ispc
@@ -4,6 +4,8 @@
 
 // REQUIRES: X86_ENABLED
 
+// The loop should be unrolled with 4 vmovups followed by 4 vfmadd instructions.
+// LLVM register allocation may insert moves between fmadd instructions.
 // CHECK:      vmovups (
 // CHECK-NEXT: vmovups 32(
 // CHECK-NEXT: vmovups 64(
@@ -11,7 +13,7 @@
 // CHECK-NEXT: vfmadd132ps (
 // CHECK-NEXT: vfmadd231ps 32(
 // CHECK-NEXT: vfmadd231ps 64(
-// CHECK-NEXT: vfmadd231ps 96(
+// CHECK: vfmadd231ps 96(
 
 unmasked uniform float dotProductSoA_Unroll(uniform float a[], uniform float b[], uniform size_t N)
 {


### PR DESCRIPTION
## Description
This PR fixes tests/lit-tests/2334_unroll.ispc test to work with recent LLVM trunk version (currently failing https://github.com/ispc/ispc/actions/runs/19661157095/job/56326339755). The test started failing after this commit https://github.com/llvm/llvm-project/commit/a6cec3f3e5234d2646bc1a53715cda8324445ed2 changing register allocation.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed