### PR TITLE
Fix LLVM 23.0 build failure: DITypeRefArray deprecated

### DIFF
--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -2904,7 +2904,11 @@ llvm::DIType *FunctionType::GetDIType(llvm::DIScope *scope) const {
         retArgTypes.push_back(t->GetDIType(scope));
     }
 
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+    llvm::DITypeArray retArgTypesArray = m->diBuilder->getOrCreateTypeArray(retArgTypes);
+#else
     llvm::DITypeRefArray retArgTypesArray = m->diBuilder->getOrCreateTypeArray(retArgTypes);
+#endif
     llvm::DIType *diType = m->diBuilder->createSubroutineType(retArgTypesArray);
     return diType;
 }


### PR DESCRIPTION
LLVM 23.0 removed DITypeRefArray in favor of DITypeArray (commit 8f90efdee83e). Added version guards in src/type.cpp to use DITypeArray for LLVM 23.0+ and DITypeRefArray for earlier versions.

Fixes #3711

## Description
Brief description of changes

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed