### PR TITLE
Fix LLVM trunk build failure: replace deprecated intrinsic

### DIFF
--- a/tests/lit-tests/intrinsic.ispc
+++ b/tests/lit-tests/intrinsic.ispc
@@ -1,7 +1,7 @@
 // RUN: %{ispc} %s --target=host --emit-llvm-text --enable-llvm-intrinsics -o - | FileCheck %s
-// CHECK: declare i16 @llvm.convert.to.fp16.f32(float)
+// CHECK: declare float @llvm.fabs.f32(float)
 
-uniform int16 foo(uniform float arg) {
-    uniform int16 ret = @llvm.convert.to.fp16.f32(arg);
+uniform float foo(uniform float arg) {
+    uniform float ret = @llvm.fabs.f32(arg);
     return ret;
 }


### PR DESCRIPTION
LLVM removed the deprecated llvm.convert.to.fp16.f32 intrinsic in January 2026. This test now uses llvm.fabs.f32, a stable intrinsic that serves the same testing purpose (verifying ISPC's ability to call LLVM intrinsics).

Fixes #3714

## Description
Brief description of changes

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed