### PR TITLE
Fix #3748: Align varying bool<N> LLVMType with mask representation

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -7945,7 +7945,7 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
         } else {
             // Emit instructions to do type conversion of each of the elements
             // of the vector.
-            llvm::Value *cast = llvm::UndefValue::get(toType->LLVMStorageType(g->ctx));
+            llvm::Value *cast = llvm::UndefValue::get(toType->LLVMType(g->ctx));
             for (int i = 0; i < toVector->GetElementCount(); ++i) {
                 llvm::Value *ei = ctx->ExtractInst(exprVal, i);
                 llvm::Value *conv = lTypeConvAtomicOrUniformVector(ctx, ei, toVector->GetElementType(),
@@ -7955,7 +7955,7 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
                 }
                 if ((toVector->GetElementType()->IsBoolType()) &&
                     (CastType<AtomicType>(toVector->GetElementType()) != nullptr)) {
-                    conv = ctx->SwitchBoolToStorageType(conv, toVector->GetElementType()->LLVMStorageType(g->ctx));
+                    conv = ctx->SwitchBoolToMaskType(conv, toVector->GetElementType()->LLVMType(g->ctx));
                 }
 
                 cast = ctx->InsertInst(cast, conv, i);
@@ -7998,11 +7998,11 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
             cast = ctx->BroadcastValue(conv, toTypeLLVM);
         } else if (llvm::isa<llvm::ArrayType>(toTypeLLVM)) {
             // Example varying float => varying float<3>
-            cast = llvm::UndefValue::get(toType->LLVMStorageType(g->ctx));
+            cast = llvm::UndefValue::get(toType->LLVMType(g->ctx));
             for (int i = 0; i < toVector->GetElementCount(); ++i) {
                 if ((toVector->GetElementType()->IsBoolType()) &&
                     (CastType<AtomicType>(toVector->GetElementType()) != nullptr)) {
-                    conv = ctx->SwitchBoolToStorageType(conv, toVector->GetElementType()->LLVMStorageType(g->ctx));
+                    conv = ctx->SwitchBoolToMaskType(conv, toVector->GetElementType()->LLVMType(g->ctx));
                 }
                 // Here's InsertInst produces InsertValueInst.
                 cast = ctx->InsertInst(cast, conv, i);

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1764,8 +1764,13 @@ static llvm::Type *lGetVectorLLVMType(llvm::LLVMContext *ctx, const VectorType *
 
     llvm::Type *bt = nullptr;
     // Non-uniform vector types are represented in IR as an array.
-    // So, creating them with base as storage type similar to arrays.
-    if (isStorage || !base->IsUniformType()) {
+    // Use the storage type only when explicitly requested (isStorage=true).
+    // For internal (non-storage) use, non-uniform bool<N> vectors use
+    // BoolVectorType (the mask representation, e.g. <W x i32>) as element
+    // type, consistent with how scalar varying bool uses BoolVectorType
+    // internally. LLVMStorageType() vs LLVMType() only differs for bool;
+    // for all other element types the two are identical.
+    if (isStorage) {
         bt = base->LLVMStorageType(ctx);
     } else {
         bt = base->LLVMType(ctx);

--- a/tests/lit-tests/3748.ispc
+++ b/tests/lit-tests/3748.ispc
@@ -1,0 +1,29 @@
+// Test for https://github.com/ispc/ispc/issues/3748
+// When passing a bool short-vector comparison result directly to a function,
+// the LLVM type must match the function signature. Previously, the comparison
+// produced [N x <W x iMASK>] but VectorType::LLVMType() for varying bool<N>
+// returned [N x <W x i8>] (storage type), causing a type mismatch and a
+// "Call parameter type does not match function signature" fatal error.
+// Fixed by aligning lGetVectorLLVMType so that varying bool<N>::LLVMType()
+// uses the mask element type (consistent with scalar varying bool).
+
+// RUN: %{ispc} %s --target=host --nostdlib --nowrap --emit-llvm-text -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx512skx-x16 --nostdlib --nowrap --emit-llvm-text -o - | FileCheck %s
+// REQUIRES: X86_ENABLED
+
+// CHECK-LABEL: @foo___
+// CHECK: fcmp oeq
+// CHECK: fcmp oeq
+// CHECK: fcmp oeq
+
+inline varying bool all_elements(bool<3> v)
+{
+    return v.x && v.y && v.z;
+}
+
+// Previously crashed with: LLVM ERROR: Broken module found, compilation aborted!
+// when passing a comparison result directly as a bool short-vector argument.
+varying bool foo(float<3> b, float<3> c)
+{
+    return all_elements(b == c);
+}


### PR DESCRIPTION
## Description
The commit f80c6e0c changed I1VecToBoolVec to produce [N x <W x iMASK>] for bool short-vector comparison results, intending to make varying bool<N> consistent with scalar varying bool (which uses BoolVectorType = iMASK internally). However it did not update lGetVectorLLVMType, which still returned [N x <W x i8>] (storage type) for VectorType::LLVMType() on varying bool<N>. This mismatch caused "Call parameter type does not match function signature" when a comparison result was passed directly to a function expecting bool<N>.

Fix: complete the original intent by removing the !base->IsUniformType() exception in lGetVectorLLVMType so that LLVMType() for varying bool<N> returns [N x <W x iMASK>] (consistent with I1VecToBoolVec), while LLVMStorageType() continues to return [N x <W x i8>]. Update TypeCastExpr to match: build the output array with LLVMType and use SwitchBoolToMaskType for bool elements in both the vector-to-vector and scalar-to-vector paths.

This design is now fully symmetric: both scalar varying bool and varying bool<N> use the target-specific mask type internally (e.g. i32 on AVX2, i1 on AVX-512) and convert to i8 only at store/load/ABI boundaries.

## Related Issue
- [X] Linked to relevant issue: #3748

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
- [X] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
