### PR TITLE
Fix #3767: Update BranchInst API for LLVM 23.0

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -232,7 +232,11 @@ FunctionEmitContext::FunctionEmitContext(const Function *func, Symbol *funSym, l
     allocaBlock = llvm::BasicBlock::Create(*g->ctx, "allocas", llvmFunction, 0);
     bblock = llvm::BasicBlock::Create(*g->ctx, "entry", llvmFunction, 0);
     /* But jump from it immediately into the real entry block */
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+    llvm::UncondBrInst::Create(bblock, allocaBlock);
+#else
     llvm::BranchInst::Create(bblock, allocaBlock);
+#endif
 
     funcStartPos = funSym->pos;
 
@@ -3490,7 +3494,11 @@ void FunctionEmitContext::setLoopMetadata(llvm::Instruction *inst,
 }
 
 llvm::Instruction *FunctionEmitContext::BranchInst(llvm::BasicBlock *dest) {
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+    llvm::Instruction *b = llvm::UncondBrInst::Create(dest, bblock);
+#else
     llvm::Instruction *b = llvm::BranchInst::Create(dest, bblock);
+#endif
     AddDebugPos(b);
     return b;
 }
@@ -3506,7 +3514,11 @@ llvm::Instruction *FunctionEmitContext::BranchInst(llvm::BasicBlock *trueBlock, 
     if (emitXeHardwareMask())
         test = XePrepareVectorBranch(test);
 #endif
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+    b = llvm::CondBrInst::Create(test, trueBlock, falseBlock, bblock);
+#else
     b = llvm::BranchInst::Create(trueBlock, falseBlock, test, bblock);
+#endif
     AddDebugPos(b);
     return b;
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -2065,7 +2065,11 @@ static void lCreateDispatchFunction(llvm::Module *module, llvm::Function *getBes
                                                 LLVMInt32(i), "isa_ok", bblock);
         llvm::BasicBlock *callBBlock = llvm::BasicBlock::Create(*g->ctx, "do_call", dispatchFunc);
         llvm::BasicBlock *nextBBlock = llvm::BasicBlock::Create(*g->ctx, "next_try", dispatchFunc);
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+        llvm::CondBrInst::Create(ok, callBBlock, nextBBlock, bblock);
+#else
         llvm::BranchInst::Create(callBBlock, nextBBlock, ok, bblock);
+#endif
 
         // Store the chosen variant in the cache.
         builder.SetInsertPoint(callBBlock);


### PR DESCRIPTION
LLVM 23.0 deprecated llvm::BranchInst and split it into UncondBrInst and CondBrInst. This commit updates all 4 call sites with version guards to maintain backward compatibility with LLVM 18-22.

Changes:
- src/ctx.cpp: Updated 3 call sites (lines 235, 3493, 3509)
  - Unconditional branches now use UncondBrInst::Create
  - Conditional branch uses CondBrInst::Create with reordered arguments
- src/module.cpp: Updated 1 call site (line 2068)
  - Conditional branch uses CondBrInst::Create with reordered arguments
- Updated copyright year to 2026 in src/module.cpp

All changes are guarded with #if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0 to preserve compatibility with earlier LLVM versions.

## Description
Brief description of changes

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed