### PR TITLE
Fix #3782: Migrate compiler frontend emission to poison

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -1483,7 +1483,7 @@ llvm::Value *FunctionEmitContext::I1VecToBoolVec(llvm::Value *b) {
         // BoolVectorStorageType is to be used only for entites that can be
         // interfaced with C/C++.
         llvm::Type *boolArrayType = llvm::ArrayType::get(LLVMTypes::BoolVectorType, at->getNumElements());
-        llvm::Value *ret = llvm::UndefValue::get(boolArrayType);
+        llvm::Value *ret = llvm::PoisonValue::get(boolArrayType);
 
         for (unsigned int i = 0; i < at->getNumElements(); ++i) {
             llvm::Value *elt = ExtractInst(b, i);
@@ -1814,7 +1814,7 @@ llvm::Value *FunctionEmitContext::BinaryOperator(llvm::Instruction::BinaryOps in
         // If this is an ispc VectorType, apply the binary operator to each
         // of the elements of the array (which in turn should be either
         // scalar types or llvm::VectorTypes.)
-        llvm::Value *ret = llvm::UndefValue::get(type);
+        llvm::Value *ret = llvm::PoisonValue::get(type);
         for (int i = 0; i < arraySize; ++i) {
             llvm::Value *a = ExtractInst(v0, i);
             llvm::Value *b = ExtractInst(v1, i);
@@ -1841,7 +1841,7 @@ llvm::Value *FunctionEmitContext::NotOperator(llvm::Value *v, const llvm::Twine 
         AddDebugPos(binst);
         return binst;
     } else {
-        llvm::Value *ret = llvm::UndefValue::get(type);
+        llvm::Value *ret = llvm::PoisonValue::get(type);
         for (int i = 0; i < arraySize; ++i) {
             llvm::Value *a = ExtractInst(v, i);
             llvm::Value *op = llvm::BinaryOperator::CreateNot(a, name.isTriviallyEmpty() ? "not" : name, bblock);
@@ -1880,7 +1880,7 @@ llvm::Value *FunctionEmitContext::FNegInst(llvm::Value *v, const llvm::Twine &na
         AddDebugPos(fneg);
         return fneg;
     } else {
-        llvm::Value *ret = llvm::UndefValue::get(type);
+        llvm::Value *ret = llvm::PoisonValue::get(type);
         for (int i = 0; i < arraySize; ++i) {
             llvm::Value *a = ExtractInst(v, i);
             llvm::Value *op = llvm::UnaryOperator::CreateFNeg(a, name.isTriviallyEmpty() ? "fneg" : name, bblock);
@@ -1923,7 +1923,7 @@ llvm::Value *FunctionEmitContext::CmpInst(llvm::Instruction::OtherOps inst, llvm
         return ci;
     } else {
         llvm::Type *boolType = lGetMatchingBoolVectorType(type);
-        llvm::Value *ret = llvm::UndefValue::get(boolType);
+        llvm::Value *ret = llvm::PoisonValue::get(boolType);
         for (int i = 0; i < arraySize; ++i) {
             llvm::Value *a = ExtractInst(v0, i);
             llvm::Value *b = ExtractInst(v1, i);
@@ -2281,7 +2281,7 @@ llvm::Value *FunctionEmitContext::MakeSlicePointer(llvm::Value *ptr, llvm::Value
     eltTypes.push_back(offset->getType());
     llvm::StructType *st = llvm::StructType::get(*g->ctx, eltTypes);
 
-    llvm::Value *ret = llvm::UndefValue::get(st);
+    llvm::Value *ret = llvm::PoisonValue::get(st);
     ret = InsertInst(ret, ptr, 0, llvm::Twine(ret->getName()) + "_slice_ptr");
     ret = InsertInst(ret, offset, 1, llvm::Twine(ret->getName()) + "_slice_offset");
     return ret;
@@ -2608,7 +2608,7 @@ llvm::Value *FunctionEmitContext::lSwitchBoolSize_1(llvm::Value *value, llvm::Ty
     if (at) {
         // We're given an array of vectors (short vector).
         llvm::Type *eltType = at->getElementType();
-        llvm::Value *ret = llvm::UndefValue::get(toType);
+        llvm::Value *ret = llvm::PoisonValue::get(toType);
         for (unsigned int i = 0; i < at->getNumElements(); ++i) {
             llvm::Value *elt = ExtractInst(value, i);
             llvm::Value *x = lSwitchBoolSize_2(elt, eltType, toStorageType, llvm::Twine(elt->getName()) + "_bv");
@@ -2711,7 +2711,7 @@ llvm::Value *FunctionEmitContext::loadUniformFromSOA(llvm::Value *ptr, llvm::Val
         // individual element loads to fill in the result structure since
         // the SOA slice of values we need isn't contiguous in memory...
         llvm::Type *llvmReturnType = unifType->LLVMType(g->ctx);
-        llvm::Value *retValue = llvm::UndefValue::get(llvmReturnType);
+        llvm::Value *retValue = llvm::PoisonValue::get(llvmReturnType);
 
         for (int i = 0; i < ct->GetElementCount(); ++i) {
             const PointerType *eltPtrType = nullptr;
@@ -2831,7 +2831,7 @@ llvm::Value *FunctionEmitContext::gather(llvm::Value *ptr, const PointerType *pt
     if (collectionType != nullptr) {
         // For collections, recursively gather element wise to find the
         // result.
-        llvm::Value *retValue = llvm::UndefValue::get(llvmReturnType);
+        llvm::Value *retValue = llvm::PoisonValue::get(llvmReturnType);
 
         const CollectionType *returnCollectionType = CastType<CollectionType>(returnType->GetBaseType());
 
@@ -3571,22 +3571,22 @@ llvm::Value *FunctionEmitContext::BroadcastValue(llvm::Value *v, llvm::Type *vec
     Assert(ty && ty->getElementType() == v->getType());
 
     // Generate the following sequence:
-    //   %name_init.i = insertelement <4 x i32> undef, i32 %val, i32 0
-    //   %name.i = shufflevector <4 x i32> %name_init.i, <4 x i32> undef,
+    //   %name_init.i = insertelement <4 x i32> poison, i32 %val, i32 0
+    //   %name.i = shufflevector <4 x i32> %name_init.i, <4 x i32> poison,
     //                                              <4 x i32> zeroinitializer
 
-    llvm::Value *undef1 = llvm::UndefValue::get(vecType);
-    llvm::Value *undef2 = llvm::UndefValue::get(vecType);
+    llvm::Value *poison1 = llvm::PoisonValue::get(vecType);
+    llvm::Value *poison2 = llvm::PoisonValue::get(vecType);
 
     // InsertElement
-    llvm::Value *insert =
-        InsertInst(undef1, v, 0, name.isTriviallyEmpty() ? (llvm::Twine(v->getName()) + "_broadcast") : name + "_init");
+    llvm::Value *insert = InsertInst(
+        poison1, v, 0, name.isTriviallyEmpty() ? (llvm::Twine(v->getName()) + "_broadcast") : name + "_init");
 
     // ShuffleVector
     llvm::Constant *zeroVec =
         llvm::ConstantVector::getSplat(llvm::ElementCount::get(static_cast<unsigned int>(ty->getNumElements()), false),
                                        llvm::Constant::getNullValue(llvm::Type::getInt32Ty(*g->ctx)));
-    llvm::Value *ret = ShuffleInst(insert, undef2, zeroVec,
+    llvm::Value *ret = ShuffleInst(insert, poison2, zeroVec,
                                    name.isTriviallyEmpty() ? (llvm::Twine(v->getName()) + "_broadcast") : name);
 
     return ret;

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -899,16 +899,16 @@ void ispc::InitSymbol(AddressInfo *ptrInfo, const Type *symType, Expr *initExpr,
                     // 3. shuffle it with resulting vector
                     // For example:
                     // uniform double<4> d = {f.x, d.x, f.y, d.y};
-                    // vResVal1 = <4 x float> <f.x, undef, f.y, undef>
-                    // vResVal1_conv = fpext <4 x float> <f.x, undef, f.y, undef> to <4 x double>
-                    // vResVal2 = <4 x double> <undef, d.x, undef, d.y>
-                    // initListVector = shufflevector %vResVal1_conv, <4 x double> %undef, <4 x i32> <i32 0, i32 5, i32
+                    // vResVal1 = <4 x float> <f.x, poison, f.y, poison>
+                    // vResVal1_conv = fpext <4 x float> <f.x, poison, f.y, poison> to <4 x double>
+                    // vResVal2 = <4 x double> <poison, d.x, poison, d.y>
+                    // initListVector = shufflevector %vResVal1_conv, <4 x double> %poison, <4 x i32> <i32 0, i32 5, i32
                     // 3, i32 7>
                     // initListVector = shufflevector %vResVal2, <4 x double> %initListVector, <4 x i32> <i32 4, i32 1,
                     // i32 6, i32 3>
 
                     // Our final vector which will be used for initialization
-                    llvm::Value *initListVector = llvm::UndefValue::get(symVectorType->LLVMType(g->ctx));
+                    llvm::Value *initListVector = llvm::PoisonValue::get(symVectorType->LLVMType(g->ctx));
                     for (const auto &[type, expr_map] : exprPerType) {
                         // There is no good way to construct AtomicType from AtomicType::BasicType,
                         // just use the first one
@@ -922,7 +922,7 @@ void ispc::InitSymbol(AddressInfo *ptrInfo, const Type *symType, Expr *initExpr,
                             // Construct ISPC vector type for resulting "initializer" vector for this type
                             const VectorType *vResType = new VectorType(aType, nVectorElements);
                             // Resulting LLVM vector for this type
-                            llvm::Value *initListVectorPerType = llvm::UndefValue::get(vResType->LLVMType(g->ctx));
+                            llvm::Value *initListVectorPerType = llvm::PoisonValue::get(vResType->LLVMType(g->ctx));
                             // Create a linear vector that will be used as a shuffle mask for
                             // shufflevector with initListVector.
                             std::vector<uint32_t> linearVector(nVectorElements);
@@ -2161,7 +2161,7 @@ llvm::Value *lEmitLogicalOp(BinaryExpr::Op op, Expr *arg0, Expr *arg1, FunctionE
 
             // We need to compute the result carefully, since vector
             // elements that were computed when the corresponding lane was
-            // disabled have undefined values:
+            // disabled have undefined or poison values:
             // result = (value0 & old_mask) | (value1 & current_mask)
             llvm::Value *value1AndMask = ctx->BinaryAndOperator(value1, ctx->GetInternalMask(), "op&mask");
             llvm::Value *result = ctx->BinaryOrOperator(value0AndMask, value1AndMask, "or_result");
@@ -3873,7 +3873,7 @@ llvm::Value *SelectExpr::GetValue(FunctionEmitContext *ctx) const {
                            (CastType<VectorType>(testType)->GetElementCount() == vt->GetElementCount()));
 
         // Do an element-wise select
-        llvm::Value *result = llvm::UndefValue::get(type->LLVMType(g->ctx));
+        llvm::Value *result = llvm::PoisonValue::get(type->LLVMType(g->ctx));
         for (int i = 0; i < vt->GetElementCount(); ++i) {
             llvm::Value *ti = ctx->ExtractInst(testVal, i);
             llvm::Value *e1i = ctx->ExtractInst(expr1Val, i);
@@ -4783,7 +4783,7 @@ static std::pair<llvm::Constant *, bool> lGetExprListConstant(const Type *type, 
             int vectorWidth = g->target->getVectorWidth();
 
             while ((cv.size() % vectorWidth) != 0) {
-                cv.push_back(llvm::UndefValue::get(lvt->getElementType()));
+                cv.push_back(llvm::PoisonValue::get(lvt->getElementType()));
             }
 
             return std::pair<llvm::Constant *, bool>(llvm::ConstantVector::get(cv), isNotValidForMultiTargetGlobal);
@@ -4796,12 +4796,12 @@ static std::pair<llvm::Constant *, bool> lGetExprListConstant(const Type *type, 
 
             // Uniform short vectors are stored as vectors of length
             // rounded up to a power of 2 bits in size but not less then 128 bit.
-            // So we add additional undef values here until we get the right size.
+            // So we add additional poison values here until we get the right size.
             const VectorType *vt = CastType<VectorType>(type);
             int vectorWidth = vt->getVectorMemoryCount();
 
             while ((cv.size() % vectorWidth) != 0) {
-                cv.push_back(llvm::UndefValue::get(lvt->getElementType()));
+                cv.push_back(llvm::PoisonValue::get(lvt->getElementType()));
             }
 
             return std::pair<llvm::Constant *, bool>(llvm::ConstantVector::get(cv), isNotValidForMultiTargetGlobal);
@@ -7635,7 +7635,7 @@ static llvm::Value *lUniformValueToVarying(FunctionEmitContext *ctx, llvm::Value
     const CollectionType *collectionType = CastType<CollectionType>(type);
     if (collectionType != nullptr) {
         llvm::Type *llvmType = type->GetAsVaryingType()->LLVMStorageType(g->ctx);
-        llvm::Value *retValue = llvm::UndefValue::get(llvmType);
+        llvm::Value *retValue = llvm::PoisonValue::get(llvmType);
 
         const StructType *structType = CastType<StructType>(type->GetAsVaryingType());
 
@@ -7945,7 +7945,7 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
         } else {
             // Emit instructions to do type conversion of each of the elements
             // of the vector.
-            llvm::Value *cast = llvm::UndefValue::get(toType->LLVMType(g->ctx));
+            llvm::Value *cast = llvm::PoisonValue::get(toType->LLVMType(g->ctx));
             for (int i = 0; i < toVector->GetElementCount(); ++i) {
                 llvm::Value *ei = ctx->ExtractInst(exprVal, i);
                 llvm::Value *conv = lTypeConvAtomicOrUniformVector(ctx, ei, toVector->GetElementType(),
@@ -7998,7 +7998,7 @@ llvm::Value *TypeCastExpr::GetValue(FunctionEmitContext *ctx) const {
             cast = ctx->BroadcastValue(conv, toTypeLLVM);
         } else if (llvm::isa<llvm::ArrayType>(toTypeLLVM)) {
             // Example varying float => varying float<3>
-            cast = llvm::UndefValue::get(toType->LLVMType(g->ctx));
+            cast = llvm::PoisonValue::get(toType->LLVMType(g->ctx));
             for (int i = 0; i < toVector->GetElementCount(); ++i) {
                 if ((toVector->GetElementType()->IsBoolType()) &&
                     (CastType<AtomicType>(toVector->GetElementType()) != nullptr)) {

--- a/tests/lit-tests/2272.ispc
+++ b/tests/lit-tests/2272.ispc
@@ -1,7 +1,7 @@
 // RUN: %{ispc} --target=host --nowrap --nostdlib --debug-phase=first:first --emit-llvm-text %s -o - | FileCheck %s
 
 // CHECK: [[TYPE:%.*]] = type { <[[WIDTH:[0-9]+]] x i8> }
-// CHECK: [[VAL:%.*]] = insertvalue [[TYPE]] undef, <[[WIDTH]] x i8> [[BUF:%.*]], 0
+// CHECK: [[VAL:%.*]] = insertvalue [[TYPE]] poison, <[[WIDTH]] x i8> [[BUF:%.*]], 0
 
 struct Test { bool b; };
 export void main_kernel(uniform const Test *uniform buffer) {

--- a/tests/lit-tests/3782.ispc
+++ b/tests/lit-tests/3782.ispc
@@ -1,0 +1,35 @@
+// Verify that frontend emission uses poison (not undef) for intermediate
+// vectors/aggregates that are immediately filled element-wise.
+// See https://github.com/ispc/ispc/issues/3782
+
+// RUN: %{ispc} %s --target=host --nowrap --nostdlib --debug-phase=first:first --emit-llvm-text -o - | FileCheck %s
+
+// BroadcastValue: insertelement + shufflevector with poison base
+// CHECK-LABEL: @broadcast_test
+// CHECK: insertelement <[[WIDTH:[0-9]+]] x i32> poison, i32 %{{.*}}, i32 0
+// CHECK-NEXT: shufflevector <[[WIDTH]] x i32> %{{.*}}, <[[WIDTH]] x i32> poison, <[[WIDTH]] x i32> zeroinitializer
+void broadcast_test(uniform int val, varying int *uniform out) {
+    *out = val;
+}
+
+// BinaryOperator array path: insertvalue with poison base
+// CHECK-LABEL: @binop_sv
+// CHECK: insertvalue [3 x <{{[0-9]+}} x i32>] poison, <{{[0-9]+}} x i32> %{{.*}}, 0
+void binop_sv(varying int<3> a, varying int<3> b, varying int<3> *uniform out) {
+    *out = a + b;
+}
+
+// CmpInst array path + bool lowering: both use poison base
+// CHECK-LABEL: @cmp_sv
+// CHECK: insertvalue [3 x <[[WIDTH3:[0-9]+]] x i1>] poison, <[[WIDTH3]] x i1> %{{.*}}, 0
+// CHECK: insertvalue [3 x <[[WIDTH3]] x i[[BOOLBITS:(1|32)]]>] poison, <[[WIDTH3]] x i[[BOOLBITS]]> %{{.*}}, 0
+void cmp_sv(varying int<3> a, varying int<3> b, varying bool<3> *uniform out) {
+    *out = a > b;
+}
+
+// NotOperator array path: insertvalue with poison base
+// CHECK-LABEL: @not_sv
+// CHECK: insertvalue [3 x <{{[0-9]+}} x i32>] poison, <{{[0-9]+}} x i32> %{{.*}}, 0
+void not_sv(varying int<3> a, varying int<3> *uniform out) {
+    *out = ~a;
+}


### PR DESCRIPTION
## Description
Replace UndefValue::get with PoisonValue::get in FunctionEmitContext methods and expression codegen where intermediate result vectors are initialized before being filled element-wise. 

Update the 2272.ispc lit test to use {{undef|poison}} to remain compatible across LLVM versions.

## Related Issue
https://github.com/ispc/ispc/issues/3782

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)