### PR TITLE
Add version guard for LLVM 23.0 IITDescriptor API change

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2024-2025, Intel Corporation
+  Copyright (c) 2024-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -456,7 +456,11 @@ bool lIsAliased(const IITDesc &L, const IITDesc &R) {
 size_t lNextIITDescs(const IITDesc &D) {
     switch (D.Kind) {
     case IITDesc::Struct:
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+        return D.StructNumElements + 1;
+#else
         return D.Struct_NumElements + 1;
+#endif
     case IITDesc::Vector:
     case IITDesc::SameVecWidthArgument:
         return 2;


### PR DESCRIPTION
## Description
Brief description of changes

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed