### PR TITLE
Disable RISC-V support by default

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -180,6 +180,17 @@ jobs:
       llvm_tar: llvm-20.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
       enable_wasm: true
 
+  linux-build-ispc-riscv:
+    needs: [define-flow]
+    uses: ./.github/workflows/reusable.ispc.build.yml
+    with:
+      platform: linux
+      artifact_name: ispc-riscv-linux
+      runner: ubuntu-22.04
+      llvm_version: "20.1"
+      llvm_tar: llvm-20.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
+      enable_riscv: true
+
   linux-test:
     needs: [define-flow, linux-build-ispc]
     strategy:
@@ -295,10 +306,10 @@ jobs:
       optsets: ${{ needs.define-flow.outputs.tests_optsets }}
 
   linux-test-riscv:
-    needs: [define-flow, linux-build-ispc]
+    needs: [define-flow, linux-build-ispc-riscv]
     uses: ./.github/workflows/riscv.yml
     with:
-      artifact_name: ispc_llvm20_linux
+      artifact_name: ispc-riscv-linux
 
   # Test release version
   linux-test-llvm20-release:

--- a/.github/workflows/reusable.ispc.build.yml
+++ b/.github/workflows/reusable.ispc.build.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable_riscv:
+        description: 'Build with RISC-V support'
+        required: false
+        type: boolean
+        default: false
       enable_xe:
         description: 'Build with Xe support (enables cross compilation)'
         required: false
@@ -145,6 +150,8 @@ jobs:
           # Standard build
           if [[ "${{ inputs.enable_cross }}" == "true" ]]; then
             .github/workflows/scripts/build-ispc.sh -DISPC_CROSS=ON
+          elif [[ "${{ inputs.enable_riscv }}" == "true" ]]; then
+            .github/workflows/scripts/build-ispc.sh -DRISCV_ENABLED=ON
           else
             .github/workflows/scripts/build-ispc.sh
           fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,8 @@ endif()
 
 option(X86_ENABLED "Enable x86 support" ${X86_HOST})
 option(ARM_ENABLED "Enable ARM support" ${LLVM_SUPPORTS_ARM})
-option(RISCV_ENABLED "Enable RISC-V support" ${LLVM_SUPPORTS_RISCV})
+# Turn off RISC-V support by default. Later we can use ${LLVM_SUPPORTS_RISCV} for default option value.
+option(RISCV_ENABLED "Enable RISC-V support" OFF)
 option(WASM_ENABLED "Enable experimental Web Assembly support" OFF)
 option(XE_ENABLED "Enable Intel Xe support" OFF)
 

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -885,12 +885,6 @@ These flags enable developers to collect profile data from representative progra
 runs and use it to guide compiler optimizations, potentially improving
 performance.
 
-New Architecture Support:
-
-* Added experimental RISC-V 64-bit (riscv64) architecture support with RISC-V
-  Vector Extension (RVV) ISA. The new ``rvv-x4`` target provides 4-wide
-  vectorization for RISC-V processors with vector extensions.
-
 Languages Changes:
 
 The compiler now assumes that all loops with non-constant conditions will make


### PR DESCRIPTION
## Description
Fixes #3664.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed