### PR TITLE
Fix the acos function, make it faster and improve tests

### DIFF
--- a/builtins/util-xe.m4
+++ b/builtins/util-xe.m4
@@ -4599,6 +4599,7 @@ define float @__stdlib_expm1f(float) nounwind readnone alwaysinline {
 declare double @sin(double) nounwind readnone
 declare double @sinh(double) nounwind readnone
 declare double @asin(double) nounwind readnone
+declare double @acos(double) nounwind readnone
 declare double @cos(double) nounwind readnone
 declare double @cosh(double) nounwind readnone
 declare void @sincos(double, double *, double *) nounwind
@@ -4626,6 +4627,11 @@ define double @__stdlib_sinh(double) nounwind readnone alwaysinline {
 
 define double @__stdlib_asin(double) nounwind readnone alwaysinline {
   %r = call double @asin(double %0)
+  ret double %r
+}
+
+define double @__stdlib_acos(double) nounwind readnone alwaysinline {
+  %r = call double @acos(double %0)
   ret double %r
 }
 

--- a/builtins/util.m4
+++ b/builtins/util.m4
@@ -5973,6 +5973,7 @@ define float @__stdlib_expm1f(float) nounwind readnone alwaysinline {
 declare double @sin(double) nounwind readnone
 declare double @sinh(double) nounwind readnone
 declare double @asin(double) nounwind readnone
+declare double @acos(double) nounwind readnone
 declare double @cos(double) nounwind readnone
 declare double @cosh(double) nounwind readnone
 declare void @sincos(double, double *, double *) nounwind
@@ -6000,6 +6001,11 @@ define double @__stdlib_sinh(double) nounwind readnone alwaysinline {
 
 define double @__stdlib_asin(double) nounwind readnone alwaysinline {
   %r = call double @asin(double %0)
+  ret double %r
+}
+
+define double @__stdlib_acos(double) nounwind readnone alwaysinline {
+  %r = call double @acos(double %0)
   ret double %r
 }
 

--- a/stdlib/include/builtins.isph
+++ b/stdlib/include/builtins.isph
@@ -590,6 +590,7 @@ EXT inline void __streaming_store_varying_i8(NOESCAPE uniform int8 *uniform, var
 EXT inline READNONE uniform float __stdlib_acosf(uniform float);
 EXT inline READNONE uniform float __stdlib_asinf(uniform float);
 EXT inline READNONE uniform double __stdlib_asin(uniform double);
+EXT inline READNONE uniform double __stdlib_acos(uniform double);
 EXT inline READNONE uniform float __stdlib_atan2f(uniform float, uniform float);
 EXT inline READNONE uniform double __stdlib_atan2(uniform double, uniform double);
 EXT inline READNONE uniform float __stdlib_atanf(uniform float);

--- a/stdlib/stdlib.ispc
+++ b/stdlib/stdlib.ispc
@@ -3740,21 +3740,124 @@ __declspec(safe) static inline float cosh(float x) {
     }
 }
 
-__declspec(safe) static inline float acos(float v) {
+__declspec(safe) static inline uniform float acos(uniform float x_full) {
     if (__have_native_trigonometry && !__is_xe_target) {
-        return __acos_varying_float(v);
-    } else if (__math_lib == __math_lib_svml) {
-        return __svml_acosf(v);
-    } else {
-        return 1.57079637050628662109375 - asin(v);
+        return __acos_uniform_float(x_full);
+    } else if (__math_lib == __math_lib_system || __math_lib == __math_lib_svml) {
+        return __stdlib_acos(x_full);
+    } else if (__math_lib == __math_lib_ispc_fast) {
+
+        // Precision: <15 ULP.
+        // Natively support special values (e.g. subnormal numbers and NaNs).
+
+        // Sollya:
+        // f = acos(1-x) / sqrt(x)
+        // fpminimax(f, [|0,...,5|], [|single...|], [1e-300;1.0]);
+        const uniform float c0 = +1.4142124653e+00;
+        const uniform float c1 = +1.1792322248e-01;
+        const uniform float c2 = +2.5741405785e-02;
+        const uniform float c3 = +1.0879410430e-02;
+        const uniform float c4 = -2.2721362770e-03;
+        const uniform float c5 = +4.3107867240e-03;
+
+        const uniform float x = abs(x_full);
+        const uniform float t = 1.0 - x;
+        const uniform float t2 = t * t;
+
+        // Estrin's scheme used to reduce the latency
+        uniform float poly = c5 * t + c4;
+        poly = poly * t2 + (c3 * t + c2);
+        poly = poly * t2 + (c1 * t + c0);
+        poly *= sqrt(t);
+
+        return select(x_full < 0.0, PI - poly, poly);
+    } else if (__math_lib == __math_lib_ispc) {
+
+        // Precision: <5 ULP
+
+        // Sollya:
+        // f = acos(1-x) / sqrt(x)
+        // fpminimax(f, [|0,...,6|], [|single...|], [1e-300;1.004]);
+        const uniform float c0 = +1.4142136574e+00;
+        const uniform float c1 = +1.1783879995e-01;
+        const uniform float c2 = +2.6711430400e-02;
+        const uniform float c3 = +6.7900302820e-03;
+        const uniform float c4 = +5.5398275140e-03;
+        const uniform float c5 = -2.5801914740e-03;
+        const uniform float c6 = +2.2826674390e-03;
+
+        const uniform float x = abs(x_full);
+        const uniform float t = 1.0 - x;
+        const uniform float t2 = t * t;
+
+        // Estrin's scheme used to reduce the latency
+        uniform float poly = c6;
+        poly = poly * t2 + (c5 * t + c4);
+        poly = poly * t2 + (c3 * t + c2);
+        poly = poly * t2 + (c1 * t + c0);
+        poly *= sqrt(t);
+
+        return select(x_full < 0.0, PI - poly, poly);
     }
 }
 
-__declspec(safe) static inline uniform float acos(uniform float v) {
-    if (__have_native_trigonometry && !__is_xe_target)
-        return __acos_uniform_float(v);
-    else
-        return 1.57079637050628662109375 - asin(v);
+__declspec(safe) static inline float acos(float x_full) {
+    if (__have_native_trigonometry && !__is_xe_target) {
+        return __acos_varying_float(x_full);
+    } else if (__math_lib == __math_lib_svml) {
+        return __svml_acosf(x_full);
+    } else if (__math_lib == __math_lib_system) {
+        float ret;
+        foreach_active(i) {
+            uniform float r = __stdlib_acosf(extract(x_full, i));
+            ret = insert(ret, i, r);
+        }
+        return ret;
+    } else if (__math_lib == __math_lib_ispc_fast) {
+
+        // See the uniform version for more information
+
+        const float c0 = +1.4142124653e+00;
+        const float c1 = +1.1792322248e-01;
+        const float c2 = +2.5741405785e-02;
+        const float c3 = +1.0879410430e-02;
+        const float c4 = -2.2721362770e-03;
+        const float c5 = +4.3107867240e-03;
+
+        const float x = abs(x_full);
+        const float t = 1.0 - x;
+        const float t2 = t * t;
+
+        float poly = c5 * t + c4;
+        poly = poly * t2 + (c3 * t + c2);
+        poly = poly * t2 + (c1 * t + c0);
+        poly *= sqrt(t);
+
+        return select(x_full < 0.0, PI - poly, poly);
+    } else if (__math_lib == __math_lib_ispc) {
+
+        // See the uniform version for more information
+
+        const float c0 = +1.4142136574e+00;
+        const float c1 = +1.1783879995e-01;
+        const float c2 = +2.6711430400e-02;
+        const float c3 = +6.7900302820e-03;
+        const float c4 = +5.5398275140e-03;
+        const float c5 = -2.5801914740e-03;
+        const float c6 = +2.2826674390e-03;
+
+        const float x = abs(x_full);
+        const float t = 1.0 - x;
+        const float t2 = t * t;
+
+        float poly = c6;
+        poly = poly * t2 + (c5 * t + c4);
+        poly = poly * t2 + (c3 * t + c2);
+        poly = poly * t2 + (c1 * t + c0);
+        poly *= sqrt(t);
+
+        return select(x_full < 0.0, PI - poly, poly);
+    }
 }
 
 __declspec(safe) static inline void sincos(float x_full, varying float *uniform sin_result,
@@ -6016,7 +6119,12 @@ __declspec(safe) static inline double acos(const double v) {
     } else if (__math_lib == __math_lib_svml) {
         return __svml_acosd(v);
     } else {
-        return 1.57079637050628662109375d - asin(v);
+        double ret;
+        foreach_active(i) {
+            uniform double r = __stdlib_acos(extract(v, i));
+            ret = insert(ret, i, r);
+        }
+        return ret;
     }
 }
 
@@ -6024,7 +6132,7 @@ __declspec(safe) static inline uniform double acos(const uniform double v) {
     if (__have_native_trigonometry)
         return __acos_uniform_double(v);
     else
-        return 1.57079637050628662109375d - asin(v);
+        return __stdlib_acos(v);
 }
 
 __declspec(safe) static inline void sincos(double x, varying double *uniform sin_result,

--- a/tests/func-tests/acos.ispc
+++ b/tests/func-tests/acos.ispc
@@ -1,21 +1,34 @@
 #include "test_static.isph"
-bool ok(float x, float ref) { return (abs(x - ref) < 1e-4) || abs((x-ref)/ref) < 1e-4; }
+
+bool ok(float x, float ref) {
+    return (abs(x - ref) < 1e-6) || abs((x-ref)/ref) < 1e-5;
+}
 
 task void f_v(uniform float RET[]) {
-    uniform float vals[8] = { 0, 1, 0.5, -1, -.87, -.25, 1e-3, -.99999999 };
-    uniform float r[8];
-    foreach (i = 0 ... 8) {
+    uniform float vals[15] = { 
+        0.0, 1.0, 0.5, 0.79, 1e-3, 0.995, 0.9999998, 0.999999,
+        -1.0, -0.87, -0.25, -0.01, -0.995, -0.9999998, -0.999999
+    };
+
+    uniform float r[15];
+
+    foreach (i = 0 ... 15) {
         // TODO: Possible optimization opportunity.
         #pragma ignore warning(perf)
-        r[i] = cos(acos(vals[i % 8]));
+        r[i] = cos(acos(vals[i % 15]));
     }
 
     int errors = 0;
-    for (uniform int i = 0; i < 8; ++i) {
-        if (ok(r[i], vals[i%8]) == false) {
+    for (uniform int i = 0; i < 15; ++i) {
+        if (ok(r[i], vals[i % 15]) == false) {
             ++errors;
         }
     }
+
+    // Just to be sure the function actually compute something
+    if (!ok(acos(0.972381), 0.235572))
+        ++errors;
+
     RET[programIndex] = errors;
 }
 


### PR DESCRIPTION
As the title/commit suggest, this PR fix precision issues in the `acos` function, make it faster and improve tests. Here is the commit description for more details:
> - acos now correctly calls the standard library in double precision
> - implement faster versions which are also much more accurate close to 1 (no catastrophic cancellation anymore)
> - improve the acos tests so to check more use-case and reduce the error bound

It fixes the issue #3797 about double-precision and solve the `acos` numerical stability issue mention in #2236 (which is also mentioned in the first issue).

The precision of the default math-lib function is now <5 ULP and it is <15 ULP for the fast one. Overall, the error is more balanced than before on the `[-1;+1]` range and now bounded. This means it can be a bit higher for x < 0.5 while being much lower for x > 0.95.

The default and fast implementation are both faster than previous ones. They are also much faster (about 3-4 times) than Sleef (having a relatively-close precision of <3.5 ULP). Here are benchmark results on my machine (i5-9600KF CPU) on the avx2-i32x8 target (the reported values are the time in clocks):

```
Full range of 32-bit floats (not very realistic use-case):
    - without subnormals:
        - Current main branch (default):    2.903069e9
        - Current main branch (fast):       1.650359e9
        - This PR (default):                1.404689e9  <-----
        - This PR (fast):                   1.372506e9  <-----
        - Sleef:                            5.071257e9
    - with subnormals (rather-pathological use-case):
        - Current main branch (default):    4.063371e9
        - Current main branch (fast):       2.249455e9
        - This PR (default):                1.325650e9  <-----
        - This PR (fast):                   1.372743e9  <-----
        - Sleef:                           17.094187e9


Uniform random range [-1;+1] (more realistic use-case)
    - Current main branch (default):    7.446462e9
    - Current main branch (fast):       5.399786e9
    - This PR (default):                4.561175e9  <-----
    - This PR (fast):                   4.354596e9  <-----
    - Sleef:                            8.395003e9
    - RNG alone (overhead):             2.114988e9
```

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [x] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed
