### PR TITLE
Fix lit tests for LLVM 21 and trunk

### DIFF
--- a/tests/lit-tests/3491.ispc
+++ b/tests/lit-tests/3491.ispc
@@ -8,16 +8,11 @@
 
 // CHECK-LABEL: define <16 x i8> @embedded_select___unb_3C_3_3E_unT_3C_3_3E_unT_3C_3_3E_(
 // CHECK-NEXT: allocas:
-// CHECK-NEXT:   [[COND_STORAGE:%.*]] = zext <16 x i1> %cond to <16 x i8>
-// CHECK-NEXT:   [[SHUFFLE4:%.*]] = shufflevector <16 x i8> [[COND_STORAGE]], <16 x i8> {{.*}}, <3 x i32> {{.*}}
-// CHECK-NEXT:   [[SHUFFLE3:%.*]] = shufflevector <3 x i8> [[SHUFFLE4]], <3 x i8> {{.*}}, <4 x i32> {{.*}}
-// CHECK-NEXT:   [[SHUFFLE2:%.*]] = shufflevector <4 x i8> [[SHUFFLE3]], <4 x i8> {{.*}}, <8 x i32> {{.*}}
-// CHECK-NEXT:   [[SHUFFLE1:%.*]] = shufflevector <8 x i8> [[SHUFFLE2]], <8 x i8> {{.*}}, <16 x i32> {{.*}}
-// CHECK-NEXT:   [[CMP:%.*]] = icmp eq <16 x i8> [[SHUFFLE1]], zeroinitializer
+// CHECK:   {{%.*}} = {{shufflevector <16 x i1>|zext <16 x i1>}}
+// CHECK:   {{%.*}} = {{zext <3 x i1>|shufflevector <16 x i8>}}
+// CHECK:   [[CMP:%.*]] = icmp eq <16 x i8> {{%.*}}, zeroinitializer
 // CHECK-NEXT:   [[SELECT:%.*]] = select <16 x i1> [[CMP]], <16 x i8> %f, <16 x i8> %t
-// CHECK-NEXT:   [[RESULT:%.*]] = shufflevector <16 x i8> [[SELECT]], <16 x i8> {{.*}}, <16 x i32> {{.*}}
-// CHECK-NEXT:   ret <16 x i8> [[RESULT]]
-// CHECK-NEXT: }
+// CHECK:   ret <16 x i8>
 
 #define N 3
 

--- a/tests/lit-tests/replace-masked-memops-sroa.ispc
+++ b/tests/lit-tests/replace-masked-memops-sroa.ispc
@@ -9,7 +9,7 @@
 // the alloca/store/load instruction sequence into more efficient
 // insertelement instructions.
 
-// CHECK: define void @foo___REFs_5B_unData_5D_(ptr noalias nocapture %D
+// CHECK: define void @foo___REFs_5B_unData_5D_(ptr noalias {{(nocapture|captures\(none\))}} %D
 // CHECK-NEXT: allocas:
 // CHECK-NOT:    alloca
 // CHECK-NOT:    store


### PR DESCRIPTION
## Description
The PR fixes two lit tests which started failing after https://github.com/ispc/ispc/pull/3656

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed