### PR TITLE
Add FileCheck executable parameter to lit configuration

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,8 @@ list(APPEND LIT_ARGS "-Dlinux_enabled=$<IF:$<BOOL:${ISPC_LINUX_TARGET}>,ON,OFF>"
 list(APPEND LIT_ARGS "-Dps_enabled=$<IF:$<BOOL:${ISPC_PS_TARGET}>,ON,OFF>")
 list(APPEND LIT_ARGS "-Dmacos_arm_enabled=$<IF:$<BOOL:${ISPC_MACOS_ARM_TARGET}>,ON,OFF>")
 list(APPEND LIT_ARGS "-Dmacos_ios_enabled=$<IF:$<BOOL:${ISPC_IOS_ARM_TARGET}>,ON,OFF>")
+# FileCheck executable
+list(APPEND LIT_ARGS "-Dfile_check_executable=${FILE_CHECK_EXECUTABLE}")
 # ISPC library is enabled
 list(APPEND LIT_ARGS "-Dispc_lib_enabled=$<IF:$<BOOL:${ISPC_LIBRARY}>,ON,OFF>")
 list(APPEND LIT_ARGS "-Dispc_lib_jit_enabled=$<IF:$<BOOL:${ISPC_LIBRARY_JIT}>,ON,OFF>")

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -25,7 +25,8 @@ if ispc_test_exec_root != '':
 
 config.substitutions.append(('%{ispc}', 'ispc'))
 config.substitutions.append(('%{ispc-opt}', 'ispc-opt'))
-config.substitutions.append(('FileCheck', 'FileCheck'))
+file_check_executable = lit_config.params.get('file_check_executable', 'FileCheck')
+config.substitutions.append(('FileCheck', file_check_executable))
 config.substitutions.append(('%{cc}', 'clang'))
 config.substitutions.append(('%{cxx}', 'clang++'))
 config.substitutions.append(('%{ispc_include}', os.path.join(config.ispc_build_dir, 'include')))

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -25,8 +25,8 @@ if ispc_test_exec_root != '':
 
 config.substitutions.append(('%{ispc}', 'ispc'))
 config.substitutions.append(('%{ispc-opt}', 'ispc-opt'))
-file_check_executable = lit_config.params.get('file_check_executable', 'FileCheck')
-config.substitutions.append(('FileCheck', file_check_executable))
+file_check_executable = lit_config.params.get('file_check_executable', '') or 'FileCheck'
+config.substitutions.append(('FileCheck', f'"{file_check_executable}"'))
 config.substitutions.append(('%{cc}', 'clang'))
 config.substitutions.append(('%{cxx}', 'clang++'))
 config.substitutions.append(('%{ispc_include}', os.path.join(config.ispc_build_dir, 'include')))


### PR DESCRIPTION
## Description                                                                                                                           
Forward the `FILE_CHECK_EXECUTABLE` override to lit tests.

`FILE_CHECK_EXECUTABLE` can be set at CMake configure time (e.g., `-DFILE_CHECK_EXECUTABLE=FileCheck-20`) to use a custom `FileCheck` binary. Previously this value wasn’t passed to lit, so tests always invoked the default `FileCheck` and failed if it wasn’t on the PATH.

Fix:
- In `tests/CMakeLists.txt`, add `-Dfile_check_executable=<path>` so lit receives the chosen `FileCheck` binary.
- In `tests/lit-tests/lit.cfg`, read that value and use it as the `FileCheck` command, falling back to the default `FileCheck` if nothing is provided.

## Related Issue
- [x] https://github.com/ispc/ispc/issues/3736

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed