### PR TITLE
Update Rust toolchain action to use master with stable toolchain

### DIFF
--- a/.github/workflows/opensource-projects.yml
+++ b/.github/workflows/opensource-projects.yml
@@ -243,8 +243,10 @@ jobs:
 
     steps:
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
-
+      uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+      with:
+        toolchain: stable
+        
     - name: Download ISPC artifact
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:


### PR DESCRIPTION
## Description
Update `Install Rust` step in `.github/workflows/opensource-projects.yml` according to rust-toolchain recommendations https://github.com/dtolnay/rust-toolchain

## Related Issue
https://github.com/ispc/ispc/actions/runs/22078537220/job/63798825987

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed