### PR TITLE
CI: clean space on github runner before building aarch64 package

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -58,6 +58,17 @@ jobs:
     runs-on: ubuntu-22.04-arm
     needs: [define-params]
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: false
+          dotnet: true
+          haskell: false
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:


### PR DESCRIPTION
## Description
Clean space on github runner before building aarch64 package to prevent `System.IO.IOException: No space left on device` issue

## Related Issue
- https://github.com/ispc/ispc/actions/runs/20798381179

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed