### PR TITLE
Fix LLVM 23 API compatibility for getInlineParams

### DIFF
--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -313,8 +313,14 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
     simplifyCFGopt.HoistCommonInsts = true;
 
     // SizeOptLevel of 1 corresponds to the -Os flag and 2 corresponds to the -Oz flag.
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+    // LLVM 23+ removed the SizeOptLevel parameter from getInlineParams.
+    // Size optimization is now handled via function attributes (optsize/minsize).
+    llvm::InlineParams IP = llvm::getInlineParamsFromOptLevel(optLevel);
+#else
     const unsigned SizeOptLevel = (optLevel == 1) ? 1 : 0;
     llvm::InlineParams IP = llvm::getInlineParams(optLevel, SizeOptLevel);
+#endif
     if (optLevel == 0) {
         //  This is more or less the minimum set of optimizations that we
         //  need to do to generate code that will actually run.  (We can't


### PR DESCRIPTION
LLVM trunk commit removed the two-argument getInlineParams(optLevel, SizeOptLevel) overload in favor of getInlineParamsFromOptLevel(optLevel). Size optimization is now handled via function attributes (optsize/minsize) instead of a pipeline-level SizeOptLevel parameter.

This commit adds version guards to use:
- getInlineParamsFromOptLevel(optLevel) for LLVM 23+
- getInlineParams(optLevel, SizeOptLevel) for LLVM ≤22

Fixes #3790

## Description
Brief description of changes

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)