### PR TITLE
Fix #3654: Handle enum negation in UnaryExpr::Optimize()

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1431,7 +1431,7 @@ Expr *UnaryExpr::Optimize() {
                    Type::EqualIgnoringConst(type, AtomicType::VaryingInt32)) {
             return lOptimizeNegate<int32_t>(constExpr, type, pos);
         } else if (Type::EqualIgnoringConst(type, AtomicType::UniformUInt32) ||
-                   Type::EqualIgnoringConst(type, AtomicType::VaryingUInt32)) {
+                   Type::EqualIgnoringConst(type, AtomicType::VaryingUInt32) || isEnumType == true) {
             return lOptimizeNegate<uint32_t>(constExpr, type, pos);
         } else if (Type::EqualIgnoringConst(type, AtomicType::UniformInt16) ||
                    Type::EqualIgnoringConst(type, AtomicType::VaryingInt16)) {

--- a/tests/lit-tests/3654.ispc
+++ b/tests/lit-tests/3654.ispc
@@ -1,0 +1,28 @@
+// Test that unary negation of enum values doesn't trigger an assertion failure.
+// This is a regression test for GitHub issue #3654.
+
+// RUN: %{ispc} %s --target=host --nostdlib --nowrap --emit-llvm-text -o - | FileCheck %s
+
+enum codes {
+    E_FAILED0 = 1,
+    E_FAILED1 = 2,
+    E_FAILED2 = 3,
+};
+
+// CHECK-LABEL: @func___
+// CHECK: ret <{{[0-9]+}} x i32> {{splat \(i32 -1\)|<.*i32 -1.*>}}
+int func() {
+    return -E_FAILED0;
+}
+
+// CHECK-LABEL: @func2___
+// CHECK: ret <{{[0-9]+}} x i32> {{splat \(i32 -2\)|<.*i32 -2.*>}}
+int func2() {
+    return -E_FAILED1;
+}
+
+// CHECK-LABEL: @func3___
+// CHECK: ret <{{[0-9]+}} x i32> {{splat \(i32 9\)|<.*i32 9.*>}}
+int func3() {
+    return -E_FAILED0 + 10;
+}


### PR DESCRIPTION
Fixes an assertion failure when applying unary negation to enum values. The UnaryExpr::Optimize() function now handles enum types by treating them as their underlying type (uint32_t) when performing constant folding for the negation operation.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed