### PR TITLE
CI: update copyright year in workflow files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 version: 2

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Scan Python code with Bandit

--- a/.github/workflows/clamav-release.yml
+++ b/.github/workflows/clamav-release.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Scan release archives with ClamAV

--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Scan trunk archives with ClamAV

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,4 +1,4 @@
-## Copyright 2024-2025 Intel Corporation
+## Copyright 2024-2026 Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 
 name: Lint code with clang-tidy

--- a/.github/workflows/claude-issue-deduplication.yml
+++ b/.github/workflows/claude-issue-deduplication.yml
@@ -1,4 +1,4 @@
-## Copyright 2025 Intel Corporation
+## Copyright 2025-2026 Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 name: Issue Deduplication
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,4 @@
-## Copyright 2025 Intel Corporation
+## Copyright 2025-2026 Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 name: Claude Code
 

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 name: Codex PR Review
 

--- a/.github/workflows/compiler-warnings.yml
+++ b/.github/workflows/compiler-warnings.yml
@@ -1,4 +1,4 @@
-# Copyright 2023-2025, Intel Corporation
+# Copyright 2023-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Compiler Warnings

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2025, Intel Corporation
+# Copyright 2022-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Check copyright

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Coverity

--- a/.github/workflows/cve-bin-releases.yml
+++ b/.github/workflows/cve-bin-releases.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Scan release archives with cve-bin-tool

--- a/.github/workflows/cve-bin.yml
+++ b/.github/workflows/cve-bin.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Scan trunk archives with cve-bin-tool

--- a/.github/workflows/dll-inject-release.yml
+++ b/.github/workflows/dll-inject-release.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Check against DLL injection (release)

--- a/.github/workflows/dll-inject.yml
+++ b/.github/workflows/dll-inject.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Check against DLL injection (trunk)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# Copyright 2021-2025, Intel Corporation
+# Copyright 2021-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Docs check

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2025, Intel Corporation
+# Copyright 2020-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Check code formatting

--- a/.github/workflows/hardening-check-release.yml
+++ b/.github/workflows/hardening-check-release.yml
@@ -1,4 +1,4 @@
-## Copyright 2024-2025 Intel Corporation
+## Copyright 2024-2026 Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 
 name: Hardening Checks (release)

--- a/.github/workflows/hardening-check.yml
+++ b/.github/workflows/hardening-check.yml
@@ -1,4 +1,4 @@
-## Copyright 2024-2025 Intel Corporation
+## Copyright 2024-2026 Intel Corporation
 ## SPDX-License-Identifier: BSD-3-Clause
 
 name: Hardening Checks (trunk)

--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2025, Intel Corporation
+# Copyright 2020-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Tests

--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -1,4 +1,4 @@
-# Copyright 2021-2025, Intel Corporation
+# Copyright 2021-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: SVML

--- a/.github/workflows/ispcrt.yml
+++ b/.github/workflows/ispcrt.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: ISPCRT

--- a/.github/workflows/jit-tests.yml
+++ b/.github/workflows/jit-tests.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: JIT Mode

--- a/.github/workflows/linux-nightly-trunk.yml
+++ b/.github/workflows/linux-nightly-trunk.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2025, Intel Corporation
+# Copyright 2020-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Nightly Linux run.

--- a/.github/workflows/nanobind.yml
+++ b/.github/workflows/nanobind.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Nanobind Wrappers

--- a/.github/workflows/nightly-next.yml
+++ b/.github/workflows/nightly-next.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2025, Intel Corporation
+# Copyright 2022-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Nightly Linux run.

--- a/.github/workflows/openmoonray.yml
+++ b/.github/workflows/openmoonray.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Build OpenMoonRay

--- a/.github/workflows/opensource-projects.yml
+++ b/.github/workflows/opensource-projects.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Build opensource projects

--- a/.github/workflows/pre-release-artifacts.yml
+++ b/.github/workflows/pre-release-artifacts.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 # These jobs build ISPC for every push to main pushing artifacts to Github

--- a/.github/workflows/quick-start-build.yml
+++ b/.github/workflows/quick-start-build.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Quick Start Build

--- a/.github/workflows/rebuild-llvm18.yml
+++ b/.github/workflows/rebuild-llvm18.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Intel Corporation
+# Copyright 2024-2026 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Rebuild LLVM 18.1

--- a/.github/workflows/rebuild-llvm19.yml
+++ b/.github/workflows/rebuild-llvm19.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Intel Corporation
+# Copyright 2024-2026 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Rebuild LLVM 19.1

--- a/.github/workflows/rebuild-llvm20.yml
+++ b/.github/workflows/rebuild-llvm20.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Intel Corporation
+# Copyright 2025-2026 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Rebuild LLVM 20.1

--- a/.github/workflows/rebuild-llvm21.yml
+++ b/.github/workflows/rebuild-llvm21.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Intel Corporation
+# Copyright 2025-2026 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Rebuild LLVM 21.1

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Release Pipeline

--- a/.github/workflows/reusable.ispc.build.yml
+++ b/.github/workflows/reusable.ispc.build.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Reusable ISPC build workflow

--- a/.github/workflows/reusable.ispc.test.yml
+++ b/.github/workflows/reusable.ispc.test.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Reusable ISPC test workflow

--- a/.github/workflows/reusable.rebuild.yml
+++ b/.github/workflows/reusable.rebuild.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 Intel Corporation
+# Copyright 2022-2026 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Reusable LLVM rebuild

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: RISC-V Tests

--- a/.github/workflows/rk-superbuild-release.yml
+++ b/.github/workflows/rk-superbuild-release.yml
@@ -1,5 +1,5 @@
 
-# Copyright 2024-2025 Intel Corporation
+# Copyright 2024-2026 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: RK superbuild (release)

--- a/.github/workflows/rk-superbuild.yml
+++ b/.github/workflows/rk-superbuild.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Intel Corporation
+# Copyright 2024-2026 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: RK superbuild

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,4 +1,4 @@
-# Copyright 2023-2025, Intel Corporation
+# Copyright 2023-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Sanitizers

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,4 +1,4 @@
-# Copyright 2023-2025, Intel Corporation
+# Copyright 2023-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Scorecard supply-chain security

--- a/.github/workflows/slim-binary.yml
+++ b/.github/workflows/slim-binary.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Slim Binary

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,4 +1,4 @@
-# Copyright 2023-2025, Intel Corporation
+# Copyright 2023-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Snap

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Runs linter for Docker files

--- a/.github/workflows/windows-cross.yml
+++ b/.github/workflows/windows-cross.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: Build Windows cross-compile

--- a/.github/workflows/yarpgen.yml
+++ b/.github/workflows/yarpgen.yml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Intel Corporation
+# Copyright 2024-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Runs YARPGEN

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,4 @@
-# Copyright 2025, Intel Corporation
+# Copyright 2025-2026, Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: GitHub Actions Security Analysis with zizmor


### PR DESCRIPTION
## Description
Update copyright year in all workflow files to avoid failing copyright year check from automatic dependabot updates.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed