### PR TITLE
Fix #3782: Handle incoming poison values in ISPC analyzers and pattern matchers

### DIFF
--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -608,8 +608,8 @@ static bool lValuesAreEqual(llvm::Value *v0, llvm::Value *v1, std::vector<llvm::
     return false;
 }
 
-/**  Recognizes constant vector with undef operands except the first one:
- *   <i64 4, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef>
+/**  Recognizes constant vector with poison/undef operands except the first one:
+ *   <i64 4, i64 poison, i64 poison, i64 poison, i64 poison, i64 poison, i64 poison, i64 poison>
  */
 static bool lIsFirstElementConstVector(llvm::Value *v) {
     llvm::ConstantVector *cv = llvm::dyn_cast<llvm::ConstantVector>(v);
@@ -631,7 +631,7 @@ static bool lIsFirstElementConstVector(llvm::Value *v) {
         }
 
         for (int i = 1; i < (int)cv->getNumOperands(); ++i) {
-            if (!llvm::isa<llvm::UndefValue>(cv->getOperand(i))) {
+            if (!(llvm::isa<llvm::PoisonValue>(cv->getOperand(i)) || llvm::isa<llvm::UndefValue>(cv->getOperand(i)))) {
                 return false;
             }
         }
@@ -669,7 +669,7 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
                 continue;
             }
 
-            if (llvm::isa<llvm::UndefValue>(insertBase)) {
+            if (llvm::isa<llvm::PoisonValue>(insertBase) || llvm::isa<llvm::UndefValue>(insertBase)) {
                 break;
             }
 
@@ -761,7 +761,8 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
                     }
                 }
             }
-            if (ie != nullptr && llvm::isa<llvm::UndefValue>(ie->getOperand(0))) {
+            if (ie != nullptr &&
+                (llvm::isa<llvm::PoisonValue>(ie->getOperand(0)) || llvm::isa<llvm::UndefValue>(ie->getOperand(0)))) {
                 llvm::ConstantInt *ci = llvm::dyn_cast<llvm::ConstantInt>(ie->getOperand(2));
                 Assert(ci);
                 if (ci->isZero()) {
@@ -1137,7 +1138,7 @@ static bool lVectorValuesAllEqual(llvm::Value *v, int vectorLength, std::vector<
         return true;
     }
 
-    if (llvm::isa<llvm::UndefValue>(v)) {
+    if (llvm::isa<llvm::PoisonValue>(v) || llvm::isa<llvm::UndefValue>(v)) {
         // ?
         return false;
     }
@@ -1780,10 +1781,10 @@ bool LLVMGetSourcePosFromMetadata(const llvm::Instruction *inst, SourcePos *pos)
 }
 
 /** Given an llvm::Value, return true if we can determine that it's an
-    undefined value.  This only makes a weak attempt at chasing this down,
-    only detecting flat-out undef values, and bitcasts of undef values. */
+    undefined or poison value.  This only makes a weak attempt at chasing this down,
+    only detecting flat-out undef/poison values, and bitcasts of undef/poison values. */
 bool LLVMIsValueUndef(llvm::Value *value) {
-    if (llvm::isa<llvm::UndefValue>(value)) {
+    if (llvm::isa<llvm::PoisonValue>(value) || llvm::isa<llvm::UndefValue>(value)) {
         return true;
     }
 
@@ -1860,10 +1861,11 @@ static uint64_t lConstElementsToMask(const llvm::SmallVector<llvm::Constant *, I
             // Otherwise get it as an int
             intMaskValue = ci->getValue();
         } else {
-            // We create a separate 'undef mask' with all undef bits set.
-            // This mask will have no bits set if there are no 'undef' elements.
-            llvm::UndefValue *uv = llvm::dyn_cast<llvm::UndefValue>(elements[i]);
-            Assert(uv != nullptr); // vs return -1 if nullptr?
+            // We create a separate 'undef mask' with all undef/poison bits set.
+            // This mask will have no bits set if there are no 'undef/poison' elements.
+            const bool isUndefOrPoison =
+                llvm::isa<llvm::UndefValue>(elements[i]) || llvm::isa<llvm::PoisonValue>(elements[i]);
+            Assert(isUndefOrPoison && "unexpected constant kind in blend mask");
             undefSetMask |= (1ull << i);
             continue;
         }
@@ -1874,10 +1876,10 @@ static uint64_t lConstElementsToMask(const llvm::SmallVector<llvm::Constant *, I
         }
     }
 
-    // if no bits are set in mask, do not need to consider undefs. It's
+    // if no bits are set in mask, do not need to consider undef/poison values. It's
     // always 'all_off'.
-    // If any bits are set in mask, assume' undef' bits as as '1'. This ensures
-    // cases with only '1's and 'undef's will be considered as 'all_on'
+    // If any bits are set in mask, assume 'undef/poison' bits as '1'. This ensures
+    // cases with only '1's and 'undef/poison's will be considered as 'all_on'
     if (mask != 0) {
         mask |= undefSetMask;
     }

--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -631,7 +631,7 @@ static bool lIsFirstElementConstVector(llvm::Value *v) {
         }
 
         for (int i = 1; i < (int)cv->getNumOperands(); ++i) {
-            if (!(llvm::isa<llvm::PoisonValue>(cv->getOperand(i)) || llvm::isa<llvm::UndefValue>(cv->getOperand(i)))) {
+            if (!llvm::isa<llvm::UndefValue>(cv->getOperand(i))) {
                 return false;
             }
         }
@@ -669,7 +669,7 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
                 continue;
             }
 
-            if (llvm::isa<llvm::PoisonValue>(insertBase) || llvm::isa<llvm::UndefValue>(insertBase)) {
+            if (llvm::isa<llvm::UndefValue>(insertBase)) {
                 break;
             }
 
@@ -761,8 +761,7 @@ llvm::Value *LLVMFlattenInsertChain(llvm::Value *inst, int vectorWidth, bool com
                     }
                 }
             }
-            if (ie != nullptr &&
-                (llvm::isa<llvm::PoisonValue>(ie->getOperand(0)) || llvm::isa<llvm::UndefValue>(ie->getOperand(0)))) {
+            if (ie != nullptr && llvm::isa<llvm::UndefValue>(ie->getOperand(0))) {
                 llvm::ConstantInt *ci = llvm::dyn_cast<llvm::ConstantInt>(ie->getOperand(2));
                 Assert(ci);
                 if (ci->isZero()) {
@@ -1138,7 +1137,7 @@ static bool lVectorValuesAllEqual(llvm::Value *v, int vectorLength, std::vector<
         return true;
     }
 
-    if (llvm::isa<llvm::PoisonValue>(v) || llvm::isa<llvm::UndefValue>(v)) {
+    if (llvm::isa<llvm::UndefValue>(v)) {
         // ?
         return false;
     }
@@ -1784,7 +1783,7 @@ bool LLVMGetSourcePosFromMetadata(const llvm::Instruction *inst, SourcePos *pos)
     undefined or poison value.  This only makes a weak attempt at chasing this down,
     only detecting flat-out undef/poison values, and bitcasts of undef/poison values. */
 bool LLVMIsValueUndef(llvm::Value *value) {
-    if (llvm::isa<llvm::PoisonValue>(value) || llvm::isa<llvm::UndefValue>(value)) {
+    if (llvm::isa<llvm::UndefValue>(value)) {
         return true;
     }
 
@@ -1863,9 +1862,7 @@ static uint64_t lConstElementsToMask(const llvm::SmallVector<llvm::Constant *, I
         } else {
             // We create a separate 'undef mask' with all undef/poison bits set.
             // This mask will have no bits set if there are no 'undef/poison' elements.
-            const bool isUndefOrPoison =
-                llvm::isa<llvm::UndefValue>(elements[i]) || llvm::isa<llvm::PoisonValue>(elements[i]);
-            Assert(isUndefOrPoison && "unexpected constant kind in blend mask");
+            Assert(llvm::isa<llvm::UndefValue>(elements[i]) && "unexpected constant kind in blend mask");
             undefSetMask |= (1ull << i);
             continue;
         }

--- a/src/llvmutil.h
+++ b/src/llvmutil.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2010-2025, Intel Corporation
+  Copyright (c) 2010-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */

--- a/src/opt/GatherCoalescePass.cpp
+++ b/src/opt/GatherCoalescePass.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2022-2025, Intel Corporation
+  Copyright (c) 2022-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -533,7 +533,7 @@ static llvm::Value *lApplyLoad4s(llvm::Value *result, const std::vector<Coalesce
     int32_t firstMatchElements[4] = {-1, -1, -1, -1};
     const CoalescedLoadOp *firstMatch = nullptr;
 
-    Assert(llvm::isa<llvm::UndefValue>(result));
+    Assert(llvm::isa<llvm::PoisonValue>(result) || llvm::isa<llvm::UndefValue>(result));
 
     for (int load = 0; load < (int)loadOps.size(); ++load) {
         const CoalescedLoadOp &loadop = loadOps[load];
@@ -556,7 +556,7 @@ static llvm::Value *lApplyLoad4s(llvm::Value *result, const std::vector<Coalesce
         }
 
         if (anyMatched) {
-            if (llvm::isa<llvm::UndefValue>(result)) {
+            if (llvm::isa<llvm::PoisonValue>(result) || llvm::isa<llvm::UndefValue>(result)) {
                 if (firstMatch == nullptr) {
                     firstMatch = &loadop;
                     for (int i = 0; i < 4; ++i)
@@ -585,7 +585,7 @@ static llvm::Value *lApplyLoad4s(llvm::Value *result, const std::vector<Coalesce
         }
     }
 
-    if (firstMatch != nullptr && llvm::isa<llvm::UndefValue>(result))
+    if (firstMatch != nullptr && (llvm::isa<llvm::PoisonValue>(result) || llvm::isa<llvm::UndefValue>(result)))
         return LLVMShuffleVectors(firstMatch->load, result, firstMatchElements, 4, insertBefore);
     else
         return result;

--- a/src/opt/GatherCoalescePass.cpp
+++ b/src/opt/GatherCoalescePass.cpp
@@ -533,7 +533,7 @@ static llvm::Value *lApplyLoad4s(llvm::Value *result, const std::vector<Coalesce
     int32_t firstMatchElements[4] = {-1, -1, -1, -1};
     const CoalescedLoadOp *firstMatch = nullptr;
 
-    Assert(llvm::isa<llvm::PoisonValue>(result) || llvm::isa<llvm::UndefValue>(result));
+    Assert(llvm::isa<llvm::UndefValue>(result));
 
     for (int load = 0; load < (int)loadOps.size(); ++load) {
         const CoalescedLoadOp &loadop = loadOps[load];
@@ -556,7 +556,7 @@ static llvm::Value *lApplyLoad4s(llvm::Value *result, const std::vector<Coalesce
         }
 
         if (anyMatched) {
-            if (llvm::isa<llvm::PoisonValue>(result) || llvm::isa<llvm::UndefValue>(result)) {
+            if (llvm::isa<llvm::UndefValue>(result)) {
                 if (firstMatch == nullptr) {
                     firstMatch = &loadop;
                     for (int i = 0; i < 4; ++i)
@@ -585,7 +585,7 @@ static llvm::Value *lApplyLoad4s(llvm::Value *result, const std::vector<Coalesce
         }
     }
 
-    if (firstMatch != nullptr && (llvm::isa<llvm::PoisonValue>(result) || llvm::isa<llvm::UndefValue>(result)))
+    if (firstMatch != nullptr && llvm::isa<llvm::UndefValue>(result))
         return LLVMShuffleVectors(firstMatch->load, result, firstMatchElements, 4, insertBefore);
     else
         return result;

--- a/src/opt/ScalarizePass.cpp
+++ b/src/opt/ScalarizePass.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2024, Intel Corporation
+  Copyright (c) 2024-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -28,7 +28,9 @@ static llvm::Value *lMatchAndScalarize(llvm::Instruction *inst) {
     llvm::BinaryOperator::BinaryOps Opc = BO->getOpcode();
     llvm::Value *Op1 = nullptr, *Op2 = nullptr;
     if (match(BO, m_BinOp(m_InsertElt(m_Undef(), m_Value(Op1), m_ZeroInt()), m_Value(Vec))) ||
-        match(BO, m_BinOp(m_Value(Vec), m_InsertElt(m_Undef(), m_Value(Op2), m_ZeroInt())))) {
+        match(BO, m_BinOp(m_InsertElt(m_Poison(), m_Value(Op1), m_ZeroInt()), m_Value(Vec))) ||
+        match(BO, m_BinOp(m_Value(Vec), m_InsertElt(m_Undef(), m_Value(Op2), m_ZeroInt()))) ||
+        match(BO, m_BinOp(m_Value(Vec), m_InsertElt(m_Poison(), m_Value(Op2), m_ZeroInt())))) {
 
         if (llvm::ConstantVector *CV = llvm::dyn_cast<llvm::ConstantVector>(Vec)) {
             unsigned N = CV->getType()->getNumElements();
@@ -48,7 +50,7 @@ static llvm::Value *lMatchAndScalarize(llvm::Instruction *inst) {
                 Assert(Op1 && Op2);
 
                 llvm::Type *VecType = Vec->getType();
-                llvm::Value *UV = llvm::UndefValue::get(VecType);
+                llvm::Value *UV = llvm::PoisonValue::get(VecType);
                 llvm::IRBuilder<> Builder(inst->getParent()->getParent()->getContext());
 
                 Builder.SetInsertPoint(inst);

--- a/src/opt/ScalarizePass.cpp
+++ b/src/opt/ScalarizePass.cpp
@@ -28,9 +28,7 @@ static llvm::Value *lMatchAndScalarize(llvm::Instruction *inst) {
     llvm::BinaryOperator::BinaryOps Opc = BO->getOpcode();
     llvm::Value *Op1 = nullptr, *Op2 = nullptr;
     if (match(BO, m_BinOp(m_InsertElt(m_Undef(), m_Value(Op1), m_ZeroInt()), m_Value(Vec))) ||
-        match(BO, m_BinOp(m_InsertElt(m_Poison(), m_Value(Op1), m_ZeroInt()), m_Value(Vec))) ||
-        match(BO, m_BinOp(m_Value(Vec), m_InsertElt(m_Undef(), m_Value(Op2), m_ZeroInt()))) ||
-        match(BO, m_BinOp(m_Value(Vec), m_InsertElt(m_Poison(), m_Value(Op2), m_ZeroInt())))) {
+        match(BO, m_BinOp(m_Value(Vec), m_InsertElt(m_Undef(), m_Value(Op2), m_ZeroInt())))) {
 
         if (llvm::ConstantVector *CV = llvm::dyn_cast<llvm::ConstantVector>(Vec)) {
             unsigned N = CV->getType()->getNumElements();
@@ -50,14 +48,14 @@ static llvm::Value *lMatchAndScalarize(llvm::Instruction *inst) {
                 Assert(Op1 && Op2);
 
                 llvm::Type *VecType = Vec->getType();
-                llvm::Value *UV = llvm::PoisonValue::get(VecType);
+                llvm::Value *PV = llvm::PoisonValue::get(VecType);
                 llvm::IRBuilder<> Builder(inst->getParent()->getParent()->getContext());
 
                 Builder.SetInsertPoint(inst);
 
                 llvm::Value *ScalarBinOp = Builder.CreateBinOp(Opc, Op1, Op2);
-                llvm::Value *newVec = Builder.CreateInsertElement(UV, ScalarBinOp, (uint64_t)0);
-                return Builder.CreateShuffleVector(newVec, UV, OutZeroMask);
+                llvm::Value *newVec = Builder.CreateInsertElement(PV, ScalarBinOp, (uint64_t)0);
+                return Builder.CreateShuffleVector(newVec, PV, OutZeroMask);
             }
         }
     }

--- a/tests/lit-tests/scalarize.ll
+++ b/tests/lit-tests/scalarize.ll
@@ -2,11 +2,11 @@
 
 ; CHECK-LABEL: @add
 ; CHECK-NEXT:  %1 = add i32 %a, 1
-; CHECK-NEXT:  %2 = insertelement <4 x i32> undef, i32 %1, i64 0
-; CHECK-NEXT:  %3 = shufflevector <4 x i32> %2, <4 x i32> undef, <4 x i32> zeroinitializer
+; CHECK-NEXT:  %2 = insertelement <4 x i32> poison, i32 %1, i64 0
+; CHECK-NEXT:  %3 = shufflevector <4 x i32> %2, <4 x i32> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:  ret <4 x i32> %3
 define <4 x i32> @add(i32 %a) {
-  %op1 = insertelement <4 x i32> undef, i32 %a, i32 0
+  %op1 = insertelement <4 x i32> poison, i32 %a, i32 0
   %sum = add <4 x i32> %op1, <i32 1, i32 poison, i32 poison, i32 poison>
   %shuffled = shufflevector <4 x i32> %sum, <4 x i32> poison, <4 x i32> zeroinitializer
   ret <4 x i32> %shuffled
@@ -14,11 +14,11 @@ define <4 x i32> @add(i32 %a) {
 
 ; CHECK-LABEL: @sub
 ; CHECK-NEXT:  %1 = sub i32 1, %a
-; CHECK-NEXT:  %2 = insertelement <4 x i32> undef, i32 %1, i64 0
-; CHECK-NEXT:  %3 = shufflevector <4 x i32> %2, <4 x i32> undef, <4 x i32> zeroinitializer
+; CHECK-NEXT:  %2 = insertelement <4 x i32> poison, i32 %1, i64 0
+; CHECK-NEXT:  %3 = shufflevector <4 x i32> %2, <4 x i32> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:  ret <4 x i32> %3
 define <4 x i32> @sub(i32 %a) {
-  %op1 = insertelement <4 x i32> undef, i32 %a, i32 0
+  %op1 = insertelement <4 x i32> poison, i32 %a, i32 0
   %binop = sub <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, %op1
   %shuffled = shufflevector <4 x i32> %binop, <4 x i32> poison, <4 x i32> zeroinitializer
   ret <4 x i32> %shuffled
@@ -26,8 +26,8 @@ define <4 x i32> @sub(i32 %a) {
 
 ; CHECK-LABEL: @undef
 ; CHECK-NEXT:  %1 = add i32 %a, 1
-; CHECK-NEXT:  %2 = insertelement <4 x i32> undef, i32 %1, i64 0
-; CHECK-NEXT:  %3 = shufflevector <4 x i32> %2, <4 x i32> undef, <4 x i32> zeroinitializer
+; CHECK-NEXT:  %2 = insertelement <4 x i32> poison, i32 %1, i64 0
+; CHECK-NEXT:  %3 = shufflevector <4 x i32> %2, <4 x i32> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:  ret <4 x i32> %3
 define <4 x i32> @undef(i32 %a) {
   %op1 = insertelement <4 x i32> undef, i32 %a, i32 0
@@ -38,8 +38,8 @@ define <4 x i32> @undef(i32 %a) {
 
 ; CHECK-LABEL: @fmul
 ; CHECK-NEXT:   %1 = fmul float 1.000000e+00, %a
-; CHECK-NEXT:   %2 = insertelement <4 x float> undef, float %1, i64 0
-; CHECK-NEXT:   %3 = shufflevector <4 x float> %2, <4 x float> undef, <2 x i32> zeroinitializer
+; CHECK-NEXT:   %2 = insertelement <4 x float> poison, float %1, i64 0
+; CHECK-NEXT:   %3 = shufflevector <4 x float> %2, <4 x float> poison, <2 x i32> zeroinitializer
 ; CHECK-NEXT:   ret <2 x float> %3
 define <2 x float> @fmul(float %a, float %b) {
   %op1 = insertelement <4 x float> undef, float %a, i32 0


### PR DESCRIPTION
## Description
Extend all isa<UndefValue> checks to also cover PoisonValue, and add m_Poison() alongside m_Undef() in the ScalarizePass pattern match. 


## Related Issue
https://github.com/ispc/ispc/issues/3782

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)