### PR TITLE
Fix #3742: Make FMA instruction matching flexible in 2334_unroll test

### DIFF
--- a/tests/lit-tests/2334_unroll.ispc
+++ b/tests/lit-tests/2334_unroll.ispc
@@ -10,10 +10,10 @@
 // CHECK-NEXT: vmovups 32(
 // CHECK-NEXT: vmovups 64(
 // CHECK-NEXT: vmovups 96(
-// CHECK-NEXT: vfmadd132ps (
-// CHECK-NEXT: vfmadd231ps 32(
-// CHECK-NEXT: vfmadd231ps 64(
-// CHECK: vfmadd231ps 96(
+// CHECK-NEXT: vfmadd{{[0-9]+}}ps (
+// CHECK-NEXT: vfmadd{{[0-9]+}}ps 32(
+// CHECK-NEXT: vfmadd{{[0-9]+}}ps 64(
+// CHECK: vfmadd{{[0-9]+}}ps 96(
 
 unmasked uniform float dotProductSoA_Unroll(uniform float a[], uniform float b[], uniform size_t N)
 {


### PR DESCRIPTION
LLVM trunk changed instruction selection for FMA operations in unrolled loops, now consistently generating vfmadd231ps instead of mixing vfmadd132ps and vfmadd231ps. All three FMA variants (132/213/231) are semantically equivalent, differing only in register operand order.

Updated CHECK patterns to use vfmadd{{[0-9]+}}ps regex to match any FMA variant, making the test robust to LLVM's internal codegen decisions while still verifying the loop unrolling behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed