### PR TITLE
ci: replace inline ISPC build steps with reusable workflow

### DIFF
--- a/.github/workflows/ispc-svml.yml
+++ b/.github/workflows/ispc-svml.yml
@@ -76,35 +76,13 @@ jobs:
 
   linux-build-ispc-llvm:
     needs: [define-flow]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      with:
-        submodules: true
-
-    - name: Install dependencies
-      run: |
-        .github/workflows/scripts/install-build-deps.sh
-
-    - name: Check environment
-      run: |
-        which -a clang
-        cat /proc/cpuinfo
-
-    - name: Build package
-      run: |
-        .github/workflows/scripts/build-ispc.sh
-
-    - name: Sanity testing (make check-all, make test)
-      run: |
-        .github/workflows/scripts/check-ispc.sh
-
-    - name: Upload package
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-        name: ispc_llvm_linux
-        path: build/ispc-*-linux.tar.gz
+    uses: ./.github/workflows/reusable.ispc.build.yml
+    with:
+      platform: linux
+      artifact_name: ispc_llvm_linux
+      runner: ubuntu-22.04
+      llvm_version: "21.1"
+      llvm_tar: llvm-21.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
 
 
   linux-test-llvm:

--- a/.github/workflows/openmoonray.yml
+++ b/.github/workflows/openmoonray.yml
@@ -24,25 +24,13 @@ concurrency:
 
 jobs:
   build-ispc:
-    name: Build ISPC
-    runs-on: ubuntu-22.04
-
-    steps:
-    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      with:
-        submodules: true
-
-    - name: Install ISPC build dependencies
-      run: .github/workflows/scripts/install-build-deps.sh
-
-    - name: Build ISPC
-      run: .github/workflows/scripts/build-ispc.sh
-
-    - name: Upload ISPC artifact
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-        name: ispc-fresh-build
-        path: build/ispc-*-linux.tar.gz
+    uses: ./.github/workflows/reusable.ispc.build.yml
+    with:
+      platform: linux
+      artifact_name: ispc-fresh-build
+      runner: ubuntu-22.04
+      llvm_version: "21.1"
+      llvm_tar: llvm-21.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
 
   build-openmoonray:
     name: Build OpenMoonRay AUR package

--- a/.github/workflows/opensource-projects.yml
+++ b/.github/workflows/opensource-projects.yml
@@ -23,43 +23,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-ispc:
-    name: Build ISPC (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+  build-ispc-linux:
+    uses: ./.github/workflows/reusable.ispc.build.yml
+    with:
+      platform: linux
+      artifact_name: ispc-archive
+      runner: ubuntu-22.04
+      llvm_version: "21.1"
+      llvm_tar: llvm-21.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            install_deps_args: ""
-            artifact_name: ispc-archive
-            artifact_path: build/ispc-*-linux.tar.gz
-          - os: macos-14
-            install_deps_args: macos-14
-            artifact_name: ispc-macos-arm
-            artifact_path: build/ispc-*-macos.tar.gz
-
-    steps:
-    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      with:
-        submodules: true
-
-    - name: Install ISPC build dependencies
-      run: .github/workflows/scripts/install-build-deps.sh ${{ matrix.install_deps_args }}
-
-    - name: Build ISPC
-      run: .github/workflows/scripts/build-ispc.sh
-
-    - name: Upload ISPC artifact
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-        name: ${{ matrix.artifact_name }}
-        path: ${{ matrix.artifact_path }}
+  build-ispc-macos:
+    uses: ./.github/workflows/reusable.ispc.build.yml
+    with:
+      platform: macos
+      artifact_name: ispc-macos-arm
+      runner: macos-14
+      llvm_version: "21.1"
+      llvm_tar: llvm-21.1.8-macos-Release+Asserts-universal-x86.arm.wasm.tar.xz
 
   build-projects:
     name: Build ${{ matrix.project.name }}
-    needs: build-ispc
+    needs: build-ispc-linux
     runs-on: ubuntu-22.04
     container:
       image: archlinux@sha256:2fcdd55448255f87dd337ef5c0fdbd5e4fec432345db1aa5faea4bf2764b4ca8
@@ -149,7 +133,7 @@ jobs:
 
   build-projects-with-builder:
     name: Build ${{ matrix.project.name }}
-    needs: build-ispc
+    needs: build-ispc-linux
     runs-on: ubuntu-22.04
     container:
       image: archlinux@sha256:2fcdd55448255f87dd337ef5c0fdbd5e4fec432345db1aa5faea4bf2764b4ca8
@@ -238,7 +222,7 @@ jobs:
 
   build-ispc-downsampler:
     name: Build ispc-downsampler on macOS ARM
-    needs: build-ispc
+    needs: build-ispc-macos
     runs-on: macos-14
 
     steps:

--- a/.github/workflows/rk-superbuild.yml
+++ b/.github/workflows/rk-superbuild.yml
@@ -15,58 +15,22 @@ concurrency:
 
 jobs:
   build-ispc-ubuntu-2204:
-    runs-on: ubuntu-22.04
-
-    steps:
-    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      with:
-        submodules: true
-
-    - name: Install dependencies
-      run: |
-        .github/workflows/scripts/install-build-deps.sh
-
-    - name: Check environment
-      run: |
-        which -a clang
-        cat /proc/cpuinfo
-
-    - name: Build package
-      run: |
-        .github/workflows/scripts/build-ispc.sh
-
-    - name: Upload package
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-        name: ispc_linux_package
-        path: build/ispc-*-linux.tar.gz
+    uses: ./.github/workflows/reusable.ispc.build.yml
+    with:
+      platform: linux
+      artifact_name: ispc_linux_package
+      runner: ubuntu-22.04
+      llvm_version: "21.1"
+      llvm_tar: llvm-21.1.8-ubuntu22.04-Release+Asserts-x86.arm.wasm.tar.xz
 
   build-ispc-aarch64:
-    runs-on: ubuntu-22.04-arm
-
-    steps:
-    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      with:
-        submodules: true
-
-    - name: Install dependencies
-      run: |
-        .github/workflows/scripts/install-build-deps.sh
-
-    - name: Check environment
-      run: |
-        which -a clang
-        cat /proc/cpuinfo
-
-    - name: Build package
-      run: |
-        .github/workflows/scripts/build-ispc.sh
-
-    - name: Upload package
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-        name: ispc_linux_aarch64_package
-        path: build/ispc-trunk-linux.tar.gz
+    uses: ./.github/workflows/reusable.ispc.build.yml
+    with:
+      platform: linux
+      artifact_name: ispc_linux_aarch64_package
+      runner: ubuntu-22.04-arm
+      llvm_version: "21.1"
+      llvm_tar: llvm-21.1.8-ubuntu22.04aarch64-Release+Asserts-x86.arm.wasm.tar.xz
 
   build-ispc-windows:
     runs-on: windows-2022


### PR DESCRIPTION
## Description
Modify `ispc-svml.yml`, `openmoonray.yml`, `opensource-projects.yml`, and `rk-superbuild.yml` workflows to re-use ispc build(`reusable.ispc.build.yml`) across these workflows.

## Related Issue
- [x] https://github.com/ispc/ispc/issues/3566

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed