### PR TITLE
Update args in intrinsics_vnni_llvm22_plus according to LLVM 22 changes

### DIFF
--- a/tests/lit-tests/intrinsics_vnni_llvm22_plus.ispc
+++ b/tests/lit-tests/intrinsics_vnni_llvm22_plus.ispc
@@ -15,13 +15,13 @@ int foo_busds(int arg0, uniform int8<32> arg1, uniform int8<32> arg2) {
 }
 
 // CHECK: declare <8 x i32> @llvm.x86.avx512.vpdpwssd.256(
-int foo_wssd(int arg0, int arg1, int arg2) {
+int foo_wssd(int arg0, uniform int16<16> arg1, uniform int16<16> arg2) {
     int ret = @llvm.x86.avx512.vpdpwssd.256(arg0, arg1, arg2);
     return ret;
 }
 
 // CHECK: declare <8 x i32> @llvm.x86.avx512.vpdpwssds.256(
-int foo_wssds(int arg0, int arg1, int arg2) {
+int foo_wssds(int arg0, uniform int16<16> arg1, uniform int16<16> arg2) {
     int ret = @llvm.x86.avx512.vpdpwssds.256(arg0, arg1, arg2);
     return ret;
 }


### PR DESCRIPTION
## Description
Related LLVM change: https://github.com/llvm/llvm-project/pull/169456

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed