### PR TITLE
Remove unnecessary dependency of ispc-opt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1024,7 +1024,7 @@ configure_ispc_obj(builtin)
 add_executable(ispc-opt tools/ispc-opt.cpp)
 configure_ispc_exe(ispc-opt)
 # TODO! should we link against all the same LLVM/Clang libraries? Clang libs is definetely not needed
-target_link_libraries(ispc-opt ${LINK_LIBRARIES} builtin optimization common)
+target_link_libraries(ispc-opt ${LINK_LIBRARIES} optimization common)
 
 # The final target has to be ispc due to two use-cases we do not want to
 # interfere with: make ispc and $<TARGET_FILE:ispc>.

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2177,7 +2177,7 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
         llvm::Triple triple = GetTriple();
 
         // The last validity check to ensure that supported for this target was enabled in the build.
-        if (!g->target_registry->isSupported(m_ispc_target, g->target_os, arch)) {
+        if (!g->disableTargetValidation && !g->target_registry->isSupported(m_ispc_target, g->target_os, arch)) {
             std::string target_string = ISPCTargetToString(m_ispc_target);
             std::string arch_str = ArchToString(arch);
             std::string os_str = OSToString(g->target_os);
@@ -3175,6 +3175,7 @@ Globals::Globals() {
     includeFloat16Conversions = false;
 
     enableTimeTrace = false;
+    disableTargetValidation = false;
     // set default granularity to 500.
     timeTraceGranularity = 500;
     target = nullptr;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -917,6 +917,9 @@ struct Globals {
 
     /* When true, enable compile time tracing. */
     bool enableTimeTrace;
+
+    /* If true, disable validation of target support in Target constructor. */
+    bool disableTargetValidation;
 
     /* When compile time tracing is enabled, set time granularity. */
     int timeTraceGranularity;

--- a/src/target_registry.cpp
+++ b/src/target_registry.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2025, Intel Corporation
+  Copyright (c) 2019-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -68,6 +68,9 @@ TargetLibRegistry::TargetLibRegistry() {
     // TODO: check for conflicts / duplicates.
     m_dispatch = nullptr;
     m_dispatch_macos = nullptr;
+    if (libs == nullptr) {
+        return;
+    }
     for (auto lib : *libs) {
         switch (lib->getType()) {
         case BitcodeLib::BitcodeLibType::Dispatch:

--- a/tools/ispc-opt.cpp
+++ b/tools/ispc-opt.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2024-2025, Intel Corporation
+  Copyright (c) 2024-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -134,6 +134,7 @@ int main(int argc, char **argv) {
     }
 
     ispc::g = new ispc::Globals;
+    ispc::g->disableTargetValidation = true;
     LLVMContext *ctx = ispc::g->ctx;
 
     if (Addressing == 64) {


### PR DESCRIPTION
## Description

`ispc-opt` runs optimization passes on LLVM IR and does not require the bitcode libraries provided by the builtin target. Previously, it was linked against builtin primarily to satisfy a target validation check in the Target constructor that relies on the target registry.

This change adds a `disableTargetValidation` flag to `ispc::Globals` that is used in `ispc-opt` to skip the target support check.

This reduces the binary size of ispc-opt from ~9MB to 0.9MB.

## Related Issue
- [x] Linked to relevant issue: https://github.com/ispc/ispc/issues/3737

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)