### PR TITLE
Fix #3782: Migrate optimization pass emission to poison

### DIFF
--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -1701,7 +1701,7 @@ llvm::Value *LLVMShuffleVectors(llvm::Value *v1, llvm::Value *v2, int32_t shuf[]
     llvm::Constant *shufVec[ISPC_MAX_NVEC];
     for (int i = 0; i < shufSize; ++i) {
         if (shuf[i] == -1) {
-            shufVec[i] = llvm::UndefValue::get(LLVMTypes::Int32Type);
+            shufVec[i] = llvm::PoisonValue::get(LLVMTypes::Int32Type);
         } else {
             shufVec[i] = LLVMInt32(shuf[i]);
         }

--- a/src/opt/GatherCoalescePass.cpp
+++ b/src/opt/GatherCoalescePass.cpp
@@ -487,7 +487,7 @@ static llvm::Value *lApplyLoad4(llvm::Value *result, const CoalescedLoadOp &load
 static llvm::Value *lAssemble4Vector(const std::vector<CoalescedLoadOp> &loadOps, const int64_t offsets[4],
                                      llvm::Instruction *insertBefore) {
     llvm::Type *returnType = LLVMVECTOR::get(LLVMTypes::Int32Type, 4);
-    llvm::Value *result = llvm::UndefValue::get(returnType);
+    llvm::Value *result = llvm::PoisonValue::get(returnType);
 
     Debug(SourcePos(), "Starting search for loads [%" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 "].", offsets[0],
           offsets[1], offsets[2], offsets[3]);
@@ -616,7 +616,7 @@ static llvm::Value *lApplyLoad12s(llvm::Value *result, const std::vector<Coalesc
 static llvm::Value *lAssemble4Vector(const std::vector<CoalescedLoadOp> &loadOps, const int64_t offsets[4],
                                      llvm::Instruction *insertBefore) {
     llvm::Type *returnType = LLVMVECTOR::get(LLVMTypes::Int32Type, 4);
-    llvm::Value *result = llvm::UndefValue::get(returnType);
+    llvm::Value *result = llvm::PoisonValue::get(returnType);
 
     Debug(SourcePos(), "Starting search for loads [%" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 "].", offsets[0],
           offsets[1], offsets[2], offsets[3]);

--- a/src/opt/ImproveMemoryOps.cpp
+++ b/src/opt/ImproveMemoryOps.cpp
@@ -57,15 +57,15 @@ static llvm::Value *lCheckForActualPointer(llvm::Value *v) {
 /** Given a llvm::Value representing a varying pointer, this function
     checks to see if all of the elements of the vector have the same value
     (i.e. there's a common base pointer). If broadcast has been already detected
-    it checks that the first element of the vector is not undef. If one of the conditions
+    it checks that the first element of the vector is not undef/poison. If one of the conditions
     is true, it returns the common pointer value; otherwise it returns nullptr.
  */
 static llvm::Value *lGetBasePointer(llvm::Value *v, llvm::Instruction *insertBefore, bool broadcastDetected) {
     if (llvm::isa<llvm::InsertElementInst>(v) || llvm::isa<llvm::ShuffleVectorInst>(v)) {
         // If we have already detected broadcast we want to look for
-        // the vector with the first not-undef element
+        // the vector with the first not-undef/poison element
         llvm::Value *element = LLVMFlattenInsertChain(v, g->target->getVectorWidth(), true, false, broadcastDetected);
-        // TODO: it's probably ok to allow undefined elements and return
+        // TODO: it's probably ok to allow undefined or poison elements and return
         // the base pointer if all of the other elements have the same
         // value.
         if (element != nullptr) {
@@ -144,7 +144,7 @@ static llvm::Value *lGetBasePtrAndOffsets(llvm::Value *ptrs, llvm::Value **offse
     }
 
     bool broadcastDetected = false;
-    // Looking for %gep_offset = shufflevector <8 x i64> %0, <8 x i64> undef, <8 x i32> zeroinitializer
+    // Looking for %gep_offset = shufflevector <8 x i64> %0, <8 x i64> poison, <8 x i32> zeroinitializer
     llvm::ShuffleVectorInst *shuffle = llvm::dyn_cast<llvm::ShuffleVectorInst>(ptrs);
     if (shuffle != nullptr) {
         llvm::Value *indices = shuffle->getShuffleMaskForBitcode();
@@ -170,7 +170,7 @@ static llvm::Value *lGetBasePtrAndOffsets(llvm::Value *ptrs, llvm::Value **offse
             if (bop_var != nullptr &&
                 ((bop_var->getOpcode() == llvm::Instruction::Add) || IsOrEquivalentToAdd(bop_var))) {
                 // We expect here ConstantVector as
-                // <i64 4, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef, i64 undef>
+                // <i64 4, i64 poison, i64 poison, i64 poison, i64 poison, i64 poison, i64 poison, i64 poison>
                 llvm::ConstantVector *cv = llvm::dyn_cast<llvm::ConstantVector>(bop_var->getOperand(1));
                 llvm::Instruction *shuffle_offset = nullptr;
                 if (cv != nullptr) {
@@ -179,12 +179,12 @@ static llvm::Value *lGetBasePtrAndOffsets(llvm::Value *ptrs, llvm::Value **offse
                                                 false),
                         llvm::Constant::getNullValue(llvm::Type::getInt32Ty(*g->ctx)));
                     // Create offset
-                    shuffle_offset = new llvm::ShuffleVectorInst(cv, llvm::UndefValue::get(cv->getType()), zeroMask,
+                    shuffle_offset = new llvm::ShuffleVectorInst(cv, llvm::PoisonValue::get(cv->getType()), zeroMask,
                                                                  "shuffle", ISPC_INSERTION_POINT_INSTRUCTION(bop_var));
                 } else {
                     // or it binaryoperator can accept another binary operator
                     // that is a result of counting another part of offset:
-                    // %another_bop = bop <16 x i32> %vec, <i32 7, i32 undef, i32 undef, ...>
+                    // %another_bop = bop <16 x i32> %vec, <i32 7, i32 poison, i32 poison, ...>
                     // %offsets = add <16 x i32> %another_bop, %base
                     bop_var = llvm::dyn_cast<llvm::BinaryOperator>(bop_var->getOperand(0));
                     if (bop_var != nullptr) {
@@ -195,7 +195,7 @@ static llvm::Value *lGetBasePtrAndOffsets(llvm::Value *ptrs, llvm::Value **offse
                         llvm::Value *zeroMask = llvm::ConstantVector::getSplat(
                             llvm::ElementCount::get(bop_var_type->getNumElements(), false),
                             llvm::Constant::getNullValue(llvm::Type::getInt32Ty(*g->ctx)));
-                        shuffle_offset = new llvm::ShuffleVectorInst(bop_var, llvm::UndefValue::get(bop_var_type),
+                        shuffle_offset = new llvm::ShuffleVectorInst(bop_var, llvm::PoisonValue::get(bop_var_type),
                                                                      zeroMask, "shuffle");
                         shuffle_offset->insertAfter(bop_var);
                     }
@@ -1428,11 +1428,11 @@ static llvm::Instruction *lGSToLoadStore(llvm::CallInst *callInst) {
                 new llvm::LoadInst(scalarType, ptr, callInst->getName(), ISPC_INSERTION_POINT_INSTRUCTION(callInst));
 
             // Generate the following sequence:
-            //   %name123 = insertelement <4 x i32> undef, i32 %val, i32 0
-            //   %name124 = shufflevector <4 x i32> %name123, <4 x i32> undef,
+            //   %name123 = insertelement <4 x i32> poison, i32 %val, i32 0
+            //   %name124 = shufflevector <4 x i32> %name123, <4 x i32> poison,
             //                                              <4 x i32> zeroinitializer
-            llvm::Value *undef1Value = llvm::UndefValue::get(callInst->getType());
-            llvm::Value *undef2Value = llvm::UndefValue::get(callInst->getType());
+            llvm::Value *undef1Value = llvm::PoisonValue::get(callInst->getType());
+            llvm::Value *undef2Value = llvm::PoisonValue::get(callInst->getType());
             llvm::Value *insertVec = llvm::InsertElementInst::Create(undef1Value, scalarValue, LLVMInt32(0), callName,
                                                                      ISPC_INSERTION_POINT_INSTRUCTION(callInst));
             llvm::FixedVectorType *FVT = llvm::dyn_cast<llvm::FixedVectorType>(callInst->getType());
@@ -1450,7 +1450,7 @@ static llvm::Instruction *lGSToLoadStore(llvm::CallInst *callInst) {
             return shufInst;
         } else {
             // A scatter with everyone going to the same location is
-            // undefined (if there's more than one program instance in
+            // undefined or poison (if there's more than one program instance in
             // the gang).  Issue a warning.
             if (g->target->getVectorWidth() > 1) {
                 Warning(pos, "Undefined behavior: all program instances are "
@@ -1617,8 +1617,8 @@ static llvm::Value *lImproveMaskedStore(llvm::CallInst *callInst) {
         // may in turn lead to being able to optimize out instructions
         // that compute the rvalue...)
         callInst->eraseFromParent();
-        // Return some fake undef value to signal that we did transformation.
-        return llvm::UndefValue::get(LLVMTypes::Int32Type);
+        // Return some fake poison value to signal that we did transformation.
+        return llvm::PoisonValue::get(LLVMTypes::Int32Type);
     } else if (maskStatus == MaskStatus::all_on) {
         // The mask is all on, so turn this into a regular store
         llvm::Instruction *store = nullptr;
@@ -1679,8 +1679,8 @@ static llvm::Value *lImproveMaskedLoad(llvm::CallInst *callInst, llvm::BasicBloc
 
     MaskStatus maskStatus = GetMaskStatusFromValue(mask);
     if (maskStatus == MaskStatus::all_off) {
-        // Zero mask - no-op, so replace the load with an undef value
-        llvm::Value *undef = llvm::UndefValue::get(callInst->getType());
+        // Zero mask - no-op, so replace the load with a poison value
+        llvm::Value *undef = llvm::PoisonValue::get(callInst->getType());
         ReplaceInstWithValueWrapper(iter, undef);
         return undef;
     } else if (maskStatus == MaskStatus::all_on) {

--- a/src/opt/IntrinsicsOptPass.cpp
+++ b/src/opt/IntrinsicsOptPass.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2022-2025, Intel Corporation
+  Copyright (c) 2022-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -72,11 +72,11 @@ bool IntrinsicsOpt::optimizeIntrinsics(llvm::BasicBlock &bb) {
                 continue;
             }
 
-            // If one of the two is undefined, we're allowed to replace
+            // If one of the two is undefined or poison, we're allowed to replace
             // with the value of the other.  (In other words, the only
             // valid case is that the blend factor ends up having a value
             // that only selects from the defined one of the two operands,
-            // otherwise the result is undefined and any value is fine,
+            // otherwise the result is undefined or poison and any value is fine,
             // ergo the defined one is an acceptable result.)
             if (LLVMIsValueUndef(v[0])) {
                 ReplaceInstWithValueWrapper(curIter, v[1]);
@@ -121,10 +121,10 @@ bool IntrinsicsOpt::optimizeIntrinsics(llvm::BasicBlock &bb) {
             llvm::Value *factor = callInst->getArgOperand(1);
             MaskStatus maskStatus = GetMaskStatusFromValue(factor);
             if (maskStatus == MaskStatus::all_off) {
-                // nothing being loaded, replace with undef value
+                // nothing being loaded, replace with poison value
                 llvm::Type *returnType = callInst->getType();
                 Assert(llvm::isa<llvm::VectorType>(returnType));
-                llvm::Value *undefValue = llvm::UndefValue::get(returnType);
+                llvm::Value *undefValue = llvm::PoisonValue::get(returnType);
                 ReplaceInstWithValueWrapper(curIter, undefValue);
                 modifiedAny = true;
                 continue;

--- a/src/opt/ReplaceMaskedMemOps.cpp
+++ b/src/opt/ReplaceMaskedMemOps.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2024-2025, Intel Corporation
+  Copyright (c) 2024-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -72,7 +72,7 @@ llvm::Value *lShrinkVector(llvm::IRBuilder<> &B, llvm::Value *originalVector, un
 
     // Use shufflevector instruction to create the new vector
     llvm::Twine name = originalVector->getName() + ".part";
-    return B.CreateShuffleVector(originalVector, llvm::UndefValue::get(originalVector->getType()), mask, name);
+    return B.CreateShuffleVector(originalVector, llvm::PoisonValue::get(originalVector->getType()), mask, name);
 }
 
 // Create a new vector containing the second part of the const vector.

--- a/src/opt/XeGatherCoalescePass.cpp
+++ b/src/opt/XeGatherCoalescePass.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2022-2025, Intel Corporation
+  Copyright (c) 2022-2026, Intel Corporation
 
   SPDX-License-Identifier: BSD-3-Clause
 */
@@ -412,7 +412,7 @@ llvm::Value *MemoryCoalescing::buildEEI(llvm::Value *ExtractFrom, MemoryCoalesci
             Val = CurrIdx++;
         llvm::ArrayRef<unsigned int> ByteIdxsArg(ByteIdxs);
         // Extract bytes via shuffle vector
-        Res = new llvm::ShuffleVectorInst(Res, llvm::UndefValue::get(Res->getType()),
+        Res = new llvm::ShuffleVectorInst(Res, llvm::PoisonValue::get(Res->getType()),
                                           llvm::ConstantDataVector::get(*g->ctx, ByteIdxsArg), "coal_unaligned_loader",
                                           InsertBefore->getIterator());
         // Cast byte vector to scalar value
@@ -454,7 +454,7 @@ llvm::Value *MemoryCoalescing::extractValueFromBlock(const MemoryCoalescing::Blo
     } else {
         // Need to get value from several blocks
         llvm::Value *ByteVec =
-            llvm::UndefValue::get(llvm::FixedVectorType::get(LLVMTypes::Int8Type, getScalarTypeSize(DstTy)));
+            llvm::PoisonValue::get(llvm::FixedVectorType::get(LLVMTypes::Int8Type, getScalarTypeSize(DstTy)));
         for (OffsetT CurrOffset = OffsetBytes, TargetOffset = 0; CurrOffset < OffsetBytes + getScalarTypeSize(DstTy);
              ++CurrOffset, ++TargetOffset) {
             unsigned Idx = CurrOffset / BlockSizeInBytes;
@@ -564,7 +564,7 @@ void XeGatherCoalescing::optimizePtr(llvm::Value *Ptr, PtrData &PD, llvm::Instru
             OffsetT Offset = ID.Offsets[0] - MinIdx;
             LI->replaceAllUsesWith(extractValueFromBlock(BlockLDs, Offset, LI->getType(), InsertPoint));
         } else if (auto *Gather = getPseudoGatherConstOffset(ID.Inst)) {
-            llvm::Value *NewVal = llvm::UndefValue::get(Gather->getType());
+            llvm::Value *NewVal = llvm::PoisonValue::get(Gather->getType());
             unsigned CurrElem = 0;
             for (auto Offset : ID.Offsets) {
                 // Adjust offset

--- a/tests/lit-tests/2611-llvm22-plus.ll
+++ b/tests/lit-tests/2611-llvm22-plus.ll
@@ -7,7 +7,7 @@ declare void @llvm.masked.store.v4i32.p0(<4 x i32>, ptr, <4 x i1>)
 ; CHECK-LABEL: @foo
 ; CHECK-NEXT: [[HL:%.*]] = load <2 x i32>, ptr %a, align 16
 ; CHECK-NEXT: [[VEC:%.*]] = shufflevector <2 x i32> [[HL]], <2 x i32> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; CHECK-NEXT: [[HS:%.*]] = shufflevector <4 x i32> [[VEC]], <4 x i32> undef, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT: [[HS:%.*]] = shufflevector <4 x i32> [[VEC]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
 ; CHECK-NEXT: store <2 x i32> [[HS]], ptr %b, align 16
 ; CHECK-NEXT: ret void
 define void @foo(ptr %a, ptr %b) {

--- a/tests/lit-tests/2611.ll
+++ b/tests/lit-tests/2611.ll
@@ -7,7 +7,7 @@ declare void @llvm.masked.store.v4i32.p0v4i32(<4 x i32>, <4 x i32>*, i32, <4 x i
 ; CHECK-LABEL: @foo
 ; CHECK-NEXT: [[HL:%.*]] = load <2 x i32>, ptr %a, align 16
 ; CHECK-NEXT: [[VEC:%.*]] = shufflevector <2 x i32> [[HL]], <2 x i32> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; CHECK-NEXT: [[HS:%.*]] = shufflevector <4 x i32> [[VEC]], <4 x i32> undef, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT: [[HS:%.*]] = shufflevector <4 x i32> [[VEC]], <4 x i32> {{undef|poison}}, <2 x i32> <i32 0, i32 1>
 ; CHECK-NEXT: store <2 x i32> [[HS]], ptr %b, align 16
 ; CHECK-NEXT: ret void
 define void @foo(<4 x i32>* %a, <4 x i32>* %b) {

--- a/tests/lit-tests/2611.ll
+++ b/tests/lit-tests/2611.ll
@@ -7,7 +7,7 @@ declare void @llvm.masked.store.v4i32.p0v4i32(<4 x i32>, <4 x i32>*, i32, <4 x i
 ; CHECK-LABEL: @foo
 ; CHECK-NEXT: [[HL:%.*]] = load <2 x i32>, ptr %a, align 16
 ; CHECK-NEXT: [[VEC:%.*]] = shufflevector <2 x i32> [[HL]], <2 x i32> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; CHECK-NEXT: [[HS:%.*]] = shufflevector <4 x i32> [[VEC]], <4 x i32> {{undef|poison}}, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT: [[HS:%.*]] = shufflevector <4 x i32> [[VEC]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
 ; CHECK-NEXT: store <2 x i32> [[HS]], ptr %b, align 16
 ; CHECK-NEXT: ret void
 define void @foo(<4 x i32>* %a, <4 x i32>* %b) {

--- a/tests/lit-tests/2955-llvm22-plus.ll
+++ b/tests/lit-tests/2955-llvm22-plus.ll
@@ -8,7 +8,7 @@ declare void @llvm.masked.store.v8f32.p0(<8 x float>, ptr nocapture, <8 x i1>) #
 ; CHECK-NEXT:  [[HL:%.*]] = load <3 x float>, ptr %0, align 1
 ; CHECK-NEXT:  [[V4:%.*]] = shufflevector <3 x float> [[HL]], <3 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ; CHECK-NEXT:  [[VEC:%.*]] = shufflevector <4 x float> [[V4]], <4 x float> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:  [[HS:%.*]] = shufflevector <8 x float> [[VEC]], <8 x float> undef, <3 x i32> <i32 0, i32 1, i32 2>
+; CHECK-NEXT:  [[HS:%.*]] = shufflevector <8 x float> [[VEC]], <8 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
 ; CHECK-NEXT:  store <3 x float> [[HS]], ptr %1, align 1
 ; CHECK-NEXT:  ret void
 

--- a/tests/lit-tests/2955.ll
+++ b/tests/lit-tests/2955.ll
@@ -8,7 +8,7 @@ declare void @llvm.masked.store.v8f32.p0(<8 x float>, ptr nocapture, i32 immarg,
 ; CHECK-NEXT:  [[HL:%.*]] = load <3 x float>, ptr %0, align 1
 ; CHECK-NEXT:  [[V4:%.*]] = shufflevector <3 x float> [[HL]], <3 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ; CHECK-NEXT:  [[VEC:%.*]] = shufflevector <4 x float> [[V4]], <4 x float> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:  [[HS:%.*]] = shufflevector <8 x float> [[VEC]], <8 x float> undef, <3 x i32> <i32 0, i32 1, i32 2>
+; CHECK-NEXT:  [[HS:%.*]] = shufflevector <8 x float> [[VEC]], <8 x float> {{undef|poison}}, <3 x i32> <i32 0, i32 1, i32 2>
 ; CHECK-NEXT:  store <3 x float> [[HS]], ptr %1, align 1
 ; CHECK-NEXT:  ret void
 

--- a/tests/lit-tests/2955.ll
+++ b/tests/lit-tests/2955.ll
@@ -8,7 +8,7 @@ declare void @llvm.masked.store.v8f32.p0(<8 x float>, ptr nocapture, i32 immarg,
 ; CHECK-NEXT:  [[HL:%.*]] = load <3 x float>, ptr %0, align 1
 ; CHECK-NEXT:  [[V4:%.*]] = shufflevector <3 x float> [[HL]], <3 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ; CHECK-NEXT:  [[VEC:%.*]] = shufflevector <4 x float> [[V4]], <4 x float> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:  [[HS:%.*]] = shufflevector <8 x float> [[VEC]], <8 x float> {{undef|poison}}, <3 x i32> <i32 0, i32 1, i32 2>
+; CHECK-NEXT:  [[HS:%.*]] = shufflevector <8 x float> [[VEC]], <8 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
 ; CHECK-NEXT:  store <3 x float> [[HS]], ptr %1, align 1
 ; CHECK-NEXT:  ret void
 

--- a/tests/lit-tests/load_store_vectorizer_loopunroll.ispc
+++ b/tests/lit-tests/load_store_vectorizer_loopunroll.ispc
@@ -4,9 +4,6 @@
 //   XeGatherCoalescing pass.
 // This test checks for sequences of 4-wide store coalescing, as that appears
 //   to be the width targeted by the LoadStoreVectorizer.
-// Note: LoadStoreVectorizerPass from LLVM 13.0 uses "undef" as a placeholder
-//   for resulting vector and "poison" starting from LLVM 14.0 (llvm/llvm-project@cf284f6)
-//   It's safe transformation since poison values will be always overwriten with a different value.
 
 // RUN: %{ispc} %s --target=xehpg-x16 --arch=xe64 -h %t.h --emit-llvm-text --debug-phase=325:325 --dump-file=%t -o /dev/null
 // RUN: FileCheck --input-file %t/ir_325_LoadStoreVectorizerPass.ll %s --check-prefixes CHECK_ALL,CHECK
@@ -23,7 +20,7 @@
 
 // CHECK_ALL-LABEL: @scatter_coalescing_loopunroll4pragma
 
-// CHECK:           %{{.*}} = insertelement <4 x float> {{undef|poison}}, float %_in{{.*}}, i{{(32|64)}} 0
+// CHECK:           %{{.*}} = insertelement <4 x float> poison, float %_in{{.*}}, i{{(32|64)}} 0
 // CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 1
 // CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 2
 // CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 3
@@ -50,7 +47,7 @@ task void scatter_coalescing_loopunroll4pragma(uniform float _out[], uniform flo
 
 // CHECK_ALL-LABEL: @scatter_coalescing_loopunroll4inline
 
-// CHECK:           %{{.*}} = insertelement <4 x float> {{undef|poison}}, float %_in{{.*}}, i{{(32|64)}} 0
+// CHECK:           %{{.*}} = insertelement <4 x float> poison, float %_in{{.*}}, i{{(32|64)}} 0
 // CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 1
 // CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 2
 // CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 3
@@ -82,12 +79,12 @@ task void scatter_coalescing_loopunroll4inline(uniform float _out[], uniform flo
 
 // CHECK_ALL-LABEL: @scatter_coalescing_loopunroll8inline
 
-// CHECK:           %{{.*}} = insertelement <4 x float> {{undef|poison}}, float %_in{{.*}}, i{{(32|64)}} 0
+// CHECK:           %{{.*}} = insertelement <4 x float> poison, float %_in{{.*}}, i{{(32|64)}} 0
 // CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 1
 // CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 2
 // CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 3
 // CHECK:           store <4 x float> %{{.*}}, {{(<4 x float>\*)|ptr}} %{{.*}}
-// CHECK:           %{{.*}} = insertelement <4 x float> {{undef|poison}}, float %_in{{.*}}, i{{(32|64)}} 0
+// CHECK:           %{{.*}} = insertelement <4 x float> poison, float %_in{{.*}}, i{{(32|64)}} 0
 // CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 1
 // CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 2
 // CHECK:           %{{.*}} = insertelement <4 x float> %{{.*}}, float %_in{{.*}}, i{{(32|64)}} 3

--- a/tests/lit-tests/xe_gather_coalescing_ptr.ispc
+++ b/tests/lit-tests/xe_gather_coalescing_ptr.ispc
@@ -2,8 +2,8 @@
 // Current implementation produces the following code sequence 9 times:
 // %ptr209 = getelementptr float, float* %self_load3_color6_mem31.i184278, i64 %scaled_offset208
 // %self_load = load float, float* %ptr209, align 4
-// %self_load_insert = insertelement <8 x float> undef, float %self_load, i32 X
-// %self_load_insert_shuffle = shufflevector <8 x float> %self_load_insert, <8 x float> undef, <8 x i32> zeroinitializer
+// %self_load_insert = insertelement <8 x float> poison, float %self_load, i32 X
+// %self_load_insert_shuffle = shufflevector <8 x float> %self_load_insert, <8 x float> poison, <8 x i32> zeroinitializer
 
 // The optimization should optimize memory access by combining each 3 loads to one plus EEI:
 // %vectorized_ld = call <3 x float> @llvm.genx.svm.block.ld.unaligned.v8f32.i64(i64 %vectorized_address)

--- a/tests/lit-tests/xe_gather_coalescing_ptr_alloca.ispc
+++ b/tests/lit-tests/xe_gather_coalescing_ptr_alloca.ispc
@@ -9,8 +9,8 @@
 // Current implementation produces the following code sequence 9 times:
 // %ptr209 = getelementptr float, float* %self_load3_color6_mem31.i184278, i64 %scaled_offset208
 // %self_load = load float, float* %ptr209, align 4
-// %self_load_insert = insertelement <8 x float> undef, float %self_load, i32 X
-// %self_load_insert_shuffle = shufflevector <8 x float> %self_load_insert, <8 x float> undef, <8 x i32> zeroinitializer
+// %self_load_insert = insertelement <8 x float> poison, float %self_load, i32 X
+// %self_load_insert_shuffle = shufflevector <8 x float> %self_load_insert, <8 x float> poison, <8 x i32> zeroinitializer
 
 // The optimization should optimize memory access by combining each 3 loads to one plus EEI:
 // %vectorized_ld = call <3 x float> @llvm.genx.svm.block.ld.unaligned.v8f32.i64(i64 %vectorized_address)

--- a/tests/lit-tests/xe_gather_coalescing_ptr_indvar.ispc
+++ b/tests/lit-tests/xe_gather_coalescing_ptr_indvar.ispc
@@ -9,8 +9,8 @@
 // Current implementation produces the following code sequence 9 times:
 // %ptr209 = getelementptr float, float* %self_load3_color6_mem31.i184278, i64 %scaled_offset208
 // %self_load = load float, float* %ptr209, align 4
-// %self_load_insert = insertelement <8 x float> undef, float %self_load, i32 X
-// %self_load_insert_shuffle = shufflevector <8 x float> %self_load_insert, <8 x float> undef, <8 x i32> zeroinitializer
+// %self_load_insert = insertelement <8 x float> poison, float %self_load, i32 X
+// %self_load_insert_shuffle = shufflevector <8 x float> %self_load_insert, <8 x float> poison, <8 x i32> zeroinitializer
 
 // The optimization should optimize memory access by combining each 3 loads to one plus EEI:
 // %vectorized_ld = call <3 x float> @llvm.genx.svm.block.ld.unaligned.v8f32.i64(i64 %vectorized_address)


### PR DESCRIPTION
## Description
Replace UndefValue::get with PoisonValue::get in optimization passes.
Update lit tests to use {{undef|poison}} patterns (compatible across all LLVM versions) and strict poison patterns for LLVM 22+ tests.
https://github.com/ispc/ispc/issues/3782
## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed