### PR TITLE
Revert "CI: use unofficial location for weights for lc0"

### DIFF
--- a/.github/workflows/openmoonray.yml
+++ b/.github/workflows/openmoonray.yml
@@ -86,6 +86,9 @@ jobs:
         su - builder -c "
           git clone --branch openmoonray --single-branch https://github.com/archlinux/aur.git openmoonray
           cd openmoonray
+          # Pin to v2.40.0.1 due to build failure in v3.6.0.1
+          # See: https://github.com/OpenMoonRay/openmoonray/issues/230
+          git checkout 259a4ecd
 
           # Remove ispc dependency since we have fresh build
           sed -i '/ispc/d' PKGBUILD

--- a/.github/workflows/opensource-projects.yml
+++ b/.github/workflows/opensource-projects.yml
@@ -143,26 +143,13 @@ jobs:
       matrix:
         project:
           - name: Leela Chess lc0
-            extra_packages: gtest wget
+            extra_packages: gtest
             build_cmd: |
-              su - builder -c '
+              su - builder -c "
                 git clone --branch lc0 --single-branch https://github.com/archlinux/aur.git lc0
                 cd lc0
-                # Temporary fix to use unofficial download location for weights
-                export SRCDEST=$HOME/pkg_src
-
-                # Make the directory if needed
-                mkdir -p "$SRCDEST"
-
-                # Download the weights file to SRCDEST if not present
-                # Filename must match _weights variable in PKGBUILD (weights_hanse-69722-vf2.gz)
-                weights="weights_hanse-69722-vf2.gz"
-                url="https://derr.pro/lc0/hanse-69722-vf2.gz"
-                if [ ! -f "$SRCDEST/$weights" ]; then
-                  wget -O "$SRCDEST/$weights" "$url"
-                fi
                 makepkg -s --noconfirm
-              '
+              "
 
           # Open3D disabled because open-source default runners don't have enough disk space
           # - name: Open3D


### PR DESCRIPTION
**Build reliability improvements:**
* In `.github/workflows/openmoonray.yml`, the build now explicitly checks out a specific commit (`259a4ecd`) for the `openmoonray` project to avoid a known build failure in a newer version. A comment and issue reference are included for context.

**Build process simplification:**
* In `.github/workflows/opensource-projects.yml`, the `Leela Chess lc0` build process is simplified by removing the manual download and management of the weights file. The `wget` package is also removed from the list of extra packages, as it is no longer needed.This reverts commit 6b059294cff026e4d56d9fc7cfb31b184949c0e4.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed