### PR TITLE
Add constexpr support (v1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,6 +535,8 @@ list(APPEND FRONTEND_SOURCES
     src/ast.h
     src/builtins.cpp
     src/builtins.h
+    src/constexpr.cpp
+    src/constexpr.h
     src/ctx.cpp
     src/ctx.h
     src/decl.cpp

--- a/docs/blog/constexpr_implementation.md
+++ b/docs/blog/constexpr_implementation.md
@@ -1,0 +1,122 @@
+# Implementing constexpr in ISPC: design, hacks removed, and tests
+
+## Motivation
+
+ISPC has long relied on a mix of constant folding and stdlib/builtins tricks to
+feed compile-time constants to LLVM intrinsics. This work adds a first-class
+`constexpr` feature, similar in spirit to modern C++, so users can express
+compile-time computation directly and the front end can enforce it.
+
+Key goals for v1:
+
+- `constexpr` variables and functions usable in constant-expression contexts
+  (array sizes, short-vector lengths, switch cases, enum values, template args,
+  default parameter values).
+- C++-style “constexpr-suitable” validation at function definition time.
+- Support for both uniform and varying constexpr values.
+- Aggregate support (arrays, structs) and short vectors.
+- Immediate-operand (immarg) friendly lowering for LLVM intrinsics.
+
+## Front-end design decisions
+
+1. **C++-style validation at definition time**
+   `constexpr` functions are validated as they are defined. The validator checks
+   that only constexpr-safe statements and expressions are used. This keeps the
+   language predictable and errors early.
+
+2. **Uniform control flow**
+   V1 requires uniform conditions in `if`, `switch`, `for`, `while`, and `do` in
+   constexpr functions. This simplifies evaluation and mirrors constant
+   evaluation expectations.
+
+3. **Aggregate support with element-wise evaluation**
+   `ConstExpr` now represents vectors, arrays, and structs as element lists, and
+   constexpr evaluation folds aggregates element-wise. This is what enables
+   `constexpr` arrays/structs and local aggregate initializers inside constexpr
+   functions.
+
+4. **Pointer constants with strict limits**
+   Pointer support is intentionally narrow: constexpr may materialize null or
+   addresses of globals/functions, allow pointer comparisons, pointer-to-bool,
+   and pointer +/- integer arithmetic. Pointer dereference (and pointer-pointer
+   arithmetic) remains disallowed.
+
+5. **Deferral for forward usage**
+   Global initializers and default parameter values can reference constexpr
+   functions defined later in the file. The front end defers evaluation until
+   after parsing and then resolves any remaining constexpr work. Array sizes,
+   vector lengths, and template args are still evaluated immediately and must
+   see definitions before use.
+
+6. **Immediate-operand enforcement for intrinsics**
+   LLVM requires certain intrinsic operands to be immediates. The front end now
+   marks immarg parameters and rewrites constexpr arguments to literal
+   `ConstExpr`s during type checking, so LLVM sees real immediate operands in IR.
+
+## Constexpr evaluation pipeline
+
+The implementation is layered end-to-end:
+
+- **Lexer/Parser**: new `constexpr` keyword and grammar support for constexpr
+  declarations and constexpr function definitions.
+- **AST/Types**: `constexpr` flag on symbols and function types. Function
+  parameter defaults can store constexpr expressions.
+- **Validator**: definition-time check for constexpr-suitable bodies.
+- **Evaluator**: an interpreter-style evaluator for constexpr functions,
+  supporting control flow and local variables, plus aggregate folding and
+  pointer constants.
+- **Deferral**: postponed constexpr evaluation for globals/default params, with
+  resolution prior to IR generation.
+
+## Hacks removed (and what remains)
+
+### Removed or replaced
+
+- **Compiler-side immarg checks** no longer rely on fragile constant folding; the
+  front end now enforces immarg parameters and rewrites constexpr arguments to
+  immediate constants in IR.
+
+### Still present (by design or future work)
+
+- **`*l` immarg literal spellings** in `builtins/generic.ispc` remain unchanged.
+  They satisfy existing builtin intrinsic calls, while the new constexpr
+  evaluator is focused on source-level constant expressions at immarg call
+  sites.
+- **`convert_scale_to_const*` switch macros** in `builtins/util.m4` and
+  `builtins/target-avx512-utils.ll` remain as runtime fallbacks for dynamic
+  gather/scatter scales. The front end can now enforce constant scales, but
+  there is still an opportunity to bypass these switches for constexpr scales.
+- **`__is_compile_time_constant_*` probes** in `builtins/util*.m4` and
+  `builtins/target-*.ll` remain for backend optimization (shuffle/rotate and
+  mask-known fast paths). These are optimization-only and can coexist with
+  constexpr; a constexpr-first path could skip them in the front end.
+
+## Test coverage
+
+The new behavior is covered with lit tests across the feature surface:
+
+- Basic constexpr variable folding and constexpr function calls.
+- Varying constexpr lane-wise evaluation.
+- Control flow validation (if/switch/loops) and error diagnostics.
+- Non-type template args using constexpr expressions.
+- Aggregate constexpr values (structs, arrays, short vectors), including
+  initializer lists and element access.
+- Pointer constexpr support (null and non-null addresses, pointer conditions,
+  pointer arithmetic).
+- Immarg enforcement for LLVM intrinsics using constexpr values.
+- Deferred evaluation for globals and default parameters referencing constexpr
+  functions defined later in the file.
+
+These tests intentionally check both positive behavior (IR constants) and
+negative behavior (errors for disallowed constructs) to keep the front end
+honest.
+
+## What remains
+
+The feature is usable, but there are obvious follow-ups for a “v2”:
+
+- Extend deferred constexpr evaluation to array sizes, vector lengths, and
+  template arguments.
+- Relax the `constant_expression_no_gt` grammar workaround for template args.
+- Evaluate whether aggregate folding should be unified with general optimizer
+  constant folding to remove constexpr-only paths.

--- a/docs/design/constexpr.rst
+++ b/docs/design/constexpr.rst
@@ -1,0 +1,368 @@
+======================
+Constexpr for ISPC (v1)
+======================
+
+Summary
+-------
+
+Add a ``constexpr`` specifier for variables and functions. ``constexpr`` values
+are compile-time constants and can be used in constant-expression contexts such
+as array sizes, short-vector lengths, switch case labels, and non-type template
+arguments. ``constexpr`` functions are validated for constant-evaluation
+compatibility at definition time (C++-style "constexpr-suitable" checks).
+
+V1 supports both uniform and varying constexpr values. Aggregate constexpr
+values (arrays, structs) and short vectors are supported. Pointer constants are
+supported for null and addresses of globals/functions, but dereference is not
+allowed in constexpr evaluation.
+
+
+Goals
+-----
+
+- Provide a first-class, explicit compile-time constant feature.
+- Allow constexpr function calls in constant-expression contexts.
+- Support varying constexpr values (lane-wise compile-time constants).
+- Validate constexpr functions at definition time.
+
+
+Non-goals (v1)
+-------------
+
+- No constexpr evaluation of memory dereference or dynamic allocation.
+- No constexpr support for tasks, exports, or external ABI functions.
+
+
+Syntax
+------
+
+``constexpr`` is a declaration specifier.
+
+Variables:
+
+.. code-block:: c++
+
+    constexpr uniform int Tile = 16;
+    constexpr varying int lane = programIndex;
+
+Functions:
+
+.. code-block:: c++
+
+    constexpr uniform int gcd(uniform int a, uniform int b) {
+        while (b != 0) {
+            uniform int t = a % b;
+            a = b;
+            b = t;
+        }
+        return a;
+    }
+
+
+Semantics
+---------
+
+constexpr variables
+~~~~~~~~~~~~~~~~~~~
+
+- ``constexpr`` implies ``const``.
+- ``constexpr`` is not allowed on ``typedef`` declarations.
+- The initializer must be a constant expression (constant-evaluable).
+- Allowed v1 types:
+  - atomic types (bool, int, float, double, etc.)
+  - enum types
+  - pointer types (value-only, no dereference in constexpr evaluation)
+  - short vector types of allowed element types
+  - arrays and structs of allowed element types
+- Arrays must have fully specified sizes.
+- Pointer values are limited to null or addresses of globals/functions.
+- The value is available to constant-expression evaluation.
+- For variables, storage class and linkage follow existing rules.
+
+constexpr functions
+~~~~~~~~~~~~~~~~~~~
+
+- A constexpr function is compiled like a normal function and may also be
+  evaluated at compile time when called in a constant-expression context.
+- The selected overload must be ``constexpr`` for constant evaluation.
+- ``constexpr`` functions must be "constexpr-suitable" at definition time.
+- The return type can be any constexpr-supported type (including aggregates).
+- ``constexpr`` is not allowed on function parameters.
+- Linkage follows C++ constexpr function behavior.
+- Non-``static`` constexpr functions are emitted with ODR linkage
+  (``linkonce_odr``).
+- ``static`` constexpr functions have internal linkage.
+
+constexpr-suitable validation (definition time)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+At definition time, the compiler validates that the function body only uses
+constexpr-safe constructs. Examples of allowed and disallowed constructs are
+listed below.
+
+Allowed:
+
+- Local variable declarations and assignments.
+- Arithmetic, bitwise, and comparison operators.
+- ``if``, ``switch``, ``for``, ``while``, ``do`` (with standard control flow).
+- Uniform conditions for control flow.
+- ``break`` and ``continue``.
+- ``return`` with a value.
+- Calls to other ``constexpr`` functions.
+- ``sizeof``, ``alignof``, and type casts.
+- Aggregate local variables with constant initializers.
+
+Disallowed (v1):
+
+- Writes to non-local storage (globals, captured references, or pointer
+  dereference).
+- Taking the address of local variables or parameters; only global/function
+  addresses are allowed.
+- ``new``, ``delete``, ``launch``, ``invoke_sycl``, ``sync``, ``print``,
+  atomics, and any other side-effecting builtins.
+- ``foreach*`` statements (``foreach``, ``foreach_active``, ``foreach_unique``).
+- ``goto`` and labels.
+- Calls to non-``constexpr`` functions.
+- Return type ``void`` (v1 restriction).
+
+These checks are purely structural; the function body is not executed at
+definition time.
+
+Constant-expression contexts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following contexts require constant expressions and can use constexpr
+variables and constexpr function calls:
+
+- Array sizes.
+- Short vector lengths (``float<N>``).
+- ``switch`` case labels.
+- Enumerator values.
+- Non-type template arguments.
+- Default parameter values.
+
+Existing constant expressions (literals, enum constants, and const variables
+with constant initializers) remain valid. ``constexpr`` extends these contexts
+to allow constexpr function calls.
+
+Varying constexpr values
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``constexpr varying`` values are lane-wise compile-time constants. Constant
+evaluation follows SPMD semantics and produces a compile-time vector of values
+using the target width.
+
+Examples:
+
+.. code-block:: c++
+
+    constexpr varying int lane = programIndex;
+    constexpr varying int off = lane * 4;
+
+These values are valid in constant expressions that accept varying results,
+such as constant folding and builtins that operate on varying values. Contexts
+that require uniform constants (array sizes, vector lengths, template args)
+require the constexpr result to be uniform.
+
+Target dependence
+~~~~~~~~~~~~~~~~~
+
+If constexpr evaluation depends on target-specific values (for example
+``programCount`` or ``sizeof(varying T)``), the resulting value may differ
+across targets. In multi-target compilation, such values are rejected where a
+single, target-independent constant is required (global initializers, template
+args, etc.). This mirrors existing behavior for constant expressions with
+``sizeof``.
+
+Forward references and deferral
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Global initializers and default parameter values may call constexpr functions
+defined later in the same file. The compiler defers evaluation of such
+initializers until after parsing. This deferral does not apply to array sizes,
+short vector lengths, or template arguments; those contexts still require
+definitions to be visible before use.
+
+
+Examples
+--------
+
+Uniform constexpr variable for array size:
+
+.. code-block:: c++
+
+    constexpr uniform int Tile = 16;
+    uniform float buf[Tile];
+
+Varying constexpr values:
+
+.. code-block:: c++
+
+    constexpr varying int lane = programIndex;
+    constexpr varying int lane2 = lane * 2 + 1;
+
+constexpr function used in a constant context:
+
+.. code-block:: c++
+
+    constexpr uniform int gcd(uniform int a, uniform int b) {
+        while (b != 0) {
+            uniform int t = a % b;
+            a = b;
+            b = t;
+        }
+        return a;
+    }
+
+    uniform int buf[gcd(48, 18)];
+
+constexpr function in template args:
+
+.. code-block:: c++
+
+    constexpr uniform int width() { return 8; }
+
+    template <int N>
+    void foo(float<N> v);
+
+    void bar(float<width()> v) {
+        foo<width()>(v);
+    }
+
+Aggregate constexpr values:
+
+.. code-block:: c++
+
+    struct Pair { int a; int b; };
+    constexpr uniform Pair p = { 1, 2 };
+    constexpr uniform int pb = p.b;
+
+    constexpr uniform int arr[3] = { 10, 20, 30 };
+    constexpr uniform int a2 = arr[2];
+
+Pointer constexpr values:
+
+.. code-block:: c++
+
+    uniform int g;
+    constexpr uniform int *getp() { return &g; }
+    constexpr uniform int *pg = getp();
+
+Errors (v1):
+
+.. code-block:: c++
+
+    // Error: side effects in constexpr function.
+    constexpr uniform int bad(uniform int x) {
+        print("x=%d", x);
+        return x;
+    }
+
+    // Error: pointer dereference is not allowed in constexpr evaluation.
+    constexpr uniform int bad_ptr(uniform int *p) {
+        return *p;
+    }
+
+
+Proposed docs/ispc.rst section
+------------------------------
+
+Constexpr
+~~~~~~~~~
+
+``constexpr`` declares variables and functions that are usable in
+constant-expression contexts.
+
+``constexpr`` variables
+^^^^^^^^^^^^^^^^^^^^^^^
+
+- ``constexpr`` implies ``const``.
+- ``constexpr`` is not allowed on ``typedef`` declarations.
+- The initializer must be a constant expression.
+- V1 supports atomic, enum, pointer, short vector, array, and struct types.
+- Arrays must have fully specified sizes.
+- Pointer values are limited to null or addresses of globals/functions.
+- ``constexpr`` values may be ``uniform`` or ``varying``. Varying constexpr
+  values are lane-wise compile-time constants.
+
+Examples:
+
+.. code-block:: c++
+
+    constexpr uniform int Tile = 16;
+    uniform float buf[Tile];
+
+    constexpr varying int lane = programIndex;
+    constexpr varying int off = lane * 4;
+
+``constexpr`` functions
+^^^^^^^^^^^^^^^^^^^^^^^
+
+``constexpr`` functions can be evaluated at compile time when called in a
+constant-expression context. The function is still generated as normal code
+and can be called at runtime.
+
+Requirements (v1):
+
+- The function body must be constexpr-suitable at definition time.
+- The function must return a value (no ``void`` return in v1).
+- The function may only call other ``constexpr`` functions.
+- ``constexpr`` is not allowed on function parameters.
+- Control flow conditions must be uniform.
+- Pointer dereference is not allowed; address-of is limited to
+  globals/functions (not locals/parameters).
+- ``task``, ``export``, and ``extern "C"/"SYCL"`` are not allowed on
+  ``constexpr`` functions in v1.
+- Linkage follows C++ constexpr function behavior.
+- Non-``static`` constexpr functions are emitted with ODR linkage
+  (``linkonce_odr``).
+- ``static`` constexpr functions have internal linkage.
+
+Examples:
+
+.. code-block:: c++
+
+    constexpr uniform int gcd(uniform int a, uniform int b) {
+        while (b != 0) {
+            uniform int t = a % b;
+            a = b;
+            b = t;
+        }
+        return a;
+    }
+
+    uniform int buf[gcd(48, 18)];
+
+Constant-expression contexts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Constant expressions are required in:
+
+- Array sizes.
+- Short vector lengths.
+- ``switch`` case labels.
+- Enumerator values.
+- Non-type template arguments.
+- Default parameter values.
+
+``constexpr`` extends constant expressions by allowing constexpr function
+calls in these contexts.
+
+Forward references
+^^^^^^^^^^^^^^^^^^
+
+Global initializers and default parameter values may call ``constexpr``
+functions defined later in the same file. Other constant-expression contexts
+(array sizes, short vector lengths, template arguments) still require
+definitions to be visible before use.
+
+Template non-type arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Update the existing rule in the Function Template section:
+
+- Old: "Integral constants, enumeration constants and template parameters
+  can be used as non-type template arguments. Constant expressions are not
+  allowed."
+- New: "Integral constants, enumeration constants, constexpr expressions,
+  and template parameters can be used as non-type template arguments."

--- a/docs/design/constexpr_impl_notes.md
+++ b/docs/design/constexpr_impl_notes.md
@@ -1,0 +1,241 @@
+=============================
+Constexpr implementation notes
+=============================
+
+This file captures issues discovered while prototyping constexpr that were not
+fully accounted for in the initial plan, plus adjustments to the design and
+implementation approach.
+
+Initial findings
+----------------
+
+1. The builtins IR in `builtins/util.m4` and `builtins/util-xe.m4` use
+   `__is_compile_time_constant_*` to branch between a constant-specialized
+   path and a generic path (e.g., `shuffle2`, `rotate`). This effectively
+   emulates constexpr by relying on late IR constant folding. If constexpr
+   is implemented as an earlier front-end evaluation, we need to decide
+   whether to keep these IR-level checks (as a backend optimization) or
+   replace them with constexpr-only semantics in the stdlib. This is both
+   a design and layering consideration.
+
+2. Some LLVM intrinsics require immediate operands (immarg), and the stdlib
+   uses literal constants or runtime switches to satisfy this requirement:
+   `@llvm.prefetch`/`@llvm.masked.gather`/`@llvm.masked.scatter` in
+   `builtins/generic.ispc` use literal `*l` constants, while
+   `convert_scale_to_const` in `builtins/util.m4` emits a `switch` to
+   select an immarg scale at runtime. With constexpr, we must ensure that
+   constexpr uniform values become true compile-time constants in IR (not
+   loads from storage), otherwise immarg constraints will still be
+   violated. This suggests that constexpr evaluation must happen early
+   enough to emit literal constants, and/or we may need explicit front-end
+   checks for "immediate-required" params.
+
+3. Varying constexpr constants are supported in v1, but constant contexts
+   often require uniform values (array sizes, vector lengths, template
+   args). We need explicit diagnostics for "constexpr evaluates to varying"
+   when a uniform constant is required. This requirement is already implied
+   but should be implemented and tested explicitly.
+
+4. The current constant expression machinery (`Expr::GetConstant`) produces
+   `llvm::Constant` but does not model side effects or statement execution.
+   For constexpr functions (with loops/branches), we need a separate
+   evaluator and a definition-time validator. This requires a clear
+   boundary between "compile-time constant expression" and
+   "constexpr-evaluable function body" in the front-end.
+
+5. Template non-type arguments currently accept only literals/enum/template
+   params, not constant expressions. Extending this to constexpr requires
+   changes in both parsing/type-checking and template argument mangling, to
+   ensure constexpr-evaluated values are used rather than raw expressions.
+
+Additional prototype notes
+--------------------------
+
+1. `constexpr` evaluation relies on function bodies being available at the
+   time constant expressions are parsed. Deferral now handles forward usage
+   for global initializers and default parameter values, but array sizes,
+   vector lengths, and template arguments still require definitions to be
+   visible before use.
+
+2. Allowing full `constant_expression` inside `<...>` (vector sizes and
+   non-type template args) is ambiguous in the LALR grammar: `T<WIDTH> x`
+   can be parsed as `T < WIDTH > x`. The current prototype introduces
+   `constant_expression_no_gt` in those contexts to prevent `>`/`>=`
+   operators from consuming the closing `>` token. This is a pragmatic
+   restriction; a cleaner long-term fix likely needs a dedicated
+   template-arg parser or lexer context to disambiguate `<`/`>`.
+
+3. The constexpr evaluator handles control flow only for uniform
+   conditions; validator now enforces uniform conditions for `if`,
+   `loop`, and `switch` in constexpr functions. Varying control flow is
+   rejected at definition time in v1.
+
+4. Pointer constexpr support initially only round-tripped null pointers;
+   it now supports non-null addresses of globals/functions, pointer-to-bool
+   conversion, and pointer +/- integer arithmetic. Pointer dereference and
+   pointer-pointer arithmetic remain disallowed.
+
+5. Target-dependent-constant metadata is now propagated through constexpr
+   evaluation and deferred resolution so multi-target warnings/errors match
+   constant folding behavior.
+
+6. Constexpr evaluation for `ExprList` now covers varying atomic/enum lists,
+   short vectors, and aggregate (array/struct) initializer lists, including
+   nested lists in constexpr function locals.
+
+7. Local variables inside constexpr functions currently must have
+   initializers; uninitialized locals are rejected during constexpr
+   validation to match the evaluator's limitations.
+
+8. `programIndex`/`programCount` in `stdlib/include/core.isph` and math library
+   selectors in `stdlib/include/target.isph` were migrated to
+   `static constexpr` once aggregate/short-vector constexpr evaluation landed;
+   no special-case remains.
+
+9. Immarg enforcement for LLVM intrinsics ended up requiring parameter-level
+   metadata in the front-end. The prototype attaches immarg flags to
+   `FunctionType` when creating intrinsic symbols, and `FunctionCallExpr`
+   checks immarg arguments with `ConstexprEvaluate`. This works for direct
+   intrinsic calls but is not currently propagated through function pointer
+   types or non-intrinsic builtins. A from-scratch design should consider
+   a dedicated intrinsic metadata table or explicit parameter attributes.
+
+10. Immarg validation alone was insufficient: LLVM requires literal
+    immediates in IR. The prototype now rewrites immarg arguments to
+    `ConstExpr` during type checking after `ConstexprEvaluate`, otherwise
+    constexpr function calls still lower to runtime calls and trip the LLVM
+    verifier (`immarg operand has non-immediate parameter`).
+
+11. Const local variables were not visible to constexpr evaluation during
+    immarg checks because `constValue` was set after type checking. The
+    prototype now seeds `constValue` for `const` locals during declaration
+    type checking so immarg validation can see them. This should be part of
+    a from-scratch plan for constexpr evaluation ordering.
+
+12. Intrinsic signatures are picky about varying vs. uniform types; e.g.,
+    `llvm.x86.sse41.round.ps` expects `varying float` (vector width), not
+    `uniform float<4>`. Tests and examples should mirror intrinsic types to
+    avoid false negatives.
+
+13. Error output is word-wrapped by `PrintWithWordBreaks`, so tests that
+    check constexpr/immarg diagnostics must allow line breaks in messages.
+
+14. `builtins/generic.ispc` still uses `*l` literal immarg spellings in
+    prefetch/masked load/store/gather/scatter. Those calls already satisfy LLVM
+    immarg requirements, so the v1 constexpr implementation keeps that stdlib
+    code unchanged and focuses on source-level constexpr expressions at immarg
+    call sites. IR-level switches (e.g. `convert_scale_to_const` in
+    `builtins/util.m4`) remain as future cleanup.
+
+15. Adding short-vector/aggregate constexpr support required extending
+    `ConstExpr` to represent collection types (vectors/arrays/structs). This
+    had a knock-on effect: const array symbols now optimize to
+    `ConstSymbolExpr`, and `AddressOfExpr::GetConstant` previously only
+    accepted `SymbolExpr` bases. That broke constant evaluation for global
+    pointer-array initializers like `b + 3` (tests/lit-tests/1596.ispc). The
+    fix was to accept `ConstSymbolExpr` in the constant-address path. A
+    from-scratch design should account for this interaction between const
+    folding and address-of constant generation.
+
+16. Constexpr evaluation now performs element-wise folding for vector
+   expressions inside constexpr functions, while general optimizer constant
+   folding still skips aggregates to avoid calling `ConstExpr::GetValues`
+   on them. A from-scratch design should unify the constant representation
+   so vector/aggregate folding does not need separate constexpr-only logic.
+
+17. Pointer constants exposed a mismatch between `ConstExpr` representation
+    and utility helpers: `ConstExpr::GetValues` historically asserted
+    `!isPointer`, but constexpr evaluation can legitimately flow pointer
+    constants into boolean contexts (e.g. `if (p)`). The prototype fixes
+    this by treating pointer constants as boolean values for
+    `GetValues(bool*)`. A from-scratch design should unify pointer constant
+    representation and avoid implicit numeric conversions.
+
+18. Mental fuzzing found that uniform/varying qualifiers still matter for
+    aggregate locals in constexpr functions: `Pair p = {}` defaults to
+    varying and cannot be returned from a `constexpr uniform Pair` function.
+    This is expected ISPC behavior but worth calling out in docs/examples to
+    avoid surprising users when constexpr enters the picture.
+
+19. Switching enum/array size validation from `Expr::GetConstant()` (LLVM
+    `ConstantInt`) to `ConstexprEvaluate()` introduced a subtle regression:
+    unsigned 32-bit values with the high bit set (e.g. `0x80000000`,
+    `0xffffffff`) were rejected by a signed 32-bit representability check.
+    The fix was to validate unsigned values via `uint64_t` -> `uint32_t`
+    truncation when the expression type is unsigned, preserving the previous
+    behavior while still rejecting >32-bit values.
+
+
+Planned adjustments
+-------------------
+
+- Keep `__is_compile_time_constant_*` in IR for backend optimization. Add
+  constexpr-friendly stdlib APIs only where the immediate value is surfaced as
+  a template argument or direct intrinsic argument, so the value remains visible
+  at the call site instead of becoming an ordinary function parameter.
+
+- Keep scale-switch macros (`convert_scale_to_const*`) for the existing dynamic
+  gather/scatter wrappers. With the v1 design, constexpr can support parallel
+  const-scale template APIs, but it cannot specialize an ordinary `uniform int`
+  wrapper parameter after the call crosses the function boundary.
+
+- Consider extending deferred constexpr evaluation to array sizes, vector
+  lengths, and template arguments; these contexts currently require
+  definitions to be visible before use. A dedicated template-arg parser may be
+  needed to relax the `constant_expression_no_gt` workaround.
+
+Systematic test ideas
+---------------------
+
+- Differential testing: run constexpr functions both at compile time and
+  runtime for a fixed input set, comparing results in a single test file.
+  This can be automated by generating a constexpr value and a runtime value
+  from the same function and `assert`ing equality in a task/kernel.
+- Grammar fuzzing: generate random constant expressions (bounded operators,
+  casts, and small aggregates) and ensure the front end either folds them
+  identically to runtime evaluation or rejects them with deterministic errors.
+- Target-matrix coverage: compile the same constexpr tests across multiple
+  targets (SSE/AVX/AVX512/Xe) to ensure target-dependent constant metadata is
+  preserved and diagnostics remain stable.
+- Negative test corpus: maintain a focused suite of disallowed constructs
+  (pointer deref, varying control flow, non-constexpr calls) with strict
+  diagnostics to prevent regressions in validation.
+
+Stdlib/builtins hacks inventory
+-------------------------------
+
+- Immarg literal constants in `builtins/generic.ispc`: prefetch and masked
+  load/store/gather/scatter use immediate operands (prefetch read/write and
+  locality, masked load/store/gather/scatter alignment). Historically these
+  were hard-coded as `0l/1l/2l/3l` to avoid casts and satisfy LLVM immarg
+  requirements. The v1 implementation leaves these existing builtin call sites
+  unchanged; its functional change is that the front end rewrites source-level
+  immarg arguments to `ConstExpr` during type checking, so constexpr values
+  survive lowering without relying on ad-hoc literal syntax.
+- SSE/SSE2 intrinsics headers (`xmmintrin.isph`, `emmintrin.isph`): immediate
+  style APIs retain their existing compatibility forms with ordinary immediate
+  arguments and add explicit template overloads for shuffles, lane
+  extract/insert, byte shifts, bit shifts, and prefetch hints. This is the
+  stdlib pattern that works with v1: a user can write a `constexpr` helper that
+  returns the control value and pass it as a non-type template argument, so the
+  stdlib implementation sees a compile-time value in the function body.
+- Scale switch macros in `builtins/util.m4` and `builtins/target-avx512-utils.ll`:
+  `convert_scale_to_const`, `convert_scale_to_const_gather`, and
+  `convert_scale_to_const_scatter` generate `switch`es on `scale` (1/2/4/8)
+  and dispatch to the target gather/scatter intrinsics with immediate scale.
+  These are used by `__gather_base_offsets*`/`__scatter_base_offsets*` and by
+  the pseudo-gather/scatter lowering pipeline. They are a runtime fallback
+  for dynamic scales and imply `unreachable` for other values; they also
+  inflate code size and obscure the constant requirement. The current design
+  does not remove these switches for ordinary wrapper calls because the `scale`
+  parameter is not constexpr inside the wrapper body. A future const-scale
+  template API could select the intrinsic directly for constant scales, leaving
+  the existing switch wrappers for dynamic scales.
+- IR-level constant probes in `builtins/util.m4`, `builtins/util-xe.m4`, and
+  `builtins/target-*.ll`: `__is_compile_time_constant_{uniform_int32,
+  varying_int32,mask}` gates fast paths in shuffle/rotate and mask-known
+  code (e.g., full/empty mask checks). These are declared in
+  `stdlib/include/core.isph` and are meant for LLVM to fold away when
+  inputs are constant. This is optimization-only and can coexist with
+  constexpr; a future constexpr-first path could bypass these probes in the
+  front end and rely on constexpr evaluation to select the fast path.

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -3866,6 +3866,88 @@ them:
     const varying int x = { 1, 2, 3, 2 + 2 };
     const varying int y = x * 2;
 
+Constexpr
+^^^^^^^^^
+
+``constexpr`` declares variables and functions that can be evaluated at
+compile time. ``constexpr`` values can be used in constant-expression
+contexts such as array sizes, short vector lengths, ``switch`` case labels,
+enumerator values, non-type template arguments, and default parameter values.
+
+**Constexpr variables**
+
+- ``constexpr`` implies ``const``.
+- ``constexpr`` is not allowed on ``typedef`` declarations.
+- The initializer must be a constant expression.
+- Supported types (v1): atomic, enum, pointer, short vector, array, and struct.
+- Arrays must have fully specified sizes.
+- Struct/array elements must themselves be constexpr-supported types.
+- Pointer values are limited to null or addresses of globals/functions.
+- ``constexpr`` values may be ``uniform`` or ``varying``. Varying constexpr
+  values are lane-wise compile-time constants; contexts that require uniform
+  constants still require uniform results.
+
+Examples:
+
+::
+
+    constexpr uniform int Tile = 16;
+    uniform float buf[Tile];
+
+    struct Pair { int a; int b; };
+    constexpr uniform Pair P = { 1, 2 };
+    constexpr uniform int PB = P.b;
+
+    constexpr uniform int Arr[3] = { 10, 20, 30 };
+    constexpr uniform int A2 = Arr[2];
+
+    constexpr varying int lane = programIndex;
+    constexpr varying int off = lane * 4;
+
+**Constexpr functions**
+
+``constexpr`` functions can be evaluated at compile time when called in a
+constant-expression context. The function is still generated as normal code
+and can be called at runtime.
+
+Requirements (v1):
+
+- The function body must be constexpr-suitable at definition time.
+- The function must return a value (no ``void`` return in v1).
+- The function may only call other ``constexpr`` functions.
+- ``constexpr`` is not allowed on function parameters.
+- Control flow conditions must be uniform.
+- Pointer dereference is not allowed; address-of is limited to globals/functions
+  (not locals/parameters).
+- ``task``, ``export``, and ``extern "C"/"SYCL"`` are not allowed on
+  ``constexpr`` functions in v1.
+- Linkage follows C++ constexpr function behavior.
+- Non-``static`` constexpr functions are emitted with ODR linkage
+  (``linkonce_odr``).
+- ``static`` constexpr functions have internal linkage.
+
+Example:
+
+::
+
+    constexpr uniform int gcd(uniform int a, uniform int b) {
+        while (b != 0) {
+            uniform int t = a % b;
+            a = b;
+            b = t;
+        }
+        return a;
+    }
+
+    uniform int buf[gcd(48, 18)];
+
+**Forward references**
+
+Global initializers and default parameter values may call ``constexpr``
+functions defined later in the same file. Other constant-expression contexts
+(array sizes, short vector lengths, template arguments) still require
+definitions to be visible before use.
+
 
 Attributes
 ----------
@@ -5214,8 +5296,8 @@ For non-type template parameters, the following rules apply:
       }
 
 * Varying types are not allowed.
-* Integral constants, enumeration constants and template parameters (in the context of the nested templates)
-  can be used as non-type template arguments. Constant expressions are not allowed.
+* Integral constants, enumeration constants, constexpr expressions, and template parameters (in the context of
+  the nested templates) can be used as non-type template arguments.
 * Partial specialization of function templates with non-type template parameters is not allowed.
 
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2025, Intel Corporation
+  Copyright (c) 2011-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -124,7 +124,9 @@ void AST::AddFunction(Symbol *sym, Stmt *code) {
     if (sym == nullptr) {
         return;
     }
-    functions.push_back(new Function(sym, code));
+    Function *fn = new Function(sym, code);
+    sym->parentFunction = fn;
+    functions.push_back(fn);
 }
 
 void AST::AddFunctionTemplate(TemplateSymbol *templSym, Stmt *code) {

--- a/src/constexpr.cpp
+++ b/src/constexpr.cpp
@@ -1,0 +1,2102 @@
+/*
+  Copyright (c) 2026, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** @file constexpr.cpp
+    @brief Helpers for constexpr validation and evaluation.
+*/
+
+#include "constexpr.h"
+
+#include "ast.h"
+#include "expr.h"
+#include "func.h"
+#include "llvmutil.h"
+#include "stmt.h"
+#include "sym.h"
+#include "type.h"
+#include "util.h"
+
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <llvm/IR/Constants.h>
+
+using namespace ispc;
+
+namespace {
+
+constexpr int kMaxConstexprSteps = 100000;
+constexpr int kMaxConstexprCallDepth = 64;
+
+struct EvalResult {
+    enum class Kind { Ok, Return, Break, Continue, Error } kind;
+    ConstExpr *value;
+};
+
+static ConstExpr *lMakeZeroConstExpr(const Type *type, SourcePos pos);
+static bool lIsNullPointerConstexpr(ConstExpr *value);
+static llvm::Constant *lConvertConstexprPointer(llvm::Constant *c, const Type *toType);
+
+static ConstExpr *lConvertConstExpr(ConstExpr *value, const Type *toType, SourcePos pos) {
+    if (value == nullptr || toType == nullptr) {
+        return nullptr;
+    }
+    if (Type::Equal(value->GetType(), toType)) {
+        return value;
+    }
+    if (Type::EqualIgnoringConst(value->GetType(), toType)) {
+        return value;
+    }
+    const Type *fromType = value->GetType();
+    const Type *toBase = toType->GetAsNonConstType();
+    const Type *fromBase = fromType ? fromType->GetAsNonConstType() : nullptr;
+    const VectorType *toVector = CastType<VectorType>(toBase);
+    const VectorType *fromVector = CastType<VectorType>(fromBase);
+    const PointerType *toPointer = CastType<PointerType>(toBase);
+    const PointerType *fromPointer = CastType<PointerType>(fromBase);
+
+    if (value->IsAggregate() || toVector != nullptr || fromVector != nullptr) {
+        if (toVector != nullptr && fromVector != nullptr) {
+            if (toVector->GetElementCount() != fromVector->GetElementCount()) {
+                return nullptr;
+            }
+            if (!value->IsAggregate()) {
+                return nullptr;
+            }
+            std::vector<ConstExpr *> converted;
+            const std::vector<ConstExpr *> &elements = value->GetAggregateValues();
+            if ((int)elements.size() != toVector->GetElementCount()) {
+                return nullptr;
+            }
+            converted.reserve(elements.size());
+            for (ConstExpr *elem : elements) {
+                ConstExpr *conv = lConvertConstExpr(elem, toVector->GetElementType(), pos);
+                if (conv == nullptr) {
+                    return nullptr;
+                }
+                converted.push_back(conv);
+            }
+            return new ConstExpr(toType, converted, pos);
+        }
+        if (toVector != nullptr && fromVector == nullptr) {
+            if (value->IsAggregate()) {
+                return nullptr;
+            }
+            ConstExpr *elem = lConvertConstExpr(value, toVector->GetElementType(), pos);
+            if (elem == nullptr) {
+                return nullptr;
+            }
+            std::vector<ConstExpr *> elements(toVector->GetElementCount(), elem);
+            return new ConstExpr(toType, elements, pos);
+        }
+        if (toVector == nullptr && fromVector != nullptr) {
+            if (!value->IsAggregate() || fromVector->GetElementCount() != 1) {
+                return nullptr;
+            }
+            const std::vector<ConstExpr *> &elements = value->GetAggregateValues();
+            if (elements.empty()) {
+                return nullptr;
+            }
+            return lConvertConstExpr(elements[0], toType, pos);
+        }
+        return nullptr;
+    }
+    auto isZero = [](ConstExpr *candidate) -> bool {
+        if (candidate == nullptr || candidate->IsAggregate()) {
+            return false;
+        }
+        if (candidate->IsPointerConst()) {
+            llvm::Constant *c = candidate->GetPointerConstant();
+            return c != nullptr && c->isNullValue();
+        }
+        const Type *base = candidate->GetType() ? candidate->GetType()->GetAsNonConstType() : nullptr;
+        const AtomicType *at = CastType<AtomicType>(base);
+        const EnumType *et = CastType<EnumType>(base);
+        const PointerType *pt = CastType<PointerType>(base);
+        if (pt == nullptr && et == nullptr && (at == nullptr || (!at->IsIntType() && !at->IsBoolType()))) {
+            return false;
+        }
+        int64_t vals[ISPC_MAX_NVEC] = {};
+        candidate->GetValues(vals, candidate->GetType()->IsVaryingType());
+        for (int i = 0; i < candidate->Count(); ++i) {
+            if (vals[i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    if (toPointer != nullptr || fromPointer != nullptr) {
+        if (value->GetType() && value->GetType()->IsVaryingType() && toType->IsUniformType()) {
+            return nullptr;
+        }
+        if (toPointer != nullptr && fromPointer != nullptr) {
+            if (value->IsPointerConst()) {
+                llvm::Constant *c = lConvertConstexprPointer(value->GetPointerConstant(), toType);
+                if (c == nullptr) {
+                    return nullptr;
+                }
+                return new ConstExpr(toType, c, pos);
+            }
+            if (isZero(value)) {
+                return lMakeZeroConstExpr(toType, pos);
+            }
+            return nullptr;
+        }
+        if (fromPointer != nullptr && toPointer == nullptr) {
+            const AtomicType *toAtomic = CastType<AtomicType>(toBase);
+            if (toAtomic != nullptr && toAtomic->IsBoolType()) {
+                bool isNull = lIsNullPointerConstexpr(value) || isZero(value);
+                if (toType->IsVaryingType()) {
+                    bool vals[ISPC_MAX_NVEC];
+                    for (int i = 0; i < g->target->getVectorWidth(); ++i) {
+                        vals[i] = !isNull;
+                    }
+                    return new ConstExpr(toType->GetAsConstType(), vals, pos);
+                }
+                return new ConstExpr(toType->GetAsConstType(), !isNull, pos);
+            }
+            return nullptr;
+        }
+        if (toPointer != nullptr && fromPointer == nullptr) {
+            if (isZero(value)) {
+                return lMakeZeroConstExpr(toType, pos);
+            }
+            return nullptr;
+        }
+    }
+
+    Expr *converted = TypeConvertExpr(value, toType, "constexpr evaluation");
+    if (converted == nullptr) {
+        return nullptr;
+    }
+    converted = TypeCheckAndOptimize(converted);
+    return llvm::dyn_cast<ConstExpr>(converted);
+}
+
+static bool lIsNullPointerConstexpr(ConstExpr *value) {
+    if (value == nullptr || value->IsAggregate()) {
+        return false;
+    }
+    if (value->IsPointerConst()) {
+        llvm::Constant *c = value->GetPointerConstant();
+        return c != nullptr && c->isNullValue();
+    }
+    const Type *base = value->GetType() ? value->GetType()->GetAsNonConstType() : nullptr;
+    if (CastType<PointerType>(base) == nullptr) {
+        return false;
+    }
+    int64_t vals[ISPC_MAX_NVEC] = {};
+    value->GetValues(vals, value->GetType()->IsVaryingType());
+    for (int i = 0; i < value->Count(); ++i) {
+        if (vals[i] != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static llvm::Constant *lConvertConstexprPointer(llvm::Constant *c, const Type *toType) {
+    if (c == nullptr || toType == nullptr) {
+        return nullptr;
+    }
+    llvm::Type *llvmType = toType->LLVMType(g->ctx);
+    if (llvmType == nullptr) {
+        return nullptr;
+    }
+    if (c->getType() == llvmType) {
+        return c;
+    }
+    if (llvmType->isPointerTy()) {
+        if (c->getType()->isPointerTy()) {
+            return llvm::ConstantExpr::getBitCast(c, llvmType);
+        }
+        return llvm::ConstantExpr::getIntToPtr(c, llvmType);
+    }
+    llvm::Constant *intPtr =
+        c->getType()->isPointerTy() ? llvm::ConstantExpr::getPtrToInt(c, LLVMTypes::PointerIntType) : c;
+    int count = toType->IsVaryingType() ? g->target->getVectorWidth() : toType->GetSOAWidth();
+    std::vector<llvm::Constant *> smear;
+    smear.reserve(count);
+    for (int i = 0; i < count; ++i) {
+        smear.push_back(intPtr);
+    }
+    if (toType->IsVaryingType()) {
+        return llvm::ConstantVector::get(smear);
+    }
+    llvm::ArrayType *at = llvm::ArrayType::get(LLVMTypes::PointerIntType, count);
+    return llvm::ConstantArray::get(at, smear);
+}
+
+static ConstExpr *lConstExprFromConstant(const Type *type, llvm::Constant *constant, SourcePos pos) {
+    if (type == nullptr || constant == nullptr) {
+        return nullptr;
+    }
+    const Type *baseType = type->GetAsNonConstType();
+    if (baseType->IsVaryingType()) {
+        baseType = baseType->GetAsUniformType();
+    }
+    const AtomicType *at = CastType<AtomicType>(baseType);
+    const EnumType *et = CastType<EnumType>(baseType);
+    if (at == nullptr && et == nullptr) {
+        return nullptr;
+    }
+    if (llvm::ConstantInt *ci = llvm::dyn_cast<llvm::ConstantInt>(constant)) {
+        int64_t v = ci->getSExtValue();
+        switch (at ? at->basicType : AtomicType::TYPE_UINT32) {
+        case AtomicType::TYPE_BOOL:
+            return new ConstExpr(type->GetAsConstType(), (bool)(v != 0), pos);
+        case AtomicType::TYPE_INT8:
+            return new ConstExpr(type->GetAsConstType(), (int8_t)v, pos);
+        case AtomicType::TYPE_UINT8:
+            return new ConstExpr(type->GetAsConstType(), (uint8_t)v, pos);
+        case AtomicType::TYPE_INT16:
+            return new ConstExpr(type->GetAsConstType(), (int16_t)v, pos);
+        case AtomicType::TYPE_UINT16:
+            return new ConstExpr(type->GetAsConstType(), (uint16_t)v, pos);
+        case AtomicType::TYPE_INT32:
+            return new ConstExpr(type->GetAsConstType(), (int32_t)v, pos);
+        case AtomicType::TYPE_UINT32:
+            return new ConstExpr(type->GetAsConstType(), (uint32_t)ci->getZExtValue(), pos);
+        case AtomicType::TYPE_INT64:
+            return new ConstExpr(type->GetAsConstType(), (int64_t)v, pos);
+        case AtomicType::TYPE_UINT64:
+            return new ConstExpr(type->GetAsConstType(), (uint64_t)ci->getZExtValue(), pos);
+        default:
+            return nullptr;
+        }
+    }
+    if (llvm::ConstantFP *cf = llvm::dyn_cast<llvm::ConstantFP>(constant)) {
+        llvm::APFloat val = cf->getValueAPF();
+        switch (at ? at->basicType : AtomicType::TYPE_UINT32) {
+        case AtomicType::TYPE_FLOAT16:
+        case AtomicType::TYPE_FLOAT:
+        case AtomicType::TYPE_DOUBLE:
+            return new ConstExpr(type->GetAsConstType(), val, pos);
+        default:
+            return nullptr;
+        }
+    }
+    return nullptr;
+}
+
+static int lVectorSwizzleIndex(char id) {
+    switch (id) {
+    case 'x':
+    case 'r':
+    case 'u':
+        return 0;
+    case 'y':
+    case 'g':
+    case 'v':
+        return 1;
+    case 'z':
+    case 'b':
+        return 2;
+    case 'w':
+    case 'a':
+        return 3;
+    default:
+        return -1;
+    }
+}
+
+static ConstExpr *lMakeZeroConstExpr(const Type *type, SourcePos pos) {
+    if (type == nullptr) {
+        return nullptr;
+    }
+    const Type *baseType = type->GetAsNonConstType();
+    if (const AtomicType *at = CastType<AtomicType>(baseType)) {
+        const Type *constType = type->GetAsConstType();
+        switch (at->basicType) {
+        case AtomicType::TYPE_BOOL:
+            if (type->IsVaryingType()) {
+                bool vals[ISPC_MAX_NVEC] = {};
+                return new ConstExpr(constType, vals, pos);
+            }
+            return new ConstExpr(constType, false, pos);
+        case AtomicType::TYPE_INT8: {
+            if (type->IsVaryingType()) {
+                int8_t vals[ISPC_MAX_NVEC] = {};
+                return new ConstExpr(constType, vals, pos);
+            }
+            return new ConstExpr(constType, (int8_t)0, pos);
+        }
+        case AtomicType::TYPE_UINT8: {
+            if (type->IsVaryingType()) {
+                uint8_t vals[ISPC_MAX_NVEC] = {};
+                return new ConstExpr(constType, vals, pos);
+            }
+            return new ConstExpr(constType, (uint8_t)0, pos);
+        }
+        case AtomicType::TYPE_INT16: {
+            if (type->IsVaryingType()) {
+                int16_t vals[ISPC_MAX_NVEC] = {};
+                return new ConstExpr(constType, vals, pos);
+            }
+            return new ConstExpr(constType, (int16_t)0, pos);
+        }
+        case AtomicType::TYPE_UINT16: {
+            if (type->IsVaryingType()) {
+                uint16_t vals[ISPC_MAX_NVEC] = {};
+                return new ConstExpr(constType, vals, pos);
+            }
+            return new ConstExpr(constType, (uint16_t)0, pos);
+        }
+        case AtomicType::TYPE_INT32: {
+            if (type->IsVaryingType()) {
+                int32_t vals[ISPC_MAX_NVEC] = {};
+                return new ConstExpr(constType, vals, pos);
+            }
+            return new ConstExpr(constType, (int32_t)0, pos);
+        }
+        case AtomicType::TYPE_UINT32: {
+            if (type->IsVaryingType()) {
+                uint32_t vals[ISPC_MAX_NVEC] = {};
+                return new ConstExpr(constType, vals, pos);
+            }
+            return new ConstExpr(constType, (uint32_t)0, pos);
+        }
+        case AtomicType::TYPE_INT64: {
+            if (type->IsVaryingType()) {
+                int64_t vals[ISPC_MAX_NVEC] = {};
+                return new ConstExpr(constType, vals, pos);
+            }
+            return new ConstExpr(constType, (int64_t)0, pos);
+        }
+        case AtomicType::TYPE_UINT64: {
+            if (type->IsVaryingType()) {
+                uint64_t vals[ISPC_MAX_NVEC] = {};
+                return new ConstExpr(constType, vals, pos);
+            }
+            return new ConstExpr(constType, (uint64_t)0, pos);
+        }
+        case AtomicType::TYPE_FLOAT16:
+        case AtomicType::TYPE_FLOAT:
+        case AtomicType::TYPE_DOUBLE: {
+            llvm::Type *llvmType = type->GetAsUniformType()->LLVMType(g->ctx);
+            if (llvmType == nullptr) {
+                return nullptr;
+            }
+            llvm::APFloat zero = llvm::APFloat::getZero(llvmType->getFltSemantics());
+            if (type->IsVaryingType()) {
+                std::vector<llvm::APFloat> vals;
+                vals.resize(g->target->getVectorWidth(), zero);
+                return new ConstExpr(constType, vals, pos);
+            }
+            return new ConstExpr(constType, zero, pos);
+        }
+        default:
+            return nullptr;
+        }
+    }
+    if (CastType<EnumType>(baseType) != nullptr) {
+        const Type *constType = type->GetAsConstType();
+        if (type->IsVaryingType()) {
+            uint32_t vals[ISPC_MAX_NVEC] = {};
+            return new ConstExpr(constType, vals, pos);
+        }
+        return new ConstExpr(constType, (uint32_t)0, pos);
+    }
+    if (CastType<PointerType>(baseType) != nullptr) {
+        const Type *constType = type->GetAsConstType();
+        if (type->IsVaryingType()) {
+            if (g->target->is32Bit()) {
+                uint32_t vals[ISPC_MAX_NVEC] = {};
+                return new ConstExpr(constType, vals, pos);
+            }
+            uint64_t vals[ISPC_MAX_NVEC] = {};
+            return new ConstExpr(constType, vals, pos);
+        }
+        if (g->target->is32Bit()) {
+            return new ConstExpr(constType, (uint32_t)0, pos);
+        }
+        return new ConstExpr(constType, (uint64_t)0, pos);
+    }
+    if (const CollectionType *ct = CastType<CollectionType>(baseType)) {
+        int count = ct->GetElementCount();
+        std::vector<ConstExpr *> elements;
+        elements.reserve(count);
+        for (int i = 0; i < count; ++i) {
+            ConstExpr *elem = lMakeZeroConstExpr(ct->GetElementType(i), pos);
+            if (elem == nullptr) {
+                return nullptr;
+            }
+            elements.push_back(elem);
+        }
+        return new ConstExpr(type->GetAsConstType(), elements, pos);
+    }
+    return nullptr;
+}
+
+class ConstexprEvaluator {
+  public:
+    explicit ConstexprEvaluator(int callDepth = 0, bool allowDeferredEval = false)
+        : depth(callDepth), allowDeferred(allowDeferredEval) {}
+
+    ConstExpr *EvalExpr(const Expr *expr);
+    ConstExpr *EvalExprList(const ExprList *exprList, const Type *expectedType);
+    ConstExpr *EvalFunction(const Function *func, const std::vector<ConstExpr *> &args);
+    bool Failed() const { return hasError; }
+    bool Deferred() const { return deferred; }
+    bool IsTargetDependent() const { return targetDependent; }
+
+  private:
+    struct Scope {
+        std::unordered_map<const Symbol *, ConstExpr *> values;
+    };
+
+    std::vector<Scope> scopes;
+    int depth = 0;
+    int steps = 0;
+    bool hasError = false;
+    bool allowDeferred = false;
+    bool deferred = false;
+    bool targetDependent = false;
+
+    void SetError() { hasError = true; }
+    void SetDeferred() { deferred = true; }
+    void SetTargetDependent() { targetDependent = true; }
+
+    void PushScope() { scopes.push_back(Scope()); }
+    void PopScope() {
+        if (!scopes.empty()) {
+            scopes.pop_back();
+        }
+    }
+
+    void DeclareValue(const Symbol *sym, ConstExpr *value) {
+        if (scopes.empty()) {
+            PushScope();
+        }
+        scopes.back().values[sym] = value;
+    }
+
+    bool UpdateValue(const Symbol *sym, ConstExpr *value) {
+        for (auto it = scopes.rbegin(); it != scopes.rend(); ++it) {
+            auto found = it->values.find(sym);
+            if (found != it->values.end()) {
+                found->second = value;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    ConstExpr *LookupValue(const Symbol *sym) const {
+        for (auto it = scopes.rbegin(); it != scopes.rend(); ++it) {
+            auto found = it->values.find(sym);
+            if (found != it->values.end()) {
+                return found->second;
+            }
+        }
+        return nullptr;
+    }
+
+    EvalResult EvalStmt(const Stmt *stmt);
+    EvalResult EvalStmtList(const StmtList *stmtList);
+
+    ConstExpr *FoldExpr(Expr *expr) {
+        Expr *folded = TypeCheckAndOptimize(expr);
+        return llvm::dyn_cast<ConstExpr>(folded);
+    }
+
+    ConstExpr *FoldUnary(UnaryExpr::Op op, ConstExpr *arg, SourcePos pos) {
+        if (arg == nullptr) {
+            return nullptr;
+        }
+        const Type *argBase = arg->GetType() ? arg->GetType()->GetAsNonConstType() : nullptr;
+        if (CastType<PointerType>(argBase) != nullptr && op == UnaryExpr::LogicalNot) {
+            bool isNull = lIsNullPointerConstexpr(arg);
+            if (arg->GetType()->IsVaryingType()) {
+                bool vals[ISPC_MAX_NVEC];
+                for (int i = 0; i < g->target->getVectorWidth(); ++i) {
+                    vals[i] = isNull;
+                }
+                return new ConstExpr(AtomicType::VaryingBool->GetAsConstType(), vals, pos);
+            }
+            return new ConstExpr(AtomicType::UniformBool->GetAsConstType(), isNull, pos);
+        }
+        if (arg->IsAggregate()) {
+            const VectorType *vt = CastType<VectorType>(arg->GetType()->GetAsNonConstType());
+            if (vt == nullptr) {
+                return nullptr;
+            }
+            const std::vector<ConstExpr *> &elements = arg->GetAggregateValues();
+            if ((int)elements.size() != vt->GetElementCount()) {
+                return nullptr;
+            }
+            std::vector<ConstExpr *> results;
+            results.reserve(elements.size());
+            const Type *elementType = nullptr;
+            for (ConstExpr *elem : elements) {
+                ConstExpr *res = FoldUnary(op, elem, pos);
+                if (res == nullptr) {
+                    return nullptr;
+                }
+                if (elementType == nullptr) {
+                    elementType = res->GetType();
+                } else if (!Type::EqualIgnoringConst(elementType, res->GetType())) {
+                    return nullptr;
+                }
+                results.push_back(res);
+            }
+            if (elementType == nullptr) {
+                return nullptr;
+            }
+            const VectorType *resultType = new VectorType(elementType, vt->GetElementCount());
+            return new ConstExpr(resultType, results, pos);
+        }
+        UnaryExpr *expr = new UnaryExpr(op, arg, pos);
+        return FoldExpr(expr);
+    }
+
+    ConstExpr *FoldBinary(BinaryExpr::Op op, ConstExpr *lhs, ConstExpr *rhs, SourcePos pos) {
+        if (lhs == nullptr || rhs == nullptr) {
+            return nullptr;
+        }
+        const VectorType *lhsVec =
+            lhs->IsAggregate() ? CastType<VectorType>(lhs->GetType()->GetAsNonConstType()) : nullptr;
+        const VectorType *rhsVec =
+            rhs->IsAggregate() ? CastType<VectorType>(rhs->GetType()->GetAsNonConstType()) : nullptr;
+        if (!lhs->IsAggregate() && !rhs->IsAggregate()) {
+            BinaryExpr *expr = new BinaryExpr(op, lhs, rhs, pos);
+            return FoldExpr(expr);
+        }
+        if ((lhs->IsAggregate() && lhsVec == nullptr) || (rhs->IsAggregate() && rhsVec == nullptr)) {
+            return nullptr;
+        }
+        if (lhsVec != nullptr && rhsVec == nullptr) {
+            ConstExpr *elem = lConvertConstExpr(rhs, lhsVec->GetElementType(), pos);
+            if (elem == nullptr) {
+                return nullptr;
+            }
+            std::vector<ConstExpr *> elems(lhsVec->GetElementCount(), elem);
+            rhs = new ConstExpr(lhs->GetType(), elems, pos);
+            rhsVec = lhsVec;
+        } else if (lhsVec == nullptr && rhsVec != nullptr) {
+            ConstExpr *elem = lConvertConstExpr(lhs, rhsVec->GetElementType(), pos);
+            if (elem == nullptr) {
+                return nullptr;
+            }
+            std::vector<ConstExpr *> elems(rhsVec->GetElementCount(), elem);
+            lhs = new ConstExpr(rhs->GetType(), elems, pos);
+            lhsVec = rhsVec;
+        }
+        if (lhsVec == nullptr || rhsVec == nullptr) {
+            return nullptr;
+        }
+        if (lhsVec->GetElementCount() != rhsVec->GetElementCount()) {
+            return nullptr;
+        }
+        const std::vector<ConstExpr *> &lhsElems = lhs->GetAggregateValues();
+        const std::vector<ConstExpr *> &rhsElems = rhs->GetAggregateValues();
+        if (lhsElems.size() != rhsElems.size()) {
+            return nullptr;
+        }
+        std::vector<ConstExpr *> results;
+        results.reserve(lhsElems.size());
+        const Type *elementType = nullptr;
+        for (size_t i = 0; i < lhsElems.size(); ++i) {
+            ConstExpr *res = FoldBinary(op, lhsElems[i], rhsElems[i], pos);
+            if (res == nullptr) {
+                return nullptr;
+            }
+            if (elementType == nullptr) {
+                elementType = res->GetType();
+            } else if (!Type::EqualIgnoringConst(elementType, res->GetType())) {
+                return nullptr;
+            }
+            results.push_back(res);
+        }
+        if (elementType == nullptr) {
+            return nullptr;
+        }
+        const VectorType *resultType = new VectorType(elementType, lhsVec->GetElementCount());
+        return new ConstExpr(resultType, results, pos);
+    }
+
+    ConstExpr *FoldSelect(ConstExpr *cond, ConstExpr *tExpr, ConstExpr *fExpr, SourcePos pos) {
+        if (cond == nullptr || tExpr == nullptr || fExpr == nullptr) {
+            return nullptr;
+        }
+        if (!cond->IsAggregate()) {
+            const Type *condBase = cond->GetType() ? cond->GetType()->GetAsNonConstType() : nullptr;
+            if (CastType<PointerType>(condBase) != nullptr) {
+                ConstExpr *condBool = lConvertConstExpr(cond, AtomicType::UniformBool, pos);
+                if (condBool == nullptr) {
+                    return nullptr;
+                }
+                cond = condBool;
+            }
+        }
+        if (tExpr->IsAggregate() || fExpr->IsAggregate()) {
+            const VectorType *tVec =
+                tExpr->IsAggregate() ? CastType<VectorType>(tExpr->GetType()->GetAsNonConstType()) : nullptr;
+            const VectorType *fVec =
+                fExpr->IsAggregate() ? CastType<VectorType>(fExpr->GetType()->GetAsNonConstType()) : nullptr;
+            if (tVec == nullptr || fVec == nullptr || tVec->GetElementCount() != fVec->GetElementCount()) {
+                return nullptr;
+            }
+            const std::vector<ConstExpr *> &tElems = tExpr->GetAggregateValues();
+            const std::vector<ConstExpr *> &fElems = fExpr->GetAggregateValues();
+            if (tElems.size() != fElems.size()) {
+                return nullptr;
+            }
+            std::vector<ConstExpr *> results;
+            results.reserve(tElems.size());
+            if (!cond->IsAggregate() && cond->Count() == 1) {
+                bool cv[ISPC_MAX_NVEC];
+                int count = cond->GetValues(cv);
+                if (count != 1) {
+                    return nullptr;
+                }
+                return cv[0] ? tExpr : fExpr;
+            }
+            if (cond->IsAggregate()) {
+                const std::vector<ConstExpr *> &cElems = cond->GetAggregateValues();
+                if (cElems.size() != tElems.size()) {
+                    return nullptr;
+                }
+                for (size_t i = 0; i < tElems.size(); ++i) {
+                    ConstExpr *res = FoldSelect(cElems[i], tElems[i], fElems[i], pos);
+                    if (res == nullptr) {
+                        return nullptr;
+                    }
+                    results.push_back(res);
+                }
+            } else {
+                for (size_t i = 0; i < tElems.size(); ++i) {
+                    ConstExpr *res = FoldSelect(cond, tElems[i], fElems[i], pos);
+                    if (res == nullptr) {
+                        return nullptr;
+                    }
+                    results.push_back(res);
+                }
+            }
+            return new ConstExpr(tExpr->GetType(), results, pos);
+        }
+        SelectExpr *expr = new SelectExpr(cond, tExpr, fExpr, pos);
+        return FoldExpr(expr);
+    }
+
+    ConstExpr *FoldCast(const Type *toType, ConstExpr *arg, SourcePos pos) {
+        if (arg == nullptr) {
+            return nullptr;
+        }
+        const Type *toBase = toType->GetAsNonConstType();
+        if (arg->IsAggregate() || CastType<CollectionType>(toBase) != nullptr ||
+            CastType<PointerType>(toBase) != nullptr) {
+            return lConvertConstExpr(arg, toType, pos);
+        }
+        TypeCastExpr *expr = new TypeCastExpr(toType, arg, pos);
+        return FoldExpr(expr);
+    }
+
+    ConstExpr *EvalAssign(const AssignExpr *expr);
+    ConstExpr *EvalIncDec(const UnaryExpr *expr);
+};
+
+ConstExpr *ConstexprEvaluator::EvalAssign(const AssignExpr *expr) {
+    const SymbolExpr *se = llvm::dyn_cast<SymbolExpr>(expr->lvalue);
+    if (se == nullptr) {
+        SetError();
+        return nullptr;
+    }
+    Symbol *sym = se->GetBaseSymbol();
+    if (sym == nullptr || sym->type == nullptr || sym->type->IsConstType()) {
+        SetError();
+        return nullptr;
+    }
+    ConstExpr *rhs = EvalExpr(expr->rvalue);
+    if (rhs == nullptr) {
+        SetError();
+        return nullptr;
+    }
+    if (expr->op != AssignExpr::Assign) {
+        ConstExpr *lhs = LookupValue(sym);
+        if (lhs == nullptr) {
+            SetError();
+            return nullptr;
+        }
+        BinaryExpr::Op bop = BinaryExpr::Add;
+        switch (expr->op) {
+        case AssignExpr::MulAssign:
+            bop = BinaryExpr::Mul;
+            break;
+        case AssignExpr::DivAssign:
+            bop = BinaryExpr::Div;
+            break;
+        case AssignExpr::ModAssign:
+            bop = BinaryExpr::Mod;
+            break;
+        case AssignExpr::AddAssign:
+            bop = BinaryExpr::Add;
+            break;
+        case AssignExpr::SubAssign:
+            bop = BinaryExpr::Sub;
+            break;
+        case AssignExpr::ShlAssign:
+            bop = BinaryExpr::Shl;
+            break;
+        case AssignExpr::ShrAssign:
+            bop = BinaryExpr::Shr;
+            break;
+        case AssignExpr::AndAssign:
+            bop = BinaryExpr::BitAnd;
+            break;
+        case AssignExpr::XorAssign:
+            bop = BinaryExpr::BitXor;
+            break;
+        case AssignExpr::OrAssign:
+            bop = BinaryExpr::BitOr;
+            break;
+        default:
+            SetError();
+            return nullptr;
+        }
+        rhs = FoldBinary(bop, lhs, rhs, expr->pos);
+        if (rhs == nullptr) {
+            SetError();
+            return nullptr;
+        }
+    }
+    if (!UpdateValue(sym, rhs)) {
+        SetError();
+        return nullptr;
+    }
+    return rhs;
+}
+
+ConstExpr *ConstexprEvaluator::EvalIncDec(const UnaryExpr *expr) {
+    const SymbolExpr *se = llvm::dyn_cast<SymbolExpr>(expr->expr);
+    if (se == nullptr) {
+        SetError();
+        return nullptr;
+    }
+    Symbol *sym = se->GetBaseSymbol();
+    if (sym == nullptr || sym->type == nullptr || sym->type->IsConstType()) {
+        SetError();
+        return nullptr;
+    }
+    ConstExpr *current = LookupValue(sym);
+    if (current == nullptr) {
+        SetError();
+        return nullptr;
+    }
+    ConstExpr *one = new ConstExpr(AtomicType::UniformInt32->GetAsConstType(), 1, expr->pos);
+    BinaryExpr::Op op =
+        (expr->op == UnaryExpr::PreDec || expr->op == UnaryExpr::PostDec) ? BinaryExpr::Sub : BinaryExpr::Add;
+    ConstExpr *updated = FoldBinary(op, current, one, expr->pos);
+    if (updated == nullptr) {
+        SetError();
+        return nullptr;
+    }
+    if (!UpdateValue(sym, updated)) {
+        SetError();
+        return nullptr;
+    }
+    if (expr->op == UnaryExpr::PostInc || expr->op == UnaryExpr::PostDec) {
+        return current;
+    }
+    return updated;
+}
+
+ConstExpr *ConstexprEvaluator::EvalExpr(const Expr *expr) {
+    if (expr == nullptr || hasError) {
+        return nullptr;
+    }
+    if (auto *ce = llvm::dyn_cast<ConstExpr>(expr)) {
+        return const_cast<ConstExpr *>(ce);
+    }
+    if (auto *npe = llvm::dyn_cast<NullPointerExpr>(expr)) {
+        return lMakeZeroConstExpr(npe->GetType(), npe->pos);
+    }
+    if (auto *se = llvm::dyn_cast<SymbolExpr>(expr)) {
+        Symbol *sym = se->GetBaseSymbol();
+        if (sym != nullptr) {
+            if (ConstExpr *local = LookupValue(sym)) {
+                return local;
+            }
+            if (sym->constValue) {
+                return sym->constValue;
+            }
+            if (allowDeferred && sym->constEvalPending) {
+                SetDeferred();
+                return nullptr;
+            }
+        }
+        SetError();
+        return nullptr;
+    }
+    if (auto *ue = llvm::dyn_cast<UnaryExpr>(expr)) {
+        if (ue->op == UnaryExpr::PreInc || ue->op == UnaryExpr::PreDec || ue->op == UnaryExpr::PostInc ||
+            ue->op == UnaryExpr::PostDec) {
+            return EvalIncDec(ue);
+        }
+        ConstExpr *arg = EvalExpr(ue->expr);
+        if (arg == nullptr) {
+            SetError();
+            return nullptr;
+        }
+        ConstExpr *result = FoldUnary(ue->op, arg, ue->pos);
+        if (result == nullptr) {
+            SetError();
+        }
+        return result;
+    }
+    if (auto *be = llvm::dyn_cast<BinaryExpr>(expr)) {
+        if (be->op == BinaryExpr::Comma) {
+            ConstExpr *lhs = EvalExpr(be->arg0);
+            if (lhs == nullptr) {
+                return nullptr;
+            }
+            return EvalExpr(be->arg1);
+        }
+        ConstExpr *lhs = EvalExpr(be->arg0);
+        ConstExpr *rhs = EvalExpr(be->arg1);
+        if (lhs == nullptr || rhs == nullptr) {
+            SetError();
+            return nullptr;
+        }
+        const Type *lhsBase = lhs->GetType() ? lhs->GetType()->GetAsNonConstType() : nullptr;
+        const Type *rhsBase = rhs->GetType() ? rhs->GetType()->GetAsNonConstType() : nullptr;
+        const PointerType *lhsPtr = CastType<PointerType>(lhsBase);
+        const PointerType *rhsPtr = CastType<PointerType>(rhsBase);
+        if (lhsPtr != nullptr || rhsPtr != nullptr) {
+            if (be->op == BinaryExpr::Equal || be->op == BinaryExpr::NotEqual) {
+                bool lhsNull = lIsNullPointerConstexpr(lhs);
+                bool rhsNull = lIsNullPointerConstexpr(rhs);
+                bool equal = false;
+                if (lhsNull || rhsNull) {
+                    equal = lhsNull && rhsNull;
+                } else if (lhs->IsPointerConst() && rhs->IsPointerConst()) {
+                    equal = lhs->GetPointerConstant() == rhs->GetPointerConstant();
+                } else {
+                    SetError();
+                    return nullptr;
+                }
+                bool result = (be->op == BinaryExpr::Equal) ? equal : !equal;
+                return new ConstExpr(AtomicType::UniformBool->GetAsConstType(), result, be->pos);
+            }
+            if (be->op == BinaryExpr::Add || be->op == BinaryExpr::Sub) {
+                if (lhsPtr != nullptr && rhsPtr != nullptr) {
+                    Error(be->pos, "constexpr pointer arithmetic requires a pointer and integer offset.");
+                    SetError();
+                    return nullptr;
+                }
+                const Type *ptrType = lhsPtr ? lhs->GetType() : rhs->GetType();
+                if (ptrType == nullptr || ptrType->IsVaryingType()) {
+                    Error(be->pos, "constexpr pointer arithmetic requires a uniform pointer.");
+                    SetError();
+                    return nullptr;
+                }
+                BinaryExpr *tmp = new BinaryExpr(be->op, lhs, rhs, be->pos);
+                Expr *typed = TypeCheckAndOptimize(tmp);
+                if (typed == nullptr || typed->GetType() == nullptr) {
+                    SetError();
+                    return nullptr;
+                }
+                std::pair<llvm::Constant *, bool> cpair = typed->GetConstant(typed->GetType());
+                if (cpair.first == nullptr) {
+                    SetError();
+                    return nullptr;
+                }
+                if (cpair.second) {
+                    SetTargetDependent();
+                }
+                return new ConstExpr(typed->GetType(), cpair.first, be->pos);
+            }
+            SetError();
+            return nullptr;
+        }
+        ConstExpr *result = FoldBinary(be->op, lhs, rhs, be->pos);
+        if (result == nullptr) {
+            SetError();
+        }
+        return result;
+    }
+    if (auto *ae = llvm::dyn_cast<AssignExpr>(expr)) {
+        return EvalAssign(ae);
+    }
+    if (auto *te = llvm::dyn_cast<TypeCastExpr>(expr)) {
+        ConstExpr *arg = EvalExpr(te->expr);
+        if (arg == nullptr) {
+            SetError();
+            return nullptr;
+        }
+        ConstExpr *result = FoldCast(te->GetType(), arg, te->pos);
+        if (result == nullptr) {
+            SetError();
+        }
+        return result;
+    }
+    if (auto *se = llvm::dyn_cast<SelectExpr>(expr)) {
+        ConstExpr *cond = EvalExpr(se->test);
+        ConstExpr *tExpr = EvalExpr(se->expr1);
+        ConstExpr *fExpr = EvalExpr(se->expr2);
+        if (cond == nullptr || tExpr == nullptr || fExpr == nullptr) {
+            SetError();
+            return nullptr;
+        }
+        ConstExpr *result = FoldSelect(cond, tExpr, fExpr, se->pos);
+        if (result == nullptr) {
+            SetError();
+        }
+        return result;
+    }
+    if (auto *fce = llvm::dyn_cast<FunctionCallExpr>(expr)) {
+        if (depth >= kMaxConstexprCallDepth) {
+            SetError();
+            return nullptr;
+        }
+        const FunctionSymbolExpr *fse = llvm::dyn_cast<FunctionSymbolExpr>(fce->func);
+        if (fse == nullptr) {
+            SetError();
+            return nullptr;
+        }
+        Symbol *calleeSym = fse->GetBaseSymbol();
+        if (calleeSym == nullptr) {
+            SetError();
+            return nullptr;
+        }
+        const FunctionType *calleeType = CastType<FunctionType>(calleeSym->type);
+        if (calleeType == nullptr || !calleeType->IsConstexpr()) {
+            SetError();
+            return nullptr;
+        }
+        const Function *calleeFunc = calleeSym->parentFunction;
+        if (calleeFunc == nullptr || calleeFunc->GetCode() == nullptr) {
+            if (allowDeferred) {
+                SetDeferred();
+                return nullptr;
+            }
+            SetError();
+            return nullptr;
+        }
+
+        std::vector<ConstExpr *> argValues;
+        int provided = fce->args ? (int)fce->args->exprs.size() : 0;
+        for (int i = 0; i < provided; ++i) {
+            ConstExpr *val = EvalExpr(fce->args->exprs[i]);
+            if (val == nullptr) {
+                SetError();
+                return nullptr;
+            }
+            val = lConvertConstExpr(val, calleeType->GetParameterType(i), fce->args->exprs[i]->pos);
+            if (val == nullptr) {
+                SetError();
+                return nullptr;
+            }
+            argValues.push_back(val);
+        }
+        for (int i = provided; i < calleeType->GetNumParameters(); ++i) {
+            Expr *def = calleeType->GetParameterDefault(i);
+            if (def == nullptr) {
+                SetError();
+                return nullptr;
+            }
+            ConstExpr *val = EvalExpr(def);
+            if (val == nullptr) {
+                SetError();
+                return nullptr;
+            }
+            val = lConvertConstExpr(val, calleeType->GetParameterType(i), def->pos);
+            if (val == nullptr) {
+                SetError();
+                return nullptr;
+            }
+            argValues.push_back(val);
+        }
+
+        ConstexprEvaluator nested(depth + 1, allowDeferred);
+        ConstExpr *result = nested.EvalFunction(calleeFunc, argValues);
+        if (nested.Deferred()) {
+            SetDeferred();
+            return nullptr;
+        }
+        if (result == nullptr || nested.Failed()) {
+            SetError();
+            return nullptr;
+        }
+        if (nested.IsTargetDependent()) {
+            SetTargetDependent();
+        }
+        return result;
+    }
+    if (auto *ao = llvm::dyn_cast<AddressOfExpr>(expr)) {
+        const Type *ptrType = ao->GetType();
+        if (ptrType == nullptr) {
+            SetError();
+            return nullptr;
+        }
+        std::pair<llvm::Constant *, bool> cpair = ao->GetConstant(ptrType);
+        if (cpair.first == nullptr) {
+            SetError();
+            return nullptr;
+        }
+        if (cpair.second) {
+            SetTargetDependent();
+        }
+        return new ConstExpr(ptrType, cpair.first, ao->pos);
+    }
+    if (auto *ie = llvm::dyn_cast<IndexExpr>(expr)) {
+        ConstExpr *base = EvalExpr(ie->baseExpr);
+        ConstExpr *idxExpr = EvalExpr(ie->index);
+        if (base == nullptr || idxExpr == nullptr || !base->IsAggregate()) {
+            SetError();
+            return nullptr;
+        }
+        ConstExpr *idxConst = lConvertConstExpr(idxExpr, AtomicType::UniformInt64, ie->index->pos);
+        if (idxConst == nullptr) {
+            SetError();
+            return nullptr;
+        }
+        int64_t idxVals[ISPC_MAX_NVEC];
+        int count = idxConst->GetValues(idxVals);
+        if (count != 1) {
+            Error(ie->pos, "constexpr array/vector index must be a uniform constant.");
+            SetError();
+            return nullptr;
+        }
+        int64_t idx = idxVals[0];
+        const std::vector<ConstExpr *> &elements = base->GetAggregateValues();
+        if (idx < 0 || idx >= (int64_t)elements.size()) {
+            Error(ie->pos, "constexpr array/vector index is out of bounds.");
+            SetError();
+            return nullptr;
+        }
+        return elements[(int)idx];
+    }
+    if (auto *me = llvm::dyn_cast<MemberExpr>(expr)) {
+        ConstExpr *base = EvalExpr(me->expr);
+        if (base == nullptr || !base->IsAggregate()) {
+            SetError();
+            return nullptr;
+        }
+        const std::vector<ConstExpr *> &elements = base->GetAggregateValues();
+        if (auto *sme = llvm::dyn_cast<StructMemberExpr>(me)) {
+            int idx = sme->getElementNumber();
+            if (idx < 0 || idx >= (int)elements.size()) {
+                SetError();
+                return nullptr;
+            }
+            return elements[idx];
+        }
+        if (auto *vme = llvm::dyn_cast<VectorMemberExpr>(me)) {
+            const std::string &swizzle = me->identifier;
+            if (swizzle.size() == 1) {
+                int idx = vme->getElementNumber();
+                if (idx < 0 || idx >= (int)elements.size()) {
+                    SetError();
+                    return nullptr;
+                }
+                return elements[idx];
+            }
+            std::vector<ConstExpr *> swizzled;
+            swizzled.reserve(swizzle.size());
+            for (char ch : swizzle) {
+                int idx = lVectorSwizzleIndex(ch);
+                if (idx < 0 || idx >= (int)elements.size()) {
+                    Error(me->pos, "Invalid swizzle character '%c' for constexpr vector.", ch);
+                    SetError();
+                    return nullptr;
+                }
+                swizzled.push_back(elements[idx]);
+            }
+            return new ConstExpr(vme->getElementType(), swizzled, me->pos);
+        }
+        SetError();
+        return nullptr;
+    }
+    if (auto *sizeofExpr = llvm::dyn_cast<SizeOfExpr>(expr)) {
+        std::pair<llvm::Constant *, bool> cpair = sizeofExpr->GetConstant(sizeofExpr->GetType());
+        ConstExpr *value = lConstExprFromConstant(sizeofExpr->GetType(), cpair.first, sizeofExpr->pos);
+        if (value == nullptr) {
+            SetError();
+        }
+        if (cpair.second) {
+            SetTargetDependent();
+        }
+        return value;
+    }
+
+    SetError();
+    return nullptr;
+}
+
+ConstExpr *ConstexprEvaluator::EvalExprList(const ExprList *exprList, const Type *expectedType) {
+    if (exprList == nullptr || expectedType == nullptr || hasError) {
+        SetError();
+        return nullptr;
+    }
+
+    const Type *baseType = expectedType->GetAsNonConstType();
+    const AtomicType *atomic = CastType<AtomicType>(baseType);
+    const EnumType *enumType = CastType<EnumType>(baseType);
+    const CollectionType *collection = CastType<CollectionType>(baseType);
+    const int nInits = (int)exprList->exprs.size();
+
+    auto evalElement = [&](Expr *expr, const Type *elementType) -> ConstExpr * {
+        if (expr == nullptr || llvm::dyn_cast<ExprList>(expr) != nullptr) {
+            return nullptr;
+        }
+        Expr *checked = TypeCheckAndOptimize(expr);
+        if (checked == nullptr) {
+            return nullptr;
+        }
+        Expr *converted = TypeConvertExpr(checked, elementType, "initializer list");
+        if (converted == nullptr) {
+            return nullptr;
+        }
+        converted = TypeCheckAndOptimize(converted);
+        if (converted == nullptr) {
+            return nullptr;
+        }
+        ConstExpr *val = EvalExpr(converted);
+        if (val == nullptr || val->Count() != 1) {
+            return nullptr;
+        }
+        return lConvertConstExpr(val, elementType, expr->pos);
+    };
+
+    if (collection != nullptr) {
+        int elementCount = collection->GetElementCount();
+        if (nInits > elementCount) {
+            std::string name = "aggregate";
+            if (CastType<StructType>(baseType) != nullptr) {
+                name = "struct";
+            } else if (CastType<ArrayType>(baseType) != nullptr) {
+                name = "array";
+            } else if (CastType<VectorType>(baseType) != nullptr) {
+                name = "vector";
+            }
+            Error(exprList->pos, "Initializer for %s type \"%s\" requires no more than %d values; %d provided.",
+                  name.c_str(), expectedType->GetString().c_str(), elementCount, nInits);
+            SetError();
+            return nullptr;
+        }
+
+        std::vector<ConstExpr *> elements;
+        elements.reserve(elementCount);
+        for (int i = 0; i < elementCount; ++i) {
+            const Type *elementType = collection->GetElementType(i);
+            if (elementType == nullptr) {
+                SetError();
+                return nullptr;
+            }
+            ConstExpr *val = nullptr;
+            if (i < nInits) {
+                Expr *expr = exprList->exprs[i];
+                if (auto *elist = llvm::dyn_cast_or_null<ExprList>(expr)) {
+                    if (CastType<CollectionType>(elementType->GetAsNonConstType()) == nullptr) {
+                        SetError();
+                        return nullptr;
+                    }
+                    val = EvalExprList(elist, elementType);
+                } else {
+                    val = EvalExpr(expr);
+                    if (val != nullptr) {
+                        val = lConvertConstExpr(val, elementType, expr->pos);
+                    }
+                }
+            } else {
+                val = lMakeZeroConstExpr(elementType, exprList->pos);
+            }
+            if (val == nullptr) {
+                SetError();
+                return nullptr;
+            }
+            elements.push_back(val);
+        }
+        return new ConstExpr(expectedType, elements, exprList->pos);
+    }
+
+    if (baseType->IsVaryingType() && (atomic != nullptr || enumType != nullptr)) {
+        const int width = g->target->getVectorWidth();
+        if (nInits > width) {
+            Error(exprList->pos, "Initializer for varying type \"%s\" requires no more than %d values; %d provided.",
+                  expectedType->GetString().c_str(), width, nInits);
+            SetError();
+            return nullptr;
+        }
+        if (nInits < width && nInits != 1) {
+            Error(exprList->pos, "Initializer for varying type \"%s\" requires %d values; %d provided.",
+                  expectedType->GetString().c_str(), width, nInits);
+            SetError();
+            return nullptr;
+        }
+
+        const Type *elementType = expectedType->GetAsUniformType();
+        AtomicType::BasicType basicType = atomic ? atomic->basicType : AtomicType::TYPE_UINT32;
+        switch (basicType) {
+        case AtomicType::TYPE_BOOL: {
+            bool vals[ISPC_MAX_NVEC];
+            for (int i = 0; i < nInits; ++i) {
+                ConstExpr *ce = evalElement(exprList->exprs[i], elementType);
+                if (ce == nullptr) {
+                    SetError();
+                    return nullptr;
+                }
+                ce->GetValues(&vals[i]);
+            }
+            if (nInits == 1) {
+                for (int i = 1; i < width; ++i) {
+                    vals[i] = vals[0];
+                }
+            }
+            return new ConstExpr(expectedType, vals, exprList->pos);
+        }
+        case AtomicType::TYPE_INT8: {
+            int8_t vals[ISPC_MAX_NVEC];
+            for (int i = 0; i < nInits; ++i) {
+                ConstExpr *ce = evalElement(exprList->exprs[i], elementType);
+                if (ce == nullptr) {
+                    SetError();
+                    return nullptr;
+                }
+                ce->GetValues(&vals[i]);
+            }
+            if (nInits == 1) {
+                for (int i = 1; i < width; ++i) {
+                    vals[i] = vals[0];
+                }
+            }
+            return new ConstExpr(expectedType, vals, exprList->pos);
+        }
+        case AtomicType::TYPE_UINT8: {
+            uint8_t vals[ISPC_MAX_NVEC];
+            for (int i = 0; i < nInits; ++i) {
+                ConstExpr *ce = evalElement(exprList->exprs[i], elementType);
+                if (ce == nullptr) {
+                    SetError();
+                    return nullptr;
+                }
+                ce->GetValues(&vals[i]);
+            }
+            if (nInits == 1) {
+                for (int i = 1; i < width; ++i) {
+                    vals[i] = vals[0];
+                }
+            }
+            return new ConstExpr(expectedType, vals, exprList->pos);
+        }
+        case AtomicType::TYPE_INT16: {
+            int16_t vals[ISPC_MAX_NVEC];
+            for (int i = 0; i < nInits; ++i) {
+                ConstExpr *ce = evalElement(exprList->exprs[i], elementType);
+                if (ce == nullptr) {
+                    SetError();
+                    return nullptr;
+                }
+                ce->GetValues(&vals[i]);
+            }
+            if (nInits == 1) {
+                for (int i = 1; i < width; ++i) {
+                    vals[i] = vals[0];
+                }
+            }
+            return new ConstExpr(expectedType, vals, exprList->pos);
+        }
+        case AtomicType::TYPE_UINT16: {
+            uint16_t vals[ISPC_MAX_NVEC];
+            for (int i = 0; i < nInits; ++i) {
+                ConstExpr *ce = evalElement(exprList->exprs[i], elementType);
+                if (ce == nullptr) {
+                    SetError();
+                    return nullptr;
+                }
+                ce->GetValues(&vals[i]);
+            }
+            if (nInits == 1) {
+                for (int i = 1; i < width; ++i) {
+                    vals[i] = vals[0];
+                }
+            }
+            return new ConstExpr(expectedType, vals, exprList->pos);
+        }
+        case AtomicType::TYPE_INT32: {
+            int32_t vals[ISPC_MAX_NVEC];
+            for (int i = 0; i < nInits; ++i) {
+                ConstExpr *ce = evalElement(exprList->exprs[i], elementType);
+                if (ce == nullptr) {
+                    SetError();
+                    return nullptr;
+                }
+                ce->GetValues(&vals[i]);
+            }
+            if (nInits == 1) {
+                for (int i = 1; i < width; ++i) {
+                    vals[i] = vals[0];
+                }
+            }
+            return new ConstExpr(expectedType, vals, exprList->pos);
+        }
+        case AtomicType::TYPE_UINT32: {
+            uint32_t vals[ISPC_MAX_NVEC];
+            for (int i = 0; i < nInits; ++i) {
+                ConstExpr *ce = evalElement(exprList->exprs[i], elementType);
+                if (ce == nullptr) {
+                    SetError();
+                    return nullptr;
+                }
+                ce->GetValues(&vals[i]);
+            }
+            if (nInits == 1) {
+                for (int i = 1; i < width; ++i) {
+                    vals[i] = vals[0];
+                }
+            }
+            return new ConstExpr(expectedType, vals, exprList->pos);
+        }
+        case AtomicType::TYPE_INT64: {
+            int64_t vals[ISPC_MAX_NVEC];
+            for (int i = 0; i < nInits; ++i) {
+                ConstExpr *ce = evalElement(exprList->exprs[i], elementType);
+                if (ce == nullptr) {
+                    SetError();
+                    return nullptr;
+                }
+                ce->GetValues(&vals[i]);
+            }
+            if (nInits == 1) {
+                for (int i = 1; i < width; ++i) {
+                    vals[i] = vals[0];
+                }
+            }
+            return new ConstExpr(expectedType, vals, exprList->pos);
+        }
+        case AtomicType::TYPE_UINT64: {
+            uint64_t vals[ISPC_MAX_NVEC];
+            for (int i = 0; i < nInits; ++i) {
+                ConstExpr *ce = evalElement(exprList->exprs[i], elementType);
+                if (ce == nullptr) {
+                    SetError();
+                    return nullptr;
+                }
+                ce->GetValues(&vals[i]);
+            }
+            if (nInits == 1) {
+                for (int i = 1; i < width; ++i) {
+                    vals[i] = vals[0];
+                }
+            }
+            return new ConstExpr(expectedType, vals, exprList->pos);
+        }
+        case AtomicType::TYPE_FLOAT16:
+        case AtomicType::TYPE_FLOAT:
+        case AtomicType::TYPE_DOUBLE: {
+            std::vector<llvm::APFloat> vals;
+            vals.reserve(width);
+            llvm::Type *llvmElementType = elementType->LLVMType(g->ctx);
+            for (int i = 0; i < nInits; ++i) {
+                ConstExpr *ce = evalElement(exprList->exprs[i], elementType);
+                if (ce == nullptr) {
+                    SetError();
+                    return nullptr;
+                }
+                std::vector<llvm::APFloat> tmp;
+                ce->GetValues(tmp, llvmElementType);
+                vals.push_back(tmp[0]);
+            }
+            if (nInits == 1) {
+                for (int i = 1; i < width; ++i) {
+                    vals.push_back(vals[0]);
+                }
+            }
+            return new ConstExpr(expectedType, vals, exprList->pos);
+        }
+        default:
+            break;
+        }
+    }
+
+    if (atomic == nullptr && enumType == nullptr) {
+        return nullptr;
+    }
+
+    if (nInits == 1) {
+        ConstExpr *val = evalElement(exprList->exprs[0], expectedType);
+        if (val == nullptr) {
+            SetError();
+            return nullptr;
+        }
+        return lConvertConstExpr(val, expectedType, exprList->exprs[0]->pos);
+    }
+
+    if (nInits > 1) {
+        return nullptr;
+    }
+    SetError();
+    return nullptr;
+}
+
+EvalResult ConstexprEvaluator::EvalStmtList(const StmtList *stmtList) {
+    if (stmtList == nullptr) {
+        return {EvalResult::Kind::Ok, nullptr};
+    }
+    PushScope();
+    for (auto *stmt : stmtList->stmts) {
+        EvalResult res = EvalStmt(stmt);
+        if (res.kind != EvalResult::Kind::Ok) {
+            PopScope();
+            return res;
+        }
+    }
+    PopScope();
+    return {EvalResult::Kind::Ok, nullptr};
+}
+
+EvalResult ConstexprEvaluator::EvalStmt(const Stmt *stmt) {
+    if (stmt == nullptr) {
+        return {EvalResult::Kind::Ok, nullptr};
+    }
+    if (hasError) {
+        return {EvalResult::Kind::Error, nullptr};
+    }
+    if (++steps > kMaxConstexprSteps) {
+        SetError();
+        return {EvalResult::Kind::Error, nullptr};
+    }
+
+    if (auto *sl = llvm::dyn_cast<StmtList>(stmt)) {
+        return EvalStmtList(sl);
+    }
+    if (auto *cs = llvm::dyn_cast<CaseStmt>(stmt)) {
+        return EvalStmt(cs->stmts);
+    }
+    if (auto *ds = llvm::dyn_cast<DefaultStmt>(stmt)) {
+        return EvalStmt(ds->stmts);
+    }
+    if (auto *ds = llvm::dyn_cast<DeclStmt>(stmt)) {
+        for (const auto &var : ds->vars) {
+            if (var.sym == nullptr || var.init == nullptr) {
+                SetError();
+                return {EvalResult::Kind::Error, nullptr};
+            }
+            ConstExpr *val = nullptr;
+            if (auto *elist = llvm::dyn_cast<ExprList>(var.init)) {
+                val = EvalExprList(elist, var.sym->type);
+            } else {
+                val = EvalExpr(var.init);
+            }
+            if (val == nullptr) {
+                SetError();
+                return {EvalResult::Kind::Error, nullptr};
+            }
+            val = lConvertConstExpr(val, var.sym->type, var.sym->pos);
+            if (val == nullptr) {
+                SetError();
+                return {EvalResult::Kind::Error, nullptr};
+            }
+            DeclareValue(var.sym, val);
+        }
+        return {EvalResult::Kind::Ok, nullptr};
+    }
+    if (auto *es = llvm::dyn_cast<ExprStmt>(stmt)) {
+        if (es->expr != nullptr) {
+            ConstExpr *val = EvalExpr(es->expr);
+            if (val == nullptr) {
+                SetError();
+                return {EvalResult::Kind::Error, nullptr};
+            }
+        }
+        return {EvalResult::Kind::Ok, nullptr};
+    }
+    if (auto *rs = llvm::dyn_cast<ReturnStmt>(stmt)) {
+        if (rs->expr == nullptr) {
+            SetError();
+            return {EvalResult::Kind::Error, nullptr};
+        }
+        ConstExpr *val = EvalExpr(rs->expr);
+        if (val == nullptr) {
+            SetError();
+            return {EvalResult::Kind::Error, nullptr};
+        }
+        return {EvalResult::Kind::Return, val};
+    }
+    if (auto *us = llvm::dyn_cast<UnmaskedStmt>(stmt)) {
+        return EvalStmt(us->stmts);
+    }
+    if (auto *ifs = llvm::dyn_cast<IfStmt>(stmt)) {
+        ConstExpr *cond = EvalExpr(ifs->test);
+        if (cond == nullptr) {
+            SetError();
+            return {EvalResult::Kind::Error, nullptr};
+        }
+        cond = lConvertConstExpr(cond, AtomicType::UniformBool, ifs->test->pos);
+        if (cond == nullptr) {
+            SetError();
+            return {EvalResult::Kind::Error, nullptr};
+        }
+        bool cv[ISPC_MAX_NVEC];
+        int count = cond->GetValues(cv);
+        if (count != 1) {
+            SetError();
+            return {EvalResult::Kind::Error, nullptr};
+        }
+        if (cv[0]) {
+            return EvalStmt(ifs->trueStmts);
+        }
+        return EvalStmt(ifs->falseStmts);
+    }
+    if (auto *ss = llvm::dyn_cast<SwitchStmt>(stmt)) {
+        ConstExpr *cond = EvalExpr(ss->expr);
+        if (cond == nullptr) {
+            SetError();
+            return {EvalResult::Kind::Error, nullptr};
+        }
+        cond = lConvertConstExpr(cond, AtomicType::UniformInt64, ss->expr->pos);
+        if (cond == nullptr) {
+            SetError();
+            return {EvalResult::Kind::Error, nullptr};
+        }
+        int64_t iv[ISPC_MAX_NVEC];
+        int count = cond->GetValues(iv);
+        if (count != 1) {
+            SetError();
+            return {EvalResult::Kind::Error, nullptr};
+        }
+
+        std::vector<const Stmt *> stmts;
+        if (auto *sl = llvm::dyn_cast<StmtList>(ss->stmts)) {
+            stmts.assign(sl->stmts.begin(), sl->stmts.end());
+        } else if (ss->stmts != nullptr) {
+            stmts.push_back(ss->stmts);
+        }
+
+        int startIndex = -1;
+        int defaultIndex = -1;
+        for (int i = 0; i < (int)stmts.size(); ++i) {
+            if (auto *cs = llvm::dyn_cast<CaseStmt>(stmts[i])) {
+                if ((int64_t)cs->value == iv[0]) {
+                    startIndex = i;
+                    break;
+                }
+            } else if (defaultIndex < 0 && llvm::dyn_cast<DefaultStmt>(stmts[i])) {
+                defaultIndex = i;
+            }
+        }
+        if (startIndex < 0) {
+            startIndex = defaultIndex;
+        }
+        if (startIndex < 0) {
+            return {EvalResult::Kind::Ok, nullptr};
+        }
+
+        bool scoped = llvm::isa<StmtList>(ss->stmts);
+        if (scoped) {
+            PushScope();
+        }
+        for (int i = startIndex; i < (int)stmts.size(); ++i) {
+            const Stmt *cur = stmts[i];
+            EvalResult res;
+            if (auto *cs = llvm::dyn_cast<CaseStmt>(cur)) {
+                res = EvalStmt(cs->stmts);
+            } else if (auto *ds = llvm::dyn_cast<DefaultStmt>(cur)) {
+                res = EvalStmt(ds->stmts);
+            } else {
+                res = EvalStmt(cur);
+            }
+            if (res.kind == EvalResult::Kind::Return || res.kind == EvalResult::Kind::Error ||
+                res.kind == EvalResult::Kind::Continue) {
+                if (scoped) {
+                    PopScope();
+                }
+                return res;
+            }
+            if (res.kind == EvalResult::Kind::Break) {
+                if (scoped) {
+                    PopScope();
+                }
+                return {EvalResult::Kind::Ok, nullptr};
+            }
+        }
+        if (scoped) {
+            PopScope();
+        }
+        return {EvalResult::Kind::Ok, nullptr};
+    }
+    if (auto *fs = llvm::dyn_cast<ForStmt>(stmt)) {
+        PushScope();
+        if (fs->init != nullptr) {
+            EvalResult initRes = EvalStmt(fs->init);
+            if (initRes.kind != EvalResult::Kind::Ok) {
+                PopScope();
+                return initRes;
+            }
+        }
+        while (true) {
+            if (fs->test != nullptr) {
+                ConstExpr *cond = EvalExpr(fs->test);
+                if (cond == nullptr) {
+                    SetError();
+                    PopScope();
+                    return {EvalResult::Kind::Error, nullptr};
+                }
+                cond = lConvertConstExpr(cond, AtomicType::UniformBool, fs->test->pos);
+                if (cond == nullptr) {
+                    SetError();
+                    PopScope();
+                    return {EvalResult::Kind::Error, nullptr};
+                }
+                bool cv[ISPC_MAX_NVEC];
+                int count = cond->GetValues(cv);
+                if (count != 1) {
+                    SetError();
+                    PopScope();
+                    return {EvalResult::Kind::Error, nullptr};
+                }
+                if (!cv[0]) {
+                    break;
+                }
+            }
+            EvalResult bodyRes = EvalStmt(fs->stmts);
+            if (bodyRes.kind == EvalResult::Kind::Return) {
+                PopScope();
+                return bodyRes;
+            }
+            if (bodyRes.kind == EvalResult::Kind::Break) {
+                break;
+            }
+            if (bodyRes.kind == EvalResult::Kind::Error) {
+                PopScope();
+                return bodyRes;
+            }
+            if (fs->step != nullptr) {
+                EvalResult stepRes = EvalStmt(fs->step);
+                if (stepRes.kind == EvalResult::Kind::Return) {
+                    PopScope();
+                    return stepRes;
+                }
+                if (stepRes.kind == EvalResult::Kind::Error) {
+                    PopScope();
+                    return stepRes;
+                }
+            }
+        }
+        PopScope();
+        return {EvalResult::Kind::Ok, nullptr};
+    }
+    if (auto *ds = llvm::dyn_cast<DoStmt>(stmt)) {
+        PushScope();
+        while (true) {
+            EvalResult bodyRes = EvalStmt(ds->bodyStmts);
+            if (bodyRes.kind == EvalResult::Kind::Return) {
+                PopScope();
+                return bodyRes;
+            }
+            if (bodyRes.kind == EvalResult::Kind::Break) {
+                break;
+            }
+            if (bodyRes.kind == EvalResult::Kind::Error) {
+                PopScope();
+                return bodyRes;
+            }
+            ConstExpr *cond = EvalExpr(ds->testExpr);
+            if (cond == nullptr) {
+                SetError();
+                PopScope();
+                return {EvalResult::Kind::Error, nullptr};
+            }
+            cond = lConvertConstExpr(cond, AtomicType::UniformBool, ds->testExpr->pos);
+            if (cond == nullptr) {
+                SetError();
+                PopScope();
+                return {EvalResult::Kind::Error, nullptr};
+            }
+            bool cv[ISPC_MAX_NVEC];
+            int count = cond->GetValues(cv);
+            if (count != 1) {
+                SetError();
+                PopScope();
+                return {EvalResult::Kind::Error, nullptr};
+            }
+            if (!cv[0]) {
+                break;
+            }
+        }
+        PopScope();
+        return {EvalResult::Kind::Ok, nullptr};
+    }
+    if (llvm::isa<BreakStmt>(stmt)) {
+        return {EvalResult::Kind::Break, nullptr};
+    }
+    if (llvm::isa<ContinueStmt>(stmt)) {
+        return {EvalResult::Kind::Continue, nullptr};
+    }
+
+    SetError();
+    return {EvalResult::Kind::Error, nullptr};
+}
+
+ConstExpr *ConstexprEvaluator::EvalFunction(const Function *func, const std::vector<ConstExpr *> &args) {
+    if (func == nullptr || func->GetCode() == nullptr) {
+        if (allowDeferred) {
+            SetDeferred();
+            return nullptr;
+        }
+        SetError();
+        return nullptr;
+    }
+    const FunctionType *ft = func->GetType();
+    if (ft == nullptr || !ft->IsConstexpr()) {
+        SetError();
+        return nullptr;
+    }
+    if ((int)args.size() != ft->GetNumParameters()) {
+        SetError();
+        return nullptr;
+    }
+
+    PushScope();
+    const std::vector<Symbol *> &params = func->GetParameterSymbols();
+    for (int i = 0; i < ft->GetNumParameters(); ++i) {
+        if (i < (int)params.size() && params[i] != nullptr) {
+            ConstExpr *val = lConvertConstExpr(args[i], ft->GetParameterType(i), func->GetCode()->pos);
+            if (val == nullptr) {
+                SetError();
+                PopScope();
+                return nullptr;
+            }
+            DeclareValue(params[i], val);
+        }
+    }
+    EvalResult res = EvalStmt(func->GetCode());
+    PopScope();
+    if (res.kind != EvalResult::Kind::Return || res.value == nullptr) {
+        SetError();
+        return nullptr;
+    }
+    ConstExpr *converted = lConvertConstExpr(res.value, ft->GetReturnType(), func->GetCode()->pos);
+    if (converted == nullptr) {
+        SetError();
+        return nullptr;
+    }
+    return converted;
+}
+
+} // namespace
+
+bool ispc::IsConstexprTypeAllowed(const Type *type) {
+    if (type == nullptr) {
+        return false;
+    }
+    const Type *t = type->GetAsNonConstType();
+    if (CastType<AtomicType>(t) != nullptr || CastType<EnumType>(t) != nullptr || CastType<PointerType>(t) != nullptr) {
+        return true;
+    }
+    if (const VectorType *vt = CastType<VectorType>(t)) {
+        const Type *elt = vt->GetElementType()->GetAsNonConstType();
+        return CastType<AtomicType>(elt) != nullptr || CastType<EnumType>(elt) != nullptr;
+    }
+    if (const ArrayType *at = CastType<ArrayType>(t)) {
+        if (at->IsUnsized()) {
+            return false;
+        }
+        return IsConstexprTypeAllowed(at->GetElementType());
+    }
+    if (const StructType *st = CastType<StructType>(t)) {
+        for (int i = 0; i < st->GetElementCount(); ++i) {
+            if (!IsConstexprTypeAllowed(st->GetElementType(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+ConstexprEvalResult ispc::ConstexprEvaluateDetailed(Expr *expr, const Type *expectedType, bool allowDeferred) {
+    ConstexprEvalResult result{nullptr, false, false};
+    if (expr == nullptr) {
+        return result;
+    }
+    ConstexprEvaluator eval(0, allowDeferred);
+    ConstExpr *value = nullptr;
+    if (auto *elist = llvm::dyn_cast<ExprList>(expr)) {
+        value = eval.EvalExprList(elist, expectedType);
+    } else {
+        value = eval.EvalExpr(expr);
+    }
+    if (value == nullptr || eval.Failed()) {
+        result.deferred = eval.Deferred();
+        return result;
+    }
+    if (expectedType != nullptr) {
+        value = lConvertConstExpr(value, expectedType, expr->pos);
+    }
+    result.value = value;
+    result.deferred = eval.Deferred();
+    result.targetDependent = eval.IsTargetDependent();
+    return result;
+}
+
+ConstExpr *ispc::ConstexprEvaluate(Expr *expr, const Type *expectedType) {
+    ConstexprEvalResult result = ConstexprEvaluateDetailed(expr, expectedType, false);
+    return result.value;
+}
+
+namespace {
+
+class ConstexprValidator {
+  public:
+    explicit ConstexprValidator(const Function *f) : func(f) {
+        if (func) {
+            funcName = func->GetName();
+        }
+    }
+
+    bool Validate();
+
+  private:
+    const Function *func = nullptr;
+    std::string funcName;
+    bool ok = true;
+    std::unordered_set<const Symbol *> locals;
+
+    void GatherLocal(ASTNode *node);
+    bool CheckNode(ASTNode *node);
+    bool CheckStmt(const Stmt *stmt);
+    bool CheckExpr(const Expr *expr);
+    void CheckUniform(const Expr *expr, const char *context);
+    static bool GatherLocalsCallback(ASTNode *node, void *data);
+    static bool ValidateCallback(ASTNode *node, void *data);
+
+    bool IsLocalOrParam(const Symbol *sym) const {
+        if (sym == nullptr) {
+            return false;
+        }
+        if (sym->GetSymbolKind() == Symbol::SymbolKind::FunctionParm) {
+            return true;
+        }
+        return locals.find(sym) != locals.end();
+    }
+
+    void DisallowedStmt(const Stmt *stmt, const char *what) {
+        if (!stmt || !func) {
+            return;
+        }
+        Error(stmt->pos, "constexpr function \"%s\" contains disallowed statement \"%s\".", funcName.c_str(), what);
+        ok = false;
+    }
+
+    void DisallowedExpr(const Expr *expr, const char *what) {
+        if (!expr || !func) {
+            return;
+        }
+        Error(expr->pos, "constexpr function \"%s\" contains disallowed expression \"%s\".", funcName.c_str(), what);
+        ok = false;
+    }
+};
+
+void ConstexprValidator::GatherLocal(ASTNode *node) {
+    if (auto *ds = llvm::dyn_cast_or_null<DeclStmt>(node)) {
+        for (const auto &var : ds->vars) {
+            if (var.sym) {
+                locals.insert(var.sym);
+            }
+        }
+    }
+}
+
+bool ConstexprValidator::CheckExpr(const Expr *expr) {
+    if (expr == nullptr) {
+        return true;
+    }
+    if (llvm::dyn_cast<NewExpr>(expr)) {
+        DisallowedExpr(expr, "new");
+        return false;
+    }
+    if (llvm::dyn_cast<SyncExpr>(expr)) {
+        DisallowedExpr(expr, "sync");
+        return false;
+    }
+    if (llvm::dyn_cast<AllocaExpr>(expr)) {
+        DisallowedExpr(expr, "alloca");
+        return false;
+    }
+    if (llvm::dyn_cast<SizeOfExpr>(expr)) {
+        return false;
+    }
+    if (auto *fce = llvm::dyn_cast<FunctionCallExpr>(expr)) {
+        const FunctionSymbolExpr *fse = llvm::dyn_cast<FunctionSymbolExpr>(fce->func);
+        if (fse == nullptr || fse->GetBaseSymbol() == nullptr) {
+            if (fse == nullptr) {
+                DisallowedExpr(expr, "function pointer call");
+            }
+            return false;
+        }
+        Symbol *callee = fse->GetBaseSymbol();
+        if (!callee->isConstexpr) {
+            Error(expr->pos, "constexpr function \"%s\" calls non-constexpr function \"%s\".", funcName.c_str(),
+                  callee->name.c_str());
+            ok = false;
+            return false;
+        }
+    }
+    if (auto *ae = llvm::dyn_cast<AssignExpr>(expr)) {
+        const SymbolExpr *lhs = llvm::dyn_cast<SymbolExpr>(ae->lvalue);
+        Symbol *sym = lhs ? lhs->GetBaseSymbol() : nullptr;
+        if (lhs == nullptr || sym == nullptr || !IsLocalOrParam(sym) || sym->storageClass.IsStatic()) {
+            DisallowedExpr(expr, "assignment");
+            return false;
+        }
+    }
+    if (auto *ue = llvm::dyn_cast<UnaryExpr>(expr)) {
+        if (ue->op == UnaryExpr::PreInc || ue->op == UnaryExpr::PreDec || ue->op == UnaryExpr::PostInc ||
+            ue->op == UnaryExpr::PostDec) {
+            const SymbolExpr *lhs = llvm::dyn_cast<SymbolExpr>(ue->expr);
+            Symbol *sym = lhs ? lhs->GetBaseSymbol() : nullptr;
+            if (lhs == nullptr || sym == nullptr || !IsLocalOrParam(sym) || sym->storageClass.IsStatic()) {
+                DisallowedExpr(expr, "increment/decrement");
+                return false;
+            }
+        }
+    }
+
+    if (auto *ie = llvm::dyn_cast<IndexExpr>(expr)) {
+        const Type *baseType = ie->baseExpr ? ie->baseExpr->GetType() : nullptr;
+        if (baseType != nullptr && !baseType->IsDependent() && CastType<PointerType>(baseType) != nullptr) {
+            DisallowedExpr(expr, "pointer dereference");
+            return false;
+        }
+    } else if (auto *me = llvm::dyn_cast<MemberExpr>(expr)) {
+        const Type *baseType = me->expr ? me->expr->GetType() : nullptr;
+        if (baseType != nullptr && !baseType->IsDependent() && CastType<PointerType>(baseType) != nullptr) {
+            DisallowedExpr(expr, "pointer dereference");
+            return false;
+        }
+    } else if (llvm::dyn_cast<PtrDerefExpr>(expr)) {
+        DisallowedExpr(expr, "pointer dereference");
+        return true;
+    } else if (auto *ao = llvm::dyn_cast<AddressOfExpr>(expr)) {
+        Symbol *sym = ao->GetBaseSymbol();
+        if (sym == nullptr || (sym->GetSymbolKind() != Symbol::SymbolKind::Function && IsLocalOrParam(sym))) {
+            DisallowedExpr(expr, "address-of");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void ConstexprValidator::CheckUniform(const Expr *expr, const char *context) {
+    if (expr == nullptr) {
+        return;
+    }
+    const Type *t = expr->GetType();
+    if (t == nullptr || t->IsDependent()) {
+        return;
+    }
+    if (t->IsVaryingType()) {
+        Error(expr->pos, "constexpr function \"%s\" requires a uniform condition in \"%s\".", funcName.c_str(),
+              context);
+        ok = false;
+    }
+}
+
+bool ConstexprValidator::CheckStmt(const Stmt *stmt) {
+    if (stmt == nullptr) {
+        return true;
+    }
+    if (llvm::dyn_cast<PrintStmt>(stmt)) {
+        DisallowedStmt(stmt, "print");
+        return false;
+    }
+    if (llvm::dyn_cast<AssertStmt>(stmt)) {
+        DisallowedStmt(stmt, "assert");
+        return false;
+    }
+    if (llvm::dyn_cast<ForeachStmt>(stmt) || llvm::dyn_cast<ForeachActiveStmt>(stmt) ||
+        llvm::dyn_cast<ForeachUniqueStmt>(stmt)) {
+        DisallowedStmt(stmt, "foreach");
+        return false;
+    }
+    if (llvm::dyn_cast<GotoStmt>(stmt) || llvm::dyn_cast<LabeledStmt>(stmt)) {
+        DisallowedStmt(stmt, "goto");
+        return false;
+    }
+    if (llvm::dyn_cast<DeleteStmt>(stmt)) {
+        DisallowedStmt(stmt, "delete");
+        return false;
+    }
+    if (auto *ds = llvm::dyn_cast<DeclStmt>(stmt)) {
+        for (const auto &var : ds->vars) {
+            if (var.init == nullptr) {
+                const char *name = var.sym ? var.sym->name.c_str() : "<unnamed>";
+                Error(stmt->pos, "constexpr function \"%s\" requires initializer for local variable \"%s\".",
+                      funcName.c_str(), name);
+                ok = false;
+            }
+        }
+        return true;
+    }
+    if (auto *ifs = llvm::dyn_cast<IfStmt>(stmt)) {
+        CheckUniform(ifs->test, "if");
+        return true;
+    }
+    if (auto *fs = llvm::dyn_cast<ForStmt>(stmt)) {
+        CheckUniform(fs->test, "loop");
+        return true;
+    }
+    if (auto *ds = llvm::dyn_cast<DoStmt>(stmt)) {
+        CheckUniform(ds->testExpr, "loop");
+        return true;
+    }
+    if (auto *ss = llvm::dyn_cast<SwitchStmt>(stmt)) {
+        CheckUniform(ss->expr, "switch");
+        return true;
+    }
+    return true;
+}
+
+bool ConstexprValidator::CheckNode(ASTNode *node) {
+    if (auto *stmt = llvm::dyn_cast_or_null<Stmt>(node)) {
+        return CheckStmt(stmt);
+    }
+    if (auto *expr = llvm::dyn_cast_or_null<Expr>(node)) {
+        return CheckExpr(expr);
+    }
+    return true;
+}
+
+bool ConstexprValidator::GatherLocalsCallback(ASTNode *node, void *data) {
+    ConstexprValidator *validator = static_cast<ConstexprValidator *>(data);
+    validator->GatherLocal(node);
+    return true;
+}
+
+bool ConstexprValidator::ValidateCallback(ASTNode *node, void *data) {
+    ConstexprValidator *validator = static_cast<ConstexprValidator *>(data);
+    return validator->CheckNode(node);
+}
+
+bool ConstexprValidator::Validate() {
+    if (func == nullptr) {
+        return false;
+    }
+    const FunctionType *ft = func->GetType();
+    if (ft == nullptr) {
+        return false;
+    }
+    if (ft->GetReturnType()->IsVoidType()) {
+        Error(ft->GetSourcePos(), "constexpr function \"%s\" must return a value.", funcName.c_str());
+        ok = false;
+    }
+    Stmt *body = const_cast<Stmt *>(func->GetCode());
+    WalkAST(body, GatherLocalsCallback, nullptr, this);
+    WalkAST(body, ValidateCallback, nullptr, this);
+    return ok;
+}
+
+} // namespace
+
+bool ispc::ValidateConstexprFunction(const Function *func) {
+    ConstexprValidator validator(func);
+    return validator.Validate();
+}

--- a/src/constexpr.h
+++ b/src/constexpr.h
@@ -1,0 +1,41 @@
+/*
+  Copyright (c) 2026, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** @file constexpr.h
+    @brief Helpers for constexpr validation and evaluation.
+*/
+
+#pragma once
+
+namespace ispc {
+
+class ConstExpr;
+class Expr;
+class Function;
+class Type;
+
+struct ConstexprEvalResult {
+    ConstExpr *value;
+    bool deferred;
+    bool targetDependent;
+};
+
+/** Returns true if the type is allowed for constexpr variables in v1. */
+bool IsConstexprTypeAllowed(const Type *type);
+
+/** Try to evaluate an expression to a ConstExpr using constexpr rules.
+    Returns nullptr if the expression can't be constant-evaluated. */
+ConstExpr *ConstexprEvaluate(Expr *expr, const Type *expectedType);
+
+/** Evaluate an expression to a ConstExpr using constexpr rules, capturing
+    deferral and target-dependent information. */
+ConstexprEvalResult ConstexprEvaluateDetailed(Expr *expr, const Type *expectedType, bool allowDeferred);
+
+/** Validate constexpr-suitable constructs in a function definition.
+    Returns false if any errors were emitted. */
+bool ValidateConstexprFunction(const Function *func);
+
+} // namespace ispc

--- a/src/decl.cpp
+++ b/src/decl.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -10,6 +10,7 @@
 */
 
 #include "decl.h"
+#include "constexpr.h"
 #include "expr.h"
 #include "module.h"
 #include "stmt.h"
@@ -76,6 +77,9 @@ void lCheckVariableTypeQualifiers(int typeQualifiers, SourcePos pos) {
 }
 
 void lCheckTypeQualifiers(int typeQualifiers, DeclaratorKind kind, SourcePos pos) {
+    if (typeQualifiers & TYPEQUAL_CONSTEXPR) {
+        Error(pos, "\"constexpr\" qualifier is illegal in declarator qualifier lists.");
+    }
     if (kind != DK_FUNCTION) {
         lCheckVariableTypeQualifiers(typeQualifiers, pos);
     }
@@ -102,6 +106,9 @@ std::string DeclSpecs::GetTypeQualifiersString(int typeQualifiers) {
 
     if (typeQualifiers & TYPEQUAL_INLINE) {
         result += "inline ";
+    }
+    if (typeQualifiers & TYPEQUAL_CONSTEXPR) {
+        result += "constexpr ";
     }
     if (typeQualifiers & TYPEQUAL_CONST) {
         result += "const ";
@@ -532,6 +539,12 @@ Declarator::Declarator(DeclaratorKind dk, SourcePos p) : pos(p), kind(dk), stora
 Declarator::~Declarator() { delete attributeList; }
 
 void Declarator::InitFromDeclSpecs(DeclSpecs *ds) {
+    int declTypeQualifiers = ds->typeQualifiers;
+    if (ds->storageClass.IsTypedef() && (declTypeQualifiers & TYPEQUAL_CONSTEXPR)) {
+        Error(pos, "\"constexpr\" qualifier is illegal in typedef declarations.");
+        declTypeQualifiers &= ~TYPEQUAL_CONSTEXPR;
+    }
+
     if (attributeList) {
         attributeList->MergeAttrList(*ds->attributeList);
     } else {
@@ -547,7 +560,7 @@ void Declarator::InitFromDeclSpecs(DeclSpecs *ds) {
     }
 
     if (!lIsFunctionKind(this)) {
-        lCheckVariableTypeQualifiers(ds->typeQualifiers, pos);
+        lCheckVariableTypeQualifiers(declTypeQualifiers, pos);
     }
 
     InitFromType(baseType, ds);
@@ -583,6 +596,9 @@ void Declarator::InitFromDeclSpecs(DeclSpecs *ds) {
             int64_t addrSpace = attributeList->GetAttribute("address_space")->arg.intVal;
             lCheckAddressSpace(addrSpace, name, pos);
             type = lGetTypeWithAddressSpace(type, addrSpace, name, pos);
+        }
+        if (declTypeQualifiers & TYPEQUAL_CONSTEXPR) {
+            type = type->GetAsConstType();
         }
     }
 
@@ -735,6 +751,7 @@ unsigned int lCreateFunctionFlagsAndCostOverride(int &costOverride, DeclSpecs *d
     bool isUnmasked = typeQualifiers & TYPEQUAL_UNMASKED;
     bool isVectorCall = typeQualifiers & TYPEQUAL_VECTORCALL;
     bool isRegCall = typeQualifiers & TYPEQUAL_REGCALL;
+    bool isConstexpr = typeQualifiers & TYPEQUAL_CONSTEXPR;
     bool isUnmangled = attributeList && attributeList->HasAttribute("unmangled");
     bool isCdecl = attributeList && attributeList->HasAttribute("cdecl");
 
@@ -770,6 +787,10 @@ unsigned int lCreateFunctionFlagsAndCostOverride(int &costOverride, DeclSpecs *d
         flags |= FunctionType::FUNC_REG_CALL;
     }
 
+    if (isConstexpr) {
+        flags |= FunctionType::FUNC_CONSTEXPR;
+    }
+
     if (isUnmangled) {
         flags |= FunctionType::FUNC_UNMANGLED;
     }
@@ -780,6 +801,23 @@ unsigned int lCreateFunctionFlagsAndCostOverride(int &costOverride, DeclSpecs *d
 
     if (!isExported && isExternalOnly) {
         Error(pos, "\"external_only\" attribute is only valid for exported functions.");
+        return 0;
+    }
+
+    if (isConstexpr && isTask) {
+        Error(pos, "Function can't have both \"constexpr\" and \"task\" qualifiers");
+        return 0;
+    }
+    if (isConstexpr && isExported) {
+        Error(pos, "Function can't have both \"constexpr\" and \"export\" qualifiers");
+        return 0;
+    }
+    if (isConstexpr && isExternC) {
+        Error(pos, "Function can't have both \"constexpr\" and \"extern \\\"C\\\"\" qualifiers");
+        return 0;
+    }
+    if (isConstexpr && isExternSYCL) {
+        Error(pos, "Function can't have both \"constexpr\" and \"extern \\\"SYCL\\\"\" qualifiers");
         return 0;
     }
 
@@ -930,6 +968,13 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
         llvm::SmallVector<std::string, 8> argNames;
         llvm::SmallVector<Expr *, 8> argDefaults;
         llvm::SmallVector<SourcePos, 8> argPos;
+        struct DeferredParamDefault {
+            int index;
+            Expr *expr;
+            SourcePos pos;
+            std::string name;
+        };
+        std::vector<DeferredParamDefault> deferredDefaults;
 
         // Loop over the function arguments and store the names, types,
         // default values (if any), and source file positions each one in
@@ -979,6 +1024,11 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
                       "function parameter declaration for parameter \"%s\".",
                       d->declSpecs->storageClass.GetString().c_str(), decl->name.c_str());
             }
+            if (d->declSpecs->typeQualifiers & TYPEQUAL_CONSTEXPR) {
+                Error(decl->pos,
+                      "\"constexpr\" qualifier is illegal in function parameter declaration for parameter \"%s\".",
+                      decl->name.c_str());
+            }
             if (decl->type->IsVoidType()) {
                 Error(decl->pos, "Parameter with type \"void\" illegal in function "
                                  "parameter list.");
@@ -1026,15 +1076,20 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
                 if (decl->initExpr != nullptr) {
                     decl->initExpr = TypeCheckAndOptimize(decl->initExpr);
                     if (decl->initExpr != nullptr) {
-                        init = llvm::dyn_cast<ConstExpr>(decl->initExpr);
-                        if (init == nullptr) {
+                        ConstexprEvalResult evalResult = ConstexprEvaluateDetailed(decl->initExpr, decl->type, true);
+                        if (evalResult.value != nullptr) {
+                            init = evalResult.value;
+                        } else if (evalResult.deferred) {
+                            init = decl->initExpr;
+                            deferredDefaults.push_back({(int)i, init, decl->initExpr->pos, decl->name});
+                        } else {
                             init = llvm::dyn_cast<NullPointerExpr>(decl->initExpr);
-                        }
-                        if (init == nullptr) {
-                            Error(decl->initExpr->pos,
-                                  "Default value for parameter "
-                                  "\"%s\" must be a compile-time constant.",
-                                  decl->name.c_str());
+                            if (init == nullptr) {
+                                Error(decl->initExpr->pos,
+                                      "Default value for parameter "
+                                      "\"%s\" must be a compile-time constant.",
+                                      decl->name.c_str());
+                            }
                         }
                     }
                     break;
@@ -1073,6 +1128,12 @@ void Declarator::InitFromType(const Type *baseType, DeclSpecs *ds) {
 
         const FunctionType *functionType =
             new FunctionType(returnType, args, argNames, argDefaults, argPos, costOverride, functionFlags, pos);
+        if (!deferredDefaults.empty()) {
+            for (const auto &entry : deferredDefaults) {
+                m->AddDeferredConstexprParam(const_cast<FunctionType *>(functionType), entry.index, entry.expr,
+                                             entry.pos, entry.name);
+            }
+        }
 
         child->InitFromType(functionType, ds);
         type = child->type;
@@ -1136,6 +1197,7 @@ std::vector<VariableDeclaration> Declaration::GetVariableDeclarations() const {
 
             Symbol *sym =
                 new Symbol(decl->name, decl->pos, Symbol::SymbolKind::Variable, decl->type, decl->storageClass, AL);
+            sym->isConstexpr = ((declSpecs->typeQualifiers | decl->typeQualifiers) & TYPEQUAL_CONSTEXPR) != 0;
             m->symbolTable->AddVariable(sym);
             vars.push_back(VariableDeclaration(sym, decl->initExpr));
         } else {

--- a/src/decl.h
+++ b/src/decl.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -55,6 +55,7 @@ class Declarator;
 #define TYPEQUAL_NOINLINE (1 << 9)
 #define TYPEQUAL_VECTORCALL (1 << 10)
 #define TYPEQUAL_REGCALL (1 << 11)
+#define TYPEQUAL_CONSTEXPR (1 << 12)
 
 enum AttrArgKind { ATTR_ARG_UINT32, ATTR_ARG_STRING, ATTR_ARG_UNKNOWN };
 

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -11,6 +11,7 @@
 #include "expr.h"
 #include "ast.h"
 #include "builtins-decl.h"
+#include "constexpr.h"
 #include "ctx.h"
 #include "func.h"
 #include "llvmutil.h"
@@ -45,6 +46,7 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Type.h>
+#include <llvm/Support/raw_ostream.h>
 
 using namespace ispc;
 
@@ -1408,6 +1410,9 @@ Expr *UnaryExpr::Optimize() {
     if (constExpr == nullptr) {
         return this;
     }
+    if (constExpr->IsAggregate()) {
+        return this;
+    }
 
     const Type *type = constExpr->GetType();
     bool isEnumType = CastType<EnumType>(type) != nullptr;
@@ -2709,6 +2714,9 @@ Expr *BinaryExpr::Optimize() {
 
     ConstExpr *constArg0 = llvm::dyn_cast<ConstExpr>(arg0);
     ConstExpr *constArg1 = llvm::dyn_cast<ConstExpr>(arg1);
+    if ((constArg0 != nullptr && constArg0->IsAggregate()) || (constArg1 != nullptr && constArg1->IsAggregate())) {
+        return this;
+    }
 
     if (g->opt.fastMath == Opt::FastMathMode::Legacy) {
         // TODO: consider moving fast-math optimizations to backend
@@ -2776,7 +2784,9 @@ Expr *BinaryExpr::Optimize() {
         return this;
     }
 
-    AssertPos(pos, Type::EqualIgnoringConst(arg0->GetType(), arg1->GetType()));
+    if (!Type::EqualIgnoringConst(arg0->GetType(), arg1->GetType())) {
+        return this;
+    }
     const Type *type = arg0->GetType()->GetAsNonConstType();
     if (Type::Equal(type, AtomicType::UniformFloat16) || Type::Equal(type, AtomicType::VaryingFloat16)) {
         return lConstFoldBinaryFPOp(constArg0, constArg1, op, this, LLVMTypes::Float16Type, pos);
@@ -3968,6 +3978,9 @@ Expr *SelectExpr::Optimize() {
     if (constTest == nullptr) {
         return this;
     }
+    if (constTest->IsAggregate()) {
+        return this;
+    }
 
     // The test is a constant; see if we can resolve to one of the
     // expressions..
@@ -3997,6 +4010,9 @@ Expr *SelectExpr::Optimize() {
         ConstExpr *constExpr1 = llvm::dyn_cast<ConstExpr>(expr1);
         ConstExpr *constExpr2 = llvm::dyn_cast<ConstExpr>(expr2);
         if (constExpr1 == nullptr || constExpr2 == nullptr) {
+            return this;
+        }
+        if (constExpr1->IsAggregate() || constExpr2->IsAggregate()) {
             return this;
         }
 
@@ -4551,6 +4567,47 @@ Expr *FunctionCallExpr::TypeCheck() {
 
     if (!isInvoke && funcType->IsExternSYCL()) {
         Error(pos, "Illegal to call \'extern \"SYCL\"\'-qualified function without \"invoke_sycl\" expression.");
+        return nullptr;
+    }
+
+    bool immArgError = false;
+    if (funcType != nullptr && args != nullptr) {
+        int argCount = (int)args->exprs.size();
+        int paramCount = funcType->GetNumParameters();
+        int checkCount = (argCount < paramCount) ? argCount : paramCount;
+        Symbol *funcSym = (fse != nullptr) ? fse->GetBaseSymbol() : nullptr;
+        const std::string funcName = funcSym ? funcSym->name : "";
+        auto emitImmArgError = [&](Expr *argExpr, int index, const char *message) {
+            if (!funcName.empty()) {
+                Error(argExpr->pos, "Immediate argument %d to \"%s\" %s.", index + 1, funcName.c_str(), message);
+            } else {
+                Error(argExpr->pos, "Immediate argument %d %s.", index + 1, message);
+            }
+        };
+        for (int i = 0; i < checkCount; ++i) {
+            if (!funcType->IsParameterImmArg(i)) {
+                continue;
+            }
+            Expr *argExpr = args->exprs[i];
+            if (argExpr == nullptr) {
+                continue;
+            }
+            ConstExpr *ce = ConstexprEvaluate(argExpr, funcType->GetParameterType(i));
+            if (ce == nullptr) {
+                emitImmArgError(argExpr, i, "must be a compile-time constant");
+                immArgError = true;
+                continue;
+            }
+            const Type *ceType = ce->GetType();
+            if (ceType == nullptr || !ceType->IsUniformType() || ce->Count() != 1) {
+                emitImmArgError(argExpr, i, "must be a uniform scalar compile-time constant");
+                immArgError = true;
+                continue;
+            }
+            args->exprs[i] = new ConstExpr(ce, argExpr->pos);
+        }
+    }
+    if (immArgError) {
         return nullptr;
     }
 
@@ -6243,17 +6300,20 @@ ConstExpr::ConstExpr(const Type *t, int32_t *i, SourcePos p) : Expr(p, ConstExpr
 ConstExpr::ConstExpr(const Type *t, uint32_t u, SourcePos p) : Expr(p, ConstExprID) {
     type = t;
     type = type->GetAsConstType();
+    const Type *baseType = type->GetAsNonConstType();
     AssertPos(pos, Type::Equal(type, AtomicType::UniformUInt32->GetAsConstType()) ||
-                       (CastType<EnumType>(type) != nullptr && type->IsUniformType()));
+                       (CastType<EnumType>(type) != nullptr && type->IsUniformType()) ||
+                       CastType<PointerType>(baseType) != nullptr);
     uint32Val[0] = u;
 }
 
 ConstExpr::ConstExpr(const Type *t, uint32_t *u, SourcePos p) : Expr(p, ConstExprID) {
     type = t;
     type = type->GetAsConstType();
+    const Type *baseType = type->GetAsNonConstType();
     AssertPos(pos, Type::Equal(type, AtomicType::UniformUInt32->GetAsConstType()) ||
                        Type::Equal(type, AtomicType::VaryingUInt32->GetAsConstType()) ||
-                       (CastType<EnumType>(type) != nullptr));
+                       (CastType<EnumType>(type) != nullptr) || CastType<PointerType>(baseType) != nullptr);
     for (int j = 0; j < Count(); ++j) {
         uint32Val[j] = u[j];
     }
@@ -6302,15 +6362,19 @@ ConstExpr::ConstExpr(const Type *t, int64_t *i, SourcePos p) : Expr(p, ConstExpr
 ConstExpr::ConstExpr(const Type *t, uint64_t u, SourcePos p) : Expr(p, ConstExprID) {
     type = t;
     type = type->GetAsConstType();
-    AssertPos(pos, Type::Equal(type, AtomicType::UniformUInt64->GetAsConstType()));
+    const Type *baseType = type->GetAsNonConstType();
+    AssertPos(pos, Type::Equal(type, AtomicType::UniformUInt64->GetAsConstType()) ||
+                       CastType<PointerType>(baseType) != nullptr);
     uint64Val[0] = u;
 }
 
 ConstExpr::ConstExpr(const Type *t, uint64_t *u, SourcePos p) : Expr(p, ConstExprID) {
     type = t;
     type = type->GetAsConstType();
+    const Type *baseType = type->GetAsNonConstType();
     AssertPos(pos, Type::Equal(type, AtomicType::UniformUInt64->GetAsConstType()) ||
-                       Type::Equal(type, AtomicType::VaryingUInt64->GetAsConstType()));
+                       Type::Equal(type, AtomicType::VaryingUInt64->GetAsConstType()) ||
+                       CastType<PointerType>(baseType) != nullptr);
     for (int j = 0; j < Count(); ++j) {
         uint64Val[j] = u[j];
     }
@@ -6333,8 +6397,39 @@ ConstExpr::ConstExpr(const Type *t, bool *b, SourcePos p) : Expr(p, ConstExprID)
     }
 }
 
+ConstExpr::ConstExpr(const Type *t, llvm::Constant *ptr, SourcePos p) : Expr(p, ConstExprID) {
+    type = t;
+    type = type ? type->GetAsConstType() : type;
+    const Type *baseType = type ? type->GetAsNonConstType() : nullptr;
+    AssertPos(pos, CastType<PointerType>(baseType) != nullptr);
+    isPointer = true;
+    ptrConst = ptr;
+}
+
+ConstExpr::ConstExpr(const Type *t, const std::vector<ConstExpr *> &values, SourcePos p) : Expr(p, ConstExprID) {
+    type = t;
+    type = type ? type->GetAsConstType() : type;
+    isAggregate = true;
+    aggregateValues = values;
+    const CollectionType *ct = CastType<CollectionType>(type ? type->GetAsNonConstType() : nullptr);
+    AssertPos(pos, ct != nullptr);
+    if (ct != nullptr) {
+        AssertPos(pos, ct->GetElementCount() == (int)aggregateValues.size());
+    }
+}
+
 ConstExpr::ConstExpr(const ConstExpr *old, SourcePos p, unsigned scid) : Expr(p, scid) {
     type = old->type;
+    isAggregate = old->isAggregate;
+    if (isAggregate) {
+        aggregateValues = old->aggregateValues;
+        return;
+    }
+    isPointer = old->isPointer;
+    if (isPointer) {
+        ptrConst = old->ptrConst;
+        return;
+    }
 
     AtomicType::BasicType basicType = getBasicType();
 
@@ -6382,19 +6477,32 @@ ConstExpr::ConstExpr(const ConstExpr *old, SourcePos p) : ConstExpr(old, p, Cons
 ConstExpr::ConstExpr(const Symbol *s, SourcePos p) : ConstExpr(s->constValue, p, ConstSymbolExprID) {}
 
 AtomicType::BasicType ConstExpr::getBasicType() const {
-    const AtomicType *at = CastType<AtomicType>(type);
+    AssertPos(pos, !isAggregate);
+    AssertPos(pos, !isPointer);
+    const Type *baseType = type ? type->GetAsNonConstType() : nullptr;
+    const AtomicType *at = CastType<AtomicType>(baseType);
     if (at != nullptr) {
         return at->basicType;
-    } else {
-        AssertPos(pos, CastType<EnumType>(type) != nullptr);
-        return AtomicType::TYPE_UINT32;
     }
+    if (CastType<PointerType>(baseType) != nullptr) {
+        return g->target->is32Bit() ? AtomicType::TYPE_UINT32 : AtomicType::TYPE_UINT64;
+    }
+    AssertPos(pos, CastType<EnumType>(baseType) != nullptr);
+    return AtomicType::TYPE_UINT32;
 }
 
 const Type *ConstExpr::GetTypeImpl() const { return type; }
 
 llvm::Value *ConstExpr::GetValue(FunctionEmitContext *ctx) const {
     ctx->SetDebugPos(pos);
+    if (isAggregate || isPointer) {
+        std::pair<llvm::Constant *, bool> cpair = GetConstant(type);
+        return cpair.first;
+    }
+    if (CastType<PointerType>(type->GetAsNonConstType()) != nullptr) {
+        std::pair<llvm::Constant *, bool> cpair = GetConstant(type);
+        return cpair.first;
+    }
     bool isVarying = type->IsVaryingType();
 
     AtomicType::BasicType basicType = getBasicType();
@@ -6443,6 +6551,42 @@ bool ConstExpr::IsEqual(const ConstExpr *ce) const {
 
     if (!Type::EqualIgnoringConst(type, ce->type)) {
         return false;
+    }
+    if (isAggregate || ce->isAggregate) {
+        if (isAggregate != ce->isAggregate) {
+            return false;
+        }
+        if (aggregateValues.size() != ce->aggregateValues.size()) {
+            return false;
+        }
+        for (size_t i = 0; i < aggregateValues.size(); ++i) {
+            if (!aggregateValues[i]->IsEqual(ce->aggregateValues[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+    if (isPointer || ce->isPointer) {
+        if (isPointer && ce->isPointer) {
+            return ptrConst == ce->ptrConst;
+        }
+        const ConstExpr *ptrExpr = isPointer ? this : ce;
+        const ConstExpr *numExpr = isPointer ? ce : this;
+        const Type *numBase = numExpr->type ? numExpr->type->GetAsNonConstType() : nullptr;
+        if (CastType<PointerType>(numBase) == nullptr) {
+            return false;
+        }
+        int64_t vals[ISPC_MAX_NVEC] = {};
+        numExpr->GetValues(vals, numExpr->type->IsVaryingType());
+        bool allZero = true;
+        for (int i = 0; i < numExpr->Count(); ++i) {
+            if (vals[i] != 0) {
+                allZero = false;
+                break;
+            }
+        }
+        bool isNull = (ptrExpr->ptrConst != nullptr) ? ptrExpr->ptrConst->isNullValue() : false;
+        return allZero && isNull;
     }
 
     for (int i = 0; i < Count(); ++i) {
@@ -6585,6 +6729,7 @@ static void lConvert(const From *from, std::vector<llvm::APFloat> &to, llvm::Typ
 }
 
 int ConstExpr::GetValues(std::vector<llvm::APFloat> &fpt) const {
+    AssertPos(pos, !isAggregate);
     AtomicType::BasicType bType = getBasicType();
     AssertPos(pos, (bType == AtomicType::TYPE_FLOAT16) || (bType == AtomicType::TYPE_FLOAT) ||
                        (bType == AtomicType::TYPE_DOUBLE));
@@ -6593,6 +6738,7 @@ int ConstExpr::GetValues(std::vector<llvm::APFloat> &fpt) const {
 }
 
 int ConstExpr::GetValues(std::vector<llvm::APFloat> &fpt, llvm::Type *type, bool forceVarying) const {
+    AssertPos(pos, !isAggregate);
     switch (getBasicType()) {
     case AtomicType::TYPE_INT1:
     case AtomicType::TYPE_BOOL:
@@ -6634,6 +6780,8 @@ int ConstExpr::GetValues(std::vector<llvm::APFloat> &fpt, llvm::Type *type, bool
 }
 
 #define CONVERT_SWITCH                                                                                                 \
+    AssertPos(pos, !isAggregate);                                                                                      \
+    AssertPos(pos, !isPointer);                                                                                        \
     switch (getBasicType()) {                                                                                          \
     case AtomicType::TYPE_INT1:                                                                                        \
     case AtomicType::TYPE_BOOL:                                                                                        \
@@ -6673,7 +6821,23 @@ int ConstExpr::GetValues(std::vector<llvm::APFloat> &fpt, llvm::Type *type, bool
     }                                                                                                                  \
     return Count();
 
-int ConstExpr::GetValues(bool *toPtr, bool forceVarying) const { CONVERT_SWITCH; }
+int ConstExpr::GetValues(bool *toPtr, bool forceVarying) const {
+    if (isPointer) {
+        bool isNull = (ptrConst != nullptr) ? ptrConst->isNullValue() : false;
+        bool value = !isNull;
+        int count = Count();
+        for (int i = 0; i < count; ++i) {
+            toPtr[i] = value;
+        }
+        if (forceVarying && count == 1) {
+            for (int i = 1; i < g->target->getVectorWidth(); ++i) {
+                toPtr[i] = toPtr[0];
+            }
+        }
+        return count;
+    }
+    CONVERT_SWITCH;
+}
 
 int ConstExpr::GetValues(int8_t *toPtr, bool forceVarying) const { CONVERT_SWITCH; }
 
@@ -6691,7 +6855,92 @@ int ConstExpr::GetValues(int64_t *toPtr, bool forceVarying) const { CONVERT_SWIT
 
 int ConstExpr::GetValues(uint64_t *toPtr, bool forceVarying) const { CONVERT_SWITCH; }
 
-int ConstExpr::Count() const { return GetType()->IsVaryingType() ? g->target->getVectorWidth() : 1; }
+int ConstExpr::Count() const {
+    if (isAggregate) {
+        return (int)aggregateValues.size();
+    }
+    if (isPointer) {
+        return GetType()->IsVaryingType() ? g->target->getVectorWidth() : 1;
+    }
+    return GetType()->IsVaryingType() ? g->target->getVectorWidth() : 1;
+}
+
+static llvm::Constant *lConvertPointerConstant(llvm::Constant *c, const Type *constType);
+
+static std::pair<llvm::Constant *, bool> lGetAggregateConstExprConstant(const Type *constType, const ConstExpr *cExpr,
+                                                                        bool isStorageType) {
+    if (constType == nullptr || cExpr == nullptr) {
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
+    }
+
+    const Type *baseType = constType->GetAsNonConstType();
+    const CollectionType *collectionType = CastType<CollectionType>(baseType);
+    if (collectionType == nullptr) {
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
+    }
+
+    bool isNotValidForMultiTargetGlobal = false;
+    const std::vector<ConstExpr *> &values = cExpr->GetAggregateValues();
+    int elementCount = collectionType->GetElementCount();
+    if ((int)values.size() > elementCount) {
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
+    }
+
+    std::vector<llvm::Constant *> cv;
+    cv.reserve(elementCount);
+    for (int i = 0; i < elementCount; ++i) {
+        const Type *elementType = collectionType->GetElementType(i);
+        if (elementType == nullptr) {
+            return std::pair<llvm::Constant *, bool>(nullptr, false);
+        }
+        if (i < (int)values.size()) {
+            std::pair<llvm::Constant *, bool> cPair =
+                isStorageType ? values[i]->GetStorageConstant(elementType) : values[i]->GetConstant(elementType);
+            if (cPair.first == nullptr) {
+                return std::pair<llvm::Constant *, bool>(nullptr, false);
+            }
+            isNotValidForMultiTargetGlobal = isNotValidForMultiTargetGlobal || cPair.second;
+            cv.push_back(cPair.first);
+        } else {
+            llvm::Type *llvmType = elementType->LLVMType(g->ctx);
+            if (llvmType == nullptr) {
+                return std::pair<llvm::Constant *, bool>(nullptr, false);
+            }
+            cv.push_back(llvm::Constant::getNullValue(llvmType));
+        }
+    }
+
+    if (CastType<StructType>(baseType) != nullptr) {
+        llvm::StructType *llvmStructType = llvm::dyn_cast<llvm::StructType>(baseType->LLVMType(g->ctx));
+        if (llvmStructType == nullptr) {
+            return std::pair<llvm::Constant *, bool>(nullptr, false);
+        }
+        return std::pair<llvm::Constant *, bool>(llvm::ConstantStruct::get(llvmStructType, cv),
+                                                 isNotValidForMultiTargetGlobal);
+    }
+
+    llvm::Type *lt = baseType->LLVMType(g->ctx);
+    if (lt == nullptr) {
+        return std::pair<llvm::Constant *, bool>(nullptr, false);
+    }
+    llvm::ArrayType *lat = llvm::dyn_cast<llvm::ArrayType>(lt);
+    if (lat != nullptr) {
+        return std::pair<llvm::Constant *, bool>(llvm::ConstantArray::get(lat, cv), isNotValidForMultiTargetGlobal);
+    }
+
+    const VectorType *vt = CastType<VectorType>(baseType);
+    llvm::VectorType *lvt = llvm::dyn_cast<llvm::VectorType>(lt);
+    if (vt == nullptr || lvt == nullptr) {
+        return std::pair<llvm::Constant *, bool>(nullptr, isNotValidForMultiTargetGlobal);
+    }
+
+    int vectorWidth = vt->getVectorMemoryCount();
+    while ((int)cv.size() < vectorWidth) {
+        cv.push_back(llvm::UndefValue::get(lvt->getElementType()));
+    }
+
+    return std::pair<llvm::Constant *, bool>(llvm::ConstantVector::get(cv), isNotValidForMultiTargetGlobal);
+}
 
 static std::pair<llvm::Constant *, bool> lGetConstExprConstant(const Type *constType, const ConstExpr *cExpr,
                                                                bool isStorageType) {
@@ -6699,6 +6948,9 @@ static std::pair<llvm::Constant *, bool> lGetConstExprConstant(const Type *const
     // constant type.
     SourcePos pos = cExpr->pos;
     bool isNotValidForMultiTargetGlobal = false;
+    if (cExpr->IsAggregate()) {
+        return lGetAggregateConstExprConstant(constType, cExpr, isStorageType);
+    }
     if (constType->IsUniformType()) {
         AssertPos(pos, cExpr->Count() == 1);
     }
@@ -6812,6 +7064,24 @@ static std::pair<llvm::Constant *, bool> lGetConstExprConstant(const Type *const
             return std::pair<llvm::Constant *, bool>(LLVMDoubleVector(dv), isNotValidForMultiTargetGlobal);
         }
     } else if (CastType<PointerType>(constType) != nullptr) {
+        if (cExpr->IsPointerConst()) {
+            llvm::Constant *c = cExpr->GetPointerConstant();
+            if (c == nullptr) {
+                return std::pair<llvm::Constant *, bool>(nullptr, false);
+            }
+            llvm::Type *llvmType = constType->LLVMType(g->ctx);
+            if (llvmType == nullptr) {
+                return std::pair<llvm::Constant *, bool>(nullptr, false);
+            }
+            if (c->getType() != llvmType) {
+                if (llvmType->isPointerTy() && c->getType()->isPointerTy()) {
+                    c = llvm::ConstantExpr::getBitCast(c, llvmType);
+                } else {
+                    c = lConvertPointerConstant(c, constType);
+                }
+            }
+            return std::pair<llvm::Constant *, bool>(c, isNotValidForMultiTargetGlobal);
+        }
         // The only time we should get here is if we have an integer '0'
         // constant that should be turned into a nullptr pointer of the
         // appropriate type.
@@ -6856,6 +7126,26 @@ ConstExpr *ConstExpr::Instantiate(TemplateInstantiation &templInst) const { retu
 
 std::string ConstExpr::GetValuesAsStr(const std::string &separator) const {
     std::stringstream result;
+    if (isAggregate) {
+        result << "{";
+        for (size_t i = 0; i < aggregateValues.size(); ++i) {
+            if (i != 0) {
+                result << separator;
+            }
+            result << aggregateValues[i]->GetString();
+        }
+        result << "}";
+        return result.str();
+    }
+    if (isPointer) {
+        if (ptrConst == nullptr) {
+            return "<null ptr>";
+        }
+        std::string s;
+        llvm::raw_string_ostream os(s);
+        ptrConst->print(os);
+        return os.str();
+    }
     for (int i = 0; i < Count(); ++i) {
         if (i != 0) {
             result << separator;
@@ -8862,7 +9152,7 @@ std::pair<llvm::Constant *, bool> AddressOfExpr::GetConstant(const Type *type) c
     if (ptr && llvm::dyn_cast<llvm::GlobalVariable>(ptr)) {
         const Type *eTYPE = GetType();
         if (type->LLVMType(g->ctx) == eTYPE->LLVMType(g->ctx)) {
-            if (llvm::dyn_cast<SymbolExpr>(expr) != nullptr) {
+            if (llvm::dyn_cast<SymbolExpr>(expr) != nullptr || llvm::dyn_cast<ConstSymbolExpr>(expr) != nullptr) {
                 return std::pair<llvm::Constant *, bool>(llvm::cast<llvm::Constant>(ptr),
                                                          isNotValidForMultiTargetGlobal);
 
@@ -8882,7 +9172,8 @@ std::pair<llvm::Constant *, bool> AddressOfExpr::GetConstant(const Type *type) c
                 }
                 // The base expression needs to be a global symbol so that the
                 // address is a constant.
-                if (llvm::dyn_cast<SymbolExpr>(mBaseExpr) == nullptr) {
+                if (llvm::dyn_cast<SymbolExpr>(mBaseExpr) == nullptr &&
+                    llvm::dyn_cast<ConstSymbolExpr>(mBaseExpr) == nullptr) {
                     return std::pair<llvm::Constant *, bool>(nullptr, false);
                 }
                 gepIndex.insert(gepIndex.begin(), LLVMInt64(0));

--- a/src/func.h
+++ b/src/func.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2025, Intel Corporation
+  Copyright (c) 2011-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -26,6 +26,9 @@ class Function {
 
     const Type *GetReturnType() const;
     const FunctionType *GetType() const;
+    const std::string &GetName() const;
+    const std::vector<Symbol *> &GetParameterSymbols() const;
+    const Stmt *GetCode() const;
 
     /** Generate LLVM IR for the function into the current module. */
     void GenerateIR() const;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -14,6 +14,7 @@
 #include <string>
 
 #include <llvm/Bitcode/BitcodeWriter.h>
+#include <llvm/IR/Attributes.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/raw_ostream.h>
@@ -299,6 +300,15 @@ Symbol *lCreateISPCSymbolForLLVMIntrinsic(llvm::Function *func, SymbolTable *sym
         argTypes.push_back(type);
     }
     FunctionType *funcType = new FunctionType(returnType, argTypes, noPos);
+    if (funcType != nullptr) {
+        llvm::AttributeList attrs = func->getAttributes();
+        unsigned int numParams = func->arg_size();
+        for (unsigned int j = 0; j < numParams; ++j) {
+            if (attrs.hasParamAttr(j, llvm::Attribute::ImmArg)) {
+                funcType->SetParameterImmArg(j, true);
+            }
+        }
+    }
     Debug(noPos, "Created Intrinsic symbol \"%s\" [%s]\n", name.c_str(), funcType->GetString().c_str());
     Symbol *sym = new Symbol(name, noPos, Symbol::SymbolKind::Function, funcType);
     sym->function = func;

--- a/src/lex.ll
+++ b/src/lex.ll
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -56,6 +56,7 @@ void ParserInit() {
     tokenToName[TOKEN_CIF] = "cif";
     tokenToName[TOKEN_CWHILE] = "cwhile";
     tokenToName[TOKEN_CONST] = "const";
+    tokenToName[TOKEN_CONSTEXPR] = "constexpr";
     tokenToName[TOKEN_CONTINUE] = "continue";
     tokenToName[TOKEN_DEFAULT] = "default";
     tokenToName[TOKEN_DO] = "do";
@@ -185,6 +186,7 @@ void ParserInit() {
     tokenNameRemap["TOKEN_CIF"] = "\'cif\'";
     tokenNameRemap["TOKEN_CWHILE"] = "\'cwhile\'";
     tokenNameRemap["TOKEN_CONST"] = "\'const\'";
+    tokenNameRemap["TOKEN_CONSTEXPR"] = "\'constexpr\'";
     tokenNameRemap["TOKEN_CONTINUE"] = "\'continue\'";
     tokenNameRemap["TOKEN_DEFAULT"] = "\'default\'";
     tokenNameRemap["TOKEN_DO"] = "\'do\'";
@@ -325,6 +327,7 @@ cdo { return TOKEN_CDO; }
 cfor { return TOKEN_CFOR; }
 cif { return TOKEN_CIF; }
 cwhile { return TOKEN_CWHILE; }
+constexpr { return TOKEN_CONSTEXPR; }
 const { return TOKEN_CONST; }
 continue { return TOKEN_CONTINUE; }
 creturn { Warning(yylloc, "\"creturn\" is deprecated. Use \"return\"."); return TOKEN_RETURN; }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -11,6 +11,7 @@
 
 #include "module.h"
 #include "builtins.h"
+#include "constexpr.h"
 #include "ctx.h"
 #include "expr.h"
 #include "func.h"
@@ -358,6 +359,120 @@ int Module::parse() {
     return 0;
 }
 
+void Module::ResolveDeferredConstexpr() {
+    if (deferredConstexprGlobals.empty() && deferredConstexprParams.empty()) {
+        return;
+    }
+
+    bool progress = true;
+    while (progress) {
+        progress = false;
+
+        for (size_t i = 0; i < deferredConstexprGlobals.size();) {
+            DeferredConstexprGlobal entry = deferredConstexprGlobals[i];
+            ConstexprEvalResult evalResult = ConstexprEvaluateDetailed(entry.initExpr, entry.type, true);
+            if (evalResult.value != nullptr) {
+                Expr *initExpr = evalResult.value;
+                std::pair<llvm::Constant *, bool> initPair = initExpr->GetStorageConstant(entry.type);
+                if (initPair.first == nullptr) {
+                    Error(entry.pos, "Initializer for global variable \"%s\" must be a constant.",
+                          entry.sym ? entry.sym->name.c_str() : "<unknown>");
+                } else {
+                    if (evalResult.targetDependent) {
+                        initPair.second = true;
+                    }
+                    if (entry.sym && !entry.sym->storageClass.IsStatic() && initPair.second) {
+                        if (g->isMultiTargetCompilation) {
+                            Error(entry.pos,
+                                  "Initializer for global variable \"%s\" is not a constant for multi-target "
+                                  "compilation.",
+                                  entry.sym->name.c_str());
+                        } else {
+                            Warning(entry.pos,
+                                    "Initializer for global variable \"%s\" "
+                                    "is a constant for single-target compilation "
+                                    "but not for multi-target compilation.",
+                                    entry.sym->name.c_str());
+                        }
+                    }
+                    if (entry.sym && entry.sym->storageInfo) {
+                        llvm::GlobalVariable *gv =
+                            llvm::dyn_cast<llvm::GlobalVariable>(entry.sym->storageInfo->getPointer());
+                        if (gv) {
+                            gv->setInitializer(initPair.first);
+                        }
+                    }
+                    if (entry.sym) {
+                        entry.sym->constEvalPending = false;
+                        if (entry.sym->type && entry.sym->type->IsConstType()) {
+                            entry.sym->constValue = llvm::dyn_cast<ConstExpr>(initExpr);
+                        }
+                    }
+                }
+                if (entry.sym) {
+                    entry.sym->constEvalPending = false;
+                }
+                deferredConstexprGlobals[i] = deferredConstexprGlobals.back();
+                deferredConstexprGlobals.pop_back();
+                progress = true;
+                continue;
+            }
+            if (!evalResult.deferred) {
+                Error(entry.pos, "Initializer for global variable \"%s\" must be a constant.",
+                      entry.sym ? entry.sym->name.c_str() : "<unknown>");
+                if (entry.sym) {
+                    entry.sym->constEvalPending = false;
+                }
+                deferredConstexprGlobals[i] = deferredConstexprGlobals.back();
+                deferredConstexprGlobals.pop_back();
+                progress = true;
+                continue;
+            }
+            ++i;
+        }
+
+        for (size_t i = 0; i < deferredConstexprParams.size();) {
+            DeferredConstexprParam entry = deferredConstexprParams[i];
+            const Type *paramType = entry.funcType ? entry.funcType->GetParameterType(entry.index) : nullptr;
+            ConstexprEvalResult evalResult = ConstexprEvaluateDetailed(entry.expr, paramType, true);
+            if (evalResult.value != nullptr && entry.funcType != nullptr) {
+                entry.funcType->SetParameterDefault(entry.index, evalResult.value);
+                deferredConstexprParams[i] = deferredConstexprParams.back();
+                deferredConstexprParams.pop_back();
+                progress = true;
+                continue;
+            }
+            if (!evalResult.deferred) {
+                Error(entry.pos, "Default value for parameter \"%s\" must be a compile-time constant.",
+                      entry.paramName.c_str());
+                deferredConstexprParams[i] = deferredConstexprParams.back();
+                deferredConstexprParams.pop_back();
+                progress = true;
+                continue;
+            }
+            ++i;
+        }
+    }
+
+    if (!deferredConstexprGlobals.empty()) {
+        for (const auto &entry : deferredConstexprGlobals) {
+            Error(entry.pos, "Initializer for global variable \"%s\" must be a constant.",
+                  entry.sym ? entry.sym->name.c_str() : "<unknown>");
+            if (entry.sym) {
+                entry.sym->constEvalPending = false;
+            }
+        }
+        deferredConstexprGlobals.clear();
+    }
+    if (!deferredConstexprParams.empty()) {
+        for (const auto &entry : deferredConstexprParams) {
+            Error(entry.pos, "Default value for parameter \"%s\" must be a compile-time constant.",
+                  entry.paramName.c_str());
+        }
+        deferredConstexprParams.clear();
+    }
+}
+
 int Module::CompileFile() {
     llvm::TimeTraceScope CompileFileTimeScope(
         "CompileFile", llvm::StringRef(srcFile + ("_" + std::string(g->target->GetISAString()))));
@@ -382,6 +497,10 @@ int Module::CompileFile() {
     debugDumpModule(module, "Parsed", pre_stage++);
 
     ast->Print(g->astDump);
+
+    if (errorCount == 0) {
+        ResolveDeferredConstexpr();
+    }
 
     if (g->NoOmitFramePointer) {
         for (llvm::Function &f : *module) {
@@ -569,7 +688,7 @@ Expr *lConvertExprListToConstExpr(Expr *initExpr, const Type *type, const std::s
     return nullptr;
 }
 
-void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
+void Module::AddGlobalVariable(Declarator *decl, bool isConst, bool isConstexpr) {
     const std::string &name = decl->name;
     const Type *type = decl->type;
     Expr *initExpr = decl->initExpr;
@@ -662,6 +781,12 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
         return;
     }
 
+    if (isConstexpr && !IsConstexprTypeAllowed(type)) {
+        Error(pos, "constexpr variable \"%s\" must have an atomic, enum, pointer, short vector, array, or struct type",
+              name.c_str());
+        return;
+    }
+
     llvm::Type *llvmType = type->LLVMStorageType(g->ctx);
     if (llvmType == nullptr) {
         return;
@@ -671,6 +796,11 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
     // make sure it's a compile-time constant!
     llvm::Constant *llvmInitializer = nullptr;
     ConstExpr *constValue = nullptr;
+    bool deferredInit = false;
+    if (isConstexpr && initExpr == nullptr) {
+        Error(pos, "Missing initializer for constexpr variable \"%s\".", name.c_str());
+        return;
+    }
     if (storageClass.IsExtern()) {
         if (initExpr != nullptr) {
             Error(pos, "Initializer can't be provided with \"extern\" global variable \"%s\".", name.c_str());
@@ -703,14 +833,30 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
                         Error(pos, "Initialization of global variable \"%s\" was unsuccessful.", name.c_str());
                         return;
                     }
+
+                    std::pair<llvm::Constant *, bool> initPair = initExpr->GetStorageConstant(type);
+                    bool initIsTargetDependent = initPair.second;
+
+                    ConstexprEvalResult evalResult = ConstexprEvaluateDetailed(initExpr, type, true);
+                    if (evalResult.value != nullptr) {
+                        initExpr = evalResult.value;
+                        if (initPair.first == nullptr) {
+                            initPair = initExpr->GetStorageConstant(type);
+                        }
+                        if (initIsTargetDependent || evalResult.targetDependent) {
+                            initPair.second = true;
+                        }
+                    } else if (evalResult.deferred) {
+                        deferredInit = true;
+                    }
+
                     // Fingers crossed, now let's see if we've got a
                     // constant value..
-                    std::pair<llvm::Constant *, bool> initPair = initExpr->GetStorageConstant(type);
                     llvmInitializer = initPair.first;
 
                     // If compiling for multitarget, skip initialization for
                     // indentified scenarios unless it's static
-                    if (llvmInitializer != nullptr) {
+                    if (!deferredInit && llvmInitializer != nullptr) {
                         if (!storageClass.IsStatic() && initPair.second) {
                             if (g->isMultiTargetCompilation == true) {
                                 Error(initExpr->pos,
@@ -734,7 +880,7 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
                             // represent their values.
                             constValue = llvm::dyn_cast<ConstExpr>(initExpr);
                         }
-                    } else {
+                    } else if (!deferredInit) {
                         Error(initExpr->pos, "Initializer for global variable \"%s\" must be a constant.",
                               name.c_str());
                     }
@@ -787,6 +933,13 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
 
         // Update the symbol's constValue
         sym->constValue = constValue;
+        if (isConstexpr) {
+            sym->isConstexpr = true;
+        }
+        if (deferredInit) {
+            sym->constEvalPending = true;
+            deferredConstexprGlobals.push_back({sym, initExpr, type, pos, isConst, isConstexpr});
+        }
 
         return;
     }
@@ -794,6 +947,11 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
     symbolTable->AddVariable(sym);
 
     sym->constValue = constValue;
+    sym->isConstexpr = isConstexpr;
+    if (deferredInit) {
+        sym->constEvalPending = true;
+        deferredConstexprGlobals.push_back({sym, initExpr, type, pos, isConst, isConstexpr});
+    }
 
     llvm::GlobalValue::LinkageTypes linkage =
         sym->storageClass.IsStatic() ? llvm::GlobalValue::InternalLinkage : llvm::GlobalValue::ExternalLinkage;
@@ -821,6 +979,11 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
             diSpace, name, name, file, pos.first_line, sym->type->GetDIType(diSpace), sym->storageClass.IsStatic());
         sym_GV_storagePtr->addDebugInfo(var);
     }
+}
+
+void Module::AddDeferredConstexprParam(FunctionType *funcType, int index, Expr *expr, SourcePos pos,
+                                       const std::string &paramName) {
+    deferredConstexprParams.push_back({funcType, index, expr, pos, paramName});
 }
 
 /** Given an arbitrary type, see if it or any of the leaf types contained
@@ -985,6 +1148,12 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
             // and type.  This also hits when we have previously declared
             // the function and are about to define it.
             if (Type::Equal(overloadFunc->type, functionType)) {
+                if (overloadFunc->isConstexpr != functionType->IsConstexpr()) {
+                    Error(pos,
+                          "Function \"%s\" redeclared with different \"constexpr\" qualifier "
+                          "(previous declaration at %s:%d).",
+                          name.c_str(), overloadFunc->pos.name, overloadFunc->pos.first_line);
+                }
                 return;
             }
 
@@ -1263,6 +1432,7 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
     // symbol table
     Symbol *funSym =
         new Symbol(name, pos, Symbol::SymbolKind::Function, functionType, storageClass, decl->attributeList);
+    funSym->isConstexpr = functionType->IsConstexpr();
     funSym->function = function;
     bool ok = symbolTable->AddFunction(funSym);
     Assert(ok);
@@ -1275,6 +1445,12 @@ void Module::AddFunctionDefinition(const std::string &name, const FunctionType *
         return;
     }
 
+    if (sym->isConstexpr != type->IsConstexpr()) {
+        Error(code->pos,
+              "Definition of function \"%s\" conflicts in \"constexpr\" qualifier with previous declaration at %s:%d.",
+              name.c_str(), sym->pos.name, sym->pos.first_line);
+        return;
+    }
     sym->pos = code->pos;
 
     // FIXME: because we encode the parameter names in the function type,

--- a/src/module.h
+++ b/src/module.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -84,7 +84,11 @@ class Module {
     void AddTypeDef(const std::string &name, const Type *type, SourcePos pos);
 
     /** Add a new global variable corresponding to the decl. */
-    void AddGlobalVariable(Declarator *decl, bool isConst);
+    void AddGlobalVariable(Declarator *decl, bool isConst, bool isConstexpr);
+
+    /** Record a deferred constexpr default parameter for later evaluation. */
+    void AddDeferredConstexprParam(FunctionType *funcType, int index, Expr *expr, SourcePos pos,
+                                   const std::string &paramName);
 
     /** Add a declaration of the function defined by the given function
         symbol to the module. */
@@ -399,6 +403,23 @@ class Module {
     std::map<std::string, llvm::StructType *> structTypeMap;
 
   private:
+    struct DeferredConstexprGlobal {
+        Symbol *sym;
+        Expr *initExpr;
+        const Type *type;
+        SourcePos pos;
+        bool isConst;
+        bool isConstexpr;
+    };
+
+    struct DeferredConstexprParam {
+        FunctionType *funcType;
+        int index;
+        Expr *expr;
+        SourcePos pos;
+        std::string paramName;
+    };
+
     const char *srcFile{nullptr};
     AST *ast{nullptr};
 
@@ -434,6 +455,11 @@ class Module {
     /* This set is used to store strings that is referenced in yylloc (SourcePos)
        in lexer once and not to lost memory via just strduping them. */
     std::set<std::string> pseudoDependencies;
+
+    std::vector<DeferredConstexprGlobal> deferredConstexprGlobals;
+    std::vector<DeferredConstexprParam> deferredConstexprParams;
+
+    void ResolveDeferredConstexpr();
 
     /**
      * Compiles the module for a single target architecture.

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -11,6 +11,7 @@
 #include "stmt.h"
 #include "builtins-decl.h"
 #include "builtins-info.h"
+#include "constexpr.h"
 #include "ctx.h"
 #include "expr.h"
 #include "func.h"
@@ -261,10 +262,17 @@ void DeclStmt::EmitCode(FunctionEmitContext *ctx) const {
             // this before the initializer stuff.
             ctx->EmitVariableDebugInfo(sym);
             if (initExpr == 0 && sym->type->IsConstType()) {
-                Error(sym->pos,
-                      "Missing initializer for const variable "
-                      "\"%s\".",
-                      sym->name.c_str());
+                if (sym->isConstexpr) {
+                    Error(sym->pos,
+                          "Missing initializer for constexpr variable "
+                          "\"%s\".",
+                          sym->name.c_str());
+                } else {
+                    Error(sym->pos,
+                          "Missing initializer for const variable "
+                          "\"%s\".",
+                          sym->name.c_str());
+                }
             }
 
             // And then get it initialized...
@@ -296,6 +304,12 @@ Stmt *DeclStmt::Optimize() {
             Symbol *sym = vars[i].sym;
             if (sym->type && sym->type->IsConstType() && Type::Equal(init->GetType(), sym->type)) {
                 sym->constValue = llvm::dyn_cast<ConstExpr>(init);
+            }
+            if (sym->type && sym->type->IsConstType() && sym->constValue == nullptr) {
+                ConstExpr *ce = ConstexprEvaluate(init, sym->type);
+                if (ce != nullptr) {
+                    sym->constValue = ce;
+                }
             }
         }
     }
@@ -391,11 +405,57 @@ Stmt *DeclStmt::TypeCheck() {
                 Error(pos, "variable '%s' has incomplete struct type '%s' and cannot be defined", name.c_str(),
                       type->GetString().c_str());
             }
+            if (vars[i].sym->isConstexpr) {
+                Error(vars[i].sym->pos, "Missing initializer for constexpr variable \"%s\".", name.c_str());
+                encounteredError = true;
+            }
             continue;
+        }
+
+        if (type != nullptr && !type->IsDependent()) {
+            type = ArrayType::SizeUnsizedArrays(type, vars[i].init);
+            if (type == nullptr) {
+                encounteredError = true;
+                continue;
+            }
+            vars[i].sym->type = type;
         }
 
         // Check an init.
         encounteredError |= lCheckInit(type, &(vars[i].init), name);
+
+        if (vars[i].sym->isConstexpr) {
+            if (!IsConstexprTypeAllowed(type)) {
+                Error(vars[i].sym->pos,
+                      "constexpr variable \"%s\" must have an atomic, enum, pointer, short vector, array, or struct "
+                      "type",
+                      name.c_str());
+                encounteredError = true;
+                continue;
+            }
+            if (type && type->IsDependent()) {
+                continue;
+            }
+            ConstExpr *ce = ConstexprEvaluate(vars[i].init, type);
+            if (ce == nullptr) {
+                Error(vars[i].sym->pos, "Initializer for constexpr variable \"%s\" must be a compile-time constant.",
+                      name.c_str());
+                encounteredError = true;
+            } else {
+                vars[i].init = ce;
+                vars[i].sym->constValue = ce;
+            }
+        }
+        if (vars[i].sym->type && vars[i].sym->type->IsConstType() && vars[i].init != nullptr &&
+            llvm::dyn_cast<ExprList>(vars[i].init) == nullptr && vars[i].sym->constValue == nullptr) {
+            ConstExpr *ce = llvm::dyn_cast<ConstExpr>(vars[i].init);
+            if (ce == nullptr) {
+                ce = ConstexprEvaluate(vars[i].init, vars[i].sym->type);
+            }
+            if (ce != nullptr) {
+                vars[i].sym->constValue = ce;
+            }
+        }
     }
     return encounteredError ? nullptr : this;
 }

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -26,7 +26,7 @@ using namespace ispc;
 
 Symbol::Symbol(const std::string &n, SourcePos p, SymbolKind st, const Type *t, StorageClass sc, AttributeList *a)
     : pos(p), name(n), storageInfo(nullptr), function(nullptr), exportedFunction(nullptr), type(t), constValue(nullptr),
-      storageClass(sc), varyingCFDepth(0), parentFunction(nullptr),
+      isConstexpr(false), constEvalPending(false), storageClass(sc), varyingCFDepth(0), parentFunction(nullptr),
       attrs(a != nullptr ? new AttributeList(*a) : nullptr), kind(st) {}
 
 Symbol::~Symbol() {

--- a/src/sym.h
+++ b/src/sym.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -76,12 +76,14 @@ class Symbol : public Traceable {
     ConstExpr *constValue;     /*!< For symbols with const-qualified types, this may store
                                     the symbol's compile-time constant value.  This value may
                                     validly be nullptr for a const-qualified type, however; for
-                                    example, the ConstExpr class can't currently represent
-                                    struct types.  For cases like these, ConstExpr is nullptr,
+                                    example, the ConstExpr class doesn't always represent
+                                    all complex constant values. For cases like these, ConstExpr is nullptr,
                                     though for all const symbols, the value pointed to by the
                                     storageInfo pointer member will be its constant value.  (This
                                     messiness is due to needing an ispc ConstExpr for the early
                                     constant folding optimizations). */
+    bool isConstexpr;          /*!< True if the symbol was declared with constexpr. */
+    bool constEvalPending;     /*!< True if constant evaluation of the initializer is deferred. */
     StorageClass storageClass; /*!< Records the storage class (if any) provided with the
                                     symbol's declaration. */
     int varyingCFDepth;        /*!< This member records the number of levels of nested 'varying'

--- a/src/type.h
+++ b/src/type.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -994,7 +994,8 @@ class FunctionType : public Type {
         FUNC_VECTOR_CALL = 1 << 7,   // 0x0080
         FUNC_REG_CALL = 1 << 8,      // 0x0100
         FUNC_CDECL = 1 << 9,         // 0x0200
-        FUNC_SAFE = 1 << 10          // 0x0400
+        FUNC_SAFE = 1 << 10,         // 0x0400
+        FUNC_CONSTEXPR = 1 << 11     // 0x0800
     };
 
     FunctionType(const Type *returnType, const llvm::SmallVector<const Type *, 8> &argTypes, SourcePos pos);
@@ -1068,8 +1069,11 @@ class FunctionType : public Type {
     int GetNumParameters() const { return (int)paramTypes.size(); }
     const Type *GetParameterType(int i) const;
     Expr *GetParameterDefault(int i) const;
+    void SetParameterDefault(int i, Expr *expr);
     const SourcePos &GetParameterSourcePos(int i) const;
     const std::string &GetParameterName(int i) const;
+    bool IsParameterImmArg(int i) const;
+    void SetParameterImmArg(int i, bool immarg);
 
     int GetCostOverride() const { return costOverride; }
 
@@ -1099,6 +1103,10 @@ class FunctionType : public Type {
         mask). */
     bool IsUnmasked() const { return flags & FUNC_UNMASKED; }
 
+    /** Return true if the function had a 'constexpr' qualifier in the
+        source program. */
+    bool IsConstexpr() const { return flags & FUNC_CONSTEXPR; }
+
     /** Indicates whether the function name should be mangled. */
     bool IsUnmangled() const { return flags & FUNC_UNMANGLED; }
 
@@ -1126,6 +1134,7 @@ class FunctionType : public Type {
     // in turn the length returned by GetNumParameters()).
     llvm::SmallVector<const Type *, 8> paramTypes;
     const llvm::SmallVector<std::string, 8> paramNames;
+    llvm::SmallVector<bool, 8> paramImmArgs;
     /** Default values of the function's arguments.  For arguments without
         default values provided, nullptr is stored. */
     llvm::SmallVector<Expr *, 8> paramDefaults;

--- a/stdlib/include/amx.isph
+++ b/stdlib/include/amx.isph
@@ -86,6 +86,35 @@ inline void amx_tile_store(uniform uint8 tile, uniform int8 *uniform data, unifo
     __amx_tile_store(tile, data, stride);
 }
 
+/// Named AMX tile IDs for constexpr/template use.
+/// `static` avoids linkage conflicts when included from multiple translation units.
+static constexpr uniform int amx_tmm0 = 0;
+static constexpr uniform int amx_tmm1 = 1;
+static constexpr uniform int amx_tmm2 = 2;
+static constexpr uniform int amx_tmm3 = 3;
+static constexpr uniform int amx_tmm4 = 4;
+static constexpr uniform int amx_tmm5 = 5;
+static constexpr uniform int amx_tmm6 = 6;
+static constexpr uniform int amx_tmm7 = 7;
+
+///////////////////////////////////////////////////////////////////////////////
+// AMX template wrappers for compile-time tile IDs
+///////////////////////////////////////////////////////////////////////////////
+
+template <int Tile> inline void amx_tile_zero() { __amx_tile_zero((uniform uint8)Tile); }
+
+template <int Tile> inline void amx_tile_load(const uniform int8 *uniform data, uniform int64 stride) {
+    __amx_tile_load((uniform uint8)Tile, data, stride);
+}
+
+template <int Tile> inline void amx_tile_load_t1(const uniform int8 *uniform data, uniform int64 stride) {
+    __amx_tile_load_t1((uniform uint8)Tile, data, stride);
+}
+
+template <int Tile> inline void amx_tile_store(uniform int8 *uniform data, uniform int64 stride) {
+    __amx_tile_store((uniform uint8)Tile, data, stride);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // AMX INT8 Dot Products (requires amx-int8)
 ///////////////////////////////////////////////////////////////////////////////
@@ -114,6 +143,22 @@ inline void amx_dpbusd(uniform uint8 dst, uniform uint8 src1, uniform uint8 src2
 /// @param src2 Source tile 2 number (0-7).
 inline void amx_dpbuud(uniform uint8 dst, uniform uint8 src1, uniform uint8 src2) { __amx_dpbuud(dst, src1, src2); }
 
+template <int DstTile, int Src1Tile, int Src2Tile> inline void amx_dpbssd() {
+    __amx_dpbssd((uniform uint8)DstTile, (uniform uint8)Src1Tile, (uniform uint8)Src2Tile);
+}
+
+template <int DstTile, int Src1Tile, int Src2Tile> inline void amx_dpbsud() {
+    __amx_dpbsud((uniform uint8)DstTile, (uniform uint8)Src1Tile, (uniform uint8)Src2Tile);
+}
+
+template <int DstTile, int Src1Tile, int Src2Tile> inline void amx_dpbusd() {
+    __amx_dpbusd((uniform uint8)DstTile, (uniform uint8)Src1Tile, (uniform uint8)Src2Tile);
+}
+
+template <int DstTile, int Src1Tile, int Src2Tile> inline void amx_dpbuud() {
+    __amx_dpbuud((uniform uint8)DstTile, (uniform uint8)Src1Tile, (uniform uint8)Src2Tile);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // AMX FP16 Dot Product (requires amx-fp16)
 ///////////////////////////////////////////////////////////////////////////////
@@ -124,6 +169,10 @@ inline void amx_dpbuud(uniform uint8 dst, uniform uint8 src1, uniform uint8 src2
 /// @param src2 Source tile 2 number (0-7).
 inline void amx_dpfp16ps(uniform uint8 dst, uniform uint8 src1, uniform uint8 src2) { __amx_dpfp16ps(dst, src1, src2); }
 
+template <int DstTile, int Src1Tile, int Src2Tile> inline void amx_dpfp16ps() {
+    __amx_dpfp16ps((uniform uint8)DstTile, (uniform uint8)Src1Tile, (uniform uint8)Src2Tile);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // AMX BF16 Dot Product (requires amx-bf16)
 ///////////////////////////////////////////////////////////////////////////////
@@ -133,5 +182,9 @@ inline void amx_dpfp16ps(uniform uint8 dst, uniform uint8 src1, uniform uint8 sr
 /// @param src1 Source tile 1 number (0-7).
 /// @param src2 Source tile 2 number (0-7).
 inline void amx_dpbf16ps(uniform uint8 dst, uniform uint8 src1, uniform uint8 src2) { __amx_dpbf16ps(dst, src1, src2); }
+
+template <int DstTile, int Src1Tile, int Src2Tile> inline void amx_dpbf16ps() {
+    __amx_dpbf16ps((uniform uint8)DstTile, (uniform uint8)Src1Tile, (uniform uint8)Src2Tile);
+}
 
 #undef EXT

--- a/stdlib/include/intrinsics/emmintrin.isph
+++ b/stdlib/include/intrinsics/emmintrin.isph
@@ -569,8 +569,16 @@ static inline unmasked uniform int _mm_movemask_pd(uniform __m128d _A) {
 
 static inline unmasked uniform __m128d _mm_shuffle_pd(uniform __m128d _A, uniform __m128d _B, uniform unsigned int _I) {
     uniform double<2> _R;
-    _R[0] = _A.m128d_f64[_I & 0x3];
-    _R[1] = _B.m128d_f64[(_I >> 2) & 0x3];
+    _R[0] = _A.m128d_f64[_I & 0x1];
+    _R[1] = _B.m128d_f64[(_I >> 1) & 0x1];
+    return *((uniform __m128d * uniform) & _R);
+}
+
+template <int I>
+inline unmasked uniform __m128d _mm_shuffle_pd(uniform __m128d _A, uniform __m128d _B) {
+    uniform double<2> _R;
+    _R[0] = _A.m128d_f64[I & 0x1];
+    _R[1] = _B.m128d_f64[(I >> 1) & 0x1];
     return *((uniform __m128d * uniform) & _R);
 }
 
@@ -1019,6 +1027,16 @@ static inline unmasked uniform __m128i _mm_slli_si128(uniform __m128i _A, unifor
     return *((uniform __m128i * uniform) & Result);
 }
 
+template <int Imm>
+inline unmasked uniform __m128i _mm_slli_si128(uniform __m128i _A) {
+    uniform uint8<16> S0, Result;
+    *((uniform uint8<16> * uniform) & S0) = *((uniform uint8<16> * uniform) & _A);
+    foreach (i = 0 ... 16) {
+        Result[i] = i < (Imm & 0xF) ? 0 : S0[i - (Imm & 0xF)];
+    }
+    return *((uniform __m128i * uniform) & Result);
+}
+
 #define _mm_bslli_si128 _mm_slli_si128
 
 static inline unmasked uniform __m128i _mm_slli_epi16(uniform __m128i _A, uniform int _Count) {
@@ -1026,6 +1044,14 @@ static inline unmasked uniform __m128i _mm_slli_epi16(uniform __m128i _A, unifor
     *((uniform int16<8> * uniform) & S0) = *((uniform int16<8> * uniform) & _A);
     _Count &= 0xFF;
     S0 = (_Count > 15) ? 0 : S0 << _Count;
+    return *((uniform __m128i * uniform) & S0);
+}
+
+template <int Count>
+inline unmasked uniform __m128i _mm_slli_epi16(uniform __m128i _A) {
+    uniform int16<8> S0, Result;
+    *((uniform int16<8> * uniform) & S0) = *((uniform int16<8> * uniform) & _A);
+    S0 = ((Count & 0xFF) > 15) ? 0 : S0 << (Count & 0xFF);
     return *((uniform __m128i * uniform) & S0);
 }
 
@@ -1045,6 +1071,14 @@ static inline unmasked uniform __m128i _mm_slli_epi32(uniform __m128i _A, unifor
     return *((uniform __m128i * uniform) & S0);
 }
 
+template <int Count>
+inline unmasked uniform __m128i _mm_slli_epi32(uniform __m128i _A) {
+    uniform int32<4> S0, Result;
+    *((uniform int32<4> * uniform) & S0) = *((uniform int32<4> * uniform) & _A);
+    S0 = ((Count & 0xFF) > 31) ? 0 : S0 << (Count & 0xFF);
+    return *((uniform __m128i * uniform) & S0);
+}
+
 static inline unmasked uniform __m128i _mm_sll_epi32(uniform __m128i _A, uniform __m128i _Count) {
     uniform int32<4> S0, Result;
     *((uniform int32<4> * uniform) & S0) = *((uniform int32<4> * uniform) & _A);
@@ -1058,6 +1092,14 @@ static inline unmasked uniform __m128i _mm_slli_epi64(uniform __m128i _A, unifor
     *((uniform int64<2> * uniform) & S0) = *((uniform int64<2> * uniform) & _A);
     _Count &= 0xFF;
     S0 = (_Count > 63) ? 0 : S0 << _Count;
+    return *((uniform __m128i * uniform) & S0);
+}
+
+template <int Count>
+inline unmasked uniform __m128i _mm_slli_epi64(uniform __m128i _A) {
+    uniform int64<2> S0, Result;
+    *((uniform int64<2> * uniform) & S0) = *((uniform int64<2> * uniform) & _A);
+    S0 = ((Count & 0xFF) > 63) ? 0 : S0 << (Count & 0xFF);
     return *((uniform __m128i * uniform) & S0);
 }
 
@@ -1077,6 +1119,14 @@ static inline unmasked uniform __m128i _mm_srai_epi16(uniform __m128i _A, unifor
     return *((uniform __m128i * uniform) & S0);
 }
 
+template <int Count>
+inline unmasked uniform __m128i _mm_srai_epi16(uniform __m128i _A) {
+    uniform int16<8> S0, Result;
+    *((uniform int16<8> * uniform) & S0) = *((uniform int16<8> * uniform) & _A);
+    S0 = ((Count & 0xFF) > 15) ? (S0 ? 0xFFFF : 0) : S0 >> (Count & 0xFF);
+    return *((uniform __m128i * uniform) & S0);
+}
+
 static inline unmasked uniform __m128i _mm_sra_epi16(uniform __m128i _A, uniform __m128i _Count) {
     uniform int16<8> S0, Result;
     *((uniform int16<8> * uniform) & S0) = *((uniform int16<8> * uniform) & _A);
@@ -1090,6 +1140,14 @@ static inline unmasked uniform __m128i _mm_srai_epi32(uniform __m128i _A, unifor
     *((uniform int32<4> * uniform) & S0) = *((uniform int32<4> * uniform) & _A);
     _Count &= 0xFF;
     S0 = (_Count > 31) ? (S0 ? 0xFFFFFFFF : 0) : S0 >> _Count;
+    return *((uniform __m128i * uniform) & S0);
+}
+
+template <int Count>
+inline unmasked uniform __m128i _mm_srai_epi32(uniform __m128i _A) {
+    uniform int32<4> S0, Result;
+    *((uniform int32<4> * uniform) & S0) = *((uniform int32<4> * uniform) & _A);
+    S0 = ((Count & 0xFF) > 31) ? (S0 ? 0xFFFFFFFF : 0) : S0 >> (Count & 0xFF);
     return *((uniform __m128i * uniform) & S0);
 }
 
@@ -1111,6 +1169,16 @@ static inline unmasked uniform __m128i _mm_srli_si128(uniform __m128i _A, unifor
     return *((uniform __m128i * uniform) & Result);
 }
 
+template <int Imm>
+inline unmasked uniform __m128i _mm_srli_si128(uniform __m128i _A) {
+    uniform uint8<16> S0, Result;
+    *((uniform uint8<16> * uniform) & S0) = *((uniform uint8<16> * uniform) & _A);
+    foreach (i = 0 ... 16) {
+        Result[i] = 16 - i > (Imm & 0xF) ? S0[i + (Imm & 0xF)] : 0;
+    }
+    return *((uniform __m128i * uniform) & Result);
+}
+
 #define _mm_bsrli_si128 _mm_srli_si128
 
 static inline unmasked uniform __m128i _mm_srli_epi16(uniform __m128i _A, uniform int _Count) {
@@ -1118,6 +1186,14 @@ static inline unmasked uniform __m128i _mm_srli_epi16(uniform __m128i _A, unifor
     *((uniform uint16<8> * uniform) & S0) = *((uniform uint16<8> * uniform) & _A);
     _Count &= 0xFF;
     S0 = (_Count > 15) ? (S0 ? 0xFFFF : 0) : S0 >> _Count;
+    return *((uniform __m128i * uniform) & S0);
+}
+
+template <int Count>
+inline unmasked uniform __m128i _mm_srli_epi16(uniform __m128i _A) {
+    uniform uint16<8> S0, Result;
+    *((uniform uint16<8> * uniform) & S0) = *((uniform uint16<8> * uniform) & _A);
+    S0 = ((Count & 0xFF) > 15) ? (S0 ? 0xFFFF : 0) : S0 >> (Count & 0xFF);
     return *((uniform __m128i * uniform) & S0);
 }
 
@@ -1137,6 +1213,14 @@ static inline unmasked uniform __m128i _mm_srli_epi32(uniform __m128i _A, unifor
     return *((uniform __m128i * uniform) & S0);
 }
 
+template <int Count>
+inline unmasked uniform __m128i _mm_srli_epi32(uniform __m128i _A) {
+    uniform uint32<4> S0, Result;
+    *((uniform uint32<4> * uniform) & S0) = *((uniform uint32<4> * uniform) & _A);
+    S0 = ((Count & 0xFF) > 31) ? (S0 ? 0xFFFFFFFF : 0) : S0 >> (Count & 0xFF);
+    return *((uniform __m128i * uniform) & S0);
+}
+
 static inline unmasked uniform __m128i _mm_srl_epi32(uniform __m128i _A, uniform __m128i _Count) {
     uniform uint32<4> S0, Result;
     *((uniform uint32<4> * uniform) & S0) = *((uniform uint32<4> * uniform) & _A);
@@ -1150,6 +1234,14 @@ static inline unmasked uniform __m128i _mm_srli_epi64(uniform __m128i _A, unifor
     *((uniform uint64<2> * uniform) & S0) = *((uniform uint64<2> * uniform) & _A);
     _Count &= 0xFF;
     S0 = (_Count > 63) ? (S0 ? 0xFFFFFFFFFFFFFFFF : 0) : S0 >> _Count;
+    return *((uniform __m128i * uniform) & S0);
+}
+
+template <int Count>
+inline unmasked uniform __m128i _mm_srli_epi64(uniform __m128i _A) {
+    uniform uint64<2> S0, Result;
+    *((uniform uint64<2> * uniform) & S0) = *((uniform uint64<2> * uniform) & _A);
+    S0 = ((Count & 0xFF) > 63) ? (S0 ? 0xFFFFFFFFFFFFFFFF : 0) : S0 >> (Count & 0xFF);
     return *((uniform __m128i * uniform) & S0);
 }
 
@@ -1302,10 +1394,24 @@ static inline unmasked uniform int _mm_extract_epi16(uniform __m128i _A, uniform
     return (uniform int)_APtr[_Imm];
 }
 
+template <int Imm>
+inline unmasked uniform int _mm_extract_epi16(uniform __m128i _A) {
+    const uniform int16 *uniform _APtr = (const uniform int16 *uniform) & _A;
+    return (uniform int)_APtr[Imm];
+}
+
 static inline unmasked uniform __m128i _mm_insert_epi16(uniform __m128i _A, uniform int _B, uniform int _Imm) {
     uniform int16<8> S0;
     *((uniform int16<8> * uniform) & S0) = *((uniform int16<8> * uniform) & _A);
     S0[_Imm] = (uniform int16)_B;
+    return *((uniform __m128i * uniform) & S0);
+}
+
+template <int Imm>
+inline unmasked uniform __m128i _mm_insert_epi16(uniform __m128i _A, uniform int _B) {
+    uniform int16<8> S0;
+    *((uniform int16<8> * uniform) & S0) = *((uniform int16<8> * uniform) & _A);
+    S0[Imm] = (uniform int16)_B;
     return *((uniform __m128i * uniform) & S0);
 }
 
@@ -1329,6 +1435,16 @@ static inline unmasked uniform __m128i _mm_shuffle_epi32(uniform __m128i _A, uni
     return *((uniform __m128i * uniform) & R);
 }
 
+template <int Imm8>
+inline unmasked uniform __m128i _mm_shuffle_epi32(uniform __m128i _A) {
+    uniform int<4> R;
+    R[0] = _A.m128i_i32[Imm8 & 0x3];
+    R[1] = _A.m128i_i32[(Imm8 >> 2) & 0x3];
+    R[2] = _A.m128i_i32[(Imm8 >> 4) & 0x3];
+    R[3] = _A.m128i_i32[(Imm8 >> 6) & 0x3];
+    return *((uniform __m128i * uniform) & R);
+}
+
 static inline unmasked uniform __m128i _mm_shufflehi_epi16(uniform __m128i _A, uniform unsigned int _Imm8) {
     uniform int16<8> S0, S1;
     *((uniform int16<8> * uniform) & S1) = *((uniform int16<8> * uniform) & _A);
@@ -1341,6 +1457,19 @@ static inline unmasked uniform __m128i _mm_shufflehi_epi16(uniform __m128i _A, u
     return *((uniform __m128i * uniform) & S1);
 }
 
+template <int Imm8>
+inline unmasked uniform __m128i _mm_shufflehi_epi16(uniform __m128i _A) {
+    uniform int16<8> S0, S1;
+    *((uniform int16<8> * uniform) & S1) = *((uniform int16<8> * uniform) & _A);
+    *((uniform int16<4> * uniform) & S0) = *((uniform int16<4> * uniform) & _A.m128i_i32[2]);
+    S0[0] = S0[Imm8 & 0x3];
+    S0[1] = S0[(Imm8 >> 2) & 0x3];
+    S0[2] = S0[(Imm8 >> 4) & 0x3];
+    S0[3] = S0[(Imm8 >> 6) & 0x3];
+    *((uniform int16<4> * uniform) & S1[4]) = *((uniform int16<4> * uniform) & S0);
+    return *((uniform __m128i * uniform) & S1);
+}
+
 static inline unmasked uniform __m128i _mm_shufflelo_epi16(uniform __m128i _A, uniform unsigned int _Imm8) {
     uniform int16<8> S0;
     *((uniform int16<8> * uniform) & S0) = *((uniform int16<8> * uniform) & _A);
@@ -1348,6 +1477,17 @@ static inline unmasked uniform __m128i _mm_shufflelo_epi16(uniform __m128i _A, u
     S0[1] = S0[(_Imm8 >> 2) & 0x3];
     S0[2] = S0[(_Imm8 >> 4) & 0x3];
     S0[3] = S0[(_Imm8 >> 6) & 0x3];
+    return *((uniform __m128i * uniform) & S0);
+}
+
+template <int Imm8>
+inline unmasked uniform __m128i _mm_shufflelo_epi16(uniform __m128i _A) {
+    uniform int16<8> S0;
+    *((uniform int16<8> * uniform) & S0) = *((uniform int16<8> * uniform) & _A);
+    S0[0] = S0[Imm8 & 0x3];
+    S0[1] = S0[(Imm8 >> 2) & 0x3];
+    S0[2] = S0[(Imm8 >> 4) & 0x3];
+    S0[3] = S0[(Imm8 >> 6) & 0x3];
     return *((uniform __m128i * uniform) & S0);
 }
 

--- a/stdlib/include/intrinsics/xmmintrin.isph
+++ b/stdlib/include/intrinsics/xmmintrin.isph
@@ -552,6 +552,16 @@ static inline unmasked uniform __m128 _mm_shuffle_ps(uniform __m128 _A, uniform 
     return *((uniform __m128 * uniform) & _R);
 }
 
+template <int Imm8>
+inline unmasked uniform __m128 _mm_shuffle_ps(uniform __m128 _A, uniform __m128 _B) {
+    uniform float<4> _R;
+    _R[0] = _A.m128_f32[Imm8 & 0x3];
+    _R[1] = _A.m128_f32[(Imm8 >> 2) & 0x3];
+    _R[2] = _B.m128_f32[(Imm8 >> 4) & 0x3];
+    _R[3] = _B.m128_f32[(Imm8 >> 6) & 0x3];
+    return *((uniform __m128 * uniform) & _R);
+}
+
 static inline unmasked uniform __m128 _mm_unpackhi_ps(uniform __m128 _A, uniform __m128 _B) {
     const uniform float<4> _R = {_A.m128_f32[2], _B.m128_f32[2], _A.m128_f32[3], _B.m128_f32[3]};
     return *((uniform __m128 * uniform) & _R);
@@ -680,6 +690,24 @@ static inline unmasked void _mm_storeu_ps(uniform float *uniform _V, const unifo
 
 static inline unmasked void _mm_prefetch(uniform int8 const *uniform _A, uniform int _Sel) {
     switch (_Sel) {
+    case _MM_HINT_NTA:
+        prefetch_nt((void *uniform)_A);
+        break;
+    case _MM_HINT_T0:
+        prefetch_l1((void *uniform)_A);
+        break;
+    case _MM_HINT_T1:
+        prefetch_l2((void *uniform)_A);
+        break;
+    case _MM_HINT_T2:
+        prefetch_l3((void *uniform)_A);
+        break;
+    }
+}
+
+template <int Sel>
+inline unmasked void _mm_prefetch(uniform int8 const *uniform _A) {
+    switch (Sel) {
     case _MM_HINT_NTA:
         prefetch_nt((void *uniform)_A);
         break;

--- a/tests/lit-tests/1654.ispc
+++ b/tests/lit-tests/1654.ispc
@@ -11,10 +11,9 @@ const int r = 7;
 //; CHECK_2_ERR: 12:18: Error: Initializer for global variable "n" must be a constant.
 uniform int n = {1, 3};
 
-//; CHECK_ALL_ERR: 16:19: Error: Can't convert from type "const varying int32" to type "uniform float" for initializer.
-//; CHECK_2_ERR: 16:19: Error: Can't convert from type "const varying int32" to type "uniform float" for initializer.
+//; CHECK_ALL_ERR: 15:19: Error: Can't convert from type "const varying int32" to type "uniform float" for initializer.
 uniform float p = r;
 
-//; CHECK_ALL_ERR: 20:1: Error: syntax error, unexpected identifier.
-//; CHECK_2_ERR-NOT: 20:1: Error: syntax error, unexpected identifier.
+//; CHECK_ALL_ERR: 19:1: Error: syntax error, unexpected identifier.
+//; CHECK_2_ERR-NOT: 19:1: Error: syntax error, unexpected identifier.
 r = 1;

--- a/tests/lit-tests/builtins_amx_fp16.ispc
+++ b/tests/lit-tests/builtins_amx_fp16.ispc
@@ -44,9 +44,12 @@
 
 #include <amx.isph>
 
+constexpr uniform int tile_dst_id() { return amx_tmm2; }
+constexpr uniform int tile_src0_id() { return amx_tmm0; }
+constexpr uniform int tile_src1_id() { return amx_tmm1; }
+
 __attribute__((external_only))
 export void test_amx_fp16() {
     // require amxfp16 feature (GNR+)
-    amx_dpfp16ps(2, 0, 1);
+    amx_dpfp16ps<tile_dst_id(), tile_src0_id(), tile_src1_id()>();
 }
-

--- a/tests/lit-tests/builtins_amx_int8_bf16.ispc
+++ b/tests/lit-tests/builtins_amx_int8_bf16.ispc
@@ -72,17 +72,21 @@
 
 #include <amx.isph>
 
+constexpr uniform int tile_dst_id() { return amx_tmm2; }
+constexpr uniform int tile_src0_id() { return amx_tmm0; }
+constexpr uniform int tile_src1_id() { return amx_tmm1; }
+
 __attribute__((external_only))
 export void test_amx_int8() {
     // require amxint8 feature (SPR+)
-    amx_dpbssd(2, 0, 1);
-    amx_dpbsud(2, 0, 1);
-    amx_dpbusd(2, 0, 1);
-    amx_dpbuud(2, 0, 1);
+    amx_dpbssd<tile_dst_id(), tile_src0_id(), tile_src1_id()>();
+    amx_dpbsud<tile_dst_id(), tile_src0_id(), tile_src1_id()>();
+    amx_dpbusd<tile_dst_id(), tile_src0_id(), tile_src1_id()>();
+    amx_dpbuud<tile_dst_id(), tile_src0_id(), tile_src1_id()>();
 }
 
 __attribute__((external_only))
 export void test_amx_bf16() {
     // require amxbf16 feature (SPR+)
-    amx_dpbf16ps(2, 0, 1);
+    amx_dpbf16ps<tile_dst_id(), tile_src0_id(), tile_src1_id()>();
 }

--- a/tests/lit-tests/builtins_amx_tile.ispc
+++ b/tests/lit-tests/builtins_amx_tile.ispc
@@ -78,15 +78,19 @@
 
 #include <amx.isph>
 
+constexpr uniform int tile_zero_id() { return amx_tmm2; }
+constexpr uniform int tile_load_id() { return amx_tmm0; }
+constexpr uniform int tile_load_t1_id() { return amx_tmm1; }
+
 __attribute__((external_only))
 export void test_amx_tile(uniform int8* uniform config, uniform int8* uniform data) {
     // Base AMX tile operations - require amxtile feature
     amx_tile_loadconfig(config);
     amx_tile_storeconfig(config);
-    amx_tile_zero(2);
-    amx_tile_load(0, data, (uniform int64)64);
-    amx_tile_load_t1(1, data, (uniform int64)64);
-    amx_tile_store(0, data, (uniform int64)64);
+    // Exercise constexpr + template AMX wrappers for tile immargs.
+    amx_tile_zero<tile_zero_id()>();
+    amx_tile_load<tile_load_id()>(data, (uniform int64)64);
+    amx_tile_load_t1<tile_load_t1_id()>(data, (uniform int64)64);
+    amx_tile_store<tile_load_id()>(data, (uniform int64)64);
     amx_tile_release();
 }
-

--- a/tests/lit-tests/constexpr-address-of-local-error.ispc
+++ b/tests/lit-tests/constexpr-address-of-local-error.ispc
@@ -1,0 +1,11 @@
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap -o /dev/null 2>&1 | FileCheck %s
+
+constexpr uniform int bad_addr() {
+    uniform int x = 1;
+    uniform int *uniform p = &x;
+    return p != NULL;
+}
+
+uniform int arr[bad_addr()];
+
+// CHECK: Error: constexpr function "bad_addr" contains disallowed expression "address-of".

--- a/tests/lit-tests/constexpr-aggregate-errors.ispc
+++ b/tests/lit-tests/constexpr-aggregate-errors.ispc
@@ -1,0 +1,19 @@
+// REQUIRES: X86_ENABLED && X86_64_HOST
+// RUN: not %{ispc} %s --target=generic-i32x4 --nostdlib --nowrap -o /dev/null 2>&1 | FileCheck %s
+
+struct Pair {
+    uniform int a;
+    uniform int b;
+};
+
+constexpr uniform int bad_arr[2] = {1, 2, 3};
+constexpr uniform Pair bad_struct = {1, 2, 3};
+
+constexpr uniform int<2> v2 = {1, 2};
+constexpr uniform int<2> bad_swizzle_char = v2.qy;
+constexpr uniform int<2> bad_swizzle_oob = v2.zw;
+
+// CHECK: Error: Initializer list for array "const uniform int32[2]" must have no more than 2 elements (has 3).
+// CHECK: Error: Initializer list for struct "const uniform struct Pair" must have no more than 2 elements (has 3).
+// CHECK: Error: Vector element identifier "qy" unknown.
+// CHECK: Error: Invalid swizzle character 'z' for constexpr vector.

--- a/tests/lit-tests/constexpr-aggregate.ispc
+++ b/tests/lit-tests/constexpr-aggregate.ispc
@@ -1,0 +1,42 @@
+// REQUIRES: X86_ENABLED && X86_64_HOST
+// RUN: %{ispc} %s --target=generic-i32x4 --nostdlib --emit-llvm-text -o - | FileCheck %s
+
+struct Pair {
+    uniform int a;
+    uniform int b;
+};
+
+constexpr uniform Pair P0 = {1, 4};
+constexpr uniform int PB = P0.b;
+
+constexpr uniform int Arr0[3] = {10, 20, 30};
+constexpr uniform int Arr1 = Arr0[2];
+
+constexpr uniform int<4> make_vec(uniform int base) {
+    uniform int<4> v = {base, base + 1, base + 2, base + 3};
+    return v + 2;
+}
+
+constexpr uniform int<4> V0 = make_vec(3);
+constexpr uniform int VY = V0.y;
+constexpr uniform int<2> VXY = V0.xy;
+constexpr uniform int<4> VBroadcast = 3;
+
+constexpr uniform int arr_sum() {
+    uniform int a[3] = {1, 2, 3};
+    return a[1] + a[2];
+}
+
+constexpr uniform int A0 = arr_sum();
+
+uniform int foo() { return PB + A0 + Arr1; }
+uniform int<2> bar() { return VXY; }
+uniform int<4> baz() { return V0; }
+
+// CHECK-DAG: @PB = {{.*}} i32 4
+// CHECK-DAG: @Arr1 = {{.*}} i32 30
+// CHECK-DAG: @A0 = {{.*}} i32 5
+// CHECK-DAG: @V0 = {{.*}} <4 x i32> <i32 5, i32 6, i32 7, i32 8>
+// CHECK-DAG: @VY = {{.*}} i32 6
+// CHECK-DAG: @VXY = {{.*}} <4 x i32> <i32 5, i32 6, i32 undef, i32 undef>
+// CHECK-DAG: @VBroadcast = {{.*}} {{<4 x i32> splat \(i32 3\)|<4 x i32> <i32 3, i32 3, i32 3, i32 3>}}

--- a/tests/lit-tests/constexpr-basic.ispc
+++ b/tests/lit-tests/constexpr-basic.ispc
@@ -1,0 +1,19 @@
+// RUN: %{ispc} %s --target=host --nostdlib --emit-llvm-text -o - | FileCheck %s
+
+constexpr uniform int A = 7;
+constexpr uniform int B = A * 2;
+
+constexpr uniform int add(uniform int x, uniform int y) { return x + y; }
+
+uniform int g[B];
+uniform int h[add(3, 4)];
+
+uniform int not_constexpr(uniform int x) { return x; }
+
+constexpr uniform int sizeof_unevaluated() { return sizeof(not_constexpr(1)); }
+
+uniform int s[sizeof_unevaluated()];
+
+// CHECK: @g = {{.*}} [14 x i32]
+// CHECK: @h = {{.*}} [7 x i32]
+// CHECK: @s = {{.*}} [4 x i32]

--- a/tests/lit-tests/constexpr-contexts.ispc
+++ b/tests/lit-tests/constexpr-contexts.ispc
@@ -1,0 +1,29 @@
+// RUN: %{ispc} %s --target=host --nostdlib --emit-llvm-text -o - | FileCheck %s
+
+constexpr uniform int width() { return 4; }
+constexpr uniform int four() { return 4; }
+
+enum E {
+    EA = width(),
+    EB = four() + 2
+};
+
+uniform int<width()> gv;
+uniform int arr[EB];
+
+uniform int use_case_values(uniform int x) {
+    switch (x) {
+    case four():
+        return 11;
+    case EB:
+        return 22;
+    default:
+        return 33;
+    }
+}
+
+// CHECK-DAG: @gv = {{.*}} <4 x i32> zeroinitializer
+// CHECK-DAG: @arr = {{.*}} [6 x i32] zeroinitializer
+// CHECK-LABEL: @use_case_values
+// CHECK: icmp eq i32 %{{.*}}, 6
+// CHECK: icmp eq i32 %{{.*}}, 4

--- a/tests/lit-tests/constexpr-controlflow.ispc
+++ b/tests/lit-tests/constexpr-controlflow.ispc
@@ -1,0 +1,10 @@
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap -o /dev/null 2>&1 | FileCheck %s
+
+constexpr uniform int bad(varying int x) {
+    if (x > 0) {
+        return 1;
+    }
+    return 2;
+}
+
+// CHECK: Error: constexpr function "bad" requires a uniform condition in "if".

--- a/tests/lit-tests/constexpr-deferred-comma-global-error.ispc
+++ b/tests/lit-tests/constexpr-deferred-comma-global-error.ispc
@@ -1,0 +1,6 @@
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap -o /dev/null 2>&1 | FileCheck %s
+
+constexpr uniform int f();
+constexpr uniform int bad = (f(), 1);
+
+// CHECK: Error: Initializer for global variable "bad" must be a constant.

--- a/tests/lit-tests/constexpr-deferred-comma-param-error.ispc
+++ b/tests/lit-tests/constexpr-deferred-comma-param-error.ispc
@@ -1,0 +1,6 @@
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap -o /dev/null 2>&1 | FileCheck %s
+
+constexpr uniform int f();
+void bad(uniform int x = (f(), 1)) {}
+
+// CHECK: Error: Default value for parameter "x" must be a compile-time constant.

--- a/tests/lit-tests/constexpr-deferred-default.ispc
+++ b/tests/lit-tests/constexpr-deferred-default.ispc
@@ -1,0 +1,12 @@
+// RUN: %{ispc} %s --target=host --nostdlib --emit-llvm-text -O0 -o - | FileCheck %s
+
+constexpr uniform int later();
+
+uniform int bar(uniform int x = later()) { return x + 1; }
+
+constexpr uniform int later() { return 6; }
+
+uniform int use() { return bar(); }
+
+// CHECK-LABEL: @use
+// CHECK: store i32 6

--- a/tests/lit-tests/constexpr-deferred-global.ispc
+++ b/tests/lit-tests/constexpr-deferred-global.ispc
@@ -1,0 +1,13 @@
+// RUN: %{ispc} %s --target=host --nostdlib --emit-llvm-text -o - | FileCheck %s
+
+constexpr uniform int later();
+
+constexpr uniform int G = later();
+uniform int H = later() + 5;
+
+constexpr uniform int later() { return 12; }
+
+uniform int use() { return G + H; }
+
+// CHECK-DAG: @G = {{.*}} i32 12
+// CHECK-DAG: @H = {{.*}} i32 17

--- a/tests/lit-tests/constexpr-errors.ispc
+++ b/tests/lit-tests/constexpr-errors.ispc
@@ -1,0 +1,19 @@
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap -o /dev/null 2>&1 | FileCheck %s
+
+uniform int g = 1;
+constexpr uniform int badinit = g;
+
+constexpr uniform int noinit;
+
+uniform int nonconstexpr(uniform int x) { return x + 1; }
+constexpr uniform int badcall(uniform int x) { return nonconstexpr(x); }
+
+constexpr uniform int badstmt(uniform int x) {
+    print("x=%d", x);
+    return x;
+}
+
+// CHECK: Error: Initializer for global variable "badinit" must be a constant.
+// CHECK: Error: Missing initializer for constexpr variable "noinit".
+// CHECK: Error: constexpr function "badcall" calls non-constexpr function "nonconstexpr".
+// CHECK: Error: constexpr function "badstmt" contains disallowed statement "print".

--- a/tests/lit-tests/constexpr-exprlist.ispc
+++ b/tests/lit-tests/constexpr-exprlist.ispc
@@ -1,0 +1,19 @@
+// REQUIRES: X86_ENABLED && X86_64_HOST
+// RUN: %{ispc} %s --target=generic-i32x4 --nostdlib --emit-llvm-text -o - | FileCheck %s
+
+constexpr varying int Lanes = {0, 1, 2, 3};
+constexpr varying int Lanes2 = Lanes + 5;
+
+varying int foo() { return Lanes2; }
+
+constexpr varying int make() {
+    varying int v = {10, 11, 12, 13};
+    return v + 2;
+}
+
+constexpr varying int Made = make();
+
+varying int bar() { return Made; }
+
+// CHECK: ret <4 x i32> <i32 5, i32 6, i32 7, i32 8>
+// CHECK: ret <4 x i32> <i32 12, i32 13, i32 14, i32 15>

--- a/tests/lit-tests/constexpr-extern-noinit-error.ispc
+++ b/tests/lit-tests/constexpr-extern-noinit-error.ispc
@@ -1,0 +1,5 @@
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap -o /dev/null 2>&1 | FileCheck %s
+
+extern constexpr uniform int E;
+
+// CHECK: Error: Missing initializer for constexpr variable "E".

--- a/tests/lit-tests/constexpr-fast-math-template.ispc
+++ b/tests/lit-tests/constexpr-fast-math-template.ispc
@@ -1,0 +1,17 @@
+// RUN: %{ispc} %s --target=sse4.1-i32x4 --math-lib=fast --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK_FAST
+// RUN: %{ispc} %s --target=sse4.1-i32x4 --math-lib=default --emit-llvm-text -o - 2>&1 | FileCheck %s --check-prefix=CHECK_ISPC
+// REQUIRES: X86_ENABLED
+
+// Use constexpr with fast-math configuration and feed it into a template
+// non-type parameter to verify constexpr + template integration.
+constexpr uniform int fast_math_enabled() { return __math_lib == ISPC_MATH_LIB_ISPC_FAST_VAL; }
+
+template <int FastMode> uniform int fast_mode_tag() { return FastMode; }
+
+uniform int get_fast_mode_tag() { return fast_mode_tag<fast_math_enabled()>(); }
+
+// CHECK_FAST-LABEL: @get_fast_mode_tag
+// CHECK_FAST: ret i32 1
+
+// CHECK_ISPC-LABEL: @get_fast_mode_tag
+// CHECK_ISPC: ret i32 0

--- a/tests/lit-tests/constexpr-linkage.ispc
+++ b/tests/lit-tests/constexpr-linkage.ispc
@@ -1,0 +1,12 @@
+// RUN: %{ispc} %s --target=host --nostdlib --emit-llvm-text -O0 -o - | FileCheck %s
+
+noinline constexpr uniform int f(uniform int x) { return x + 1; }
+static noinline constexpr uniform int fs(uniform int x) { return x + 2; }
+
+uniform int use(uniform int y) { return f(y) + fs(y); }
+
+// CHECK: define linkonce_odr {{.*}} @f___{{.*}}(
+// CHECK: define internal {{.*}} @fs___{{.*}}(
+// CHECK-LABEL: @use___
+// CHECK: call {{.*}} @f___{{.*}}(
+// CHECK: call {{.*}} @fs___{{.*}}(

--- a/tests/lit-tests/constexpr-parameter-qualifier-error.ispc
+++ b/tests/lit-tests/constexpr-parameter-qualifier-error.ispc
@@ -1,0 +1,5 @@
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap -o /dev/null 2>&1 | FileCheck %s
+
+void bad(constexpr uniform int x) {}
+
+// CHECK: Error: "constexpr" qualifier is illegal in function parameter declaration for parameter "x".

--- a/tests/lit-tests/constexpr-pointer-aggregate.ispc
+++ b/tests/lit-tests/constexpr-pointer-aggregate.ispc
@@ -1,0 +1,23 @@
+// REQUIRES: X86_ENABLED && X86_64_HOST
+// RUN: %{ispc} %s --target=generic-i32x4 --nostdlib --emit-llvm-text -o - | FileCheck %s
+
+typedef uniform int *uniform IntPtr;
+
+struct PtrPair {
+    IntPtr p;
+    uniform int v;
+};
+
+constexpr uniform PtrPair P0 = {NULL, 5};
+constexpr uniform PtrPair P1 = {(IntPtr)0, 7};
+constexpr uniform PtrPair P2 = {NULL};
+constexpr uniform IntPtr GP0 = NULL;
+constexpr uniform IntPtr GP1 = (IntPtr)0;
+
+uniform int use() { return P0.v + P1.v + P2.v; }
+
+// CHECK-DAG: @P0 = {{.*}} { ptr null, i32 5 }
+// CHECK-DAG: @P1 = {{.*}} { ptr null, i32 7 }
+// CHECK-DAG: @P2 = {{.*}} zeroinitializer
+// CHECK-DAG: @GP0 = {{.*}} ptr null
+// CHECK-DAG: @GP1 = {{.*}} ptr null

--- a/tests/lit-tests/constexpr-pointer-function.ispc
+++ b/tests/lit-tests/constexpr-pointer-function.ispc
@@ -1,0 +1,24 @@
+// RUN: %{ispc} %s --target=host --nostdlib --emit-llvm-text -o - | FileCheck %s
+
+typedef int (*FuncType)();
+
+int f0() { return 1; }
+int f1() { return 2; }
+
+constexpr uniform FuncType F0 = f0;
+constexpr uniform FuncType F1 = f1;
+
+constexpr uniform int has_fn(uniform FuncType f) {
+    if (f) {
+        return 1;
+    }
+    return 0;
+}
+
+constexpr uniform int Flag = has_fn(F1);
+
+uniform int foo() { return Flag; }
+
+// CHECK-DAG: @F0 = {{.*}} ptr @f0
+// CHECK-DAG: @F1 = {{.*}} ptr @f1
+// CHECK-DAG: @Flag = {{.*}} i32 1

--- a/tests/lit-tests/constexpr-pointer-nonnull.ispc
+++ b/tests/lit-tests/constexpr-pointer-nonnull.ispc
@@ -1,0 +1,23 @@
+// RUN: %{ispc} %s --target=host --nostdlib --emit-llvm-text -o - | FileCheck %s
+
+uniform int g0 = 1;
+
+constexpr uniform int *uniform getp() { return &g0; }
+
+constexpr uniform int *uniform PG = getp();
+constexpr uniform int *uniform PG2 = PG + 2;
+
+constexpr uniform int is_nonnull(uniform int *uniform p) {
+    if (p) {
+        return 1;
+    }
+    return 0;
+}
+
+constexpr uniform int PFlag = is_nonnull(PG);
+
+uniform int use() { return PFlag; }
+
+// CHECK-DAG: @PG = {{.*}} ptr @g0
+// CHECK-DAG: @PG2 = {{.*}} getelementptr {{.*}} @g0
+// CHECK-DAG: @PFlag = {{.*}} i32 1

--- a/tests/lit-tests/constexpr-pointer-qualifier-error.ispc
+++ b/tests/lit-tests/constexpr-pointer-qualifier-error.ispc
@@ -1,0 +1,6 @@
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap -o /dev/null 2>&1 | FileCheck %s
+
+uniform int g = 1;
+uniform int * constexpr P = &g;
+
+// CHECK: Error: {{.*}}unexpected 'constexpr'{{.*}}

--- a/tests/lit-tests/constexpr-struct-member-error.ispc
+++ b/tests/lit-tests/constexpr-struct-member-error.ispc
@@ -1,0 +1,7 @@
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap -o /dev/null 2>&1 | FileCheck %s
+
+struct Bad {
+    constexpr uniform int m;
+};
+
+// CHECK: Error: "constexpr" qualifier is illegal in type names and struct member declarations.

--- a/tests/lit-tests/constexpr-switch.ispc
+++ b/tests/lit-tests/constexpr-switch.ispc
@@ -1,0 +1,29 @@
+// RUN: %{ispc} %s --target=host --nostdlib --emit-llvm-text -o - | FileCheck %s
+
+constexpr uniform int pick(uniform int x) {
+    switch (x) {
+    case 1:
+        return 4;
+    case 2:
+        return 7;
+    default:
+        return 3;
+    }
+}
+
+uniform int buf[pick(2)];
+
+// CHECK: @buf = {{.*}} [7 x i32]
+
+constexpr uniform int pick64(uniform int64 x) {
+    switch (x) {
+    case 1:
+        return 11;
+    default:
+        return 22;
+    }
+}
+
+uniform int buf64[pick64(4294967297)];
+
+// CHECK: @buf64 = {{.*}} [22 x i32]

--- a/tests/lit-tests/constexpr-template.ispc
+++ b/tests/lit-tests/constexpr-template.ispc
@@ -1,0 +1,8 @@
+// RUN: %{ispc} %s --target=host --nostdlib -o %t.o
+
+constexpr uniform int width() { return 3; }
+
+template <int N>
+uniform int foo() { return N; }
+
+uniform int bar() { return foo<width()>(); }

--- a/tests/lit-tests/constexpr-typedef-error.ispc
+++ b/tests/lit-tests/constexpr-typedef-error.ispc
@@ -1,0 +1,5 @@
+// RUN: not %{ispc} %s --target=host --nostdlib --nowrap -o /dev/null 2>&1 | FileCheck %s
+
+typedef constexpr uniform int CI;
+
+// CHECK: Error: "constexpr" qualifier is illegal in typedef declarations.

--- a/tests/lit-tests/constexpr-uniform-required.ispc
+++ b/tests/lit-tests/constexpr-uniform-required.ispc
@@ -1,0 +1,7 @@
+// REQUIRES: X86_ENABLED && X86_64_HOST
+// RUN: not %{ispc} %s --target=generic-i32x4 --nowrap -o /dev/null 2>&1 | FileCheck %s
+
+constexpr varying int Lane = programIndex;
+uniform int arr[Lane];
+
+// CHECK: Error: Array size must be a uniform compile-time constant.

--- a/tests/lit-tests/constexpr-varying.ispc
+++ b/tests/lit-tests/constexpr-varying.ispc
@@ -1,0 +1,9 @@
+// REQUIRES: X86_ENABLED && X86_64_HOST
+// RUN: %{ispc} %s --target=generic-i32x4 --emit-llvm-text -o - | FileCheck %s
+
+constexpr varying int Lane = programIndex;
+constexpr varying int Lane2 = Lane * 2 + 1;
+
+varying int foo() { return Lane2; }
+
+// CHECK: ret <4 x i32> <i32 1, i32 3, i32 5, i32 7>

--- a/tests/lit-tests/err-array.ispc
+++ b/tests/lit-tests/err-array.ispc
@@ -1,6 +1,6 @@
 // RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o - 2>&1 | FileCheck %s
 
-// CHECK: Error: Array dimension must be representable with a 32-bit integer.
+// CHECK: Error: Array size must be representable with a 32-bit integer.
 
 struct foo {
     int x[0xffffffffffff];

--- a/tests/lit-tests/func_template_array_9.ispc
+++ b/tests/lit-tests/func_template_array_9.ispc
@@ -1,7 +1,7 @@
 // Check that custom variable can't be used as template argument (yet).
 
 // RUN: not %{ispc} --target=host --nowrap --nostdlib %s -o - 2>&1 | FileCheck %s
-// CHECK: Only integral, enum types and non-type template parameters are allowed as template arguments.
+// CHECK: Only integral, bool, enum types and non-type template parameters are allowed as template arguments.
 
 template <int C> noinline void func(float arr[C]) {
     uniform float O[C] = {0};

--- a/tests/lit-tests/func_template_nontype_7.ispc
+++ b/tests/lit-tests/func_template_nontype_7.ispc
@@ -1,6 +1,5 @@
 // Check that compiler reports a error when non-type template parameters are used incorrectly.
 // RUN: not %{ispc}  %s --target=host -DVARYING --nostdlib -o %t.o --nowrap 2>&1 | FileCheck %s -check-prefix=CHECK_VARYING
-// RUN: not %{ispc}  %s --target=host -DNEGATIVE --nostdlib -o %t.o --nowrap 2>&1 | FileCheck %s -check-prefix=CHECK_NEGATIVE
 // RUN: not %{ispc}  %s --target=host -DNOT_INTEGRAL --nostdlib -o %t.o --nowrap 2>&1 | FileCheck %s -check-prefix=CHECK_NOT_INTEGRAL
 // RUN: not %{ispc}  %s --target=host -DPARAM_MODIF --nostdlib -o %t.o --nowrap 2>&1 | FileCheck %s -check-prefix=CHECK_PARAM_MODIF
 // RUN: not %{ispc}  %s --target=host -DPARAM_REDECL --nostdlib -o %t.o --nowrap 2>&1 | FileCheck %s -check-prefix=CHECK_PARAM_REDECL
@@ -9,7 +8,6 @@
 // CHECK-NOT: Please file a bug report
 
 // CHECK_VARYING: Error: syntax error, unexpected 'varying'
-// CHECK_NEGATIVE: Error: syntax error, unexpected '-'.
 // CHECK_NOT_INTEGRAL: Error: syntax error, unexpected 'float'
 // CHECK_PARAM_MODIF: Error: Can't assign to type "const uniform int32" on left-hand side of expression.
 // CHECK_PARAM_REDECL:  Error: Ignoring redeclaration of symbol "x".
@@ -23,17 +21,6 @@ noinline int bar(int k) {
 
 int foo(int k) {
     return bar<2>(k);
-}
-#endif
-
-#ifdef NEGATIVE
-template<int x>
-noinline int bar(int k) {
-    return x + k;
-}
-
-int foo(int k) {
-    return bar<-2>(k);
 }
 #endif
 

--- a/tests/lit-tests/func_template_shortvec_8.ispc
+++ b/tests/lit-tests/func_template_shortvec_8.ispc
@@ -1,7 +1,7 @@
 // Check compiler diagnostics
 // RUN: not %{ispc} --target=host %s --nowrap 2>&1 | FileCheck %s
-// CHECK: 10:38: Error: Unknown identifier "M" is used to specify the size of a vector type.
-// CHECK: 11:7: Error: syntax error, unexpected TOKEN_TYPE_NAME.
+// CHECK: Error: Undeclared symbol "M". Did you mean "N"?
+// CHECK: Error: syntax error, unexpected TOKEN_TYPE_NAME.
 
 struct S {
     int x;

--- a/tests/lit-tests/func_template_shortvec_9.ispc
+++ b/tests/lit-tests/func_template_shortvec_9.ispc
@@ -1,9 +1,8 @@
 // Check compiler diagnostics
 // RUN: not %{ispc} --target=host %s --nowrap 2>&1 | FileCheck %s
-// CHECK: 14:10: Error: Only atomic types (int, float, ...) and template type parameters are legal for vector types.
-// CHECK: 28:14: Error: Only atomic types (int, float, ...) and template type parameters are legal for vector types.
-// CHECK: 29:14: Error: Illegal to specify vector size of 0.
-// CHECK: 19:21: Warning: Array index "2" may be out of bounds for 1 element array.
+// CHECK-COUNT-2: Error: Vector size must be a compile-time constant or template non-type parameter.
+// CHECK: Error: Illegal to specify vector size of 0.
+// CHECK: Warning: Array index "2" may be out of bounds for 1 element array.
 
 struct S {
     int x;

--- a/tests/lit-tests/llvm-intrinsics-immarg-constexpr.ispc
+++ b/tests/lit-tests/llvm-intrinsics-immarg-constexpr.ispc
@@ -1,0 +1,20 @@
+// RUN: %{ispc} %s --target=sse4.1-i32x4 --emit-llvm-text --enable-llvm-intrinsics -o - 2>&1 | FileCheck %s
+// REQUIRES: X86_ENABLED
+
+constexpr uniform int kRoundMode = 3;
+
+constexpr uniform int mode_func() { return 3; }
+
+float round_constexpr(float v) {
+    return @llvm.x86.sse41.round.ps(v, kRoundMode);
+}
+
+// CHECK-LABEL: @round_constexpr
+// CHECK: call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %{{.*}}, i32 3)
+
+float round_constexpr_func(float v) {
+    return @llvm.x86.sse41.round.ps(v, mode_func());
+}
+
+// CHECK-LABEL: @round_constexpr_func
+// CHECK: call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %{{.*}}, i32 3)

--- a/tests/lit-tests/llvm-intrinsics-immarg-error.ispc
+++ b/tests/lit-tests/llvm-intrinsics-immarg-error.ispc
@@ -1,0 +1,10 @@
+// RUN: not %{ispc} %s --target=sse4.1-i32x4 --enable-llvm-intrinsics --nowrap -o /dev/null 2>&1 | FileCheck %s
+// REQUIRES: X86_ENABLED
+
+uniform int gMode = 3;
+
+float bad_round(float v) {
+    return @llvm.x86.sse41.round.ps(v, gMode);
+}
+
+// CHECK: Error: Immediate argument 2 to "llvm.x86.sse41.round.ps" must be a compile-time constant.

--- a/tests/lit-tests/sizeof-local-unsized-array.ispc
+++ b/tests/lit-tests/sizeof-local-unsized-array.ispc
@@ -1,0 +1,10 @@
+// RUN: %{ispc} %s --target=host --nostdlib --emit-llvm-text -o - | FileCheck %s
+
+export uniform int local_const_array_size() {
+    const uniform double x[] = {1.0d, 2.0d, 3.0d};
+    const uniform int count = sizeof(x) / sizeof(x[0]);
+    return count;
+}
+
+// CHECK-LABEL: define {{.*}} @local_const_array_size
+// CHECK: ret i32 3

--- a/tests/lit-tests/stdlib-intrinsics-constexpr.ispc
+++ b/tests/lit-tests/stdlib-intrinsics-constexpr.ispc
@@ -1,0 +1,58 @@
+// RUN: %{ispc} %s --target=sse2-i32x4 -I %S/../../stdlib/include -O2 --nowrap --emit-llvm-text -o - | FileCheck %s
+// REQUIRES: X86_ENABLED
+
+#include "intrinsics/emmintrin.isph"
+
+constexpr uniform int shuffle_ps_mask() { return _MM_SHUFFLE(3, 2, 1, 0); }
+constexpr uniform int shuffle_pd_mask() { return _MM_SHUFFLE2(1, 0); }
+constexpr uniform int prefetch_hint() { return _MM_HINT_T1; }
+constexpr uniform int lane() { return 4; }
+constexpr uniform int shift() { return 3; }
+
+export uniform double shuffle_pd_constexpr_template() {
+    uniform __m128d a = _mm_setr_pd(1.0, 2.0);
+    uniform __m128d b = _mm_setr_pd(3.0, 4.0);
+    uniform __m128d r = _mm_shuffle_pd<shuffle_pd_mask()>(a, b);
+    return r.m128d_f64[1];
+}
+
+// CHECK-LABEL: define double @shuffle_pd_constexpr_template()
+// CHECK: ret double 4.000000e+00
+
+export void prefetch_constexpr_template(uniform int8 const *uniform p) { _mm_prefetch<prefetch_hint()>(p); }
+
+// CHECK-LABEL: define void @prefetch_constexpr_template(ptr
+// CHECK: call void @llvm.prefetch.p0(ptr {{.*}}, i32 0, i32 2, i32 1)
+
+export void sse2_constexpr_template_smoke(uniform float *uniform fp, uniform double *uniform dp,
+                                          uniform __m128i *uniform ip, uniform int8 const *uniform cp) {
+    uniform __m128 a = _mm_loadu_ps(fp);
+    uniform __m128 b = _mm_loadu_ps(fp + 4);
+    uniform __m128 c = _mm_shuffle_ps<shuffle_ps_mask()>(a, b);
+    _mm_storeu_ps(fp, c);
+
+    uniform __m128d da = _mm_loadu_pd(dp);
+    uniform __m128d db = _mm_loadu_pd(dp + 2);
+    uniform __m128d dc = _mm_shuffle_pd<shuffle_pd_mask()>(da, db);
+    _mm_storeu_pd(dp, dc);
+
+    uniform __m128i x = _mm_loadu_si128(ip);
+    uniform int e = _mm_extract_epi16<lane()>(x);
+    x = _mm_insert_epi16<lane()>(x, e);
+    x = _mm_slli_si128<shift()>(x);
+    x = _mm_srli_si128<shift()>(x);
+    x = _mm_slli_epi16<shift()>(x);
+    x = _mm_slli_epi32<shift()>(x);
+    x = _mm_slli_epi64<shift()>(x);
+    x = _mm_srai_epi16<shift()>(x);
+    x = _mm_srai_epi32<shift()>(x);
+    x = _mm_srli_epi16<shift()>(x);
+    x = _mm_srli_epi32<shift()>(x);
+    x = _mm_srli_epi64<shift()>(x);
+    x = _mm_shuffle_epi32<shuffle_ps_mask()>(x);
+    x = _mm_shufflehi_epi16<shuffle_ps_mask()>(x);
+    x = _mm_shufflelo_epi16<shuffle_ps_mask()>(x);
+    _mm_storeu_si128(ip, x);
+
+    _mm_prefetch<prefetch_hint()>(cp);
+}


### PR DESCRIPTION
## Summary

This PR adds first-class `constexpr` support to ISPC (v1), including constexpr variables/functions, a definition-time validator, a constexpr evaluator, and full front-end plumbing (lexer/parser/AST/type system). It also migrates stdlib/builtins hacks to constexpr where possible, adds comprehensive tests, and documents the design and implementation notes.

## User-facing behavior

- New `constexpr` keyword for variables and functions.
- `constexpr` variables may be `uniform` or `varying` and can be used in constant-expression contexts.
- `constexpr` functions are validated at definition time (C++-style “constexpr-suitable”).
- V1 supports aggregates (arrays/structs), short vectors, and limited pointer constants (null or addresses of globals/functions).
- Uniform control flow required inside constexpr functions (if/switch/loops).
- Deferred constexpr evaluation for global initializers and default parameter values.
- LLVM immarg requirements are enforced in the front end and lowered as true immediates.

## Implementation overview

- Lexer/parser: new `constexpr` token and grammar support.
- AST/symbols/types: constexpr flags on symbols/function types, constexpr parameter defaults.
- Validator: definition-time checks for constexpr-suitable statements/expressions.
- Evaluator: interpreter-style constexpr evaluation with locals, control flow, and aggregate folding.
- Deferral: post-parse resolution for global init + default params that reference later constexpr definitions.
- Intrinsics: immarg metadata and argument rewriting to literal constants.

## stdlib/builtins changes

- Replaced immarg literal hacks in `builtins/generic.ispc` with constexpr constants.
- Migrated `programIndex`/`programCount` and target selectors to `static constexpr`.
- Kept `__is_compile_time_constant_*` probes as backend optimizations (no semantic change).

## Docs

- `docs/ispc.rst`: user documentation for constexpr variables/functions and constraints.
- `docs/design/constexpr.rst`: design and semantics.
- `docs/design/constexpr_impl_notes.md`: implementation notes + remaining work.
- `docs/blog/constexpr_implementation.md`: overview of the work, removed hacks, tests.

## Tests

Added lit tests covering:

- constexpr variables/functions, aggregates, short vectors
- varying constexpr evaluation
- control flow validation (uniform-only)
- template non-type args using constexpr expressions
- pointer constants (null + non-null + function pointers)
- immarg enforcement for LLVM intrinsics
- deferred evaluation for globals/default params

Tests run:

- `cmake --build superbuild/build --target ispc-stage2-check-all`

## Challenges and lessons learned

- **Forward references**: constexpr evaluation needs function bodies; only globals/default params can be deferred in v1. Array sizes, vector lengths, and template args still require definitions to be visible.
- **Grammar ambiguity**: template args use a `constant_expression_no_gt` workaround to avoid `<`/`>` parsing ambiguity; a dedicated template-arg parser is the long-term fix.
- **Immarg requirements**: LLVM requires literal immediates; it wasn’t enough to evaluate to a const value—we had to rewrite immarg arguments to `ConstExpr` during type checking.
- **Pointer constants**: enabling address-of globals/functions exposed assumptions in `ConstExpr::GetValues`; added pointer→bool conversion to support `if (p)` in constexpr.
- **Aggregates/const folding**: aggregate constexpr support required element-wise folding and adjustments to const symbol/address-of handling.
- **Validation timing**: immarg checks needed const locals to be visible earlier during type checking.
- **Target-dependent constants**: preserving target-dependence metadata across constexpr evaluation required additional plumbing to match existing constant folding behavior.

Follow-ups are tracked in `docs/design/constexpr_impl_notes.md`.
