### PR TITLE
Defer forced inlining of `inline`-qualified functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,6 +592,8 @@ list(APPEND OPT_SOURCES
     src/opt/ReplacePseudoMemoryOps.h
     src/opt/ReplaceStdlibShiftPass.cpp
     src/opt/ReplaceStdlibShiftPass.h
+    src/opt/RestoreInlineAttrPass.cpp
+    src/opt/RestoreInlineAttrPass.h
     src/opt/ScalarizePass.cpp
     src/opt/ScalarizePass.h
     src/opt/FastMath.cpp

--- a/src/func.cpp
+++ b/src/func.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2011-2025, Intel Corporation
+  Copyright (c) 2011-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -53,7 +53,12 @@ bool Function::IsInternal() const {
     bool isInline = false;
     llvm::Function *function = sym->function;
     if (function != nullptr) {
-        isInline = (function->getAttributes().getFnAttrs().hasAttribute(llvm::Attribute::AlwaysInline));
+        const llvm::AttributeSet &fnAttrs = function->getAttributes().getFnAttrs();
+        // ispc-defer-alwaysinline is the deferred form of AlwaysInline used for
+        // user-written `inline`; either marker means the source qualifier was
+        // present.
+        isInline =
+            fnAttrs.hasAttribute(llvm::Attribute::AlwaysInline) || fnAttrs.hasAttribute("ispc-defer-alwaysinline");
     }
     return sc == StorageClass::STATIC || isInline;
 }
@@ -500,10 +505,13 @@ void Function::emitCode(FunctionEmitContext *ctx, llvm::Function *function, Sour
         // entire thing inside code that tests to see if the mask is all
         // on, all off, or mixed.  If this is a simple function, then this
         // isn't worth the code bloat / overhead.
-        bool checkMask =
-            (!g->target->isXeTarget() && type->IsTask() == true) ||
-            ((function->getAttributes().getFnAttrs().hasAttribute(llvm::Attribute::AlwaysInline) == false) &&
-             costEstimate > CHECK_MASK_AT_FUNCTION_START_COST);
+        const llvm::AttributeSet &fnAttrs = function->getAttributes().getFnAttrs();
+        // ispc-defer-alwaysinline is the deferred form of alwaysinline used for
+        // user-written `inline`; treat both as "will be inlined".
+        const bool willBeInlined =
+            fnAttrs.hasAttribute(llvm::Attribute::AlwaysInline) || fnAttrs.hasAttribute("ispc-defer-alwaysinline");
+        bool checkMask = (!g->target->isXeTarget() && type->IsTask() == true) ||
+                         (!willBeInlined && costEstimate > CHECK_MASK_AT_FUNCTION_START_COST);
         checkMask &= (type->IsUnmasked() == false);
         checkMask &= (g->target->getMaskingIsFree() == false);
         checkMask &= (g->opt.disableCoherentControlFlow == false);
@@ -1326,7 +1334,9 @@ llvm::Function *TemplateInstantiation::createLLVMFunction(Symbol *functionSym) {
     g->target->markFuncWithTargetAttr(function);
 
     if (isInline) {
-        function->addFnAttr(llvm::Attribute::AlwaysInline);
+        // See AddFunctionDeclaration in module.cpp for why we use a custom
+        // attribute here instead of AlwaysInline.
+        function->addFnAttr("ispc-defer-alwaysinline");
     }
     if (isNoInline) {
         function->addFnAttr(llvm::Attribute::NoInline);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1086,7 +1086,12 @@ void Module::AddFunctionDeclaration(const std::string &name, const FunctionType 
     // Set function attributes: we never throw exceptions
     function->setDoesNotThrow();
     if (!isExternCorSYCL && isInline) {
-        function->addFnAttr(llvm::Attribute::AlwaysInline);
+        // Mark with a custom attribute now; it is converted to AlwaysInline
+        // late in the optimization pipeline by RestoreInlineAttrPass. This
+        // defers forced inlining until after function-level optimizations
+        // have run, which produces better code than inlining the function
+        // body before those passes (issue #3804).
+        function->addFnAttr("ispc-defer-alwaysinline");
     }
 
     if (isVectorCall) {

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -605,7 +605,10 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         optPM.addFunctionPass(llvm::SROAPass(llvm::SROAOptions::ModifyCFG));
         optPM.addFunctionPass(llvm::InferAlignmentPass());
         optPM.addFunctionPass(llvm::InstCombinePass());
-        optPM.addFunctionPass(IsCompileTimeConstantPass(true));
+        // Don't resolve __is_compile_time_constant_* in `inline` functions not
+        // yet inlined: the final inliner below may expose a constant argument.
+        // The post-inline cleanup resolves what is left (#3804).
+        optPM.addFunctionPass(IsCompileTimeConstantPass(true, /*skipDeferredInline=*/true));
         optPM.addFunctionPass(LowerAMXBuiltinsPass());
         optPM.addFunctionPass(IntrinsicsOpt());
         optPM.addFunctionPass(InstructionSimplifyPass());
@@ -673,6 +676,10 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         // freshly inlined bodies, recovering the cross-procedural
         // simplifications we would otherwise miss by deferring inlining.
         optPM.initFunctionPassManager();
+        // Resolve __is_compile_time_constant_* left in the just-inlined bodies
+        // (the marker is gone, so nothing is skipped now). InstCombine/SimplifyCFG
+        // below fold the result.
+        optPM.addFunctionPass(IsCompileTimeConstantPass(true));
         optPM.addFunctionPass(llvm::InferAlignmentPass());
         optPM.addFunctionPass(llvm::InstCombinePass());
         optPM.addFunctionPass(InstructionSimplifyPass());

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -343,6 +343,9 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         optPM.addFunctionPass(IsCompileTimeConstantPass(true));
         optPM.commitFunctionToModulePassManager();
 
+        // Convert the deferred ispc-defer-alwaysinline marker to LLVM alwaysinline so
+        // the inliner that runs next will honor `inline`-qualified functions.
+        optPM.addModulePass(RestoreInlineAttrPass());
         optPM.addModulePass(llvm::ModuleInlinerWrapperPass(IP));
         optPM.addModulePass(RemovePersistentFuncsPass());
 
@@ -657,6 +660,12 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         optPM.addFunctionPass(ScalarizePass());
         optPM.addFunctionPass(llvm::ADCEPass());
         optPM.commitFunctionToModulePassManager();
+        // Convert ispc-defer-alwaysinline (set on `inline`-qualified functions at
+        // parse time) to alwaysinline now that all function-level passes have
+        // run. The next inliner is the final one in the pipeline; deferring
+        // forced inlining until here lets each callee be optimized in
+        // isolation before being expanded into its callers (issue #3804).
+        optPM.addModulePass(RestoreInlineAttrPass());
         optPM.addModulePass(llvm::ModuleInlinerWrapperPass(IP));
         optPM.addModulePass(llvm::StripDeadPrototypesPass());
         optPM.addModulePass(RemovePersistentFuncsPass());

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -667,6 +667,18 @@ void ispc::Optimize(llvm::Module *module, int optLevel) {
         // isolation before being expanded into its callers (issue #3804).
         optPM.addModulePass(RestoreInlineAttrPass());
         optPM.addModulePass(llvm::ModuleInlinerWrapperPass(IP));
+        // The final inliner expands `inline`-qualified callees that were
+        // deferred by RestoreInlineAttrPass. Run a small cleanup so that
+        // caller-context constants and CFG simplifications fold through the
+        // freshly inlined bodies, recovering the cross-procedural
+        // simplifications we would otherwise miss by deferring inlining.
+        optPM.initFunctionPassManager();
+        optPM.addFunctionPass(llvm::InferAlignmentPass());
+        optPM.addFunctionPass(llvm::InstCombinePass());
+        optPM.addFunctionPass(InstructionSimplifyPass());
+        optPM.addFunctionPass(llvm::SimplifyCFGPass(simplifyCFGopt));
+        optPM.addFunctionPass(llvm::ADCEPass());
+        optPM.commitFunctionToModulePassManager();
         optPM.addModulePass(llvm::StripDeadPrototypesPass());
         optPM.addModulePass(RemovePersistentFuncsPass());
         optPM.addModulePass(llvm::GlobalDCEPass());

--- a/src/opt/ISPCPassRegistry.def
+++ b/src/opt/ISPCPassRegistry.def
@@ -2,6 +2,7 @@
 #define MODULE_PASS(NAME, CREATE_PASS)
 #endif
 MODULE_PASS("remove-persistent-funcs", RemovePersistentFuncsPass())
+MODULE_PASS("restore-inline-attr", RestoreInlineAttrPass())
 #undef MODULE_PASS
 
 #ifndef FUNCTION_PASS

--- a/src/opt/ISPCPasses.h
+++ b/src/opt/ISPCPasses.h
@@ -25,6 +25,7 @@
 #include "ReplaceMaskedMemOps.h"
 #include "ReplacePseudoMemoryOps.h"
 #include "ReplaceStdlibShiftPass.h"
+#include "RestoreInlineAttrPass.h"
 #include "ScalarizePass.h"
 #include "XeGatherCoalescePass.h"
 #include "XeReplaceLLVMIntrinsics.h"

--- a/src/opt/IsCompileTimeConstant.cpp
+++ b/src/opt/IsCompileTimeConstant.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2022-2024, Intel Corporation
+  Copyright (c) 2022-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -67,6 +67,11 @@ bool IsCompileTimeConstantPass::lowerCompileTimeConstant(llvm::BasicBlock &bb) {
         // value.  The last time through, it eventually has to give up, and
         // replaces any remaining ones with 'false' constants.
         if (isLastTry) {
+            // Keep calls in functions still awaiting forced inlining: inlining
+            // may make the argument constant. A later run resolves them (#3804).
+            if (skipDeferredInline && bb.getParent()->hasFnAttribute("ispc-defer-alwaysinline")) {
+                continue;
+            }
             ReplaceInstWithValueWrapper(curIter, LLVMFalse);
             modifiedAny = true;
             continue;

--- a/src/opt/IsCompileTimeConstant.h
+++ b/src/opt/IsCompileTimeConstant.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2022-2024, Intel Corporation
+  Copyright (c) 2022-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -25,12 +25,16 @@ namespace ispc {
 
 struct IsCompileTimeConstantPass : public llvm::PassInfoMixin<IsCompileTimeConstantPass> {
 
-    IsCompileTimeConstantPass(bool last = false) : isLastTry(last) {}
+    IsCompileTimeConstantPass(bool last = false, bool skipDeferredInline = false)
+        : isLastTry(last), skipDeferredInline(skipDeferredInline) {}
 
     llvm::PreservedAnalyses run(llvm::Function &F, llvm::FunctionAnalysisManager &FAM);
 
   private:
     bool isLastTry;
+    // On the last try, don't resolve calls in functions still awaiting forced
+    // inlining; inlining may expose a constant argument (#3804).
+    bool skipDeferredInline;
     bool lowerCompileTimeConstant(llvm::BasicBlock &BB);
 };
 

--- a/src/opt/RestoreInlineAttrPass.cpp
+++ b/src/opt/RestoreInlineAttrPass.cpp
@@ -1,0 +1,36 @@
+/*
+  Copyright (c) 2026, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include "RestoreInlineAttrPass.h"
+
+namespace ispc {
+
+llvm::PreservedAnalyses RestoreInlineAttrPass::run(llvm::Module &M, [[maybe_unused]] llvm::ModuleAnalysisManager &MAM) {
+    bool changed = false;
+    for (llvm::Function &F : M) {
+        if (F.hasFnAttribute("ispc-defer-alwaysinline")) {
+            F.removeFnAttr("ispc-defer-alwaysinline");
+            // A user-written `noinline` should win over `inline`. The two
+            // qualifiers cannot appear together in source, but a function
+            // could acquire NoInline from another path (e.g. a redeclaration);
+            // be conservative and skip in that case.
+            if (!F.hasFnAttribute(llvm::Attribute::NoInline)) {
+                F.addFnAttr(llvm::Attribute::AlwaysInline);
+            }
+            changed = true;
+        }
+    }
+
+    if (!changed) {
+        return llvm::PreservedAnalyses::all();
+    }
+
+    llvm::PreservedAnalyses PA;
+    PA.preserveSet<llvm::CFGAnalyses>();
+    return PA;
+}
+
+} // namespace ispc

--- a/src/opt/RestoreInlineAttrPass.h
+++ b/src/opt/RestoreInlineAttrPass.h
@@ -1,0 +1,39 @@
+/*
+  Copyright (c) 2026, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#pragma once
+
+#include "ISPCPass.h"
+
+namespace ispc {
+
+/** ISPC's `inline` qualifier is documented as forcing inlining (not just a
+    hint). Historically this was implemented by attaching the LLVM
+    `alwaysinline` attribute at parse time, which causes the AlwaysInliner
+    sub-pass of every ModuleInlinerWrapperPass invocation to inline the
+    function. The first such inliner runs very early in the optimization
+    pipeline, before loop optimizations, GVN, jump threading, etc. Inlining a
+    large function body into its caller before those optimizations have run on
+    the callee tends to produce noticeably worse code: the caller becomes too
+    large to optimize well, register pressure climbs, and unnecessary
+    broadcasts/blends end up in hot loops (issue #3804).
+
+    Instead, parse-time code attaches a custom string attribute
+    `ispc-defer-alwaysinline` and this pass converts it to `alwaysinline` shortly
+    before the final inliner pass runs. This delays forced inlining until
+    after the callee has been optimized in isolation, while still guaranteeing
+    that `inline`-qualified functions are inlined as the language reference
+    promises.
+ */
+class RestoreInlineAttrPass : public llvm::PassInfoMixin<RestoreInlineAttrPass> {
+  public:
+    RestoreInlineAttrPass() = default;
+
+    static llvm::StringRef getPassName() { return "Restore inline attribute"; }
+    llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &MAM);
+};
+
+} // namespace ispc

--- a/tests/lit-tests/3804-compile-time-constant.ispc
+++ b/tests/lit-tests/3804-compile-time-constant.ispc
@@ -1,0 +1,228 @@
+// #3804: an `inline` function is force-inlined only by the final inliner, after
+// the last __is_compile_time_constant resolution. `wrap` is big enough to avoid
+// early inlining, so its __is_compile_time_constant(perm) must survive until
+// inlining makes perm constant. Then every caller takes the const path, so the
+// dynamic 99999 must not survive.
+
+// RUN: %{ispc} %s --target=avx2-i32x8 --nowrap -O2 --emit-llvm-text -o - \
+// RUN:   | FileCheck %s --implicit-check-not="ret i32 99999"
+
+// REQUIRES: X86_ENABLED
+
+// CHECK: ret i32 1111
+
+inline uniform int wrap(uniform int perm, uniform int buf[]) {
+    uniform int acc = buf[0];
+    acc ^= (acc*1000003) + buf[0]; buf[0] = acc;
+    acc ^= (acc*1000004) + buf[1]; buf[1] = acc;
+    acc ^= (acc*1000005) + buf[2]; buf[2] = acc;
+    acc ^= (acc*1000006) + buf[3]; buf[3] = acc;
+    acc ^= (acc*1000007) + buf[4]; buf[4] = acc;
+    acc ^= (acc*1000008) + buf[5]; buf[5] = acc;
+    acc ^= (acc*1000009) + buf[6]; buf[6] = acc;
+    acc ^= (acc*1000010) + buf[7]; buf[7] = acc;
+    acc ^= (acc*1000011) + buf[8]; buf[8] = acc;
+    acc ^= (acc*1000012) + buf[9]; buf[9] = acc;
+    acc ^= (acc*1000013) + buf[10]; buf[10] = acc;
+    acc ^= (acc*1000014) + buf[11]; buf[11] = acc;
+    acc ^= (acc*1000015) + buf[12]; buf[12] = acc;
+    acc ^= (acc*1000016) + buf[13]; buf[13] = acc;
+    acc ^= (acc*1000017) + buf[14]; buf[14] = acc;
+    acc ^= (acc*1000018) + buf[15]; buf[15] = acc;
+    acc ^= (acc*1000019) + buf[16]; buf[16] = acc;
+    acc ^= (acc*1000020) + buf[17]; buf[17] = acc;
+    acc ^= (acc*1000021) + buf[18]; buf[18] = acc;
+    acc ^= (acc*1000022) + buf[19]; buf[19] = acc;
+    acc ^= (acc*1000023) + buf[20]; buf[20] = acc;
+    acc ^= (acc*1000024) + buf[21]; buf[21] = acc;
+    acc ^= (acc*1000025) + buf[22]; buf[22] = acc;
+    acc ^= (acc*1000026) + buf[23]; buf[23] = acc;
+    acc ^= (acc*1000027) + buf[24]; buf[24] = acc;
+    acc ^= (acc*1000028) + buf[25]; buf[25] = acc;
+    acc ^= (acc*1000029) + buf[26]; buf[26] = acc;
+    acc ^= (acc*1000030) + buf[27]; buf[27] = acc;
+    acc ^= (acc*1000031) + buf[28]; buf[28] = acc;
+    acc ^= (acc*1000032) + buf[29]; buf[29] = acc;
+    acc ^= (acc*1000033) + buf[30]; buf[30] = acc;
+    acc ^= (acc*1000034) + buf[31]; buf[31] = acc;
+    acc ^= (acc*1000035) + buf[32]; buf[32] = acc;
+    acc ^= (acc*1000036) + buf[33]; buf[33] = acc;
+    acc ^= (acc*1000037) + buf[34]; buf[34] = acc;
+    acc ^= (acc*1000038) + buf[35]; buf[35] = acc;
+    acc ^= (acc*1000039) + buf[36]; buf[36] = acc;
+    acc ^= (acc*1000040) + buf[37]; buf[37] = acc;
+    acc ^= (acc*1000041) + buf[38]; buf[38] = acc;
+    acc ^= (acc*1000042) + buf[39]; buf[39] = acc;
+    acc ^= (acc*1000043) + buf[40]; buf[40] = acc;
+    acc ^= (acc*1000044) + buf[41]; buf[41] = acc;
+    acc ^= (acc*1000045) + buf[42]; buf[42] = acc;
+    acc ^= (acc*1000046) + buf[43]; buf[43] = acc;
+    acc ^= (acc*1000047) + buf[44]; buf[44] = acc;
+    acc ^= (acc*1000048) + buf[45]; buf[45] = acc;
+    acc ^= (acc*1000049) + buf[46]; buf[46] = acc;
+    acc ^= (acc*1000050) + buf[47]; buf[47] = acc;
+    acc ^= (acc*1000051) + buf[48]; buf[48] = acc;
+    acc ^= (acc*1000052) + buf[49]; buf[49] = acc;
+    acc ^= (acc*1000053) + buf[50]; buf[50] = acc;
+    acc ^= (acc*1000054) + buf[51]; buf[51] = acc;
+    acc ^= (acc*1000055) + buf[52]; buf[52] = acc;
+    acc ^= (acc*1000056) + buf[53]; buf[53] = acc;
+    acc ^= (acc*1000057) + buf[54]; buf[54] = acc;
+    acc ^= (acc*1000058) + buf[55]; buf[55] = acc;
+    acc ^= (acc*1000059) + buf[56]; buf[56] = acc;
+    acc ^= (acc*1000060) + buf[57]; buf[57] = acc;
+    acc ^= (acc*1000061) + buf[58]; buf[58] = acc;
+    acc ^= (acc*1000062) + buf[59]; buf[59] = acc;
+    acc ^= (acc*1000063) + buf[60]; buf[60] = acc;
+    acc ^= (acc*1000064) + buf[61]; buf[61] = acc;
+    acc ^= (acc*1000065) + buf[62]; buf[62] = acc;
+    acc ^= (acc*1000066) + buf[63]; buf[63] = acc;
+    acc ^= (acc*1000067) + buf[0]; buf[0] = acc;
+    acc ^= (acc*1000068) + buf[1]; buf[1] = acc;
+    acc ^= (acc*1000069) + buf[2]; buf[2] = acc;
+    acc ^= (acc*1000070) + buf[3]; buf[3] = acc;
+    acc ^= (acc*1000071) + buf[4]; buf[4] = acc;
+    acc ^= (acc*1000072) + buf[5]; buf[5] = acc;
+    acc ^= (acc*1000073) + buf[6]; buf[6] = acc;
+    acc ^= (acc*1000074) + buf[7]; buf[7] = acc;
+    acc ^= (acc*1000075) + buf[8]; buf[8] = acc;
+    acc ^= (acc*1000076) + buf[9]; buf[9] = acc;
+    acc ^= (acc*1000077) + buf[10]; buf[10] = acc;
+    acc ^= (acc*1000078) + buf[11]; buf[11] = acc;
+    acc ^= (acc*1000079) + buf[12]; buf[12] = acc;
+    acc ^= (acc*1000080) + buf[13]; buf[13] = acc;
+    acc ^= (acc*1000081) + buf[14]; buf[14] = acc;
+    acc ^= (acc*1000082) + buf[15]; buf[15] = acc;
+    acc ^= (acc*1000083) + buf[16]; buf[16] = acc;
+    acc ^= (acc*1000084) + buf[17]; buf[17] = acc;
+    acc ^= (acc*1000085) + buf[18]; buf[18] = acc;
+    acc ^= (acc*1000086) + buf[19]; buf[19] = acc;
+    acc ^= (acc*1000087) + buf[20]; buf[20] = acc;
+    acc ^= (acc*1000088) + buf[21]; buf[21] = acc;
+    acc ^= (acc*1000089) + buf[22]; buf[22] = acc;
+    acc ^= (acc*1000090) + buf[23]; buf[23] = acc;
+    acc ^= (acc*1000091) + buf[24]; buf[24] = acc;
+    acc ^= (acc*1000092) + buf[25]; buf[25] = acc;
+    acc ^= (acc*1000093) + buf[26]; buf[26] = acc;
+    acc ^= (acc*1000094) + buf[27]; buf[27] = acc;
+    acc ^= (acc*1000095) + buf[28]; buf[28] = acc;
+    acc ^= (acc*1000096) + buf[29]; buf[29] = acc;
+    acc ^= (acc*1000097) + buf[30]; buf[30] = acc;
+    acc ^= (acc*1000098) + buf[31]; buf[31] = acc;
+    acc ^= (acc*1000099) + buf[32]; buf[32] = acc;
+    acc ^= (acc*1000100) + buf[33]; buf[33] = acc;
+    acc ^= (acc*1000101) + buf[34]; buf[34] = acc;
+    acc ^= (acc*1000102) + buf[35]; buf[35] = acc;
+    acc ^= (acc*1000103) + buf[36]; buf[36] = acc;
+    acc ^= (acc*1000104) + buf[37]; buf[37] = acc;
+    acc ^= (acc*1000105) + buf[38]; buf[38] = acc;
+    acc ^= (acc*1000106) + buf[39]; buf[39] = acc;
+    acc ^= (acc*1000107) + buf[40]; buf[40] = acc;
+    acc ^= (acc*1000108) + buf[41]; buf[41] = acc;
+    acc ^= (acc*1000109) + buf[42]; buf[42] = acc;
+    acc ^= (acc*1000110) + buf[43]; buf[43] = acc;
+    acc ^= (acc*1000111) + buf[44]; buf[44] = acc;
+    acc ^= (acc*1000112) + buf[45]; buf[45] = acc;
+    acc ^= (acc*1000113) + buf[46]; buf[46] = acc;
+    acc ^= (acc*1000114) + buf[47]; buf[47] = acc;
+    acc ^= (acc*1000115) + buf[48]; buf[48] = acc;
+    acc ^= (acc*1000116) + buf[49]; buf[49] = acc;
+    acc ^= (acc*1000117) + buf[50]; buf[50] = acc;
+    acc ^= (acc*1000118) + buf[51]; buf[51] = acc;
+    acc ^= (acc*1000119) + buf[52]; buf[52] = acc;
+    acc ^= (acc*1000120) + buf[53]; buf[53] = acc;
+    acc ^= (acc*1000121) + buf[54]; buf[54] = acc;
+    acc ^= (acc*1000122) + buf[55]; buf[55] = acc;
+    acc ^= (acc*1000123) + buf[56]; buf[56] = acc;
+    acc ^= (acc*1000124) + buf[57]; buf[57] = acc;
+    acc ^= (acc*1000125) + buf[58]; buf[58] = acc;
+    acc ^= (acc*1000126) + buf[59]; buf[59] = acc;
+    acc ^= (acc*1000127) + buf[60]; buf[60] = acc;
+    acc ^= (acc*1000128) + buf[61]; buf[61] = acc;
+    acc ^= (acc*1000129) + buf[62]; buf[62] = acc;
+    acc ^= (acc*1000130) + buf[63]; buf[63] = acc;
+    acc ^= (acc*1000131) + buf[0]; buf[0] = acc;
+    acc ^= (acc*1000132) + buf[1]; buf[1] = acc;
+    acc ^= (acc*1000133) + buf[2]; buf[2] = acc;
+    acc ^= (acc*1000134) + buf[3]; buf[3] = acc;
+    acc ^= (acc*1000135) + buf[4]; buf[4] = acc;
+    acc ^= (acc*1000136) + buf[5]; buf[5] = acc;
+    acc ^= (acc*1000137) + buf[6]; buf[6] = acc;
+    acc ^= (acc*1000138) + buf[7]; buf[7] = acc;
+    acc ^= (acc*1000139) + buf[8]; buf[8] = acc;
+    acc ^= (acc*1000140) + buf[9]; buf[9] = acc;
+    acc ^= (acc*1000141) + buf[10]; buf[10] = acc;
+    acc ^= (acc*1000142) + buf[11]; buf[11] = acc;
+    acc ^= (acc*1000143) + buf[12]; buf[12] = acc;
+    acc ^= (acc*1000144) + buf[13]; buf[13] = acc;
+    acc ^= (acc*1000145) + buf[14]; buf[14] = acc;
+    acc ^= (acc*1000146) + buf[15]; buf[15] = acc;
+    acc ^= (acc*1000147) + buf[16]; buf[16] = acc;
+    acc ^= (acc*1000148) + buf[17]; buf[17] = acc;
+    acc ^= (acc*1000149) + buf[18]; buf[18] = acc;
+    acc ^= (acc*1000150) + buf[19]; buf[19] = acc;
+    acc ^= (acc*1000151) + buf[20]; buf[20] = acc;
+    acc ^= (acc*1000152) + buf[21]; buf[21] = acc;
+    acc ^= (acc*1000153) + buf[22]; buf[22] = acc;
+    acc ^= (acc*1000154) + buf[23]; buf[23] = acc;
+    acc ^= (acc*1000155) + buf[24]; buf[24] = acc;
+    acc ^= (acc*1000156) + buf[25]; buf[25] = acc;
+    acc ^= (acc*1000157) + buf[26]; buf[26] = acc;
+    acc ^= (acc*1000158) + buf[27]; buf[27] = acc;
+    acc ^= (acc*1000159) + buf[28]; buf[28] = acc;
+    acc ^= (acc*1000160) + buf[29]; buf[29] = acc;
+    acc ^= (acc*1000161) + buf[30]; buf[30] = acc;
+    acc ^= (acc*1000162) + buf[31]; buf[31] = acc;
+    acc ^= (acc*1000163) + buf[32]; buf[32] = acc;
+    acc ^= (acc*1000164) + buf[33]; buf[33] = acc;
+    acc ^= (acc*1000165) + buf[34]; buf[34] = acc;
+    acc ^= (acc*1000166) + buf[35]; buf[35] = acc;
+    acc ^= (acc*1000167) + buf[36]; buf[36] = acc;
+    acc ^= (acc*1000168) + buf[37]; buf[37] = acc;
+    acc ^= (acc*1000169) + buf[38]; buf[38] = acc;
+    acc ^= (acc*1000170) + buf[39]; buf[39] = acc;
+    acc ^= (acc*1000171) + buf[40]; buf[40] = acc;
+    acc ^= (acc*1000172) + buf[41]; buf[41] = acc;
+    acc ^= (acc*1000173) + buf[42]; buf[42] = acc;
+    acc ^= (acc*1000174) + buf[43]; buf[43] = acc;
+    acc ^= (acc*1000175) + buf[44]; buf[44] = acc;
+    acc ^= (acc*1000176) + buf[45]; buf[45] = acc;
+    acc ^= (acc*1000177) + buf[46]; buf[46] = acc;
+    acc ^= (acc*1000178) + buf[47]; buf[47] = acc;
+    acc ^= (acc*1000179) + buf[48]; buf[48] = acc;
+    acc ^= (acc*1000180) + buf[49]; buf[49] = acc;
+    acc ^= (acc*1000181) + buf[50]; buf[50] = acc;
+    acc ^= (acc*1000182) + buf[51]; buf[51] = acc;
+    acc ^= (acc*1000183) + buf[52]; buf[52] = acc;
+    acc ^= (acc*1000184) + buf[53]; buf[53] = acc;
+    acc ^= (acc*1000185) + buf[54]; buf[54] = acc;
+    acc ^= (acc*1000186) + buf[55]; buf[55] = acc;
+    acc ^= (acc*1000187) + buf[56]; buf[56] = acc;
+    acc ^= (acc*1000188) + buf[57]; buf[57] = acc;
+    acc ^= (acc*1000189) + buf[58]; buf[58] = acc;
+    acc ^= (acc*1000190) + buf[59]; buf[59] = acc;
+    acc ^= (acc*1000191) + buf[60]; buf[60] = acc;
+    acc ^= (acc*1000192) + buf[61]; buf[61] = acc;
+    acc ^= (acc*1000193) + buf[62]; buf[62] = acc;
+    acc ^= (acc*1000194) + buf[63]; buf[63] = acc;
+    acc ^= (acc*1000195) + buf[0]; buf[0] = acc;
+    acc ^= (acc*1000196) + buf[1]; buf[1] = acc;
+    acc ^= (acc*1000197) + buf[2]; buf[2] = acc;
+    acc ^= (acc*1000198) + buf[3]; buf[3] = acc;
+    acc ^= (acc*1000199) + buf[4]; buf[4] = acc;
+    acc ^= (acc*1000200) + buf[5]; buf[5] = acc;
+    acc ^= (acc*1000201) + buf[6]; buf[6] = acc;
+    acc ^= (acc*1000202) + buf[7]; buf[7] = acc;
+    buf[1] = acc;
+    if (__is_compile_time_constant_uniform_int32(perm))
+        return 11111 + perm; // const path
+    return 99999;            // dynamic path (must be eliminated)
+}
+export uniform int call0(uniform int buf[]) { return wrap(3, buf); }
+export uniform int call1(uniform int buf[]) { return wrap(4, buf); }
+export uniform int call2(uniform int buf[]) { return wrap(5, buf); }
+export uniform int call3(uniform int buf[]) { return wrap(6, buf); }
+export uniform int call4(uniform int buf[]) { return wrap(7, buf); }
+export uniform int call5(uniform int buf[]) { return wrap(8, buf); }
+export uniform int call6(uniform int buf[]) { return wrap(9, buf); }
+export uniform int call7(uniform int buf[]) { return wrap(10, buf); }

--- a/tests/lit-tests/3804-const-arg-specialization.ispc
+++ b/tests/lit-tests/3804-const-arg-specialization.ispc
@@ -1,0 +1,38 @@
+// #3804: passing a `uniform const` arg into a helper that branches on it (the
+// common "compile-time variant" idiom) must still be specialized away after the
+// inlining changes. Calling with literal true/false should fold each branch, so
+// `run` ends up with two specialized loops (*2 and +100) and no runtime select.
+
+// RUN: %{ispc} %s --target=avx2-i32x8 --nowrap -O2 --emit-llvm-text -o - \
+// RUN:   | FileCheck %s --implicit-check-not="select"
+
+// REQUIRES: X86_ENABLED
+
+// Both helpers are fully inlined: no definition of or call to them remains.
+// CHECK-NOT: @Calculate
+// CHECK-NOT: @ProcessArray
+
+// The constant methodA is folded inside run itself: one path multiplies by 2,
+// the other adds 100.
+// CHECK-LABEL: define void @run(
+// CHECK-DAG: shl nsw <8 x i32>{{.*}}splat (i32 1)
+// CHECK-DAG: add nsw <8 x i32>{{.*}}splat (i32 100)
+
+static inline int Calculate(int value, uniform const bool methodA) {
+    if (methodA)
+        return value * 2;
+    else
+        return value + 100;
+}
+
+static void ProcessArray(uniform int values[], uniform int n, uniform const bool methodA) {
+    foreach (i = 0 ... n)
+        values[i] = Calculate(values[i], methodA);
+}
+
+export void run(uniform int values[], uniform int n, uniform const bool methodA) {
+    if (methodA)
+        ProcessArray(values, n, true);
+    else
+        ProcessArray(values, n, false);
+}

--- a/tests/lit-tests/3804.ispc
+++ b/tests/lit-tests/3804.ispc
@@ -1,0 +1,23 @@
+// Regression test for #3804: `inline`-qualified user functions used to be
+// inlined too early in the optimization pipeline, hurting code quality. The
+// parse-time marker is now `ispc-defer-alwaysinline`, which RestoreInlineAttrPass
+// converts to `alwaysinline` shortly before the final inliner pass runs. By
+// the end of optimization the callee is fully inlined and removed.
+
+// RUN: %{ispc} %s --target=host --nowrap --emit-llvm-text -o - \
+// RUN:   | FileCheck %s --implicit-check-not='@helper'
+
+// Verify the callee is inlined and erased: only `caller` remains in the
+// final IR — no standalone `helper` definition and no call to `helper`
+// from inside `caller`. --implicit-check-not enforces this across the
+// whole input, including inside `caller`'s body.
+// CHECK-LABEL: define {{.*}} @caller
+// CHECK: ret
+
+static inline uniform int helper(uniform int x) {
+    return x * 3 + 1;
+}
+
+uniform int caller(uniform int x) {
+    return helper(x) + helper(x + 7);
+}

--- a/tests/lit-tests/3804.ispc
+++ b/tests/lit-tests/3804.ispc
@@ -1,18 +1,20 @@
-// Regression test for #3804: `inline`-qualified user functions used to be
-// inlined too early in the optimization pipeline, hurting code quality. The
-// parse-time marker is now `ispc-defer-alwaysinline`, which RestoreInlineAttrPass
-// converts to `alwaysinline` shortly before the final inliner pass runs. By
-// the end of optimization the callee is fully inlined and removed.
+// #3804: `inline` used to get LLVM `alwaysinline` at parse time, forcing the
+// first inliner to expand callees before they were optimized. Now we emit a
+// deferred marker instead, converted to `alwaysinline` only before the final
+// inliner (see restore-inline-attr.ll, ispc-opt.ll).
 
+// Frontend must emit the marker, not enum alwaysinline. Catches reintroducing
+// early alwaysinline (which would print `{ alwaysinline nounwind ... }`).
+// RUN: %{ispc} %s --target=host --nowrap --nostdlib --emit-llvm-text \
+// RUN:   --debug-phase=first:first -o - | FileCheck %s --check-prefix=PREOPT
+// PREOPT: define internal {{.*}}@helper{{.*}}#[[ATTRS:[0-9]+]]
+// PREOPT: attributes #[[ATTRS]] = { nounwind "ispc-defer-alwaysinline"
+
+// ...but `inline` still gets inlined away by the end.
 // RUN: %{ispc} %s --target=host --nowrap --emit-llvm-text -o - \
-// RUN:   | FileCheck %s --implicit-check-not='@helper'
-
-// Verify the callee is inlined and erased: only `caller` remains in the
-// final IR — no standalone `helper` definition and no call to `helper`
-// from inside `caller`. --implicit-check-not enforces this across the
-// whole input, including inside `caller`'s body.
-// CHECK-LABEL: define {{.*}} @caller
-// CHECK: ret
+// RUN:   | FileCheck %s --check-prefix=FINAL --implicit-check-not='@helper'
+// FINAL-LABEL: define {{.*}} @caller
+// FINAL: ret
 
 static inline uniform int helper(uniform int x) {
     return x * 3 + 1;

--- a/tests/lit-tests/const_shuffle_i8.ispc
+++ b/tests/lit-tests/const_shuffle_i8.ispc
@@ -4,12 +4,10 @@
 
 // REQUIRES: X86_ENABLED
 
-// XFAIL: *
-// __shuffle2_i8 for icl-x64 has const path as other width, but optimization
-// pipeline fails to inline shuf2 call before the IsCompileTimeConstant pass
-// substitutes call to __is_compile_time_constant_varying_int32 to constant (it
-// should be true in this case), so this test is expected to fail for icl-x64
-// unless the inlining for this case is fixed.
+// Previously XFAIL'd: __shuffle2_i8 for icl-x64 used to have its shuf2 call
+// inlined too late for IsCompileTimeConstant to fold __is_compile_time_constant
+// to true. The deferred-inlining + post-inline cleanup added for #3804 now
+// folds the constant path correctly.
 
 template <typename T>
 unmasked void shuf2(uniform T a[], uniform T ret[], int perm) {

--- a/tests/lit-tests/ispc-opt.ll
+++ b/tests/lit-tests/ispc-opt.ll
@@ -2,6 +2,7 @@
 
 ; CHECK-PRINT: Module passes:
 ; CHECK-PRINT-NEXT:   remove-persistent-funcs
+; CHECK-PRINT-NEXT:   restore-inline-attr
 ; CHECK-PRINT-NEXT: Function passes:
 ; CHECK-PRINT-NEXT:   gather-coalesce
 ; CHECK-PRINT-NEXT:   improve-memory-ops

--- a/tests/lit-tests/restore-inline-attr.ll
+++ b/tests/lit-tests/restore-inline-attr.ll
@@ -1,0 +1,36 @@
+; Verifies the RestoreInlineAttrPass behavior in isolation:
+;   - The custom `ispc-defer-alwaysinline` string attribute is removed.
+;   - `alwaysinline` is added in its place — unless `noinline` is also present,
+;     in which case `noinline` wins and `alwaysinline` is not added.
+;   - Functions without `ispc-defer-alwaysinline` are left untouched.
+
+; RUN: %{ispc-opt} --passes=restore-inline-attr %s -o - | FileCheck %s
+
+; CHECK-LABEL: define void @forced()
+; CHECK-SAME: #[[FORCED:[0-9]+]]
+define void @forced() #0 {
+  ret void
+}
+
+; CHECK-LABEL: define void @forced_but_noinline()
+; CHECK-SAME: #[[NOINLINE:[0-9]+]]
+define void @forced_but_noinline() #1 {
+  ret void
+}
+
+; CHECK-LABEL: define void @plain()
+; CHECK-SAME: #[[PLAIN:[0-9]+]]
+define void @plain() #2 {
+  ret void
+}
+
+attributes #0 = { "ispc-defer-alwaysinline" }
+attributes #1 = { noinline "ispc-defer-alwaysinline" }
+attributes #2 = { nounwind }
+
+; "ispc-defer-alwaysinline" must not survive on any function. alwaysinline must be
+; added on @forced but NOT on @forced_but_noinline (which keeps noinline).
+; CHECK-NOT: ispc-defer-alwaysinline
+; CHECK-DAG: attributes #[[FORCED]] = { alwaysinline }
+; CHECK-DAG: attributes #[[NOINLINE]] = { noinline }
+; CHECK-DAG: attributes #[[PLAIN]] = { nounwind }


### PR DESCRIPTION
## Description

`inline` in ISPC was implemented by attaching LLVM's `alwaysinline` at parse time, which expanded the callee into the caller in the very first inliner pass, i.e.,  before some optimization passes could run on the callee in isolation. The over-large caller optimized worse: extra broadcasts/blends and more spills in hot loops (issue #3804).

This PR defers forced inlining until just before the final inliner pass, so each `inline`-qualified callee gets optimized standalone first.

## Changes

- Replace the parse-time `alwaysinline` with a custom string attribute `ispc-defer-alwaysinline`.
- New module pass `RestoreInlineAttrPass` strips the marker and adds `alwaysinline` (unless `noinline` is also present) right before the final `ModuleInlinerWrapperPass`.
- Add an cleanup after the final inliner so caller-context simplifications fold through the freshly inlined bodies.

## Results

- Issue reproducer should match now the non-inlined baseline.
- Side effect: a previously-XFAIL'd test (`const_shuffle_i8.ispc`, introduced in #3458) now passes. `IsCompileTimeConstant` can fold the `shuf2` const path now that  inlining + cleanup land at the right time.

## Related Issue
- [X] Linked to relevant issue: #3804 

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
- [X] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
