### PR TITLE
Fix all tests of the recent stdlib-math-function PRs

### DIFF
--- a/tests/func-tests/cosh-double-uniform.ispc
+++ b/tests/func-tests/cosh-double-uniform.ispc
@@ -7,11 +7,34 @@ uniform bool ok(uniform double x, uniform double ref) {
     return (abs(x - ref) < 1e-15d) || abs((x - ref) / ref) < 1e-12d;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform double ref = cosh((uniform double)((aFOO[i] / programCount) * 3.0d - 1.5d));
-        uniform double res = cosh((aFOO[i] / programCount) * 3.0d - 1.5d);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform double x[] = {
+        0.27d, 0.99d,
+        2e-2d, 1e-12d,
+        5.0d, 7.0d,
+        -3.0d, -1e-2d,
+        -0.0d, +0.0d,
+        80.0d, 379.1d
+    };
+
+    const uniform double ref[] = {
+        +1.036671972535050390e+00d, +1.531405581685653994e+00d,
+        +1.000200006666755570e+00d, +1.000000000000000000e+00d,
+        +7.420994852478784765e+01d, +5.483170351552121247e+02d,
+        +1.006766199577776533e+01d, +1.000050000416668139e+00d,
+        +1.000000000000000000e+00d, +1.000000000000000000e+00d,
+        +2.770311192196754917e+34d, +2.187802397202284545e+164d
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform double res = cosh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/cosh-double-varying.ispc
+++ b/tests/func-tests/cosh-double-varying.ispc
@@ -3,59 +3,39 @@
 // rule: skip on cpu=tgllp
 // rule: skip on cpu=dg2
 
-static double double2(uniform double a, uniform double b) {
-    double ret = 0;
-    for (uniform int i = 0; i < programCount; i += 2) {
-        ret = insert(ret, i + 0, a);
-        ret = insert(ret, i + 1, b);
-    }
-    return ret;
-}
-
 bool ok(double x, double ref) {
     return (abs(x - ref) < 1e-15d) || abs((x-ref)/ref) < 1e-12d;
 }
 
 task void f_v(uniform float RET[]) {
-    double x, ref, res;
+    const uniform double x[] = {
+        0.27d, 0.99d,
+        2e-2d, 1e-12d,
+        5.0d, 7.0d,
+        -3.0d, -1e-2d,
+        -0.0d, +0.0d,
+        80.0d, 379.1d
+    };
+
+    const uniform double ref[] = {
+        +1.036671972535050390e+00d, +1.531405581685653994e+00d,
+        +1.000200006666755570e+00d, +1.000000000000000000e+00d,
+        +7.420994852478784765e+01d, +5.483170351552121247e+02d,
+        +1.006766199577776533e+01d, +1.000050000416668139e+00d,
+        +1.000000000000000000e+00d, +1.000000000000000000e+00d,
+        +2.770311192196754917e+34d, +2.187802397202284545e+164d
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
 
     RET[programIndex] = 0;
 
-    // Case 1: Basic values
-    x = double2(0.27d, 0.99d);
-    ref = double2(1.0366719725350504d, 1.5314055816856538d);
-    res = cosh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 2: Small values
-    x = double2(2e-2d, 1e-12d);
-    ref = double2(1.0002000066667556d, 1.0d);
-    res = cosh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 3: Big values
-    x = double2(5.0d, 7.0d);
-    ref = double2(74.20994852478785d, 548.317035155212d);
-    res = cosh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 4: Negative values
-    x = double2(-3.0d, -1e-2d);
-    ref = double2(10.067661995777765d, 1.0000500004166681d);
-    res = cosh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 5: Special values
-    x = double2(-0.0d, +0.0d);
-    ref = double2(1.0d, 1.0d);
-    res = cosh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 6: Extreme values
-    x = double2(80.0d, 379.1d);
-    ref = double2(2.770311192196755e+34d, 2.1878023972022845e+164d);
-    res = cosh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
+    foreach(i = 0...count)
+    {
+        const double res = cosh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/cosh-float-uniform.ispc
+++ b/tests/func-tests/cosh-float-uniform.ispc
@@ -4,11 +4,42 @@ uniform bool ok(uniform float x, uniform float ref) {
     return (abs(x - ref) < 1e-6) || abs((x - ref) / ref) < 1e-5;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform float ref = cosh((uniform float)((aFOO[i] / programCount) * 3 - 1.5));
-        uniform float res = cosh((aFOO[i] / programCount) * 3 - 1.5);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float x[] = {
+        0.27, 0.99,
+        1.17, 2.67,
+        4e-2, 3e-4,
+        2e-6, 1e-8,
+        5.0, 7.0,
+        9.0, 11.0,
+        -11.0, -3.0,
+        -1e-2, -1e-8,
+        -0.0, +0.0,
+        21.7, 80.0
+    };
+
+    const uniform float ref[] = {
+        +1.0366719961e+00, +1.5314055681e+00,
+        +1.7661796808e+00, +7.2546114922e+00,
+        +1.0008001328e+00, +1.0000000000e+00,
+        +1.0000000000e+00, +1.0000000000e+00,
+        +7.4209945679e+01, +5.4831701660e+02,
+        +4.0515419922e+03, +2.9937070312e+04,
+        +2.9937070312e+04, +1.0067662239e+01,
+        +1.0000499487e+00, +1.0000000000e+00,
+        +1.0000000000e+00, +1.0000000000e+00,
+        +1.3278854400e+09, +2.7703112423e+34
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform float res = cosh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/cosh-float-varying.ispc
+++ b/tests/func-tests/cosh-float-varying.ispc
@@ -1,54 +1,46 @@
 #include "test_static.isph"
 
-static float float4(uniform float a, uniform float b, uniform float c, uniform float d) {
-    float ret = 0;
-    for (uniform int i = 0; i < programCount; i += 4) {
-        ret = insert(ret, i + 0, a);
-        ret = insert(ret, i + 1, b);
-        ret = insert(ret, i + 2, c);
-        ret = insert(ret, i + 3, d);
-    }
-    return ret;
-}
-
 bool ok(float x, float ref) {
     return (abs(x - ref) < 1e-6) || abs((x-ref)/ref) < 1e-5;
 }
 
 task void f_v(uniform float RET[]) {
-    float x, ref, res;
+    const uniform float x[] = {
+        0.27, 0.99,
+        1.17, 2.67,
+        4e-2, 3e-4,
+        2e-6, 1e-8,
+        5.0, 7.0,
+        9.0, 11.0,
+        -11.0, -3.0,
+        -1e-2, -1e-8,
+        -0.0, +0.0,
+        21.7, 80.0
+    };
+
+    const uniform float ref[] = {
+        +1.0366719961e+00, +1.5314055681e+00,
+        +1.7661796808e+00, +7.2546114922e+00,
+        +1.0008001328e+00, +1.0000000000e+00,
+        +1.0000000000e+00, +1.0000000000e+00,
+        +7.4209945679e+01, +5.4831701660e+02,
+        +4.0515419922e+03, +2.9937070312e+04,
+        +2.9937070312e+04, +1.0067662239e+01,
+        +1.0000499487e+00, +1.0000000000e+00,
+        +1.0000000000e+00, +1.0000000000e+00,
+        +1.3278854400e+09, +2.7703112423e+34
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
 
     RET[programIndex] = 0;
 
-    // Case 1: Basic values
-    x = float4(0.27, 0.99, 1.17, 2.67);
-    ref = float4(1.03667197, 1.53140558, 1.76617979, 7.25461071);
-    res = cosh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 2: Small values
-    x = float4(4e-2, 3e-4, 2e-6, 1e-8);
-    ref = float4(1.00080011, 1.00000005, 1.0, 1.0);
-    res = cosh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 3: Big values
-    x = float4(5.0, 7.0, 9.0, 11.0);
-    ref = float4(74.20994852, 548.31703516, 4051.54202549, 29937.07086595);
-    res = cosh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 4: Negative values
-    x = float4(-11.0, -3.0, -1e-2, -1e-8);
-    ref = float4(2.99370709e+4, 1.00676620e+1, 1.00005000e+0, 1.0);
-    res = cosh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 5: Special and extreme values
-    x = float4(-0.0, +0.0, 21.7, 80.0);
-    ref = float4(1.0, 1.0, 1.32788438e+09, 2.77031119e+34);
-    res = cosh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
+    foreach(i = 0...count)
+    {
+        const float res = cosh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/cosh-float16-uniform.ispc
+++ b/tests/func-tests/cosh-float16-uniform.ispc
@@ -6,11 +6,42 @@ uniform bool ok(uniform float16 x, uniform float16 ref) {
     return (abs(x - ref) < 0.001f16) || abs((x - ref) / ref) < 0.05f16;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform float16 ref = cosh((uniform float16)((aFOO[i] / programCount) * 3 - 1.5));
-        uniform float16 res = cosh((aFOO[i] / programCount) * 3 - 1.5);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float16 x[] = {
+        0.17, 0.99,
+        1.17, 1.67,
+        4e-1, 3e-2,
+        2e-3, 1e-4,
+        2.0, 3.0,
+        4.0, 5.0,
+        -5.0, -2.0,
+        -1e-2, -1e-6,
+        -0.0, +0.0,
+        7.1, 10.3
+    };
+
+    const uniform float16 ref[] = {
+        +1.0146e+00, +1.5312e+00,
+        +1.7656e+00, +2.7500e+00,
+        +1.0811e+00, +1.0000e+00,
+        +1.0000e+00, +1.0000e+00,
+        +3.7617e+00, +1.0070e+01,
+        +2.7312e+01, +7.4188e+01,
+        +7.4188e+01, +3.7617e+00,
+        +1.0000e+00, +1.0000e+00,
+        +1.0000e+00, +1.0000e+00,
+        +6.0700e+02, +1.4816e+04
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform float16 res = cosh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/cosh-float16-varying.ispc
+++ b/tests/func-tests/cosh-float16-varying.ispc
@@ -6,11 +6,43 @@ bool ok(float16 x, float16 ref) {
     return (abs(x - ref) < 0.001f16) || abs((x - ref) / ref) < 0.05f16;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    float16 arg = ((aFOO[programIndex] / programCount) * 3 - 1.5);
-    float16 ref = cosh((float)arg);
-    float16 res = cosh((float16)arg);
-    RET[programIndex] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float16 x[] = {
+        0.17, 0.99,
+        1.17, 1.67,
+        4e-1, 3e-2,
+        2e-3, 1e-4,
+        2.0, 3.0,
+        4.0, 5.0,
+        -5.0, -2.0,
+        -1e-2, -1e-6,
+        -0.0, +0.0,
+        7.1, 10.3
+    };
+
+    const uniform float16 ref[] = {
+        +1.0146e+00, +1.5312e+00,
+        +1.7656e+00, +2.7500e+00,
+        +1.0811e+00, +1.0000e+00,
+        +1.0000e+00, +1.0000e+00,
+        +3.7617e+00, +1.0070e+01,
+        +2.7312e+01, +7.4188e+01,
+        +7.4188e+01, +3.7617e+00,
+        +1.0000e+00, +1.0000e+00,
+        +1.0000e+00, +1.0000e+00,
+        +6.0700e+02, +1.4816e+04
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    foreach(i = 0...count)
+    {
+        const float16 res = cosh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/erf-double-uniform.ispc
+++ b/tests/func-tests/erf-double-uniform.ispc
@@ -7,11 +7,34 @@ uniform bool ok(uniform double x, uniform double ref) {
     return (abs(x - ref) < 1e-15d) || abs((x - ref) / ref) < 1e-12d;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform double ref = erf((uniform double)((aFOO[i] / programCount) * 3.0d - 1.5d));
-        uniform double res = erf((aFOO[i] / programCount) * 3.0d - 1.5d);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform double x[] = {
+        0.27d, 0.99d,
+        2e-2d, 1e-12d,
+        5.0d, 7.0d,
+        -3.0d, -1e-2d,
+        -0.0d, +0.0d,
+        -1e160d, 1e160d
+    };
+
+    const uniform double ref[] = {
+        +2.974182185470127804e-01d, +8.385080695553698282e-01d,
+        +2.256457469184494635e-02d, +1.128379167095512566e-12d,
+        +9.999999999984625632e-01d, +1.000000000000000000e+00d,
+        -9.999779095030013609e-01d, -1.128341555584961783e-02d,
+        -0.000000000000000000e+00d, +0.000000000000000000e+00d,
+        -1.000000000000000000e+00d, +1.000000000000000000e+00d
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform double res = erf(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/erf-double-varying.ispc
+++ b/tests/func-tests/erf-double-varying.ispc
@@ -3,59 +3,39 @@
 // rule: skip on cpu=tgllp
 // rule: skip on cpu=dg2
 
-static double double2(uniform double a, uniform double b) {
-    double ret = 0;
-    for (uniform int i = 0; i < programCount; i += 2) {
-        ret = insert(ret, i + 0, a);
-        ret = insert(ret, i + 1, b);
-    }
-    return ret;
-}
-
 bool ok(double x, double ref) {
     return (abs(x - ref) < 1e-15d) || abs((x-ref)/ref) < 1e-12d;
 }
 
 task void f_v(uniform float RET[]) {
-    double x, ref, res;
+    const uniform double x[] = {
+        0.27d, 0.99d,
+        2e-2d, 1e-12d,
+        5.0d, 7.0d,
+        -3.0d, -1e-2d,
+        -0.0d, +0.0d,
+        -1e160d, 1e160d
+    };
+
+    const uniform double ref[] = {
+        +2.974182185470127804e-01d, +8.385080695553698282e-01d,
+        +2.256457469184494635e-02d, +1.128379167095512566e-12d,
+        +9.999999999984625632e-01d, +1.000000000000000000e+00d,
+        -9.999779095030013609e-01d, -1.128341555584961783e-02d,
+        -0.000000000000000000e+00d, +0.000000000000000000e+00d,
+        -1.000000000000000000e+00d, +1.000000000000000000e+00d
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
 
     RET[programIndex] = 0;
 
-    // Case 1: Basic values
-    x = double2(0.27d, 0.99d);
-    ref = double2(0.2974182185470128d, 0.8385080695553698d);
-    res = erf(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 2: Small values
-    x = double2(2e-2d, 1e-12d);
-    ref = double2(0.022564574691844943d, 1.1283791670955126e-12d);
-    res = erf(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 3: Big values
-    x = double2(5.0d, 7.0d);
-    ref = double2(0.9999999999984626d, 1.0d);
-    res = erf(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 4: Negative values
-    x = double2(-3.0d, -1e-2d);
-    ref = double2(-0.9999779095030014d, -0.011283415555849616d);
-    res = erf(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 5: Special values
-    x = double2(-0.0d, +0.0d);
-    ref = double2(-0.0d,  +0.0d);
-    res = erf(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 6: Extreme values
-    x = double2(-1e160d, 1e160d);
-    ref = double2(-1.0d,  1.0d);
-    res = erf(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
+    foreach(i = 0...count)
+    {
+        const double res = erf(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/erf-float-uniform.ispc
+++ b/tests/func-tests/erf-float-uniform.ispc
@@ -4,11 +4,42 @@ uniform bool ok(uniform float x, uniform float ref) {
     return (abs(x - ref) < 1e-6) || abs((x - ref) / ref) < 1e-5;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform float ref = erf((uniform float)((aFOO[i] / programCount) * 3 - 1.5));
-        uniform float res = erf((aFOO[i] / programCount) * 3 - 1.5);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float x[] = {
+        0.27, 0.99,
+        1.17, 2.67,
+        4e-2, 3e-4,
+        2e-6, 1e-8,
+        5.0, 7.0,
+        9.0, 11.0,
+        -11.0, -3.0,
+        -1e-2, -1e-8,
+        -0.0, +0.0,
+        -1e25, 1e25
+    };
+
+    const uniform float ref[] = {
+        +2.9741823673e-01, +8.3850806952e-01,
+        +9.0200036764e-01, +9.9984061718e-01,
+        +4.5111104846e-02, +3.3851375338e-04,
+        +2.2567583073e-06, +1.1283791679e-08,
+        +1.0000000000e+00, +1.0000000000e+00,
+        +1.0000000000e+00, +1.0000000000e+00,
+        -1.0000000000e+00, -9.9997788668e-01,
+        -1.1283415370e-02, -1.1283791679e-08,
+        -0.0000000000e+00, +0.0000000000e+00,
+        -1.0000000000e+00, +1.0000000000e+00
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform float res = erf(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/erf-float-varying.ispc
+++ b/tests/func-tests/erf-float-varying.ispc
@@ -1,54 +1,46 @@
 #include "test_static.isph"
 
-static float float4(uniform float a, uniform float b, uniform float c, uniform float d) {
-    float ret = 0;
-    for (uniform int i = 0; i < programCount; i += 4) {
-        ret = insert(ret, i + 0, a);
-        ret = insert(ret, i + 1, b);
-        ret = insert(ret, i + 2, c);
-        ret = insert(ret, i + 3, d);
-    }
-    return ret;
-}
-
 bool ok(float x, float ref) {
     return (abs(x - ref) < 1e-6) || abs((x-ref)/ref) < 1e-5;
 }
 
 task void f_v(uniform float RET[]) {
-    float x, ref, res;
+    const uniform float x[] = {
+        0.27, 0.99,
+        1.17, 2.67,
+        4e-2, 3e-4,
+        2e-6, 1e-8,
+        5.0, 7.0,
+        9.0, 11.0,
+        -11.0, -3.0,
+        -1e-2, -1e-8,
+        -0.0, +0.0,
+        -1e25, 1e25
+    };
+
+    const uniform float ref[] = {
+        +2.9741823673e-01, +8.3850806952e-01,
+        +9.0200036764e-01, +9.9984061718e-01,
+        +4.5111104846e-02, +3.3851375338e-04,
+        +2.2567583073e-06, +1.1283791679e-08,
+        +1.0000000000e+00, +1.0000000000e+00,
+        +1.0000000000e+00, +1.0000000000e+00,
+        -1.0000000000e+00, -9.9997788668e-01,
+        -1.1283415370e-02, -1.1283791679e-08,
+        -0.0000000000e+00, +0.0000000000e+00,
+        -1.0000000000e+00, +1.0000000000e+00
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
 
     RET[programIndex] = 0;
 
-    // Case 1: Basic values
-    x = float4(0.27, 0.99, 1.17, 2.67);
-    ref = float4(0.29741824, 0.83850807, 0.90200037, 0.9998406);
-    res = erf(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 2: Small values
-    x = float4(4e-2, 3e-4, 2e-6, 1e-8);
-    ref = float4(4.5111105e-2, 3.3851375e-4, 2.2567583e-6, 1.1283792e-8);
-    res = erf(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 3: Big values
-    x = float4(5.0, 7.0, 9.0, 11.0);
-    ref = float4(1.0, 1.0, 1.0, 1.0);
-    res = erf(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 4: Negative values
-    x = float4(-11.0, -3.0, -1e-2, -1e-8);
-    ref = float4(-1.0000000e+0, -9.9997789e-1, -1.1283415e-2, -1.1283792e-8);
-    res = erf(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 5: Special and extreme values
-    x = float4(-0.0, +0.0, -1e25, 1e25);
-    ref = float4(-0.0,  +0.0,  -1.0,  1.0);
-    res = erf(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
+    foreach(i = 0...count)
+    {
+        const float res = erf(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/erf-float16-uniform.ispc
+++ b/tests/func-tests/erf-float16-uniform.ispc
@@ -6,11 +6,42 @@ uniform bool ok(uniform float16 x, uniform float16 ref) {
     return (abs(x - ref) < 0.001f16) || abs((x - ref) / ref) < 0.05f16;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform float16 ref = erf((uniform float16)((aFOO[i] / programCount) * 3 - 1.5));
-        uniform float16 res = erf((aFOO[i] / programCount) * 3 - 1.5);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float16 x[] = {
+        0.17, 0.99,
+        1.17, 1.67,
+        4e-1, 3e-2,
+        2e-3, 1e-4,
+        2.0, 3.0,
+        4.0, 5.0,
+        -5.0, -2.0,
+        -1e-2, -1e-6,
+        -0.0, +0.0,
+        -1e4, 1e4
+    };
+
+    const uniform float16 ref[] = {
+        +1.9006e-01, +8.3838e-01,
+        +9.0186e-01, +9.8193e-01,
+        +4.2822e-01, +3.3844e-02,
+        +2.2583e-03, +1.1283e-04,
+        +9.9512e-01, +1.0000e+00,
+        +1.0000e+00, +1.0000e+00,
+        -1.0000e+00, -9.9512e-01,
+        -1.1284e-02, -1.1325e-06,
+        -0.0000e+00, +0.0000e+00,
+        -1.0000e+00, +1.0000e+00
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform float16 res = erf(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/erf-float16-varying.ispc
+++ b/tests/func-tests/erf-float16-varying.ispc
@@ -6,11 +6,43 @@ bool ok(float16 x, float16 ref) {
     return (abs(x - ref) < 0.001f16) || abs((x - ref) / ref) < 0.05f16;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    float16 arg = ((aFOO[programIndex] / programCount) * 3 - 1.5);
-    float16 ref = erf((float)arg);
-    float16 res = erf((float16)arg);
-    RET[programIndex] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float16 x[] = {
+        0.17, 0.99,
+        1.17, 1.67,
+        4e-1, 3e-2,
+        2e-3, 1e-4,
+        2.0, 3.0,
+        4.0, 5.0,
+        -5.0, -2.0,
+        -1e-2, -1e-6,
+        -0.0, +0.0,
+        -1e4, 1e4
+    };
+
+    const uniform float16 ref[] = {
+        +1.9006e-01, +8.3838e-01,
+        +9.0186e-01, +9.8193e-01,
+        +4.2822e-01, +3.3844e-02,
+        +2.2583e-03, +1.1283e-04,
+        +9.9512e-01, +1.0000e+00,
+        +1.0000e+00, +1.0000e+00,
+        -1.0000e+00, -9.9512e-01,
+        -1.1284e-02, -1.1325e-06,
+        -0.0000e+00, +0.0000e+00,
+        -1.0000e+00, +1.0000e+00
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    foreach(i = 0...count)
+    {
+        const float16 res = erf(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/erfc-double-uniform.ispc
+++ b/tests/func-tests/erfc-double-uniform.ispc
@@ -8,11 +8,38 @@ uniform bool ok(uniform double x, uniform double ref) {
     return (abs(x - ref) < 1e-300d) || abs((x - ref) / ref) < 2e-12d;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform double ref = erfc((uniform double)((aFOO[i] / programCount) * 3.0d - 1.5d));
-        uniform double res = erfc((aFOO[i] / programCount) * 3.0d - 1.5d);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform double x[] = {
+        0.27d, 0.99d,
+        2e-2d, 1e-12d,
+        3.0d, 4.0d,
+        5.0d, 7.0d,
+        9.7d, 26.1d,
+        -3.0d, -1e-2d,
+        -0.0d, +0.0d,
+        -1e160d, 1e160d
+    };
+
+    const uniform double ref[] = {
+        +7.025817814529872196e-01d, +1.614919304446301995e-01d,
+        +9.774354253081550814e-01d, +9.999999999988715693e-01d,
+        +2.209049699858544122e-05d, +1.541725790028001999e-08d,
+        +1.537459794428034936e-12d, +4.183825607779414210e-23d,
+        +7.936107563214511110e-43d, +3.081217493314593186e-298d,
+        +1.999977909503001472e+00d, +1.011283415555849663e+00d,
+        +1.000000000000000000e+00d, +1.000000000000000000e+00d,
+        +2.000000000000000000e+00d, +0.000000000000000000e+00d
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform double res = erfc(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/erfc-double-varying.ispc
+++ b/tests/func-tests/erfc-double-varying.ispc
@@ -3,15 +3,6 @@
 // rule: skip on cpu=tgllp
 // rule: skip on cpu=dg2
 
-static double double2(uniform double a, uniform double b) {
-    double ret = 0;
-    for (uniform int i = 0; i < programCount; i += 2) {
-        ret = insert(ret, i + 0, a);
-        ret = insert(ret, i + 1, b);
-    }
-    return ret;
-}
-
 bool ok(double x, double ref) {
     // erfc is meant to be much more precise than erf for x>1
     // so the absolute precision threshold must be much smaller.
@@ -19,57 +10,38 @@ bool ok(double x, double ref) {
 }
 
 task void f_v(uniform float RET[]) {
-    double x, ref, res;
+    const uniform double x[] = {
+        0.27d, 0.99d,
+        2e-2d, 1e-12d,
+        3.0d, 4.0d,
+        5.0d, 7.0d,
+        9.7d, 26.1d,
+        -3.0d, -1e-2d,
+        -0.0d, +0.0d,
+        -1e160d, 1e160d
+    };
+
+    const uniform double ref[] = {
+        +7.025817814529872196e-01d, +1.614919304446301995e-01d,
+        +9.774354253081550814e-01d, +9.999999999988715693e-01d,
+        +2.209049699858544122e-05d, +1.541725790028001999e-08d,
+        +1.537459794428034936e-12d, +4.183825607779414210e-23d,
+        +7.936107563214511110e-43d, +3.081217493314593186e-298d,
+        +1.999977909503001472e+00d, +1.011283415555849663e+00d,
+        +1.000000000000000000e+00d, +1.000000000000000000e+00d,
+        +2.000000000000000000e+00d, +0.000000000000000000e+00d
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
 
     RET[programIndex] = 0;
 
-    // Case 1: Basic values
-    x = double2(0.27d, 0.99d);
-    ref = double2(0.7025817814529872d, 0.16149193044463017d);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 2: Small values
-    x = double2(2e-2d, 1e-12d);
-    ref = double2(0.9774354253081551d, 0.9999999999988716d);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 3: Big values
-    x = double2(3.0d, 4.0d);
-    ref = double2(2.2090496998585445e-05d, 1.541725790028002e-08d);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 4: Bigger values
-    x = double2(5.0d, 7.0d);
-    ref = double2(1.5374597944280347e-12d, 4.183825607779414e-23d);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 5: Even bigger values
-    x = double2(9.7d, 26.1d);
-    ref = double2(7.936107563214489e-43d, 3.0812174933147107e-298d);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 6: Negative values
-    x = double2(-3.0d, -1e-2d);
-    ref = double2(1.9999779095030015d, 1.0112834155558497d);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 7: Special values
-    x = double2(-0.0d, +0.0d);
-    ref = double2(1.0d, 1.0d);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 8: Extreme values
-    x = double2(-1e160d, 1e160d);
-    ref = double2(2.0d,  0.0d);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
+    foreach(i = 0...count)
+    {
+        const double res = erfc(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/erfc-float-uniform.ispc
+++ b/tests/func-tests/erfc-float-uniform.ispc
@@ -5,11 +5,42 @@ uniform bool ok(uniform float x, uniform float ref) {
     return (abs(x - ref) < 1e-35) || abs((x - ref) / ref) < 2e-5;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform float ref = erfc((uniform float)((aFOO[i] / programCount) * 3 - 1.5));
-        uniform float res = erfc((aFOO[i] / programCount) * 3 - 1.5);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float x[] = {
+        0.27, 0.99,
+        1.17, 2.67,
+        4e-2, 3e-4,
+        2e-6, 1e-8,
+        5.0, 7.0,
+        9.0, 11.0,
+        -11.0, -3.0,
+        -1e-2, -1e-8,
+        -0.0, +0.0,
+        -1e25, 1e25
+    };
+
+    const uniform float ref[] = {
+        +7.0258176327e-01, +1.6149193048e-01,
+        +9.7999610007e-02, +1.5939876903e-04,
+        +9.5488888025e-01, +9.9966150522e-01,
+        +9.9999773502e-01, +1.0000000000e+00,
+        +1.5374598296e-12, +4.1838257317e-23,
+        +4.1370317081e-37, +0.0000000000e+00,
+        +2.0000000000e+00, +1.9999779463e+00,
+        +1.0112833977e+00, +1.0000000000e+00,
+        +1.0000000000e+00, +1.0000000000e+00,
+        +2.0000000000e+00, +0.0000000000e+00
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform float res = erfc(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/erfc-float-varying.ispc
+++ b/tests/func-tests/erfc-float-varying.ispc
@@ -1,16 +1,5 @@
 #include "test_static.isph"
 
-static float float4(uniform float a, uniform float b, uniform float c, uniform float d) {
-    float ret = 0;
-    for (uniform int i = 0; i < programCount; i += 4) {
-        ret = insert(ret, i + 0, a);
-        ret = insert(ret, i + 1, b);
-        ret = insert(ret, i + 2, c);
-        ret = insert(ret, i + 3, d);
-    }
-    return ret;
-}
-
 bool ok(float x, float ref) {
     // erfc is meant to be much more precise than erf for x>1
     // so the absolute precision threshold must be much smaller.
@@ -18,39 +7,42 @@ bool ok(float x, float ref) {
 }
 
 task void f_v(uniform float RET[]) {
-    float x, ref, res;
+    const uniform float x[] = {
+        0.27, 0.99,
+        1.17, 2.67,
+        4e-2, 3e-4,
+        2e-6, 1e-8,
+        5.0, 7.0,
+        9.0, 11.0,
+        -11.0, -3.0,
+        -1e-2, -1e-8,
+        -0.0, +0.0,
+        -1e25, 1e25
+    };
+
+    const uniform float ref[] = {
+        +7.0258176327e-01, +1.6149193048e-01,
+        +9.7999610007e-02, +1.5939876903e-04,
+        +9.5488888025e-01, +9.9966150522e-01,
+        +9.9999773502e-01, +1.0000000000e+00,
+        +1.5374598296e-12, +4.1838257317e-23,
+        +4.1370317081e-37, +0.0000000000e+00,
+        +2.0000000000e+00, +1.9999779463e+00,
+        +1.0112833977e+00, +1.0000000000e+00,
+        +1.0000000000e+00, +1.0000000000e+00,
+        +2.0000000000e+00, +0.0000000000e+00
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
 
     RET[programIndex] = 0;
 
-    // Case 1: Basic values
-    x = float4(0.27, 0.99, 1.17, 2.67);
-    ref = float4(0.70258176, 0.16149193, 0.09799961, 0.00015939877);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 2: Small values
-    x = float4(4e-2, 3e-4, 2e-6, 1e-8);
-    ref = float4(0.9548889, 0.9996615, 0.99999774, 1.0);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 3: Big values
-    x = float4(5.0, 7.0, 9.0, 11.0);
-    ref = float4(1.5374598e-12, 4.1838257e-23, 4.1370317e-37, 0.0000000e+00);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 4: Negative values
-    x = float4(-11.0, -3.0, -1e-2, -1e-8);
-    ref = float4(2.0, 1.999978, 1.0112834, 1.0);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 5: Special and extreme values
-    x = float4(-0.0, +0.0, -1e25, 1e25);
-    ref = float4(1.0, 1.0, 2.0, 0.0);
-    res = erfc(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
+    foreach(i = 0...count)
+    {
+        const float res = erfc(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/erfc-float16-uniform.ispc
+++ b/tests/func-tests/erfc-float16-uniform.ispc
@@ -7,11 +7,42 @@ uniform bool ok(uniform float16 x, uniform float16 ref) {
     return (abs(x - ref) < 1e-4f16) || abs((x - ref) / ref) < 0.05f16;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform float16 ref = erfc((uniform float16)((aFOO[i] / programCount) * 3 - 1.5));
-        uniform float16 res = erfc((aFOO[i] / programCount) * 3 - 1.5);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float16 x[] = {
+        0.17, 0.99,
+        1.17, 1.67,
+        4e-1, 3e-2,
+        2e-3, 1e-4,
+        2.0, 3.0,
+        4.0, 5.0,
+        -5.0, -2.0,
+        -1e-2, -1e-6,
+        -0.0, +0.0,
+        -1e4, 1e4
+    };
+
+    const uniform float16 ref[] = {
+        +8.1006e-01, +1.6138e-01,
+        +9.8022e-02, +1.8188e-02,
+        +5.7178e-01, +9.6631e-01,
+        +9.9756e-01, +1.0000e+00,
+        +4.6768e-03, +2.2113e-05,
+        +0.0000e+00, +0.0000e+00,
+        +2.0000e+00, +1.9951e+00,
+        +1.0117e+00, +1.0000e+00,
+        +1.0000e+00, +1.0000e+00,
+        +2.0000e+00, +0.0000e+00
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform float16 res = erfc(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/erfc-float16-varying.ispc
+++ b/tests/func-tests/erfc-float16-varying.ispc
@@ -8,11 +8,43 @@ bool ok(float16 x, float16 ref) {
     return (abs(x - ref) < 1e-4f16) || abs((x - ref) / ref) < 0.05f16;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    float16 arg = ((aFOO[programIndex] / programCount) * 3 - 1.5);
-    float16 ref = erfc((float)arg);
-    float16 res = erfc((float16)arg);
-    RET[programIndex] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float16 x[] = {
+        0.17, 0.99,
+        1.17, 1.67,
+        4e-1, 3e-2,
+        2e-3, 1e-4,
+        2.0, 3.0,
+        4.0, 5.0,
+        -5.0, -2.0,
+        -1e-2, -1e-6,
+        -0.0, +0.0,
+        -1e4, 1e4
+    };
+
+    const uniform float16 ref[] = {
+        +8.1006e-01, +1.6138e-01,
+        +9.8022e-02, +1.8188e-02,
+        +5.7178e-01, +9.6631e-01,
+        +9.9756e-01, +1.0000e+00,
+        +4.6768e-03, +2.2113e-05,
+        +0.0000e+00, +0.0000e+00,
+        +2.0000e+00, +1.9951e+00,
+        +1.0117e+00, +1.0000e+00,
+        +1.0000e+00, +1.0000e+00,
+        +2.0000e+00, +0.0000e+00
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    foreach(i = 0...count)
+    {
+        const float16 res = erfc(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/expm1-double-uniform.ispc
+++ b/tests/func-tests/expm1-double-uniform.ispc
@@ -9,10 +9,33 @@ uniform bool ok(uniform double x, uniform double ref) {
 }
 
 task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform double ref = expm1((uniform double)((aFOO[i] / programCount) * 3.0d - 1.5d));
-        uniform double res = expm1((aFOO[i] / programCount) * 3.0d - 1.5d);
-        RET[i] = ok(res, ref) ? 0 : 1;
+    const uniform double x[] = {
+        0.2d, 0.42d,
+        9e-2d, 3e-4d,
+        6e-10d, 9e-120d,
+        2.3d, 4.7d,
+        11.1d, 397.3d,
+        -3.0d, -0.1d
+    };
+
+    const uniform double ref[] = {
+        +2.214027581601698547e-01d, +5.219615556186337768e-01d,
+        +9.417428370521035985e-02d, +3.000450045003374717e-04d,
+        +6.000000001799999774e-10d, +8.999999999999999979e-120d,
+        +8.974182454814718213e+00d, +1.089471724521235245e+02d,
+        +6.617016016837657662e+04d, +3.509115477556654489e+172d,
+        -9.502129316321360486e-01d, -9.516258196404042691e-02d
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform double res = expm1(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/expm1-double-varying.ispc
+++ b/tests/func-tests/expm1-double-varying.ispc
@@ -3,15 +3,6 @@
 // rule: skip on cpu=tgllp
 // rule: skip on cpu=dg2
 
-static double double2(uniform double a, uniform double b) {
-    double ret = 0;
-    for (uniform int i = 0; i < programCount; i += 2) {
-        ret = insert(ret, i + 0, a);
-        ret = insert(ret, i + 1, b);
-    }
-    return ret;
-}
-
 bool ok(double x, double ref) {
     // expm1 is meant to be much more precise than exp for x ~= 0
     // so the absolute precision threshold must be much smaller.
@@ -19,45 +10,34 @@ bool ok(double x, double ref) {
 }
 
 task void f_v(uniform float RET[]) {
-    double x, ref, res;
+    const uniform double x[] = {
+        0.2d, 0.42d,
+        9e-2d, 3e-4d,
+        6e-10d, 9e-120d,
+        2.3d, 4.7d,
+        11.1d, 397.3d,
+        -3.0d, -0.1d
+    };
+
+    const uniform double ref[] = {
+        +2.214027581601698547e-01d, +5.219615556186337768e-01d,
+        +9.417428370521035985e-02d, +3.000450045003374717e-04d,
+        +6.000000001799999774e-10d, +8.999999999999999979e-120d,
+        +8.974182454814718213e+00d, +1.089471724521235245e+02d,
+        +6.617016016837657662e+04d, +3.509115477556654489e+172d,
+        -9.502129316321360486e-01d, -9.516258196404042691e-02d
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
 
     RET[programIndex] = 0;
 
-    // Case 1: Basic values
-    x = double2(0.2d, 0.42d);
-    ref = double2(0.22140275816016985d, 0.5219615556186338d);
-    res = expm1(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 2: Small values
-    x = double2(9e-2d, 3e-4d);
-    ref = double2(0.09417428370521036d, 0.00030004500450033747d);
-    res = expm1(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 3: Tiny values
-    x = double2(6e-10d, 9e-120d);
-    ref = double2(6.0000000018e-10d, 9e-120d);
-    res = expm1(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 4: Big values
-    x = double2(2.3d, 4.7d);
-    ref = double2(8.974182454814718d, 108.94717245212351d);
-    res = expm1(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 5: Bigger values
-    x = double2(11.1d, 397.3d);
-    ref = double2(66170.16016837658d, 3.5091154775566545e+172d);
-    res = expm1(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 6: Negative values
-    x = double2(-3.0d, -0.1d);
-    ref = double2(-0.950212931632136d, -0.09516258196404043d);
-    res = expm1(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
+    foreach(i = 0...count)
+    {
+        const double res = expm1(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/expm1-float-uniform.ispc
+++ b/tests/func-tests/expm1-float-uniform.ispc
@@ -6,10 +6,36 @@ uniform bool ok(uniform float x, uniform float ref) {
 }
 
 task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform float ref = expm1((uniform float)((aFOO[i] / programCount) * 3 - 1.5));
-        uniform float res = expm1((aFOO[i] / programCount) * 3 - 1.5);
-        RET[i] = ok(res, ref) ? 0 : 1;
+    const uniform float x[] = {
+        0.2, 0.42, 0.6, 2.1,
+        9e-2, 4e-2, 3e-4, 2e-6,
+        6e-12, 7e-16, 8e-20, 9e-24,
+        5.9, 9.1, 17.2, 31.3,
+        -11.0, -0.3, -1e-2, -1e-8
+    };
+
+    const uniform float ref[] = {
+        +2.2140276432e-01, +5.2196151018e-01,
+        +8.2211881876e-01, +7.1661691666e+00,
+        +9.4174288213e-02, +4.0810775012e-02,
+        +3.0004500877e-04, +2.0000020413e-06,
+        +5.9999999760e-12, +6.9999999195e-16,
+        +7.9999997461e-20, +8.9999996828e-24,
+        +3.6403750610e+02, +8.9542958984e+03,
+        +2.9502948000e+07, +3.9211814093e+13,
+        -9.9998331070e-01, -2.5918179750e-01,
+        -9.9501656368e-03, -9.9999999392e-09
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform float res = expm1(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/expm1-float-varying.ispc
+++ b/tests/func-tests/expm1-float-varying.ispc
@@ -1,16 +1,5 @@
 #include "test_static.isph"
 
-static float float4(uniform float a, uniform float b, uniform float c, uniform float d) {
-    float ret = 0;
-    for (uniform int i = 0; i < programCount; i += 4) {
-        ret = insert(ret, i + 0, a);
-        ret = insert(ret, i + 1, b);
-        ret = insert(ret, i + 2, c);
-        ret = insert(ret, i + 3, d);
-    }
-    return ret;
-}
-
 bool ok(float x, float ref) {
     // expm1 is meant to be much more precise than exp for x ~= 0
     // so the absolute precision threshold must be much smaller.
@@ -18,39 +7,37 @@ bool ok(float x, float ref) {
 }
 
 task void f_v(uniform float RET[]) {
-    float x, ref, res;
+    const uniform float x[] = {
+        0.2, 0.42, 0.6, 2.1,
+        9e-2, 4e-2, 3e-4, 2e-6,
+        6e-12, 7e-16, 8e-20, 9e-24,
+        5.9, 9.1, 17.2, 31.3,
+        -11.0, -0.3, -1e-2, -1e-8
+    };
+
+    const uniform float ref[] = {
+        +2.2140276432e-01, +5.2196151018e-01,
+        +8.2211881876e-01, +7.1661691666e+00,
+        +9.4174288213e-02, +4.0810775012e-02,
+        +3.0004500877e-04, +2.0000020413e-06,
+        +5.9999999760e-12, +6.9999999195e-16,
+        +7.9999997461e-20, +8.9999996828e-24,
+        +3.6403750610e+02, +8.9542958984e+03,
+        +2.9502948000e+07, +3.9211814093e+13,
+        -9.9998331070e-01, -2.5918179750e-01,
+        -9.9501656368e-03, -9.9999999392e-09
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
 
     RET[programIndex] = 0;
 
-    // Case 1: Basic values
-    x = float4(0.2, 0.42, 0.6, 2.1);
-    ref = float4(0.22140276, 0.5219615, 8.2211882e-01, 7.1661692e+00);
-    res = expm1(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 2: Small values
-    x = float4(9e-2, 4e-2, 3e-4, 2e-6);
-    ref = float4(9.4174288e-02, 4.0810775e-02, 3.0004501e-04, 2.0000020e-06);
-    res = expm1(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 3: Tiny values
-    x = float4(6e-12, 7e-16, 8e-20, 9e-24);
-    ref = float4(6.0e-12, 7.0e-16, 8.0e-20, 9.0e-24);
-    res = expm1(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 4: Big values
-    x = float4(5.9, 9.1, 17.2, 31.3);
-    ref = float4(3.6403751e+02, 8.9542959e+03, 2.9502948e+07, 3.9211814e+13);
-    res = expm1(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 5: Negative values
-    x = float4(-11.0, -0.3, -1e-2, -1e-8);
-    ref = float4(-9.999833e-01, -2.591818e-01, -9.950166e-03, -1.000000e-08);
-    res = expm1(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
+    foreach(i = 0...count)
+    {
+        const float res = expm1(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/expm1-float16-uniform.ispc
+++ b/tests/func-tests/expm1-float16-uniform.ispc
@@ -7,11 +7,34 @@ uniform bool ok(uniform float16 x, uniform float16 ref) {
     return (abs(x - ref) < 1e-4f16) || abs((x - ref) / ref) < 0.05f16;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform float16 ref = expm1((uniform float16)((aFOO[i] / programCount) * 3 - 1.5));
-        uniform float16 res = expm1((aFOO[i] / programCount) * 3 - 1.5);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float16 x[] = {
+        0.2, 0.42, 0.6, 1.7,
+        9e-1, 4e-1, 3e-2, 2e-3,
+        3.9, 5.1, 7.2, 9.3,
+        -11.0, -0.3, -1e-5, -1e-6
+    };
+
+    const uniform float16 ref[] = {
+        +2.2131e-01, +5.2197e-01,
+        +8.2227e-01, +4.4766e+00,
+        +1.4590e+00, +4.9170e-01,
+        +3.0457e-02, +2.0027e-03,
+        +4.8406e+01, +1.6325e+02,
+        +1.3370e+03, +1.0904e+04,
+        -1.0000e+00, -2.5928e-01,
+        -1.0014e-05, -1.0133e-06
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform float16 res = expm1(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/expm1-float16-varying.ispc
+++ b/tests/func-tests/expm1-float16-varying.ispc
@@ -8,11 +8,35 @@ bool ok(float16 x, float16 ref) {
     return (abs(x - ref) < 1e-4f16) || abs((x - ref) / ref) < 0.05f16;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    float16 arg = ((aFOO[programIndex] / programCount) * 3 - 1.5);
-    float16 ref = expm1((float)arg);
-    float16 res = expm1((float16)arg);
-    RET[programIndex] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float16 x[] = {
+        0.2, 0.42, 0.6, 1.7,
+        9e-1, 4e-1, 3e-2, 2e-3,
+        3.9, 5.1, 7.2, 9.3,
+        -11.0, -0.3, -1e-5, -1e-6
+    };
+
+    const uniform float16 ref[] = {
+        +2.2131e-01, +5.2197e-01,
+        +8.2227e-01, +4.4766e+00,
+        +1.4590e+00, +4.9170e-01,
+        +3.0457e-02, +2.0027e-03,
+        +4.8406e+01, +1.6325e+02,
+        +1.3370e+03, +1.0904e+04,
+        -1.0000e+00, -2.5928e-01,
+        -1.0014e-05, -1.0133e-06
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    foreach(i = 0...count)
+    {
+        const float16 res = expm1(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/sinh-double-uniform.ispc
+++ b/tests/func-tests/sinh-double-uniform.ispc
@@ -7,11 +7,34 @@ uniform bool ok(uniform double x, uniform double ref) {
     return (abs(x - ref) < 1e-15d) || abs((x - ref) / ref) < 1e-12d;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform double ref = sinh((uniform double)((aFOO[i] / programCount) * 3.0d - 1.5d));
-        uniform double res = sinh((aFOO[i] / programCount) * 3.0d - 1.5d);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform double x[] = {
+        0.27d, 0.99d,
+        2e-2d, 1e-12d,
+        5.0d, 7.0d,
+        -3.0d, -1e-2d,
+        -0.0d, +0.0d,
+        80.0d, 379.1d
+    };
+
+    const uniform double ref[] = {
+        +2.732924781981971307e-01d, +1.159828890663608281e+00d,
+        +2.000133336000025491e-02d, +9.999999999999999799e-13d,
+        +7.420321057778875229e+01d, +5.483161232732464896e+02d,
+        -1.001787492740990260e+01d, -1.000016666750000276e-02d,
+        -0.000000000000000000e+00d, +0.000000000000000000e+00d,
+        +2.770311192196754917e+34d, +2.187802397202284545e+164d
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform double res = sinh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/sinh-double-varying.ispc
+++ b/tests/func-tests/sinh-double-varying.ispc
@@ -3,59 +3,39 @@
 // rule: skip on cpu=tgllp
 // rule: skip on cpu=dg2
 
-static double double2(uniform double a, uniform double b) {
-    double ret = 0;
-    for (uniform int i = 0; i < programCount; i += 2) {
-        ret = insert(ret, i + 0, a);
-        ret = insert(ret, i + 1, b);
-    }
-    return ret;
-}
-
 bool ok(double x, double ref) {
     return (abs(x - ref) < 1e-15d) || abs((x-ref)/ref) < 1e-12d;
 }
 
 task void f_v(uniform float RET[]) {
-    double x, ref, res;
+    const uniform double x[] = {
+        0.27d, 0.99d,
+        2e-2d, 1e-12d,
+        5.0d, 7.0d,
+        -3.0d, -1e-2d,
+        -0.0d, +0.0d,
+        80.0d, 379.1d
+    };
+
+    const uniform double ref[] = {
+        +2.732924781981971307e-01d, +1.159828890663608281e+00d,
+        +2.000133336000025491e-02d, +9.999999999999999799e-13d,
+        +7.420321057778875229e+01d, +5.483161232732464896e+02d,
+        -1.001787492740990260e+01d, -1.000016666750000276e-02d,
+        -0.000000000000000000e+00d, +0.000000000000000000e+00d,
+        +2.770311192196754917e+34d, +2.187802397202284545e+164d
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
 
     RET[programIndex] = 0;
 
-    // Case 1: Basic values
-    x = double2(0.27d, 0.99d);
-    ref = double2(0.27329247819819713d, 1.1598288906636083d);
-    res = sinh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 2: Small values
-    x = double2(2e-2d, 1e-12d);
-    ref = double2(0.020001333360000255d, 1e-12d);
-    res = sinh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 3: Big values
-    x = double2(5.0d, 7.0d);
-    ref = double2(74.20321057778875d, 548.3161232732465d);
-    res = sinh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 4: Negative values
-    x = double2(-3.0d, -1e-2d);
-    ref = double2(-10.017874927409903d, -0.010000166667500003d);
-    res = sinh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 5: Special values
-    x = double2(-0.0d, +0.0d);
-    ref = double2(-0.0d,  +0.0d);
-    res = sinh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 6: Extreme values
-    x = double2(80.0d, 379.1d);
-    ref = double2(2.770311192196755e+34d, 2.1878023972022845e+164d);
-    res = sinh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
+    foreach(i = 0...count)
+    {
+        const double res = sinh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/sinh-float-uniform.ispc
+++ b/tests/func-tests/sinh-float-uniform.ispc
@@ -4,11 +4,42 @@ uniform bool ok(uniform float x, uniform float ref) {
     return (abs(x - ref) < 1e-6) || abs((x - ref) / ref) < 1e-5;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform float ref = sinh((uniform float)((aFOO[i] / programCount) * 3 - 1.5));
-        uniform float res = sinh((aFOO[i] / programCount) * 3 - 1.5);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float x[] = {
+        0.27, 0.99,
+        1.17, 2.67,
+        4e-2, 3e-4,
+        2e-6, 1e-8,
+        5.0, 7.0,
+        9.0, 11.0,
+        -11.0, -3.0,
+        -1e-2, -1e-8,
+        -0.0, +0.0,
+        21.7, 80.0
+    };
+
+    const uniform float ref[] = {
+        +2.7329248190e-01, +1.1598289013e+00,
+        +1.4558128119e+00, +7.1853590012e+00,
+        +4.0010668337e-02, +3.0000001425e-04,
+        +1.9999999950e-06, +9.9999999392e-09,
+        +7.4203208923e+01, +5.4831610107e+02,
+        +4.0515419922e+03, +2.9937070312e+04,
+        -2.9937070312e+04, -1.0017874718e+01,
+        -1.0000166483e-02, -9.9999999392e-09,
+        -0.0000000000e+00, +0.0000000000e+00,
+        +1.3278854400e+09, +2.7703112423e+34
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform float res = sinh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/sinh-float-varying.ispc
+++ b/tests/func-tests/sinh-float-varying.ispc
@@ -1,54 +1,46 @@
 #include "test_static.isph"
 
-static float float4(uniform float a, uniform float b, uniform float c, uniform float d) {
-    float ret = 0;
-    for (uniform int i = 0; i < programCount; i += 4) {
-        ret = insert(ret, i + 0, a);
-        ret = insert(ret, i + 1, b);
-        ret = insert(ret, i + 2, c);
-        ret = insert(ret, i + 3, d);
-    }
-    return ret;
-}
-
 bool ok(float x, float ref) {
     return (abs(x - ref) < 1e-6) || abs((x-ref)/ref) < 1e-5;
 }
 
 task void f_v(uniform float RET[]) {
-    float x, ref, res;
+    const uniform float x[] = {
+        0.27, 0.99,
+        1.17, 2.67,
+        4e-2, 3e-4,
+        2e-6, 1e-8,
+        5.0, 7.0,
+        9.0, 11.0,
+        -11.0, -3.0,
+        -1e-2, -1e-8,
+        -0.0, +0.0,
+        21.7, 80.0
+    };
+
+    const uniform float ref[] = {
+        +2.7329248190e-01, +1.1598289013e+00,
+        +1.4558128119e+00, +7.1853590012e+00,
+        +4.0010668337e-02, +3.0000001425e-04,
+        +1.9999999950e-06, +9.9999999392e-09,
+        +7.4203208923e+01, +5.4831610107e+02,
+        +4.0515419922e+03, +2.9937070312e+04,
+        -2.9937070312e+04, -1.0017874718e+01,
+        -1.0000166483e-02, -9.9999999392e-09,
+        -0.0000000000e+00, +0.0000000000e+00,
+        +1.3278854400e+09, +2.7703112423e+34
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
 
     RET[programIndex] = 0;
 
-    // Case 1: Basic values
-    x = float4(0.27, 0.99, 1.17, 2.67);
-    ref = float4(0.27329248, 1.1598289, 1.4558128, 7.185359);
-    res = sinh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 2: Small values
-    x = float4(4e-2, 3e-4, 2e-6, 1e-8);
-    ref = float4(4.001067e-02, 3.000000e-04, 2.000000e-06, 1.000000e-08);
-    res = sinh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 3: Big values
-    x = float4(5.0, 7.0, 9.0, 11.0);
-    ref = float4(74.20321, 548.3161, 4051.542, 29937.07);
-    res = sinh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 4: Negative values
-    x = float4(-11.0, -3.0, -1e-2, -1e-8);
-    ref = float4(-2.99370703e+04, -1.00178747e+01, -1.00001665e-02, -9.99999994e-09);
-    res = sinh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 5: Special and extreme values
-    x = float4(-0.0, +0.0, 21.7, 80.0);
-    ref = float4(-0.0, +0.0, 1.3278854e+09, 2.7703112e+34);
-    res = sinh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
+    foreach(i = 0...count)
+    {
+        const float res = sinh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/sinh-float16-uniform.ispc
+++ b/tests/func-tests/sinh-float16-uniform.ispc
@@ -6,11 +6,42 @@ uniform bool ok(uniform float16 x, uniform float16 ref) {
     return (abs(x - ref) < 0.001f16) || abs((x - ref) / ref) < 0.05f16;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform float16 ref = sinh((uniform float16)((aFOO[i] / programCount) * 3 - 1.5));
-        uniform float16 res = sinh((aFOO[i] / programCount) * 3 - 1.5);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float16 x[] = {
+        0.17, 0.99,
+        1.17, 1.67,
+        4e-1, 3e-2,
+        2e-3, 1e-4,
+        2.0, 3.0,
+        4.0, 5.0,
+        -5.0, -2.0,
+        -1e-2, -1e-6,
+        -0.0, +0.0,
+        7.1, 10.3
+    };
+
+    const uniform float16 ref[] = {
+        +1.7090e-01, +1.1602e+00,
+        +1.4561e+00, +2.5625e+00,
+        +4.1064e-01, +2.9999e-02,
+        +2.0008e-03, +1.0002e-04,
+        +3.6270e+00, +1.0016e+01,
+        +2.7297e+01, +7.4188e+01,
+        -7.4188e+01, -3.6270e+00,
+        -1.0002e-02, -1.0133e-06,
+        -0.0000e+00, +0.0000e+00,
+        +6.0700e+02, +1.4816e+04
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform float16 res = sinh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/sinh-float16-varying.ispc
+++ b/tests/func-tests/sinh-float16-varying.ispc
@@ -6,11 +6,43 @@ bool ok(float16 x, float16 ref) {
     return (abs(x - ref) < 0.001f16) || abs((x - ref) / ref) < 0.05f16;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    float16 arg = ((aFOO[programIndex] / programCount) * 3 - 1.5);
-    float16 ref = sinh((float)arg);
-    float16 res = sinh((float16)arg);
-    RET[programIndex] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float16 x[] = {
+        0.17, 0.99,
+        1.17, 1.67,
+        4e-1, 3e-2,
+        2e-3, 1e-4,
+        2.0, 3.0,
+        4.0, 5.0,
+        -5.0, -2.0,
+        -1e-2, -1e-6,
+        -0.0, +0.0,
+        7.1, 10.3
+    };
+
+    const uniform float16 ref[] = {
+        +1.7090e-01, +1.1602e+00,
+        +1.4561e+00, +2.5625e+00,
+        +4.1064e-01, +2.9999e-02,
+        +2.0008e-03, +1.0002e-04,
+        +3.6270e+00, +1.0016e+01,
+        +2.7297e+01, +7.4188e+01,
+        -7.4188e+01, -3.6270e+00,
+        -1.0002e-02, -1.0133e-06,
+        -0.0000e+00, +0.0000e+00,
+        +6.0700e+02, +1.4816e+04
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    foreach(i = 0...count)
+    {
+        const float16 res = sinh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/tanh-double-uniform.ispc
+++ b/tests/func-tests/tanh-double-uniform.ispc
@@ -7,11 +7,36 @@ uniform bool ok(uniform double x, uniform double ref) {
     return (abs(x - ref) < 1e-15d) || abs((x - ref) / ref) < 1e-12d;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform double ref = tanh((uniform double)((aFOO[i] / programCount) * 3.0d - 1.5d));
-        uniform double res = tanh((aFOO[i] / programCount) * 3.0d - 1.5d);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform double x[] = {
+        0.27d, 0.99d,
+        2e-2d, 1e-12d,
+        5.0d, 7.0d,
+        -3.0d, -1e-2d,
+        -0.0d, +0.0d,
+        80.0d, 379.1d,
+        -1e160d, 1e160d
+    };
+
+    const uniform double ref[] = {
+        +2.636248354722033338e-01d, +7.573623242165262726e-01d,
+        +1.999733375993093323e-02d, +9.999999999999999799e-13d,
+        +9.999092042625951082e-01d, +9.999983369439446879e-01d,
+        -9.950547536867304643e-01d, -9.999666679999460323e-03d,
+        -0.000000000000000000e+00d, +0.000000000000000000e+00d,
+        +1.000000000000000000e+00d, +1.000000000000000000e+00d,
+        -1.000000000000000000e+00d, +1.000000000000000000e+00d
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform double res = tanh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/tanh-double-varying.ispc
+++ b/tests/func-tests/tanh-double-varying.ispc
@@ -3,65 +3,41 @@
 // rule: skip on cpu=tgllp
 // rule: skip on cpu=dg2
 
-static double double2(uniform double a, uniform double b) {
-    double ret = 0;
-    for (uniform int i = 0; i < programCount; i += 2) {
-        ret = insert(ret, i + 0, a);
-        ret = insert(ret, i + 1, b);
-    }
-    return ret;
-}
-
 bool ok(double x, double ref) {
     return (abs(x - ref) < 1e-15d) || abs((x-ref)/ref) < 1e-12d;
 }
 
 task void f_v(uniform float RET[]) {
-    double x, ref, res;
+    const uniform double x[] = {
+        0.27d, 0.99d,
+        2e-2d, 1e-12d,
+        5.0d, 7.0d,
+        -3.0d, -1e-2d,
+        -0.0d, +0.0d,
+        80.0d, 379.1d,
+        -1e160d, 1e160d
+    };
+
+    const uniform double ref[] = {
+        +2.636248354722033338e-01d, +7.573623242165262726e-01d,
+        +1.999733375993093323e-02d, +9.999999999999999799e-13d,
+        +9.999092042625951082e-01d, +9.999983369439446879e-01d,
+        -9.950547536867304643e-01d, -9.999666679999460323e-03d,
+        -0.000000000000000000e+00d, +0.000000000000000000e+00d,
+        +1.000000000000000000e+00d, +1.000000000000000000e+00d,
+        -1.000000000000000000e+00d, +1.000000000000000000e+00d
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
 
     RET[programIndex] = 0;
 
-    // Case 1: Basic values
-    x = double2(0.27d, 0.99d);
-    ref = double2(0.26362483547220333d, 0.7573623242165263d);
-    res = tanh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 2: Small values
-    x = double2(2e-2d, 1e-12d);
-    ref = double2(0.01999733375993093d, 1e-12d);
-    res = tanh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 3: Big values
-    x = double2(5.0d, 7.0d);
-    ref = double2(0.9999092042625951d, 0.9999983369439447d);
-    res = tanh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 4: Negative values
-    x = double2(-3.0d, -1e-2d);
-    ref = double2(-0.9950547536867305d, -0.00999966667999946d);
-    res = tanh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 5: Special values
-    x = double2(-0.0d, +0.0d);
-    ref = double2(-0.0d,  +0.0d);
-    res = tanh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 6: Extreme values
-    x = double2(80.0d, 379.1d);
-    ref = double2(1.0d,  1.0d);
-    res = tanh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 6: More extreme values
-    x = double2(-1e160d, 1e160d);
-    ref = double2(-1.0d,  1.0d);
-    res = tanh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
+    foreach(i = 0...count)
+    {
+        const double res = tanh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/tanh-float-uniform.ispc
+++ b/tests/func-tests/tanh-float-uniform.ispc
@@ -4,11 +4,42 @@ uniform bool ok(uniform float x, uniform float ref) {
     return (abs(x - ref) < 1e-6) || abs((x - ref) / ref) < 1e-5;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform float ref = tanh((uniform float)((aFOO[i] / programCount) * 3 - 1.5));
-        uniform float res = tanh((aFOO[i] / programCount) * 3 - 1.5);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float x[] = {
+        0.27, 0.99,
+        1.17, 2.67,
+        4e-2, 3e-4,
+        2e-6, 1e-8,
+        5.0, 7.0,
+        9.0, 11.0,
+        -11.0, -3.0,
+        -1e-2, -1e-8,
+        -0.0, +0.0,
+        -1e25, 1e25
+    };
+
+    const uniform float ref[] = {
+        +2.6362484694e-01, +7.5736230612e-01,
+        +8.2427215576e-01, +9.9045401812e-01,
+        +3.9978679270e-02, +3.0000001425e-04,
+        +1.9999999950e-06, +9.9999999392e-09,
+        +9.9990922213e-01, +9.9999833107e-01,
+        +9.9999994040e-01, +1.0000000000e+00,
+        -1.0000000000e+00, -9.9505478144e-01,
+        -9.9996663630e-03, -9.9999999392e-09,
+        -0.0000000000e+00, +0.0000000000e+00,
+        -1.0000000000e+00, +1.0000000000e+00
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform float res = tanh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/tanh-float-varying.ispc
+++ b/tests/func-tests/tanh-float-varying.ispc
@@ -1,54 +1,46 @@
 #include "test_static.isph"
 
-static float float4(uniform float a, uniform float b, uniform float c, uniform float d) {
-    float ret = 0;
-    for (uniform int i = 0; i < programCount; i += 4) {
-        ret = insert(ret, i + 0, a);
-        ret = insert(ret, i + 1, b);
-        ret = insert(ret, i + 2, c);
-        ret = insert(ret, i + 3, d);
-    }
-    return ret;
-}
-
 bool ok(float x, float ref) {
     return (abs(x - ref) < 1e-6) || abs((x-ref)/ref) < 1e-5;
 }
 
 task void f_v(uniform float RET[]) {
-    float x, ref, res;
+    const uniform float x[] = {
+        0.27, 0.99,
+        1.17, 2.67,
+        4e-2, 3e-4,
+        2e-6, 1e-8,
+        5.0, 7.0,
+        9.0, 11.0,
+        -11.0, -3.0,
+        -1e-2, -1e-8,
+        -0.0, +0.0,
+        -1e25, 1e25
+    };
+
+    const uniform float ref[] = {
+        +2.6362484694e-01, +7.5736230612e-01,
+        +8.2427215576e-01, +9.9045401812e-01,
+        +3.9978679270e-02, +3.0000001425e-04,
+        +1.9999999950e-06, +9.9999999392e-09,
+        +9.9990922213e-01, +9.9999833107e-01,
+        +9.9999994040e-01, +1.0000000000e+00,
+        -1.0000000000e+00, -9.9505478144e-01,
+        -9.9996663630e-03, -9.9999999392e-09,
+        -0.0000000000e+00, +0.0000000000e+00,
+        -1.0000000000e+00, +1.0000000000e+00
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
 
     RET[programIndex] = 0;
 
-    // Case 1: Basic values
-    x = float4(0.27, 0.99, 1.17, 2.67);
-    ref = float4(0.26362484, 0.75736232, 0.82427217, 0.99045404);
-    res = tanh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 2: Small values
-    x = float4(4e-2, 3e-4, 2e-6, 1e-8);
-    ref = float4(3.99786803e-02, 2.99999991e-04, 2.00000000e-06, 1.00000000e-08);
-    res = tanh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 3: Big values
-    x = float4(5.0, 7.0, 9.0, 11.0);
-    ref = float4(0.9999092 , 0.99999834, 0.99999997, 1.0);
-    res = tanh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 4: Negative values
-    x = float4(-11.0, -3.0, -1e-2, -1e-8);
-    ref = float4(-9.99999999e-01, -9.95054754e-01, -9.99966668e-03, -1.00000000e-08);
-    res = tanh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
-
-    // Case 5: Special and extreme values
-    x = float4(-0.0, +0.0, -1e25, 1e25);
-    ref = float4(-0.0,  +0.0,  -1.0,  1.0);
-    res = tanh(x);
-    RET[programIndex] += ok(res, ref) ? 0 : 1;
+    foreach(i = 0...count)
+    {
+        const float res = tanh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }

--- a/tests/func-tests/tanh-float16-uniform.ispc
+++ b/tests/func-tests/tanh-float16-uniform.ispc
@@ -6,11 +6,42 @@ uniform bool ok(uniform float16 x, uniform float16 ref) {
     return (abs(x - ref) < 0.001f16) || abs((x - ref) / ref) < 0.05f16;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    for (uniform int i = 0; i != programCount; ++i) {
-        uniform float16 ref = tanh((uniform float16)((aFOO[i] / programCount) * 3 - 1.5));
-        uniform float16 res = tanh((aFOO[i] / programCount) * 3 - 1.5);
-        RET[i] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float16 x[] = {
+        0.17, 0.99,
+        1.17, 1.67,
+        4e-1, 3e-2,
+        2e-3, 1e-4,
+        2.0, 3.0,
+        4.0, 5.0,
+        -5.0, -2.0,
+        -1e-2, -1e-6,
+        -0.0, +0.0,
+        -1e4, 1e4
+    };
+
+    const uniform float16 ref[] = {
+        +1.6846e-01, +7.5732e-01,
+        +8.2422e-01, +9.3164e-01,
+        +3.7988e-01, +2.9984e-02,
+        +2.0008e-03, +1.0002e-04,
+        +9.6387e-01, +9.9512e-01,
+        +9.9951e-01, +1.0000e+00,
+        -1.0000e+00, -9.6387e-01,
+        -1.0002e-02, -1.0133e-06,
+        -0.0000e+00, +0.0000e+00,
+        -1.0000e+00, +1.0000e+00
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    for (uniform int i = 0; i < count; ++i)
+    {
+        const uniform float16 res = tanh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
     }
 }
 

--- a/tests/func-tests/tanh-float16-varying.ispc
+++ b/tests/func-tests/tanh-float16-varying.ispc
@@ -6,11 +6,43 @@ bool ok(float16 x, float16 ref) {
     return (abs(x - ref) < 0.001f16) || abs((x - ref) / ref) < 0.05f16;
 }
 
-task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
-    float16 arg = ((aFOO[programIndex] / programCount) * 3 - 1.5);
-    float16 ref = tanh((float)arg);
-    float16 res = tanh((float16)arg);
-    RET[programIndex] = ok(res, ref) ? 0 : 1;
+task void f_v(uniform float RET[]) {
+    const uniform float16 x[] = {
+        0.17, 0.99,
+        1.17, 1.67,
+        4e-1, 3e-2,
+        2e-3, 1e-4,
+        2.0, 3.0,
+        4.0, 5.0,
+        -5.0, -2.0,
+        -1e-2, -1e-6,
+        -0.0, +0.0,
+        -1e4, 1e4
+    };
+
+    const uniform float16 ref[] = {
+        +1.6846e-01, +7.5732e-01,
+        +8.2422e-01, +9.3164e-01,
+        +3.7988e-01, +2.9984e-02,
+        +2.0008e-03, +1.0002e-04,
+        +9.6387e-01, +9.9512e-01,
+        +9.9951e-01, +1.0000e+00,
+        -1.0000e+00, -9.6387e-01,
+        -1.0002e-02, -1.0133e-06,
+        -0.0000e+00, +0.0000e+00,
+        -1.0000e+00, +1.0000e+00
+    };
+
+    const uniform count = sizeof(x) / sizeof(x[0]);
+    assert(count == sizeof(ref) / sizeof(ref[0]));
+
+    RET[programIndex] = 0;
+
+    foreach(i = 0...count)
+    {
+        const float16 res = tanh(x[i]);
+        RET[programIndex] += ok(res, ref[i]) ? 0 : 1;
+    }
 }
 
 task void result(uniform float RET[]) { RET[programIndex] = 0; }


### PR DESCRIPTION
This PR update the tests operating on uniform types for all recent PRs merged since they was not actually computing something useful. It should now properly compare the uniform version with the varying one. This fix is initiated from [this (AI) review post](https://github.com/ispc/ispc/pull/3796#discussion_r3111571112) (from PR #3476).

**UPDATE:**

The PR also fix all tests to make them independent. Having the `float16` tests not dependent of the `float` one certainly fix the CI issues. Indeed, some values where converted to infinities due to overflow during `float16` casts. The thing is the fast-math version is not guaranteed to return a stable result in such a case and the `ok` function may results in internal NaN in pathological cases (which is an issue per se only if aggressive fast-math flags are enabled -- otherwise the function should just return `false` even though both results are `inf`). Thus, I fixed that so there is no overflows in input/output values. I also recomputed the `float` and `double` so the results should now be ULP-perfect and better formatted. All the tests have now the same structure (a bit easier to maintained although there are a lot of independent test files).