### PR TITLE
Fix stdlib handling in slim mode to prevent dependency cycles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -995,8 +995,10 @@ function(add_ispc_slim NAME)
     # Defines targets for generic builtin implementations
     generate_generic_builtins(${NAME})
 
-    # stdlib, stdlibs-bc, stdlibs-cpp targets are created in Stdlib.cmake
-    configure_ispc_obj(stdlib)
+    # stdlib OBJECT library is only created in non-slim mode (see Stdlib.cmake)
+    if (NOT ISPC_SLIM_BINARY)
+        configure_ispc_obj(stdlib)
+    endif()
 
     add_executable(${NAME} src/main.cpp src/binary_slim.cpp)
     configure_ispc_exe(${NAME})


### PR DESCRIPTION
## Description
Brief description of changes //draft

## Related Issue
- [ ] 

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed