### PR TITLE
Add lit test verifying limited canonicalization

### DIFF
--- a/tests/lit-tests/3081.ispc
+++ b/tests/lit-tests/3081.ispc
@@ -1,5 +1,5 @@
 // RUN: %{ispc} --emit-llvm-text -O2 --opt=disable-loop-unroll --target=sse4 %s -o - | FileCheck %s -check-prefix=CHECK_SSE4
-// REQUIRE: X86_ENABLED && LLVM_20_0+
+// REQUIRES: X86_ENABLED && LLVM_20_0+
 
 extern "C" void use(uniform int);
 


### PR DESCRIPTION
## Description
It ensures canonicalization is no longer perfomed when index is constant or both instructions are in the same basic block. 
Lit test to the issue: https://github.com/ispc/ispc/pull/3637

## Related Issue
- [x] Linked to relevant issue(s): https://github.com/ispc/ispc/issues/3081

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed