### PR TITLE
Add ReplaceMaskedMemOpsPass before InstCombinePass

### DIFF
--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -446,6 +446,7 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         optPM.addFunctionPass(llvm::SimplifyCFGPass(simplifyCFGopt));
         optPM.addFunctionPass(llvm::ADCEPass());
         optPM.addFunctionPass(llvm::InferAlignmentPass());
+        optPM.addFunctionPass(ReplaceMaskedMemOpsPass());
         optPM.addFunctionPass(llvm::InstCombinePass(), 241);
         optPM.addFunctionPass(llvm::JumpThreadingPass());
         optPM.addFunctionPass(llvm::SimplifyCFGPass(simplifyCFGopt));

--- a/tests/lit-tests/3491.ispc
+++ b/tests/lit-tests/3491.ispc
@@ -9,7 +9,10 @@
 // CHECK-LABEL: define <16 x i8> @embedded_select___unb_3C_3_3E_unT_3C_3_3E_unT_3C_3_3E_(
 // CHECK-NEXT: allocas:
 // CHECK-NEXT:   [[COND_STORAGE:%.*]] = zext <16 x i1> %cond to <16 x i8>
-// CHECK-NEXT:   [[SHUFFLE1:%.*]] = shufflevector <16 x i8> [[COND_STORAGE]], <16 x i8> {{.*}}, <16 x i32> {{.*}}
+// CHECK-NEXT:   [[SHUFFLE4:%.*]] = shufflevector <16 x i8> [[COND_STORAGE]], <16 x i8> {{.*}}, <3 x i32> {{.*}}
+// CHECK-NEXT:   [[SHUFFLE3:%.*]] = shufflevector <3 x i8> [[SHUFFLE4]], <3 x i8> {{.*}}, <4 x i32> {{.*}}
+// CHECK-NEXT:   [[SHUFFLE2:%.*]] = shufflevector <4 x i8> [[SHUFFLE3]], <4 x i8> {{.*}}, <8 x i32> {{.*}}
+// CHECK-NEXT:   [[SHUFFLE1:%.*]] = shufflevector <8 x i8> [[SHUFFLE2]], <8 x i8> {{.*}}, <16 x i32> {{.*}}
 // CHECK-NEXT:   [[CMP:%.*]] = icmp eq <16 x i8> [[SHUFFLE1]], zeroinitializer
 // CHECK-NEXT:   [[SELECT:%.*]] = select <16 x i1> [[CMP]], <16 x i8> %f, <16 x i8> %t
 // CHECK-NEXT:   [[RESULT:%.*]] = shufflevector <16 x i8> [[SELECT]], <16 x i8> {{.*}}, <16 x i32> {{.*}}

--- a/tests/lit-tests/replace-masked-memops-sroa.ispc
+++ b/tests/lit-tests/replace-masked-memops-sroa.ispc
@@ -1,0 +1,35 @@
+// RUN: %{ispc} %s -O2 --emit-llvm-text --target=avx512skx-i32x4 -o - | FileCheck %s
+// RUN: %{ispc} %s -O2 --emit-llvm-text --target=avx512skx-i32x8 -o - | FileCheck %s
+// RUN: %{ispc} %s -O2 --emit-llvm-text --target=avx512skx-i32x16 -o - | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// For the following code, we expect that the SROA pass will successfully
+// promote the local variable T from memory to registers, transforming
+// the alloca/store/load instruction sequence into more efficient
+// insertelement instructions.
+
+// CHECK: define void @foo___REFs_5B_unData_5D_(ptr noalias nocapture %D
+// CHECK-NEXT: allocas:
+// CHECK-NOT:    alloca
+// CHECK-NOT:    store
+// CHECK:        [[T_VEC_INSERT_0:%.*]] = insertelement <4 x double> poison, double {{.*}}, i64 0
+// CHECK-NEXT:   [[T_VEC_INSERT_1:%.*]] = insertelement <4 x double> [[T_VEC_INSERT_0]], double {{.*}}, i64 1
+// CHECK-NEXT:   [[T_VEC_INSERT_2:%.*]] = insertelement <4 x double> [[T_VEC_INSERT_1]], double {{.*}}, i64 2
+// CHECK-NEXT:   [[T_VEC_INSERT_3:%.*]] = insertelement <4 x double> [[T_VEC_INSERT_2]], double {{.*}}, i64 3
+// CHECK-NEXT:   [[T_VEC_INSERT_4:%.*]] = insertelement <4 x double> poison, double {{.*}}, i64 0
+// CHECK-NEXT:   [[T_VEC_INSERT_5:%.*]] = insertelement <4 x double> [[T_VEC_INSERT_4]], double {{.*}}, i64 1
+// CHECK-NEXT:   [[T_VEC_INSERT_6:%.*]] = insertelement <4 x double> [[T_VEC_INSERT_5]], double {{.*}}, i64 2
+// CHECK-NEXT:   [[T_VEC_INSERT_7:%.*]] = insertelement <4 x double> [[T_VEC_INSERT_6]], double {{.*}}, i64 3
+// CHECK-NEXT:   [[ADD:%.*]] = fadd <4 x double> [[T_VEC_INSERT_3]], [[T_VEC_INSERT_7]]
+// CHECK-NEXT:   store <4 x double> [[ADD]], ptr %D
+
+struct Data {
+  double Value[3][4];
+};
+
+void foo(uniform Data &D) {
+  uniform Data T = D;
+  foreach (i = 0 ... 4)
+    D.Value[0][i] = T.Value[0][i] + T.Value[1][i];
+}


### PR DESCRIPTION
It was observed that `InstCombinePass` can transform masked load instructions (e.g., `@llvm.masked.load.v8f64.p0`) into unmasked vector loads of the same vector size followed by `shufflevector` instruction sequences. When this transformation occurs before `ReplaceMaskedMemOpsPass`, it might prevent the latter from performing similar replacements with reduced vector sizes. This can subsequently prevent `SROAPass` from registerizing allocated vectors due to overlapping loads of unnecessarily wide vectors.

To address this issue, we now run an additional `ReplaceMaskedMemOpsPass` before `InstCombinePass`. This ensures that masked operations are optimized with reduced vector sizes before `InstCombinePass` can transform them into suboptimal patterns. This change resolves performance drops of up to 150% observed when switching from `avx512skx-i32x8` to `avx512skx-i32x16` targets on some benchmarks, which were caused by excessive memory stores.

This change may result in slightly more complex `shufflevector` instruction sequences, as seen in the `3491.ispc` LIT test. However, it has been confirmed that despite appearing more complex, these sequences remain simple enough for CodeGen and produce identical assembly instructions, so no performance degradation is expected.