### PR TITLE
Optimize NEON stdlib compilation using family-based approach

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,8 +478,8 @@ endif()
 message(STATUS "BITCODE_FOLDER is ${BITCODE_FOLDER}")
 file(MAKE_DIRECTORY ${BITCODE_FOLDER})
 
-# Generate stdlib width families from X86_TARGETS and C++ code for stdlib target mapping
-# TODO: extend to ARM targets
+# Generate stdlib width families from X86_TARGETS and ARM_TARGETS
+# and C++ code for stdlib target mapping
 define_stdlib_families()
 # Generate C++ code for stdlib target mapping (used by src/target_registry.cpp)
 generate_stdlib_target_map_cpp()


### PR DESCRIPTION
Extended stdlib family optimization (from commit a157db3eb) to NEON targets. NEON stdlib files are functionally identical to generic ARM/AArch64 stdlib except for `target-cpu` attribute, allowing safe reuse of generic stdlib.

Changes:
- Add 6 NEON family definitions mapping to generic targets
- Pre-filter families by architecture (x86 vs ARM) during configuration
- Add family homogeneity validation to prevent mixed-architecture families
- Update ARM stdlib compilation to use family system
- Improve loop order consistency between x86 and ARM sections

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed