### PR TITLE
Fix #3782: Migrate builtins IR and M4 macros to use poison instead of undef

### DIFF
--- a/builtins/svml.m4
+++ b/builtins/svml.m4
@@ -201,9 +201,9 @@ define(`svml_define',`
 ;;define void @__svml_sincosf(<8 x float>, i8 *,
 ;;                                    i8 *) nounwind alwaysinline {
 ;;  ; call svml_sincosf4 two times with the two 4-wide sub-vectors
-;;  %a = shufflevector <8 x float> %0, <8 x float> undef,
+;;  %a = shufflevector <8 x float> %0, <8 x float> poison,
 ;;         <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-;;  %b = shufflevector <8 x float> %0, <8 x float> undef,
+;;  %b = shufflevector <8 x float> %0, <8 x float> poison,
 ;;         <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 ;;
 ;;  %cospa = alloca <4 x float>

--- a/builtins/target-avx-utils.ll
+++ b/builtins/target-avx-utils.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2025, Intel Corporation
+;;  Copyright (c) 2010-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -37,7 +37,7 @@ define float @__round_uniform_float(float) nounwind readonly alwaysinline {
   ;  It doesn't matter what we pass as a, since we only need the r0 value
   ;  here.  So we pass the same register for both.  Further, only the 0th
   ;  element of the b parameter matters
-  %xi = insertelement <4 x float> undef, float %0, i32 0
+  %xi = insertelement <4 x float> poison, float %0, i32 0
   %xr = call <4 x float> @llvm.x86.sse41.round.ss(<4 x float> %xi, <4 x float> %xi, i32 8)
   %rs = extractelement <4 x float> %xr, i32 0
   ret float %rs
@@ -45,7 +45,7 @@ define float @__round_uniform_float(float) nounwind readonly alwaysinline {
 
 define float @__floor_uniform_float(float) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <4 x float> undef, float %0, i32 0
+  %xi = insertelement <4 x float> poison, float %0, i32 0
   ; roundps, round down 0b01 | don't signal precision exceptions 0b1001 = 9
   %xr = call <4 x float> @llvm.x86.sse41.round.ss(<4 x float> %xi, <4 x float> %xi, i32 9)
   %rs = extractelement <4 x float> %xr, i32 0
@@ -54,7 +54,7 @@ define float @__floor_uniform_float(float) nounwind readonly alwaysinline {
 
 define float @__ceil_uniform_float(float) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <4 x float> undef, float %0, i32 0
+  %xi = insertelement <4 x float> poison, float %0, i32 0
   ; roundps, round up 0b10 | don't signal precision exceptions 0b1010 = 10
   %xr = call <4 x float> @llvm.x86.sse41.round.ss(<4 x float> %xi, <4 x float> %xi, i32 10)
   %rs = extractelement <4 x float> %xr, i32 0
@@ -67,7 +67,7 @@ define float @__ceil_uniform_float(float) nounwind readonly alwaysinline {
 declare <2 x double> @llvm.x86.sse41.round.sd(<2 x double>, <2 x double>, i32) nounwind readnone
 
 define double @__round_uniform_double(double) nounwind readonly alwaysinline {
-  %xi = insertelement <2 x double> undef, double %0, i32 0
+  %xi = insertelement <2 x double> poison, double %0, i32 0
   %xr = call <2 x double> @llvm.x86.sse41.round.sd(<2 x double> %xi, <2 x double> %xi, i32 8)
   %rs = extractelement <2 x double> %xr, i32 0
   ret double %rs
@@ -75,7 +75,7 @@ define double @__round_uniform_double(double) nounwind readonly alwaysinline {
 
 define double @__floor_uniform_double(double) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <2 x double> undef, double %0, i32 0
+  %xi = insertelement <2 x double> poison, double %0, i32 0
   ; roundsd, round down 0b01 | don't signal precision exceptions 0b1001 = 9
   %xr = call <2 x double> @llvm.x86.sse41.round.sd(<2 x double> %xi, <2 x double> %xi, i32 9)
   %rs = extractelement <2 x double> %xr, i32 0
@@ -84,7 +84,7 @@ define double @__floor_uniform_double(double) nounwind readonly alwaysinline {
 
 define double @__ceil_uniform_double(double) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <2 x double> undef, double %0, i32 0
+  %xi = insertelement <2 x double> poison, double %0, i32 0
   ; roundsd, round up 0b10 | don't signal precision exceptions 0b1010 = 10
   %xr = call <2 x double> @llvm.x86.sse41.round.sd(<2 x double> %xi, <2 x double> %xi, i32 10)
   %rs = extractelement <2 x double> %xr, i32 0
@@ -100,7 +100,7 @@ define float @__rcp_uniform_float(float) nounwind readonly alwaysinline {
   ; do the rcpss call
   ;    uniform float iv = extract(__rcp_u(v), 0);
   ;    return iv * (2. - v * iv);
-  %vecval = insertelement <4 x float> undef, float %0, i32 0
+  %vecval = insertelement <4 x float> poison, float %0, i32 0
   %call = call <4 x float> @llvm.x86.sse.rcp.ss(<4 x float> %vecval)
   %scall = extractelement <4 x float> %call, i32 0
 
@@ -114,7 +114,7 @@ define float @__rcp_uniform_float(float) nounwind readonly alwaysinline {
 define float @__rcp_fast_uniform_float(float) nounwind readonly alwaysinline {
   ;    uniform float iv = extract(__rcp_u(v), 0);
   ;    return iv;
-  %vecval = insertelement <4 x float> undef, float %0, i32 0
+  %vecval = insertelement <4 x float> poison, float %0, i32 0
   %call = call <4 x float> @llvm.x86.sse.rcp.ss(<4 x float> %vecval)
   %scall = extractelement <4 x float> %call, i32 0
   ret float %scall
@@ -127,7 +127,7 @@ declare <4 x float> @llvm.x86.sse.rsqrt.ss(<4 x float>) nounwind readnone
 
 define float @__rsqrt_uniform_float(float) nounwind readonly alwaysinline {
   ;  uniform float is = extract(__rsqrt_u(v), 0);
-  %v = insertelement <4 x float> undef, float %0, i32 0
+  %v = insertelement <4 x float> poison, float %0, i32 0
   %vis = call <4 x float> @llvm.x86.sse.rsqrt.ss(<4 x float> %v)
   %is = extractelement <4 x float> %vis, i32 0
 
@@ -144,7 +144,7 @@ define float @__rsqrt_uniform_float(float) nounwind readonly alwaysinline {
 define float @__rsqrt_fast_uniform_float(float) nounwind readonly alwaysinline {
   ;  uniform float is = extract(__rsqrt_u(v), 0);
   ;  return is;
-  %v = insertelement <4 x float> undef, float %0, i32 0
+  %v = insertelement <4 x float> poison, float %0, i32 0
   %vis = call <4 x float> @llvm.x86.sse.rsqrt.ss(<4 x float> %v)
   %is = extractelement <4 x float> %vis, i32 0
   ret float %is

--- a/builtins/target-avx1-i32x16.ll
+++ b/builtins/target-avx1-i32x16.ll
@@ -147,10 +147,10 @@ declare i32 @llvm.x86.avx.movmsk.ps.256(<8 x float>) nounwind readnone
 
 define i64 @__movmsk(<16 x i32>) nounwind readnone alwaysinline {
   %floatmask = bitcast <16 x i32> %0 to <16 x float>
-  %mask0 = shufflevector <16 x float> %floatmask, <16 x float> undef,
+  %mask0 = shufflevector <16 x float> %floatmask, <16 x float> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %v0 = call i32 @llvm.x86.avx.movmsk.ps.256(<8 x float> %mask0) nounwind readnone
-  %mask1 = shufflevector <16 x float> %floatmask, <16 x float> undef,
+  %mask1 = shufflevector <16 x float> %floatmask, <16 x float> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %v1 = call i32 @llvm.x86.avx.movmsk.ps.256(<8 x float> %mask1) nounwind readnone
 
@@ -162,10 +162,10 @@ define i64 @__movmsk(<16 x i32>) nounwind readnone alwaysinline {
 
 define i1 @__any(<16 x i32>) nounwind readnone alwaysinline {
   %floatmask = bitcast <16 x i32> %0 to <16 x float>
-  %mask0 = shufflevector <16 x float> %floatmask, <16 x float> undef,
+  %mask0 = shufflevector <16 x float> %floatmask, <16 x float> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %v0 = call i32 @llvm.x86.avx.movmsk.ps.256(<8 x float> %mask0) nounwind readnone
-  %mask1 = shufflevector <16 x float> %floatmask, <16 x float> undef,
+  %mask1 = shufflevector <16 x float> %floatmask, <16 x float> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %v1 = call i32 @llvm.x86.avx.movmsk.ps.256(<8 x float> %mask1) nounwind readnone
 
@@ -177,10 +177,10 @@ define i1 @__any(<16 x i32>) nounwind readnone alwaysinline {
 
 define i1 @__all(<16 x i32>) nounwind readnone alwaysinline {
   %floatmask = bitcast <16 x i32> %0 to <16 x float>
-  %mask0 = shufflevector <16 x float> %floatmask, <16 x float> undef,
+  %mask0 = shufflevector <16 x float> %floatmask, <16 x float> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %v0 = call i32 @llvm.x86.avx.movmsk.ps.256(<8 x float> %mask0) nounwind readnone
-  %mask1 = shufflevector <16 x float> %floatmask, <16 x float> undef,
+  %mask1 = shufflevector <16 x float> %floatmask, <16 x float> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %v1 = call i32 @llvm.x86.avx.movmsk.ps.256(<8 x float> %mask1) nounwind readnone
 
@@ -192,10 +192,10 @@ define i1 @__all(<16 x i32>) nounwind readnone alwaysinline {
 
 define i1 @__none(<16 x i32>) nounwind readnone alwaysinline {
   %floatmask = bitcast <16 x i32> %0 to <16 x float>
-  %mask0 = shufflevector <16 x float> %floatmask, <16 x float> undef,
+  %mask0 = shufflevector <16 x float> %floatmask, <16 x float> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %v0 = call i32 @llvm.x86.avx.movmsk.ps.256(<8 x float> %mask0) nounwind readnone
-  %mask1 = shufflevector <16 x float> %floatmask, <16 x float> undef,
+  %mask1 = shufflevector <16 x float> %floatmask, <16 x float> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %v1 = call i32 @llvm.x86.avx.movmsk.ps.256(<8 x float> %mask1) nounwind readnone
 
@@ -213,9 +213,9 @@ define i1 @__none(<16 x i32>) nounwind readnone alwaysinline {
 declare <8 x float> @llvm.x86.avx.hadd.ps.256(<8 x float>, <8 x float>) nounwind readnone
 
 define float @__reduce_add_float(<16 x float>) nounwind readonly alwaysinline {
-  %va = shufflevector <16 x float> %0, <16 x float> undef,
+  %va = shufflevector <16 x float> %0, <16 x float> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vb = shufflevector <16 x float> %0, <16 x float> undef,
+  %vb = shufflevector <16 x float> %0, <16 x float> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %v1 = call <8 x float> @llvm.x86.avx.hadd.ps.256(<8 x float> %va, <8 x float> %vb)
   %v2 = call <8 x float> @llvm.x86.avx.hadd.ps.256(<8 x float> %v1, <8 x float> %v1)
@@ -266,13 +266,13 @@ define i32 @__reduce_max_uint32(<16 x i32>) nounwind readnone alwaysinline {
 declare <4 x double> @llvm.x86.avx.hadd.pd.256(<4 x double>, <4 x double>) nounwind readnone
 
 define double @__reduce_add_double(<16 x double>) nounwind readonly alwaysinline {
-  %va = shufflevector <16 x double> %0, <16 x double> undef,
+  %va = shufflevector <16 x double> %0, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vb = shufflevector <16 x double> %0, <16 x double> undef,
+  %vb = shufflevector <16 x double> %0, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %vc = shufflevector <16 x double> %0, <16 x double> undef,
+  %vc = shufflevector <16 x double> %0, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %vd = shufflevector <16 x double> %0, <16 x double> undef,
+  %vd = shufflevector <16 x double> %0, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
   %vab = fadd <4 x double> %va, %vb
   %vcd = fadd <4 x double> %vc, %vd
@@ -328,10 +328,10 @@ declare <4 x double> @llvm.x86.avx.maskload.pd.256(i8 *, <4 x MdORi64> %mask)
  
 define <16 x i32> @__masked_load_i32(i8 *, <16 x i32> %mask) nounwind alwaysinline {
   %floatmask = bitcast <16 x i32> %mask to <16 x MfORi32>
-  %mask0 = shufflevector <16 x MfORi32> %floatmask, <16 x MfORi32> undef,
+  %mask0 = shufflevector <16 x MfORi32> %floatmask, <16 x MfORi32> poison,
      <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %val0 = call <8 x float> @llvm.x86.avx.maskload.ps.256(i8 * %0, <8 x MfORi32> %mask0)
-  %mask1 = shufflevector <16 x MfORi32> %floatmask, <16 x MfORi32> undef,
+  %mask1 = shufflevector <16 x MfORi32> %floatmask, <16 x MfORi32> poison,
      <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %ptr1 = getelementptr PTR_OP_ARGS(`i8') %0, i32 32    ;; 8x4 bytes = 32
   %val1 = call <8 x float> @llvm.x86.avx.maskload.ps.256(i8 * %ptr1, <8 x MfORi32> %mask1)
@@ -346,13 +346,13 @@ define <16 x i32> @__masked_load_i32(i8 *, <16 x i32> %mask) nounwind alwaysinli
 
 define <16 x i64> @__masked_load_i64(i8 *, <16 x i32> %mask) nounwind alwaysinline {
   ; double up masks, bitcast to doubles
-  %mask0 = shufflevector <16 x i32> %mask, <16 x i32> undef,
+  %mask0 = shufflevector <16 x i32> %mask, <16 x i32> poison,
      <8 x i32> <i32 0, i32 0, i32 1, i32 1, i32 2, i32 2, i32 3, i32 3>
-  %mask1 = shufflevector <16 x i32> %mask, <16 x i32> undef,
+  %mask1 = shufflevector <16 x i32> %mask, <16 x i32> poison,
      <8 x i32> <i32 4, i32 4, i32 5, i32 5, i32 6, i32 6, i32 7, i32 7>
-  %mask2 = shufflevector <16 x i32> %mask, <16 x i32> undef,
+  %mask2 = shufflevector <16 x i32> %mask, <16 x i32> poison,
      <8 x i32> <i32 8, i32 8, i32 9, i32 9, i32 10, i32 10, i32 11, i32 11>
-  %mask3 = shufflevector <16 x i32> %mask, <16 x i32> undef,
+  %mask3 = shufflevector <16 x i32> %mask, <16 x i32> poison,
      <8 x i32> <i32 12, i32 12, i32 13, i32 13, i32 14, i32 14, i32 15, i32 15>
   %mask0d = bitcast <8 x i32> %mask0 to <4 x MdORi64>
   %mask1d = bitcast <8 x i32> %mask1 to <4 x MdORi64>
@@ -399,14 +399,14 @@ define void @__masked_store_i32(<16 x i32>* nocapture, <16 x i32>,
   %val = bitcast <16 x i32> %1 to <16 x float>
   %mask = bitcast <16 x i32> %2 to <16 x MfORi32>
 
-  %val0 = shufflevector <16 x float> %val, <16 x float> undef,
+  %val0 = shufflevector <16 x float> %val, <16 x float> poison,
         <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %val1 = shufflevector <16 x float> %val, <16 x float> undef,
+  %val1 = shufflevector <16 x float> %val, <16 x float> poison,
         <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 
-  %mask0 = shufflevector <16 x MfORi32> %mask, <16 x MfORi32> undef,
+  %mask0 = shufflevector <16 x MfORi32> %mask, <16 x MfORi32> poison,
         <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %mask1 = shufflevector <16 x MfORi32> %mask, <16 x MfORi32> undef,
+  %mask1 = shufflevector <16 x MfORi32> %mask, <16 x MfORi32> poison,
         <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 
   call void @llvm.x86.avx.maskstore.ps.256(i8 * %ptr, <8 x MfORi32> %mask0, <8 x float> %val0)
@@ -422,26 +422,26 @@ define void @__masked_store_i64(<16 x i64>* nocapture, <16 x i64>,
   %val = bitcast <16 x i64> %1 to <16 x double>
 
   ; double up masks, bitcast to doubles
-  %mask0 = shufflevector <16 x i32> %mask, <16 x i32> undef,
+  %mask0 = shufflevector <16 x i32> %mask, <16 x i32> poison,
      <8 x i32> <i32 0, i32 0, i32 1, i32 1, i32 2, i32 2, i32 3, i32 3>
-  %mask1 = shufflevector <16 x i32> %mask, <16 x i32> undef,
+  %mask1 = shufflevector <16 x i32> %mask, <16 x i32> poison,
      <8 x i32> <i32 4, i32 4, i32 5, i32 5, i32 6, i32 6, i32 7, i32 7>
-  %mask2 = shufflevector <16 x i32> %mask, <16 x i32> undef,
+  %mask2 = shufflevector <16 x i32> %mask, <16 x i32> poison,
      <8 x i32> <i32 8, i32 8, i32 9, i32 9, i32 10, i32 10, i32 11, i32 11>
-  %mask3 = shufflevector <16 x i32> %mask, <16 x i32> undef,
+  %mask3 = shufflevector <16 x i32> %mask, <16 x i32> poison,
      <8 x i32> <i32 12, i32 12, i32 13, i32 13, i32 14, i32 14, i32 15, i32 15>
   %mask0d = bitcast <8 x i32> %mask0 to <4 x MdORi64>
   %mask1d = bitcast <8 x i32> %mask1 to <4 x MdORi64>
   %mask2d = bitcast <8 x i32> %mask2 to <4 x MdORi64>
   %mask3d = bitcast <8 x i32> %mask3 to <4 x MdORi64>
 
-  %val0 = shufflevector <16 x double> %val, <16 x double> undef,
+  %val0 = shufflevector <16 x double> %val, <16 x double> poison,
      <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %val1 = shufflevector <16 x double> %val, <16 x double> undef,
+  %val1 = shufflevector <16 x double> %val, <16 x double> poison,
      <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %val2 = shufflevector <16 x double> %val, <16 x double> undef,
+  %val2 = shufflevector <16 x double> %val, <16 x double> poison,
      <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %val3 = shufflevector <16 x double> %val, <16 x double> undef,
+  %val3 = shufflevector <16 x double> %val, <16 x double> poison,
      <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 
   call void @llvm.x86.avx.maskstore.pd.256(i8 * %ptr, <4 x MdORi64> %mask0d, <4 x double> %val0)
@@ -469,17 +469,17 @@ define void @__masked_store_blend_i32(<16 x i32>* nocapture, <16 x i32>,
   %oldAsFloat = bitcast <16 x i32> %oldValue to <16 x float>
   %newAsFloat = bitcast <16 x i32> %1 to <16 x float>
  
-  %old0 = shufflevector <16 x float> %oldAsFloat, <16 x float> undef,
+  %old0 = shufflevector <16 x float> %oldAsFloat, <16 x float> poison,
         <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %old1 = shufflevector <16 x float> %oldAsFloat, <16 x float> undef,
+  %old1 = shufflevector <16 x float> %oldAsFloat, <16 x float> poison,
         <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %new0 = shufflevector <16 x float> %newAsFloat, <16 x float> undef,
+  %new0 = shufflevector <16 x float> %newAsFloat, <16 x float> poison,
         <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %new1 = shufflevector <16 x float> %newAsFloat, <16 x float> undef,
+  %new1 = shufflevector <16 x float> %newAsFloat, <16 x float> poison,
         <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %mask0 = shufflevector <16 x float> %maskAsFloat, <16 x float> undef,
+  %mask0 = shufflevector <16 x float> %maskAsFloat, <16 x float> poison,
         <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %mask1 = shufflevector <16 x float> %maskAsFloat, <16 x float> undef,
+  %mask1 = shufflevector <16 x float> %maskAsFloat, <16 x float> poison,
         <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 
   %blend0 = call <8 x float> @llvm.x86.avx.blendv.ps.256(<8 x float> %old0,
@@ -504,32 +504,32 @@ define void @__masked_store_blend_i64(<16 x i64>* nocapture %ptr, <16 x i64> %ne
                                       <16 x i32> %mask) nounwind alwaysinline {
   %oldValue = load PTR_OP_ARGS(`<16 x i64>')  %ptr, align 8
   %old = bitcast <16 x i64> %oldValue to <16 x double>
-  %old0d = shufflevector <16 x double> %old, <16 x double> undef,
+  %old0d = shufflevector <16 x double> %old, <16 x double> poison,
      <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %old1d = shufflevector <16 x double> %old, <16 x double> undef,
+  %old1d = shufflevector <16 x double> %old, <16 x double> poison,
      <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %old2d = shufflevector <16 x double> %old, <16 x double> undef,
+  %old2d = shufflevector <16 x double> %old, <16 x double> poison,
      <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %old3d = shufflevector <16 x double> %old, <16 x double> undef,
+  %old3d = shufflevector <16 x double> %old, <16 x double> poison,
      <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 
   %new = bitcast <16 x i64> %newi64 to <16 x double>
-  %new0d = shufflevector <16 x double> %new, <16 x double> undef,
+  %new0d = shufflevector <16 x double> %new, <16 x double> poison,
      <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %new1d = shufflevector <16 x double> %new, <16 x double> undef,
+  %new1d = shufflevector <16 x double> %new, <16 x double> poison,
      <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %new2d = shufflevector <16 x double> %new, <16 x double> undef,
+  %new2d = shufflevector <16 x double> %new, <16 x double> poison,
      <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %new3d = shufflevector <16 x double> %new, <16 x double> undef,
+  %new3d = shufflevector <16 x double> %new, <16 x double> poison,
      <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 
-  %mask0 = shufflevector <16 x i32> %mask, <16 x i32> undef,
+  %mask0 = shufflevector <16 x i32> %mask, <16 x i32> poison,
      <8 x i32> <i32 0, i32 0, i32 1, i32 1, i32 2, i32 2, i32 3, i32 3>
-  %mask1 = shufflevector <16 x i32> %mask, <16 x i32> undef,
+  %mask1 = shufflevector <16 x i32> %mask, <16 x i32> poison,
      <8 x i32> <i32 4, i32 4, i32 5, i32 5, i32 6, i32 6, i32 7, i32 7>
-  %mask2 = shufflevector <16 x i32> %mask, <16 x i32> undef,
+  %mask2 = shufflevector <16 x i32> %mask, <16 x i32> poison,
      <8 x i32> <i32 8, i32 8, i32 9, i32 9, i32 10, i32 10, i32 11, i32 11>
-  %mask3 = shufflevector <16 x i32> %mask, <16 x i32> undef,
+  %mask3 = shufflevector <16 x i32> %mask, <16 x i32> poison,
      <8 x i32> <i32 12, i32 12, i32 13, i32 13, i32 14, i32 14, i32 15, i32 15>
   %mask0d = bitcast <8 x i32> %mask0 to <4 x double>
   %mask1d = bitcast <8 x i32> %mask1 to <4 x double>

--- a/builtins/target-avx1-i32x8.ll
+++ b/builtins/target-avx1-i32x8.ll
@@ -228,9 +228,9 @@ define float @__reduce_max_float(<8 x float>) nounwind readnone alwaysinline {
 declare <4 x double> @llvm.x86.avx.hadd.pd.256(<4 x double>, <4 x double>) nounwind readnone
 
 define double @__reduce_add_double(<8 x double>) nounwind readonly alwaysinline {
-  %v0 = shufflevector <8 x double> %0, <8 x double> undef,
+  %v0 = shufflevector <8 x double> %0, <8 x double> poison,
                       <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1 = shufflevector <8 x double> %0, <8 x double> undef,
+  %v1 = shufflevector <8 x double> %0, <8 x double> poison,
                       <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %sum0 = call <4 x double> @llvm.x86.avx.hadd.pd.256(<4 x double> %v0, <4 x double> %v1)
   %sum1 = call <4 x double> @llvm.x86.avx.hadd.pd.256(<4 x double> %sum0, <4 x double> %sum0)
@@ -312,9 +312,9 @@ define <8 x i32> @__masked_load_i32(i8 *, <8 x i32> %mask) nounwind alwaysinline
 
 define <8 x i64> @__masked_load_i64(i8 *, <8 x i32> %mask) nounwind alwaysinline {
   ; double up masks, bitcast to doubles
-  %mask0 = shufflevector <8 x i32> %mask, <8 x i32> undef,
+  %mask0 = shufflevector <8 x i32> %mask, <8 x i32> poison,
      <8 x i32> <i32 0, i32 0, i32 1, i32 1, i32 2, i32 2, i32 3, i32 3>
-  %mask1 = shufflevector <8 x i32> %mask, <8 x i32> undef,
+  %mask1 = shufflevector <8 x i32> %mask, <8 x i32> poison,
      <8 x i32> <i32 4, i32 4, i32 5, i32 5, i32 6, i32 6, i32 7, i32 7>
   %mask0d = bitcast <8 x i32> %mask0 to <4 x MdORi64>
   %mask1d = bitcast <8 x i32> %mask1 to <4 x MdORi64>
@@ -355,17 +355,17 @@ define void @__masked_store_i64(<8 x i64>* nocapture, <8 x i64>,
   %ptr = bitcast <8 x i64> * %0 to i8 *
   %val = bitcast <8 x i64> %1 to <8 x double>
 
-  %mask0 = shufflevector <8 x i32> %mask, <8 x i32> undef,
+  %mask0 = shufflevector <8 x i32> %mask, <8 x i32> poison,
      <8 x i32> <i32 0, i32 0, i32 1, i32 1, i32 2, i32 2, i32 3, i32 3>
-  %mask1 = shufflevector <8 x i32> %mask, <8 x i32> undef,
+  %mask1 = shufflevector <8 x i32> %mask, <8 x i32> poison,
      <8 x i32> <i32 4, i32 4, i32 5, i32 5, i32 6, i32 6, i32 7, i32 7>
 
   %mask0d = bitcast <8 x i32> %mask0 to <4 x MdORi64>
   %mask1d = bitcast <8 x i32> %mask1 to <4 x MdORi64>
 
-  %val0 = shufflevector <8 x double> %val, <8 x double> undef,
+  %val0 = shufflevector <8 x double> %val, <8 x double> poison,
      <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %val1 = shufflevector <8 x double> %val, <8 x double> undef,
+  %val1 = shufflevector <8 x double> %val, <8 x double> poison,
      <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   call void @llvm.x86.avx.maskstore.pd.256(i8 * %ptr, <4 x MdORi64> %mask0d, <4 x double> %val0)
@@ -408,14 +408,14 @@ define void @__masked_store_blend_i64(<8 x i64>* nocapture %ptr, <8 x i64> %new,
   ; are actually bitcast <4 x i64> values
   ;
   ; set up the first four 64-bit values
-  %old01  = shufflevector <8 x i64> %oldValue, <8 x i64> undef,
+  %old01  = shufflevector <8 x i64> %oldValue, <8 x i64> poison,
                           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %old01f = bitcast <4 x i64> %old01 to <8 x float>
-  %new01  = shufflevector <8 x i64> %new, <8 x i64> undef,
+  %new01  = shufflevector <8 x i64> %new, <8 x i64> poison,
                           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %new01f = bitcast <4 x i64> %new01 to <8 x float>
   ; compute mask--note that the indices are all doubled-up
-  %mask01 = shufflevector <8 x float> %mask, <8 x float> undef,
+  %mask01 = shufflevector <8 x float> %mask, <8 x float> poison,
                           <8 x i32> <i32 0, i32 0, i32 1, i32 1,
                                      i32 2, i32 2, i32 3, i32 3>
   ; and blend them
@@ -425,14 +425,14 @@ define void @__masked_store_blend_i64(<8 x i64>* nocapture %ptr, <8 x i64> %new,
   %result01 = bitcast <8 x float> %result01f to <4 x i64>
 
   ; and again
-  %old23  = shufflevector <8 x i64> %oldValue, <8 x i64> undef,
+  %old23  = shufflevector <8 x i64> %oldValue, <8 x i64> poison,
                           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %old23f = bitcast <4 x i64> %old23 to <8 x float>
-  %new23  = shufflevector <8 x i64> %new, <8 x i64> undef,
+  %new23  = shufflevector <8 x i64> %new, <8 x i64> poison,
                           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %new23f = bitcast <4 x i64> %new23 to <8 x float>
   ; compute mask--note that the values are doubled-up...
-  %mask23 = shufflevector <8 x float> %mask, <8 x float> undef,
+  %mask23 = shufflevector <8 x float> %mask, <8 x float> poison,
                           <8 x i32> <i32 4, i32 4, i32 5, i32 5,
                                      i32 6, i32 6, i32 7, i32 7>
   ; and blend them

--- a/builtins/target-avx1-i64x4.ll
+++ b/builtins/target-avx1-i64x4.ll
@@ -303,9 +303,9 @@ define i32 @__reduce_max_uint32(<4 x i32>) nounwind readnone alwaysinline {
 declare <4 x double> @llvm.x86.avx.hadd.pd.256(<4 x double>, <4 x double>) nounwind readnone
 
 define double @__reduce_add_double(<4 x double>) nounwind readonly alwaysinline {
-  %v0 = shufflevector <4 x double> %0, <4 x double> undef,
+  %v0 = shufflevector <4 x double> %0, <4 x double> poison,
                       <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1 = shufflevector <4 x double> <double 0.,double 0.,double 0.,double 0.>, <4 x double> undef,
+  %v1 = shufflevector <4 x double> <double 0.,double 0.,double 0.,double 0.>, <4 x double> poison,
                       <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ;;  %v1 = <4 x double> <double 0., double 0., double 0., double 0.>
   %sum0 = call <4 x double> @llvm.x86.avx.hadd.pd.256(<4 x double> %v0,   <4 x double> %v1)

--- a/builtins/target-avx2-i16x16.ll
+++ b/builtins/target-avx2-i16x16.ll
@@ -75,9 +75,9 @@ declare <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float>, i32) nounwind readnone
 
 define float @__half_to_float_uniform(i16 %v) nounwind readnone alwaysinline {
   %v1 = bitcast i16 %v to <1 x i16>
-  %vv = shufflevector <1 x i16> %v1, <1 x i16> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x i16> %v1, <1 x i16> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %rv = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %vv)
   %r = extractelement <8 x float> %rv, i32 0
   ret float %r
@@ -85,9 +85,9 @@ define float @__half_to_float_uniform(i16 %v) nounwind readnone alwaysinline {
 
 define i16 @__float_to_half_uniform(float %v) nounwind readnone alwaysinline {
   %v1 = bitcast float %v to <1 x float>
-  %vv = shufflevector <1 x float> %v1, <1 x float> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x float> %v1, <1 x float> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   ; round to nearest even
   %rv = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %vv, i32 0)
   %r = extractelement <8 x i16> %rv, i32 0
@@ -142,7 +142,7 @@ define float @__round_uniform_float(float) nounwind readonly alwaysinline {
   ;  It doesn't matter what we pass as a, since we only need the r0 value
   ;  here.  So we pass the same register for both.  Further, only the 0th
   ;  element of the b parameter matters
-  %xi = insertelement <4 x float> undef, float %0, i32 0
+  %xi = insertelement <4 x float> poison, float %0, i32 0
   %xr = call <4 x float> @llvm.x86.sse41.round.ss(<4 x float> %xi, <4 x float> %xi, i32 8)
   %rs = extractelement <4 x float> %xr, i32 0
   ret float %rs
@@ -150,7 +150,7 @@ define float @__round_uniform_float(float) nounwind readonly alwaysinline {
 
 define float @__floor_uniform_float(float) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <4 x float> undef, float %0, i32 0
+  %xi = insertelement <4 x float> poison, float %0, i32 0
   ; roundps, round down 0b01 | don't signal precision exceptions 0b1001 = 9
   %xr = call <4 x float> @llvm.x86.sse41.round.ss(<4 x float> %xi, <4 x float> %xi, i32 9)
   %rs = extractelement <4 x float> %xr, i32 0
@@ -159,7 +159,7 @@ define float @__floor_uniform_float(float) nounwind readonly alwaysinline {
 
 define float @__ceil_uniform_float(float) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <4 x float> undef, float %0, i32 0
+  %xi = insertelement <4 x float> poison, float %0, i32 0
   ; roundps, round up 0b10 | don't signal precision exceptions 0b1010 = 10
   %xr = call <4 x float> @llvm.x86.sse41.round.ss(<4 x float> %xi, <4 x float> %xi, i32 10)
   %rs = extractelement <4 x float> %xr, i32 0
@@ -172,7 +172,7 @@ define float @__ceil_uniform_float(float) nounwind readonly alwaysinline {
 declare <2 x double> @llvm.x86.sse41.round.sd(<2 x double>, <2 x double>, i32) nounwind readnone
 
 define double @__round_uniform_double(double) nounwind readonly alwaysinline {
-  %xi = insertelement <2 x double> undef, double %0, i32 0
+  %xi = insertelement <2 x double> poison, double %0, i32 0
   %xr = call <2 x double> @llvm.x86.sse41.round.sd(<2 x double> %xi, <2 x double> %xi, i32 8)
   %rs = extractelement <2 x double> %xr, i32 0
   ret double %rs
@@ -180,7 +180,7 @@ define double @__round_uniform_double(double) nounwind readonly alwaysinline {
 
 define double @__floor_uniform_double(double) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <2 x double> undef, double %0, i32 0
+  %xi = insertelement <2 x double> poison, double %0, i32 0
   ; roundsd, round down 0b01 | don't signal precision exceptions 0b1001 = 9
   %xr = call <2 x double> @llvm.x86.sse41.round.sd(<2 x double> %xi, <2 x double> %xi, i32 9)
   %rs = extractelement <2 x double> %xr, i32 0
@@ -189,7 +189,7 @@ define double @__floor_uniform_double(double) nounwind readonly alwaysinline {
 
 define double @__ceil_uniform_double(double) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <2 x double> undef, double %0, i32 0
+  %xi = insertelement <2 x double> poison, double %0, i32 0
   ; roundsd, round up 0b10 | don't signal precision exceptions 0b1010 = 10
   %xr = call <2 x double> @llvm.x86.sse41.round.sd(<2 x double> %xi, <2 x double> %xi, i32 10)
   %rs = extractelement <2 x double> %xr, i32 0

--- a/builtins/target-avx2-i32x16.ll
+++ b/builtins/target-avx2-i32x16.ll
@@ -17,18 +17,18 @@ include(`util.m4')
 ; $1: type
 ; $2: var base name
 define(`extract_4s', `
-  %$2_1 = shufflevector <16 x $1> %$2, <16 x $1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %$2_2 = shufflevector <16 x $1> %$2, <16 x $1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %$2_3 = shufflevector <16 x $1> %$2, <16 x $1> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %$2_4 = shufflevector <16 x $1> %$2, <16 x $1> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  %$2_1 = shufflevector <16 x $1> %$2, <16 x $1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %$2_2 = shufflevector <16 x $1> %$2, <16 x $1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %$2_3 = shufflevector <16 x $1> %$2, <16 x $1> poison, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  %$2_4 = shufflevector <16 x $1> %$2, <16 x $1> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 ')
 
 ; $1: type
 ; $2: var base name
 define(`extract_8s', `
-  %$2_1 = shufflevector <16 x $1> %$2, <16 x $1> undef,
+  %$2_1 = shufflevector <16 x $1> %$2, <16 x $1> poison,
                     <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %$2_2 = shufflevector <16 x $1> %$2, <16 x $1> undef,
+  %$2_2 = shufflevector <16 x $1> %$2, <16 x $1> poison,
                     <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 ')
 
@@ -199,10 +199,10 @@ declare <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16>) nounwind readnone
 declare <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float>, i32) nounwind readnone
 
 define <16 x float> @__half_to_float_varying(<16 x i16> %v) nounwind readnone {
-  %r_0 = shufflevector <16 x i16> %v, <16 x i16> undef,
+  %r_0 = shufflevector <16 x i16> %v, <16 x i16> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %vr_0 = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %r_0)
-  %r_1 = shufflevector <16 x i16> %v, <16 x i16> undef,
+  %r_1 = shufflevector <16 x i16> %v, <16 x i16> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %vr_1 = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %r_1)
   %r = shufflevector <8 x float> %vr_0, <8 x float> %vr_1, 
@@ -212,10 +212,10 @@ define <16 x float> @__half_to_float_varying(<16 x i16> %v) nounwind readnone {
 }
 
 define <16 x i16> @__float_to_half_varying(<16 x float> %v) nounwind readnone {
-  %r_0 = shufflevector <16 x float> %v, <16 x float> undef,
+  %r_0 = shufflevector <16 x float> %v, <16 x float> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %vr_0 = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %r_0, i32 0)
-  %r_1 = shufflevector <16 x float> %v, <16 x float> undef,
+  %r_1 = shufflevector <16 x float> %v, <16 x float> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %vr_1 = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %r_1, i32 0)
   %r = shufflevector <8 x i16> %vr_0, <8 x i16> %vr_1, 
@@ -226,9 +226,9 @@ define <16 x i16> @__float_to_half_varying(<16 x float> %v) nounwind readnone {
 
 define float @__half_to_float_uniform(i16 %v) nounwind readnone {
   %v1 = bitcast i16 %v to <1 x i16>
-  %vv = shufflevector <1 x i16> %v1, <1 x i16> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x i16> %v1, <1 x i16> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %rv = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %vv)
   %r = extractelement <8 x float> %rv, i32 0
   ret float %r
@@ -236,9 +236,9 @@ define float @__half_to_float_uniform(i16 %v) nounwind readnone {
 
 define i16 @__float_to_half_uniform(float %v) nounwind readnone {
   %v1 = bitcast float %v to <1 x float>
-  %vv = shufflevector <1 x float> %v1, <1 x float> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x float> %v1, <1 x float> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   ; round to nearest even
   %rv = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %vv, i32 0)
   %r = extractelement <8 x i16> %rv, i32 0
@@ -307,9 +307,9 @@ define <16 x i32> @__gather32_i32(<16 x i32> %ptrs,
   extract_8s(i32, ptrs)
   extract_8s(i32, vecmask)
 
-  %v1 = call <8 x i32> @llvm.x86.avx2.gather.d.d.256(<8 x i32> undef, i8 * null,
+  %v1 = call <8 x i32> @llvm.x86.avx2.gather.d.d.256(<8 x i32> poison, i8 * null,
                        <8 x i32> %ptrs_1, <8 x i32> %vecmask_1, i8 1)
-  %v2 = call <8 x i32> @llvm.x86.avx2.gather.d.d.256(<8 x i32> undef, i8 * null,
+  %v2 = call <8 x i32> @llvm.x86.avx2.gather.d.d.256(<8 x i32> poison, i8 * null,
                        <8 x i32> %ptrs_2, <8 x i32> %vecmask_2, i8 1)
 
   assemble_8s(i32, v, v1, v2)
@@ -323,13 +323,13 @@ define <16 x i32> @__gather64_i32(<16 x i64> %ptrs,
   extract_4s(i64, ptrs)
   extract_4s(i32, vecmask)
 
-  %v1 = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> undef, i8 * null,
+  %v1 = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> poison, i8 * null,
                       <4 x i64> %ptrs_1, <4 x i32> %vecmask_1, i8 1)
-  %v2 = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> undef, i8 * null,
+  %v2 = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> poison, i8 * null,
                       <4 x i64> %ptrs_2, <4 x i32> %vecmask_2, i8 1)
-  %v3 = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> undef, i8 * null,
+  %v3 = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> poison, i8 * null,
                       <4 x i64> %ptrs_3, <4 x i32> %vecmask_3, i8 1)
-  %v4 = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> undef, i8 * null,
+  %v4 = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> poison, i8 * null,
                       <4 x i64> %ptrs_4, <4 x i32> %vecmask_4, i8 1)
 
   assemble_4s(i32, v, v1, v2, v3, v4)
@@ -386,9 +386,9 @@ define <16 x float> @__gather32_float(<16 x i32> %ptrs,
   extract_8s(float, mask)
   extract_8s(i32, ptrs)
 
-  %v1 = call <8 x float> @llvm.x86.avx2.gather.d.ps.256(<8 x float> undef, i8 * null,
+  %v1 = call <8 x float> @llvm.x86.avx2.gather.d.ps.256(<8 x float> poison, i8 * null,
                      <8 x i32> %ptrs_1, <8 x float> %mask_1, i8 1)
-  %v2 = call <8 x float> @llvm.x86.avx2.gather.d.ps.256(<8 x float> undef, i8 * null,
+  %v2 = call <8 x float> @llvm.x86.avx2.gather.d.ps.256(<8 x float> poison, i8 * null,
                      <8 x i32> %ptrs_2, <8 x float> %mask_2, i8 1)
 
   assemble_8s(float, v, v1, v2)
@@ -403,13 +403,13 @@ define <16 x float> @__gather64_float(<16 x i64> %ptrs,
   extract_4s(i64, ptrs)
   extract_4s(float, mask)
 
-  %v1 = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> undef, i8 * null,
+  %v1 = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> poison, i8 * null,
                       <4 x i64> %ptrs_1, <4 x float> %mask_1, i8 1)
-  %v2 = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> undef, i8 * null,
+  %v2 = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> poison, i8 * null,
                       <4 x i64> %ptrs_2, <4 x float> %mask_2, i8 1)
-  %v3 = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> undef, i8 * null,
+  %v3 = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> poison, i8 * null,
                       <4 x i64> %ptrs_3, <4 x float> %mask_3, i8 1)
-  %v4 = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> undef, i8 * null,
+  %v4 = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> poison, i8 * null,
                       <4 x i64> %ptrs_4, <4 x float> %mask_4, i8 1)
 
   assemble_4s(float, v, v1, v2, v3, v4)
@@ -467,13 +467,13 @@ define <16 x i64> @__gather32_i64(<16 x i32> %ptrs,
   extract_4s(i32, ptrs)
   extract_4s(i64, vecmask)
 
-  %v1 = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> undef, i8 * null,
+  %v1 = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> poison, i8 * null,
                       <4 x i32> %ptrs_1, <4 x i64> %vecmask_1, i8 1)
-  %v2 = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> undef, i8 * null,
+  %v2 = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> poison, i8 * null,
                       <4 x i32> %ptrs_2, <4 x i64> %vecmask_2, i8 1)
-  %v3 = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> undef, i8 * null,
+  %v3 = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> poison, i8 * null,
                       <4 x i32> %ptrs_3, <4 x i64> %vecmask_3, i8 1)
-  %v4 = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> undef, i8 * null,
+  %v4 = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> poison, i8 * null,
                       <4 x i32> %ptrs_4, <4 x i64> %vecmask_4, i8 1)
 
   assemble_4s(i64, v, v1, v2, v3, v4)
@@ -487,13 +487,13 @@ define <16 x i64> @__gather64_i64(<16 x i64> %ptrs,
   extract_4s(i64, ptrs)
   extract_4s(i64, vecmask)
 
-  %v1 = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> undef, i8 * null,
+  %v1 = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> poison, i8 * null,
                       <4 x i64> %ptrs_1, <4 x i64> %vecmask_1, i8 1)
-  %v2 = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> undef, i8 * null,
+  %v2 = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> poison, i8 * null,
                       <4 x i64> %ptrs_2, <4 x i64> %vecmask_2, i8 1)
-  %v3 = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> undef, i8 * null,
+  %v3 = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> poison, i8 * null,
                       <4 x i64> %ptrs_3, <4 x i64> %vecmask_3, i8 1)
-  %v4 = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> undef, i8 * null,
+  %v4 = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> poison, i8 * null,
                       <4 x i64> %ptrs_4, <4 x i64> %vecmask_4, i8 1)
 
   assemble_4s(i64, v, v1, v2, v3, v4)
@@ -555,13 +555,13 @@ define <16 x double> @__gather32_double(<16 x i32> %ptrs,
   extract_4s(i32, ptrs)
   extract_4s(double, vecmask)
 
-  %v1 = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> undef, i8 * null,
+  %v1 = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> poison, i8 * null,
                       <4 x i32> %ptrs_1, <4 x double> %vecmask_1, i8 1)
-  %v2 = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> undef, i8 * null,
+  %v2 = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> poison, i8 * null,
                       <4 x i32> %ptrs_2, <4 x double> %vecmask_2, i8 1)
-  %v3 = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> undef, i8 * null,
+  %v3 = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> poison, i8 * null,
                       <4 x i32> %ptrs_3, <4 x double> %vecmask_3, i8 1)
-  %v4 = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> undef, i8 * null,
+  %v4 = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> poison, i8 * null,
                       <4 x i32> %ptrs_4, <4 x double> %vecmask_4, i8 1)
 
   assemble_4s(double, v, v1, v2, v3, v4)
@@ -577,13 +577,13 @@ define <16 x double> @__gather64_double(<16 x i64> %ptrs,
   extract_4s(i64, ptrs)
   extract_4s(double, vecmask)
 
-  %v1 = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> undef, i8 * null,
+  %v1 = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> poison, i8 * null,
                       <4 x i64> %ptrs_1, <4 x double> %vecmask_1, i8 1)
-  %v2 = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> undef, i8 * null,
+  %v2 = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> poison, i8 * null,
                       <4 x i64> %ptrs_2, <4 x double> %vecmask_2, i8 1)
-  %v3 = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> undef, i8 * null,
+  %v3 = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> poison, i8 * null,
                       <4 x i64> %ptrs_3, <4 x double> %vecmask_3, i8 1)
-  %v4 = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> undef, i8 * null,
+  %v4 = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> poison, i8 * null,
                       <4 x i64> %ptrs_4, <4 x double> %vecmask_4, i8 1)
 
   assemble_4s(double, v, v1, v2, v3, v4)

--- a/builtins/target-avx2-i32x4.ll
+++ b/builtins/target-avx2-i32x4.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2024-2025, Intel Corporation
+;;  Copyright (c) 2024-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -91,10 +91,10 @@ not_const:
 
 
 define(`expand_4to8', `
-  %$3 = shufflevector <4 x $1> %$2, <4 x $1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+  %$3 = shufflevector <4 x $1> %$2, <4 x $1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
 ')
 define(`extract_4from8', `
-  %$3 = shufflevector <8 x $1> %$2, <8 x $1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %$3 = shufflevector <8 x $1> %$2, <8 x $1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ')
 
 declare <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16>) nounwind readnone
@@ -117,9 +117,9 @@ define <4 x i16> @__float_to_half_varying(<4 x float> %v4) nounwind readnone {
 
 define float @__half_to_float_uniform(i16 %v) nounwind readnone {
   %v1 = bitcast i16 %v to <1 x i16>
-  %vv = shufflevector <1 x i16> %v1, <1 x i16> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x i16> %v1, <1 x i16> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %rv = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %vv)
   %r = extractelement <8 x float> %rv, i32 0
   ret float %r
@@ -127,9 +127,9 @@ define float @__half_to_float_uniform(i16 %v) nounwind readnone {
 
 define i16 @__float_to_half_uniform(float %v) nounwind readnone {
   %v1 = bitcast float %v to <1 x float>
-  %vv = shufflevector <1 x float> %v1, <1 x float> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x float> %v1, <1 x float> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   ; round to nearest even
   %rv = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %vv, i32 0)
   %r = extractelement <8 x i16> %rv, i32 0
@@ -184,7 +184,7 @@ define <4 x i32> @__gather_base_offsets64_i32(i8 * %ptr,
 define <4 x i32> @__gather32_i32(<4 x i32> %ptrs,
                                  <4 x i32> %vecmask) nounwind readonly alwaysinline {
 
-  %v = call <4 x i32> @llvm.x86.avx2.gather.d.d(<4 x i32> undef, i8 * null,
+  %v = call <4 x i32> @llvm.x86.avx2.gather.d.d(<4 x i32> poison, i8 * null,
                       <4 x i32> %ptrs, <4 x i32> %vecmask, i8 1)
   
   ret <4 x i32> %v
@@ -194,7 +194,7 @@ define <4 x i32> @__gather32_i32(<4 x i32> %ptrs,
 define <4 x i32> @__gather64_i32(<4 x i64> %ptrs, 
                                  <4 x i32> %vecmask) nounwind readonly alwaysinline {
 
-  %v = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> undef, i8 * null,
+  %v = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> poison, i8 * null,
                       <4 x i64> %ptrs, <4 x i32> %vecmask, i8 1)
 
   ret <4 x i32> %v
@@ -235,7 +235,7 @@ define <4 x float> @__gather32_float(<4 x i32> %ptrs,
                                      <4 x i32> %vecmask) nounwind readonly alwaysinline {
   %mask = bitcast <4 x i32> %vecmask to <4 x float>
 
-  %v = call <4 x float> @llvm.x86.avx2.gather.d.ps(<4 x float> undef, i8 * null,
+  %v = call <4 x float> @llvm.x86.avx2.gather.d.ps(<4 x float> poison, i8 * null,
                      <4 x i32> %ptrs, <4 x float> %mask, i8 1)
 
   ret <4 x float> %v
@@ -246,7 +246,7 @@ define <4 x float> @__gather64_float(<4 x i64> %ptrs,
                                      <4 x i32> %vecmask) nounwind readonly alwaysinline {
   %mask = bitcast <4 x i32> %vecmask to <4 x float>
 
-  %v = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> undef, i8 * null,
+  %v = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> poison, i8 * null,
                       <4 x i64> %ptrs, <4 x float> %mask, i8 1)
 
   ret <4 x float> %v
@@ -286,7 +286,7 @@ define <4 x i64> @__gather32_i64(<4 x i32> %ptrs,
                                  <4 x i32> %vecmask32) nounwind readonly alwaysinline {
 
   %vecmask = sext <4 x i32> %vecmask32 to <4 x i64>
-  %v = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> undef, i8 * null,
+  %v = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> poison, i8 * null,
                       <4 x i32> %ptrs, <4 x i64> %vecmask, i8 1)
   ret <4 x i64> %v
 }
@@ -296,7 +296,7 @@ define <4 x i64> @__gather64_i64(<4 x i64> %ptrs,
                                  <4 x i32> %vecmask32) nounwind readonly alwaysinline {
 
   %vecmask = sext <4 x i32> %vecmask32 to <4 x i64>
-  %v = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> undef, i8 * null,
+  %v = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> poison, i8 * null,
                       <4 x i64> %ptrs, <4 x i64> %vecmask, i8 1)
   ret <4 x i64> %v
 }
@@ -335,7 +335,7 @@ define <4 x double> @__gather32_double(<4 x i32> %ptrs,
   %vecmask64 = sext <4 x i32> %vecmask32 to <4 x i64>
   %vecmask = bitcast <4 x i64> %vecmask64 to <4 x double>
 
-  %v = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> undef, i8 * null,
+  %v = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> poison, i8 * null,
                       <4 x i32> %ptrs, <4 x double> %vecmask, i8 1)
 
   ret <4 x double> %v
@@ -346,7 +346,7 @@ define <4 x double> @__gather64_double(<4 x i64> %ptrs,
   %vecmask64 = sext <4 x i32> %vecmask32 to <4 x i64>
   %vecmask = bitcast <4 x i64> %vecmask64 to <4 x double>
 
-  %v = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> undef, i8 * null,
+  %v = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> poison, i8 * null,
                       <4 x i64> %ptrs, <4 x double> %vecmask, i8 1)
 
   ret <4 x double> %v

--- a/builtins/target-avx2-i32x8.ll
+++ b/builtins/target-avx2-i32x8.ll
@@ -145,9 +145,9 @@ define <8 x i16> @__float_to_half_varying(<8 x float> %v) nounwind readnone {
 
 define float @__half_to_float_uniform(i16 %v) nounwind readnone {
   %v1 = bitcast i16 %v to <1 x i16>
-  %vv = shufflevector <1 x i16> %v1, <1 x i16> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x i16> %v1, <1 x i16> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %rv = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %vv)
   %r = extractelement <8 x float> %rv, i32 0
   ret float %r
@@ -155,9 +155,9 @@ define float @__half_to_float_uniform(i16 %v) nounwind readnone {
 
 define i16 @__float_to_half_uniform(float %v) nounwind readnone {
   %v1 = bitcast float %v to <1 x float>
-  %vv = shufflevector <1 x float> %v1, <1 x float> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x float> %v1, <1 x float> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   ; round to nearest even
   %rv = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %vv, i32 0)
   %r = extractelement <8 x i16> %rv, i32 0
@@ -170,8 +170,8 @@ define i16 @__float_to_half_uniform(float %v) nounwind readnone {
 declare void @llvm.trap() noreturn nounwind
 
 define(`extract_4s', `
-  %$2_1 = shufflevector <8 x $1> %$2, <8 x $1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %$2_2 = shufflevector <8 x $1> %$2, <8 x $1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %$2_1 = shufflevector <8 x $1> %$2, <8 x $1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %$2_2 = shufflevector <8 x $1> %$2, <8 x $1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 ')
 
 ;; We need factored generic implementations when --opt=disable-gathers is used.
@@ -221,7 +221,7 @@ define <8 x i32> @__gather_base_offsets64_i32(i8 * %ptr,
 
 define <8 x i32> @__gather32_i32(<8 x i32> %ptrs, 
                                  <8 x i32> %vecmask) nounwind readonly alwaysinline {
-  %v = call <8 x i32> @llvm.x86.avx2.gather.d.d.256(<8 x i32> undef, i8 * null,
+  %v = call <8 x i32> @llvm.x86.avx2.gather.d.d.256(<8 x i32> poison, i8 * null,
                       <8 x i32> %ptrs, <8 x i32> %vecmask, i8 1)
   ret <8 x i32> %v
 }
@@ -232,9 +232,9 @@ define <8 x i32> @__gather64_i32(<8 x i64> %ptrs,
   extract_4s(i64, ptrs)
   extract_4s(i32, vecmask)
 
-  %v1 = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> undef, i8 * null,
+  %v1 = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> poison, i8 * null,
                       <4 x i64> %ptrs_1, <4 x i32> %vecmask_1, i8 1)
-  %v2 = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> undef, i8 * null,
+  %v2 = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> poison, i8 * null,
                       <4 x i64> %ptrs_2, <4 x i32> %vecmask_2, i8 1)
 
   %v = shufflevector <4 x i32> %v1, <4 x i32> %v2,
@@ -282,7 +282,7 @@ define <8 x float> @__gather32_float(<8 x i32> %ptrs,
                                      <8 x i32> %vecmask) nounwind readonly alwaysinline {
   %mask = bitcast <8 x i32> %vecmask to <8 x float>
 
-  %v = call <8 x float> @llvm.x86.avx2.gather.d.ps.256(<8 x float> undef, i8 * null,
+  %v = call <8 x float> @llvm.x86.avx2.gather.d.ps.256(<8 x float> poison, i8 * null,
                      <8 x i32> %ptrs, <8 x float> %mask, i8 1)
 
   ret <8 x float> %v
@@ -295,9 +295,9 @@ define <8 x float> @__gather64_float(<8 x i64> %ptrs,
   extract_4s(i64, ptrs)
   extract_4s(float, mask)
 
-  %v1 = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> undef, i8 * null,
+  %v1 = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> poison, i8 * null,
                       <4 x i64> %ptrs_1, <4 x float> %mask_1, i8 1)
-  %v2 = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> undef, i8 * null,
+  %v2 = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> poison, i8 * null,
                       <4 x i64> %ptrs_2, <4 x float> %mask_2, i8 1)
 
   %v = shufflevector <4 x float> %v1, <4 x float> %v2,
@@ -353,9 +353,9 @@ define <8 x i64> @__gather32_i64(<8 x i32> %ptrs,
   extract_4s(i32, ptrs)
   extract_4s(i64, vecmask)
 
-  %v1 = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> undef, i8 * null,
+  %v1 = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> poison, i8 * null,
                       <4 x i32> %ptrs_1, <4 x i64> %vecmask_1, i8 1)
-  %v2 = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> undef, i8 * null,
+  %v2 = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> poison, i8 * null,
                       <4 x i32> %ptrs_2, <4 x i64> %vecmask_2, i8 1)
   %v = shufflevector <4 x i64> %v1, <4 x i64> %v2,
                      <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -369,9 +369,9 @@ define <8 x i64> @__gather64_i64(<8 x i64> %ptrs,
   extract_4s(i64, ptrs)
   extract_4s(i64, vecmask)
 
-  %v1 = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> undef, i8 * null,
+  %v1 = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> poison, i8 * null,
                       <4 x i64> %ptrs_1, <4 x i64> %vecmask_1, i8 1)
-  %v2 = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> undef, i8 * null,
+  %v2 = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> poison, i8 * null,
                       <4 x i64> %ptrs_2, <4 x i64> %vecmask_2, i8 1)
 
   %v = shufflevector <4 x i64> %v1, <4 x i64> %v2,
@@ -427,9 +427,9 @@ define <8 x double> @__gather32_double(<8 x i32> %ptrs,
   extract_4s(i32, ptrs)
   extract_4s(double, vecmask)
 
-  %v1 = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> undef, i8 * null,
+  %v1 = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> poison, i8 * null,
                       <4 x i32> %ptrs_1, <4 x double> %vecmask_1, i8 1)
-  %v2 = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> undef, i8 * null,
+  %v2 = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> poison, i8 * null,
                       <4 x i32> %ptrs_2, <4 x double> %vecmask_2, i8 1)
 
   %v = shufflevector <4 x double> %v1, <4 x double> %v2,
@@ -444,9 +444,9 @@ define <8 x double> @__gather64_double(<8 x i64> %ptrs,
   extract_4s(i64, ptrs)
   extract_4s(double, vecmask)
 
-  %v1 = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> undef, i8 * null,
+  %v1 = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> poison, i8 * null,
                       <4 x i64> %ptrs_1, <4 x double> %vecmask_1, i8 1)
-  %v2 = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> undef, i8 * null,
+  %v2 = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> poison, i8 * null,
                       <4 x i64> %ptrs_2, <4 x double> %vecmask_2, i8 1)
 
   %v = shufflevector <4 x double> %v1, <4 x double> %v2,
@@ -893,8 +893,8 @@ define i32 @__packed_store_activei64(ptr %startptr, <8 x i64> %vals, <8 x i32> %
 ; Function Attrs: alwaysinline nounwind
 define i32 @__packed_store_active2i64(ptr %startptr, <8 x i64> %vals, <8 x i32> %full_mask) #0 {
 entry:
-  %vals_low = shufflevector <8 x i64> %vals, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vals_high = shufflevector <8 x i64> %vals, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vals_low = shufflevector <8 x i64> %vals, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vals_high = shufflevector <8 x i64> %vals, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %cmp.i = icmp ne <8 x i32> %full_mask, zeroinitializer
   %0 = bitcast <8 x i1> %cmp.i to i8
   %conv = zext i8 %0 to i32

--- a/builtins/target-avx2-i64x4.ll
+++ b/builtins/target-avx2-i64x4.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2013-2025, Intel Corporation
+;;  Copyright (c) 2013-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -26,10 +26,10 @@ rdrand_definition()
 
 
 define(`expand_4to8', `
-  %$3 = shufflevector <4 x $1> %$2, <4 x $1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
+  %$3 = shufflevector <4 x $1> %$2, <4 x $1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
 ')
 define(`extract_4from8', `
-  %$3 = shufflevector <8 x $1> %$2, <8 x $1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %$3 = shufflevector <8 x $1> %$2, <8 x $1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ')
 
 declare <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16>) nounwind readnone
@@ -52,9 +52,9 @@ define <4 x i16> @__float_to_half_varying(<4 x float> %v4) nounwind readnone {
 
 define float @__half_to_float_uniform(i16 %v) nounwind readnone {
   %v1 = bitcast i16 %v to <1 x i16>
-  %vv = shufflevector <1 x i16> %v1, <1 x i16> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x i16> %v1, <1 x i16> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %rv = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %vv)
   %r = extractelement <8 x float> %rv, i32 0
   ret float %r
@@ -62,9 +62,9 @@ define float @__half_to_float_uniform(i16 %v) nounwind readnone {
 
 define i16 @__float_to_half_uniform(float %v) nounwind readnone {
   %v1 = bitcast float %v to <1 x float>
-  %vv = shufflevector <1 x float> %v1, <1 x float> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x float> %v1, <1 x float> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   ; round to nearest even
   %rv = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %vv, i32 0)
   %r = extractelement <8 x i16> %rv, i32 0
@@ -121,7 +121,7 @@ define <4 x i32> @__gather32_i32(<4 x i32> %ptrs,
 
   %vecmask = trunc <4 x i64> %vecmask64 to <4 x i32>
 
-  %v = call <4 x i32> @llvm.x86.avx2.gather.d.d(<4 x i32> undef, i8 * null,
+  %v = call <4 x i32> @llvm.x86.avx2.gather.d.d(<4 x i32> poison, i8 * null,
                       <4 x i32> %ptrs, <4 x i32> %vecmask, i8 1)
   
   ret <4 x i32> %v
@@ -132,7 +132,7 @@ define <4 x i32> @__gather64_i32(<4 x i64> %ptrs,
                                  <4 x i64> %vecmask64) nounwind readonly alwaysinline {
   %vecmask = trunc <4 x i64> %vecmask64 to <4 x i32>
 
-  %v = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> undef, i8 * null,
+  %v = call <4 x i32> @llvm.x86.avx2.gather.q.d.256(<4 x i32> poison, i8 * null,
                       <4 x i64> %ptrs, <4 x i32> %vecmask, i8 1)
 
   ret <4 x i32> %v
@@ -176,7 +176,7 @@ define <4 x float> @__gather32_float(<4 x i32> %ptrs,
   %vecmask = trunc <4 x i64> %vecmask64 to <4 x i32>
   %mask = bitcast <4 x i32> %vecmask to <4 x float>
 
-  %v = call <4 x float> @llvm.x86.avx2.gather.d.ps(<4 x float> undef, i8 * null,
+  %v = call <4 x float> @llvm.x86.avx2.gather.d.ps(<4 x float> poison, i8 * null,
                      <4 x i32> %ptrs, <4 x float> %mask, i8 1)
 
   ret <4 x float> %v
@@ -188,7 +188,7 @@ define <4 x float> @__gather64_float(<4 x i64> %ptrs,
   %vecmask = trunc <4 x i64> %vecmask64 to <4 x i32>
   %mask = bitcast <4 x i32> %vecmask to <4 x float>
 
-  %v = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> undef, i8 * null,
+  %v = call <4 x float> @llvm.x86.avx2.gather.q.ps.256(<4 x float> poison, i8 * null,
                       <4 x i64> %ptrs, <4 x float> %mask, i8 1)
 
   ret <4 x float> %v
@@ -225,7 +225,7 @@ define <4 x i64> @__gather_base_offsets64_i64(i8 * %ptr,
 define <4 x i64> @__gather32_i64(<4 x i32> %ptrs, 
                                  <4 x i64> %vecmask) nounwind readonly alwaysinline {
 
-  %v = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> undef, i8 * null,
+  %v = call <4 x i64> @llvm.x86.avx2.gather.d.q.256(<4 x i64> poison, i8 * null,
                       <4 x i32> %ptrs, <4 x i64> %vecmask, i8 1)
   ret <4 x i64> %v
 }
@@ -233,7 +233,7 @@ define <4 x i64> @__gather32_i64(<4 x i32> %ptrs,
 
 define <4 x i64> @__gather64_i64(<4 x i64> %ptrs, 
                                  <4 x i64> %vecmask) nounwind readonly alwaysinline {
-  %v = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> undef, i8 * null,
+  %v = call <4 x i64> @llvm.x86.avx2.gather.q.q.256(<4 x i64> poison, i8 * null,
                       <4 x i64> %ptrs, <4 x i64> %vecmask, i8 1)
   ret <4 x i64> %v
 }
@@ -269,7 +269,7 @@ define <4 x double> @__gather32_double(<4 x i32> %ptrs,
                                        <4 x i64> %vecmask64) nounwind readonly alwaysinline {
   %vecmask = bitcast <4 x i64> %vecmask64 to <4 x double>
 
-  %v = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> undef, i8 * null,
+  %v = call <4 x double> @llvm.x86.avx2.gather.d.pd.256(<4 x double> poison, i8 * null,
                       <4 x i32> %ptrs, <4 x double> %vecmask, i8 1)
 
   ret <4 x double> %v
@@ -279,7 +279,7 @@ define <4 x double> @__gather64_double(<4 x i64> %ptrs,
                                        <4 x i64> %vecmask64) nounwind readonly alwaysinline {
   %vecmask = bitcast <4 x i64> %vecmask64 to <4 x double>
 
-  %v = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> undef, i8 * null,
+  %v = call <4 x double> @llvm.x86.avx2.gather.q.pd.256(<4 x double> poison, i8 * null,
                       <4 x i64> %ptrs, <4 x double> %vecmask, i8 1)
 
   ret <4 x double> %v

--- a/builtins/target-avx2-i8x32.ll
+++ b/builtins/target-avx2-i8x32.ll
@@ -73,9 +73,9 @@ declare <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float>, i32) nounwind readnone
 
 define float @__half_to_float_uniform(i16 %v) nounwind readnone alwaysinline {
   %v1 = bitcast i16 %v to <1 x i16>
-  %vv = shufflevector <1 x i16> %v1, <1 x i16> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x i16> %v1, <1 x i16> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %rv = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %vv)
   %r = extractelement <8 x float> %rv, i32 0
   ret float %r
@@ -83,9 +83,9 @@ define float @__half_to_float_uniform(i16 %v) nounwind readnone alwaysinline {
 
 define i16 @__float_to_half_uniform(float %v) nounwind readnone alwaysinline {
   %v1 = bitcast float %v to <1 x float>
-  %vv = shufflevector <1 x float> %v1, <1 x float> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x float> %v1, <1 x float> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   ; round to nearest even
   %rv = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %vv, i32 0)
   %r = extractelement <8 x i16> %rv, i32 0
@@ -144,7 +144,7 @@ define float @__round_uniform_float(float) nounwind readonly alwaysinline {
   ;  It doesn't matter what we pass as a, since we only need the r0 value
   ;  here.  So we pass the same register for both.  Further, only the 0th
   ;  element of the b parameter matters
-  %xi = insertelement <4 x float> undef, float %0, i32 0
+  %xi = insertelement <4 x float> poison, float %0, i32 0
   %xr = call <4 x float> @llvm.x86.sse41.round.ss(<4 x float> %xi, <4 x float> %xi, i32 8)
   %rs = extractelement <4 x float> %xr, i32 0
   ret float %rs
@@ -152,7 +152,7 @@ define float @__round_uniform_float(float) nounwind readonly alwaysinline {
 
 define float @__floor_uniform_float(float) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <4 x float> undef, float %0, i32 0
+  %xi = insertelement <4 x float> poison, float %0, i32 0
   ; roundps, round down 0b01 | don't signal precision exceptions 0b1001 = 9
   %xr = call <4 x float> @llvm.x86.sse41.round.ss(<4 x float> %xi, <4 x float> %xi, i32 9)
   %rs = extractelement <4 x float> %xr, i32 0
@@ -161,7 +161,7 @@ define float @__floor_uniform_float(float) nounwind readonly alwaysinline {
 
 define float @__ceil_uniform_float(float) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <4 x float> undef, float %0, i32 0
+  %xi = insertelement <4 x float> poison, float %0, i32 0
   ; roundps, round up 0b10 | don't signal precision exceptions 0b1010 = 10
   %xr = call <4 x float> @llvm.x86.sse41.round.ss(<4 x float> %xi, <4 x float> %xi, i32 10)
   %rs = extractelement <4 x float> %xr, i32 0
@@ -174,7 +174,7 @@ define float @__ceil_uniform_float(float) nounwind readonly alwaysinline {
 declare <2 x double> @llvm.x86.sse41.round.sd(<2 x double>, <2 x double>, i32) nounwind readnone
 
 define double @__round_uniform_double(double) nounwind readonly alwaysinline {
-  %xi = insertelement <2 x double> undef, double %0, i32 0
+  %xi = insertelement <2 x double> poison, double %0, i32 0
   %xr = call <2 x double> @llvm.x86.sse41.round.sd(<2 x double> %xi, <2 x double> %xi, i32 8)
   %rs = extractelement <2 x double> %xr, i32 0
   ret double %rs
@@ -182,7 +182,7 @@ define double @__round_uniform_double(double) nounwind readonly alwaysinline {
 
 define double @__floor_uniform_double(double) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <2 x double> undef, double %0, i32 0
+  %xi = insertelement <2 x double> poison, double %0, i32 0
   ; roundsd, round down 0b01 | don't signal precision exceptions 0b1001 = 9
   %xr = call <2 x double> @llvm.x86.sse41.round.sd(<2 x double> %xi, <2 x double> %xi, i32 9)
   %rs = extractelement <2 x double> %xr, i32 0
@@ -191,7 +191,7 @@ define double @__floor_uniform_double(double) nounwind readonly alwaysinline {
 
 define double @__ceil_uniform_double(double) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <2 x double> undef, double %0, i32 0
+  %xi = insertelement <2 x double> poison, double %0, i32 0
   ; roundsd, round up 0b10 | don't signal precision exceptions 0b1010 = 10
   %xr = call <2 x double> @llvm.x86.sse41.round.sd(<2 x double> %xi, <2 x double> %xi, i32 10)
   %rs = extractelement <2 x double> %xr, i32 0

--- a/builtins/target-avx512-utils.ll
+++ b/builtins/target-avx512-utils.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2015-2025, Intel Corporation
+;;  Copyright (c) 2015-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -24,9 +24,9 @@ aossoa()
 
 define float @__half_to_float_uniform(i16 %v) nounwind readnone {
   %v1 = bitcast i16 %v to <1 x i16>
-  %vv = shufflevector <1 x i16> %v1, <1 x i16> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x i16> %v1, <1 x i16> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %rv = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %vv)
   %r = extractelement <8 x float> %rv, i32 0
   ret float %r
@@ -34,9 +34,9 @@ define float @__half_to_float_uniform(i16 %v) nounwind readnone {
 
 define i16 @__float_to_half_uniform(float %v) nounwind readnone {
   %v1 = bitcast float %v to <1 x float>
-  %vv = shufflevector <1 x float> %v1, <1 x float> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x float> %v1, <1 x float> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   ; round to nearest even
   %rv = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %vv, i32 0)
   %r = extractelement <8 x i16> %rv, i32 0
@@ -105,8 +105,8 @@ define double @__max_uniform_double(double, double) nounwind readnone alwaysinli
 define(`rsqrt14_uniform', `
 declare <4 x float> @llvm.x86.avx512.rsqrt14.ss(<4 x float>, <4 x float>, <4 x float>, i8) nounwind readnone
 define float @__rsqrt_fast_uniform_float(float) nounwind readonly alwaysinline {
-  %v = insertelement <4 x float> undef, float %0, i32 0
-  %vis = call <4 x float> @llvm.x86.avx512.rsqrt14.ss(<4 x float> %v, <4 x float> %v, <4 x float> undef, i8 -1)
+  %v = insertelement <4 x float> poison, float %0, i32 0
+  %vis = call <4 x float> @llvm.x86.avx512.rsqrt14.ss(<4 x float> %v, <4 x float> %v, <4 x float> poison, i8 -1)
   %is = extractelement <4 x float> %vis, i32 0
   ret float %is
 }
@@ -126,8 +126,8 @@ define float @__rsqrt_uniform_float(float) nounwind readonly alwaysinline {
 
 declare <2 x double> @llvm.x86.avx512.rsqrt14.sd(<2 x double>, <2 x double>, <2 x double>, i8) nounwind readnone
 define double @__rsqrt_fast_uniform_double(double) nounwind readonly alwaysinline {
-  %v = insertelement <2 x double> undef, double %0, i32 0
-  %vis = call <2 x double> @llvm.x86.avx512.rsqrt14.sd(<2 x double> %v, <2 x double> %v, <2 x double> undef, i8 -1)
+  %v = insertelement <2 x double> poison, double %0, i32 0
+  %vis = call <2 x double> @llvm.x86.avx512.rsqrt14.sd(<2 x double> %v, <2 x double> %v, <2 x double> poison, i8 -1)
   %is = extractelement <2 x double> %vis, i32 0
   ret double %is
 }
@@ -135,7 +135,7 @@ define double @__rsqrt_fast_uniform_double(double) nounwind readonly alwaysinlin
 declare i8 @llvm.x86.avx512.mask.fpclass.sd(<2 x double>, i32, i8)
 define double @__rsqrt_uniform_double(double %v) nounwind readonly alwaysinline {
   ; detect +/-0 and +inf to deal with them differently.
-  %vec = insertelement <2 x double> undef, double %v, i32 0
+  %vec = insertelement <2 x double> poison, double %v, i32 0
   %corner_cases_i8 = call i8 @llvm.x86.avx512.mask.fpclass.sd(<2 x double> %vec, i32 14, i8 -1)
   %corner_cases = icmp ne i8 %corner_cases_i8, 0
   %is = call double @__rsqrt_fast_uniform_double(double %v)
@@ -168,8 +168,8 @@ define double @__rsqrt_uniform_double(double %v) nounwind readonly alwaysinline 
 define(`rcp14_uniform', `
 declare <4 x float> @llvm.x86.avx512.rcp14.ss(<4 x float>, <4 x float>, <4 x float>, i8) nounwind readnone
 define float @__rcp_fast_uniform_float(float) nounwind readonly alwaysinline {
-  %vecval = insertelement <4 x float> undef, float %0, i32 0
-  %call = call <4 x float> @llvm.x86.avx512.rcp14.ss(<4 x float> %vecval, <4 x float> %vecval, <4 x float> undef, i8 -1)
+  %vecval = insertelement <4 x float> poison, float %0, i32 0
+  %call = call <4 x float> @llvm.x86.avx512.rcp14.ss(<4 x float> %vecval, <4 x float> %vecval, <4 x float> poison, i8 -1)
   %scall = extractelement <4 x float> %call, i32 0
   ret float %scall
 }
@@ -188,8 +188,8 @@ define float @__rcp_uniform_float(float %v) nounwind readonly alwaysinline {
 
 declare <2 x double> @llvm.x86.avx512.rcp14.sd(<2 x double>, <2 x double>, <2 x double>, i8) nounwind readnone
 define double @__rcp_fast_uniform_double(double) nounwind readonly alwaysinline {
-  %vecval = insertelement <2 x double> undef, double %0, i32 0
-  %call = call <2 x double> @llvm.x86.avx512.rcp14.sd(<2 x double> %vecval, <2 x double> %vecval, <2 x double> undef, i8 -1)
+  %vecval = insertelement <2 x double> poison, double %0, i32 0
+  %call = call <2 x double> @llvm.x86.avx512.rcp14.sd(<2 x double> %vecval, <2 x double> %vecval, <2 x double> poison, i8 -1)
   %scall = extractelement <2 x double> %call, i32 0
   ret double %scall
 }
@@ -230,19 +230,19 @@ define(`convert_scale_to_const_gather', `
                                                 i32 8, label %on_eight_$1]
 
 on_one_$1:
-  %$1_1 = call <$3 x $4> @$2(<$3 x $4> undef, i8 * %$5, <$3 x $7> %$6, $9 %$8, i32 1)
+  %$1_1 = call <$3 x $4> @$2(<$3 x $4> poison, i8 * %$5, <$3 x $7> %$6, $9 %$8, i32 1)
   br label %end_bb_$1
 
 on_two_$1:
-  %$1_2 = call <$3 x $4> @$2(<$3 x $4> undef, i8 * %$5, <$3 x $7> %$6, $9 %$8, i32 2)
+  %$1_2 = call <$3 x $4> @$2(<$3 x $4> poison, i8 * %$5, <$3 x $7> %$6, $9 %$8, i32 2)
   br label %end_bb_$1
 
 on_four_$1:
-  %$1_4 = call <$3 x $4> @$2(<$3 x $4> undef, i8 * %$5, <$3 x $7> %$6, $9 %$8, i32 4)
+  %$1_4 = call <$3 x $4> @$2(<$3 x $4> poison, i8 * %$5, <$3 x $7> %$6, $9 %$8, i32 4)
   br label %end_bb_$1
 
 on_eight_$1:
-  %$1_8 = call <$3 x $4> @$2(<$3 x $4> undef, i8 * %$5, <$3 x $7> %$6, $9 %$8, i32 8)
+  %$1_8 = call <$3 x $4> @$2(<$3 x $4> poison, i8 * %$5, <$3 x $7> %$6, $9 %$8, i32 8)
   br label %end_bb_$1
 
 default_$1:

--- a/builtins/target-avx512fp16-x16-common.ll
+++ b/builtins/target-avx512fp16-x16-common.ll
@@ -8,28 +8,28 @@
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half>, <8 x half>, <8 x half>, i8)
 define half @__rcp_uniform_half(half) nounwind readonly alwaysinline {
-  %vec = insertelement <8 x half> undef, half %0, i32 0
-  %rcp = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> undef, i8 -1)
+  %vec = insertelement <8 x half> poison, half %0, i32 0
+  %rcp = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> poison, i8 -1)
   %ret = extractelement <8 x half> %rcp, i32 0
   ret half %ret
 }
 
 declare <16 x half> @llvm.x86.avx512fp16.mask.rcp.ph.256(<16 x half>, <16 x half>, i16)
 define <16 x half> @__rcp_varying_half(<16 x half>) nounwind readonly alwaysinline {
-  %ret = tail call <16 x half> @llvm.x86.avx512fp16.mask.rcp.ph.256(<16 x half> %0, <16 x half> undef, i16 -1)
+  %ret = tail call <16 x half> @llvm.x86.avx512fp16.mask.rcp.ph.256(<16 x half> %0, <16 x half> poison, i16 -1)
   ret <16 x half> %ret
 }
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half>, <8 x half>, <8 x half>, i8)
 define half @__rsqrt_uniform_half(half) nounwind readnone alwaysinline {
-  %vec = insertelement <8 x half> undef, half %0, i32 0
-  %rsqrt = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> undef, i8 -1)
+  %vec = insertelement <8 x half> poison, half %0, i32 0
+  %rsqrt = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> poison, i8 -1)
   %ret = extractelement <8 x half> %rsqrt, i32 0
   ret half %ret
 }
 
 declare <16 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.256(<16 x half>, <16 x half>, i16)
 define <16 x half> @__rsqrt_varying_half(<16 x half>) nounwind readnone alwaysinline {
-  %ret = tail call <16 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.256(<16 x half> %0, <16 x half> undef, i16 -1)
+  %ret = tail call <16 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.256(<16 x half> %0, <16 x half> poison, i16 -1)
   ret <16 x half> %ret
 }

--- a/builtins/target-avx512fp16-x32-common.ll
+++ b/builtins/target-avx512fp16-x32-common.ll
@@ -8,28 +8,28 @@
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half>, <8 x half>, <8 x half>, i8)
 define half @__rcp_uniform_half(half) nounwind readonly alwaysinline {
-  %vec = insertelement <8 x half> undef, half %0, i32 0
-  %rcp = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> undef, i8 -1)
+  %vec = insertelement <8 x half> poison, half %0, i32 0
+  %rcp = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> poison, i8 -1)
   %ret = extractelement <8 x half> %rcp, i32 0
   ret half %ret
 }
 
 declare <32 x half> @llvm.x86.avx512fp16.mask.rcp.ph.512(<32 x half>, <32 x half>, i32)
 define <32 x half> @__rcp_varying_half(<32 x half>) nounwind readonly alwaysinline {
-  %ret = tail call <32 x half> @llvm.x86.avx512fp16.mask.rcp.ph.512(<32 x half> %0, <32 x half> undef, i32 -1)
+  %ret = tail call <32 x half> @llvm.x86.avx512fp16.mask.rcp.ph.512(<32 x half> %0, <32 x half> poison, i32 -1)
   ret <32 x half> %ret
 }
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half>, <8 x half>, <8 x half>, i8)
 define half @__rsqrt_uniform_half(half) nounwind readnone alwaysinline {
-  %vec = insertelement <8 x half> undef, half %0, i32 0
-  %rsqrt = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> undef, i8 -1)
+  %vec = insertelement <8 x half> poison, half %0, i32 0
+  %rsqrt = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> poison, i8 -1)
   %ret = extractelement <8 x half> %rsqrt, i32 0
   ret half %ret
 }
 
 declare <32 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.512(<32 x half>, <32 x half>, i32)
 define <32 x half> @__rsqrt_varying_half(<32 x half>) nounwind readnone alwaysinline {
-  %ret = tail call <32 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.512(<32 x half> %0, <32 x half> undef, i32 -1)
+  %ret = tail call <32 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.512(<32 x half> %0, <32 x half> poison, i32 -1)
   ret <32 x half> %ret
 }

--- a/builtins/target-avx512fp16-x4-common.ll
+++ b/builtins/target-avx512fp16-x4-common.ll
@@ -8,36 +8,36 @@
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half>, <8 x half>, <8 x half>, i8)
 define half @__rcp_uniform_half(half) nounwind readonly alwaysinline {
-  %vec = insertelement <8 x half> undef, half %0, i32 0
-  %rcp = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> undef, i8 -1)
+  %vec = insertelement <8 x half> poison, half %0, i32 0
+  %rcp = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> poison, i8 -1)
   %ret = extractelement <8 x half> %rcp, i32 0
   ret half %ret
 }
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rcp.ph.128(<8 x half>, <8 x half>, i8)
 define <4 x half> @__rcp_varying_half(<4 x half>) nounwind readonly alwaysinline {
-  %vec = shufflevector <4 x half> %0, <4 x half> undef,
-                       <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef>
-  %rcp = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.ph.128(<8 x half> %vec, <8 x half> undef, i8 -1)
-  %ret = shufflevector <8 x half> %rcp, <8 x half> undef,
+  %vec = shufflevector <4 x half> %0, <4 x half> poison,
+                       <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison>
+  %rcp = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.ph.128(<8 x half> %vec, <8 x half> poison, i8 -1)
+  %ret = shufflevector <8 x half> %rcp, <8 x half> poison,
                        <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   ret <4 x half> %ret
 }
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half>, <8 x half>, <8 x half>, i8)
 define half @__rsqrt_uniform_half(half) nounwind readnone alwaysinline {
-  %vec = insertelement <8 x half> undef, half %0, i32 0
-  %rsqrt = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> undef, i8 -1)
+  %vec = insertelement <8 x half> poison, half %0, i32 0
+  %rsqrt = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> poison, i8 -1)
   %ret = extractelement <8 x half> %rsqrt, i32 0
   ret half %ret
 }
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.128(<8 x half>, <8 x half>, i8)
 define <4 x half> @__rsqrt_varying_half(<4 x half>) nounwind readnone alwaysinline {
-  %vec = shufflevector <4 x half> %0, <4 x half> undef,
-                       <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef>
-  %rsqrt = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.128(<8 x half> %vec, <8 x half> undef, i8 -1)
-  %ret = shufflevector <8 x half> %rsqrt, <8 x half> undef,
+  %vec = shufflevector <4 x half> %0, <4 x half> poison,
+                       <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison>
+  %rsqrt = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.128(<8 x half> %vec, <8 x half> poison, i8 -1)
+  %ret = shufflevector <8 x half> %rsqrt, <8 x half> poison,
                        <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   ret <4 x half> %ret
 }

--- a/builtins/target-avx512fp16-x64-common.ll
+++ b/builtins/target-avx512fp16-x64-common.ll
@@ -8,26 +8,26 @@
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half>, <8 x half>, <8 x half>, i8)
 define half @__rcp_uniform_half(half) nounwind readonly alwaysinline {
-  %vec = insertelement <8 x half> undef, half %0, i32 0
-  %rcp = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> undef, i8 -1)
+  %vec = insertelement <8 x half> poison, half %0, i32 0
+  %rcp = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> poison, i8 -1)
   %ret = extractelement <8 x half> %rcp, i32 0
   ret half %ret
 }
 
 declare <32 x half> @llvm.x86.avx512fp16.mask.rcp.ph.512(<32 x half>, <32 x half>, i32)
 define <64 x half> @__rcp_varying_half(<64 x half>) nounwind readonly alwaysinline {
-  %vec1 = shufflevector <64 x half> %0, <64 x half> undef,
+  %vec1 = shufflevector <64 x half> %0, <64 x half> poison,
                         <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                                     i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                                     i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23,
                                     i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  %vec2 = shufflevector <64 x half> %0, <64 x half> undef,
+  %vec2 = shufflevector <64 x half> %0, <64 x half> poison,
                         <32 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39,
                                     i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47,
                                     i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55,
                                     i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-  %rcp1 = tail call <32 x half> @llvm.x86.avx512fp16.mask.rcp.ph.512(<32 x half> %vec1, <32 x half> undef, i32 -1)
-  %rcp2 = tail call <32 x half> @llvm.x86.avx512fp16.mask.rcp.ph.512(<32 x half> %vec2, <32 x half> undef, i32 -1)
+  %rcp1 = tail call <32 x half> @llvm.x86.avx512fp16.mask.rcp.ph.512(<32 x half> %vec1, <32 x half> poison, i32 -1)
+  %rcp2 = tail call <32 x half> @llvm.x86.avx512fp16.mask.rcp.ph.512(<32 x half> %vec2, <32 x half> poison, i32 -1)
   %ret = shufflevector <32 x half> %rcp1, <32 x half> %rcp2,
                        <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                                     i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
@@ -42,26 +42,26 @@ define <64 x half> @__rcp_varying_half(<64 x half>) nounwind readonly alwaysinli
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half>, <8 x half>, <8 x half>, i8)
 define half @__rsqrt_uniform_half(half) nounwind readnone alwaysinline {
-  %vec = insertelement <8 x half> undef, half %0, i32 0
-  %rsqrt = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> undef, i8 -1)
+  %vec = insertelement <8 x half> poison, half %0, i32 0
+  %rsqrt = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> poison, i8 -1)
   %ret = extractelement <8 x half> %rsqrt, i32 0
   ret half %ret
 }
 
 declare <32 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.512(<32 x half>, <32 x half>, i32)
 define <64 x half> @__rsqrt_varying_half(<64 x half>) nounwind readnone alwaysinline {
-  %vec1 = shufflevector <64 x half> %0, <64 x half> undef,
+  %vec1 = shufflevector <64 x half> %0, <64 x half> poison,
                         <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                                     i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                                     i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23,
                                     i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  %vec2 = shufflevector <64 x half> %0, <64 x half> undef,
+  %vec2 = shufflevector <64 x half> %0, <64 x half> poison,
                         <32 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39,
                                     i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47,
                                     i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55,
                                     i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-  %rsqrt1 = tail call <32 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.512(<32 x half> %vec1, <32 x half> undef, i32 -1)
-  %rsqrt2 = tail call <32 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.512(<32 x half> %vec2, <32 x half> undef, i32 -1)
+  %rsqrt1 = tail call <32 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.512(<32 x half> %vec1, <32 x half> poison, i32 -1)
+  %rsqrt2 = tail call <32 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.512(<32 x half> %vec2, <32 x half> poison, i32 -1)
   %ret = shufflevector <32 x half> %rsqrt1, <32 x half> %rsqrt2,
                        <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                                     i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,

--- a/builtins/target-avx512fp16-x8-common.ll
+++ b/builtins/target-avx512fp16-x8-common.ll
@@ -8,28 +8,28 @@
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half>, <8 x half>, <8 x half>, i8)
 define half @__rcp_uniform_half(half) nounwind readonly alwaysinline {
-  %vec = insertelement <8 x half> undef, half %0, i32 0
-  %rcp = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> undef, i8 -1)
+  %vec = insertelement <8 x half> poison, half %0, i32 0
+  %rcp = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> poison, i8 -1)
   %ret = extractelement <8 x half> %rcp, i32 0
   ret half %ret
 }
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rcp.ph.128(<8 x half>, <8 x half>, i8)
 define <8 x half> @__rcp_varying_half(<8 x half>) nounwind readonly alwaysinline {
-  %ret = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.ph.128(<8 x half> %0, <8 x half> undef, i8 -1)
+  %ret = tail call <8 x half> @llvm.x86.avx512fp16.mask.rcp.ph.128(<8 x half> %0, <8 x half> poison, i8 -1)
   ret <8 x half> %ret
 }
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half>, <8 x half>, <8 x half>, i8)
 define half @__rsqrt_uniform_half(half) nounwind readnone alwaysinline {
-  %vec = insertelement <8 x half> undef, half %0, i32 0
-  %rsqrt = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> undef, i8 -1)
+  %vec = insertelement <8 x half> poison, half %0, i32 0
+  %rsqrt = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.sh(<8 x half> %vec, <8 x half> %vec, <8 x half> poison, i8 -1)
   %ret = extractelement <8 x half> %rsqrt, i32 0
   ret half %ret
 }
 
 declare <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.128(<8 x half>, <8 x half>, i8)
 define <8 x half> @__rsqrt_varying_half(<8 x half>) nounwind readnone alwaysinline {
-  %ret = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.128(<8 x half> %0, <8 x half> undef, i8 -1)
+  %ret = tail call <8 x half> @llvm.x86.avx512fp16.mask.rsqrt.ph.128(<8 x half> %0, <8 x half> poison, i8 -1)
   ret <8 x half> %ret
 }

--- a/builtins/target-avx512skx-x16-nozmm.ll
+++ b/builtins/target-avx512skx-x16-nozmm.ll
@@ -101,10 +101,10 @@ declare <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16>) nounwind readnone
 declare <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float>, i32) nounwind readnone
 
 define <16 x float> @__half_to_float_varying(<16 x i16> %v) nounwind readnone {
-  %r_0 = shufflevector <16 x i16> %v, <16 x i16> undef,
+  %r_0 = shufflevector <16 x i16> %v, <16 x i16> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %vr_0 = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %r_0)
-  %r_1 = shufflevector <16 x i16> %v, <16 x i16> undef,
+  %r_1 = shufflevector <16 x i16> %v, <16 x i16> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %vr_1 = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %r_1)
   %r = shufflevector <8 x float> %vr_0, <8 x float> %vr_1,
@@ -114,10 +114,10 @@ define <16 x float> @__half_to_float_varying(<16 x i16> %v) nounwind readnone {
 }
 
 define <16 x i16> @__float_to_half_varying(<16 x float> %v) nounwind readnone {
-  %r_0 = shufflevector <16 x float> %v, <16 x float> undef,
+  %r_0 = shufflevector <16 x float> %v, <16 x float> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %vr_0 = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %r_0, i32 0)
-  %r_1 = shufflevector <16 x float> %v, <16 x float> undef,
+  %r_1 = shufflevector <16 x float> %v, <16 x float> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %vr_1 = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %r_1, i32 0)
   %r = shufflevector <8 x i16> %vr_0, <8 x i16> %vr_1,
@@ -335,9 +335,9 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 declare <8 x float> @llvm.x86.avx.hadd.ps.256(<8 x float>, <8 x float>) nounwind readnone
 
 define float @__reduce_add_float(<16 x float>) nounwind readonly alwaysinline {
-  %va = shufflevector <16 x float> %0, <16 x float> undef,
+  %va = shufflevector <16 x float> %0, <16 x float> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vb = shufflevector <16 x float> %0, <16 x float> undef,
+  %vb = shufflevector <16 x float> %0, <16 x float> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %v1 = call <8 x float> @llvm.x86.avx.hadd.ps.256(<8 x float> %va, <8 x float> %vb)
   %v2 = call <8 x float> @llvm.x86.avx.hadd.ps.256(<8 x float> %v1, <8 x float> %v1)
@@ -384,13 +384,13 @@ define i32 @__reduce_max_uint32(<16 x i32>) nounwind readnone alwaysinline {
 declare <4 x double> @llvm.x86.avx.hadd.pd.256(<4 x double>, <4 x double>) nounwind readnone
 
 define double @__reduce_add_double(<16 x double>) nounwind readonly alwaysinline {
-  %va = shufflevector <16 x double> %0, <16 x double> undef,
+  %va = shufflevector <16 x double> %0, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vb = shufflevector <16 x double> %0, <16 x double> undef,
+  %vb = shufflevector <16 x double> %0, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %vc = shufflevector <16 x double> %0, <16 x double> undef,
+  %vc = shufflevector <16 x double> %0, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %vd = shufflevector <16 x double> %0, <16 x double> undef,
+  %vd = shufflevector <16 x double> %0, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
   %vab = fadd <4 x double> %va, %vb
   %vcd = fadd <4 x double> %vc, %vd
@@ -1031,8 +1031,8 @@ rcp14_uniform()
 declare <8 x float> @llvm.x86.avx512.rcp14.ps.256(<8 x float>, <8 x float>, i8) nounwind readnone
 define <16 x float> @__rcp_fast_varying_float(<16 x float>) nounwind readonly alwaysinline {
   v16tov8(float, %0, %val_lo, %val_hi)
-  %ret_lo = call <8 x float> @llvm.x86.avx512.rcp14.ps.256(<8 x float> %val_lo, <8 x float> undef, i8 -1)
-  %ret_hi = call <8 x float> @llvm.x86.avx512.rcp14.ps.256(<8 x float> %val_hi, <8 x float> undef, i8 -1)
+  %ret_lo = call <8 x float> @llvm.x86.avx512.rcp14.ps.256(<8 x float> %val_lo, <8 x float> poison, i8 -1)
+  %ret_hi = call <8 x float> @llvm.x86.avx512.rcp14.ps.256(<8 x float> %val_hi, <8 x float> poison, i8 -1)
   v8tov16(float, %ret_lo, %ret_hi, %ret)
   ret <16 x float> %ret
 }
@@ -1054,10 +1054,10 @@ define <16 x float> @__rcp_varying_float(<16 x float>) nounwind readonly alwaysi
 declare <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double>, <4 x double>, i8) nounwind readnone
 define <16 x double> @__rcp_fast_varying_double(<16 x double> %val) nounwind readonly alwaysinline {
   v16tov4(double, %val, %val_0, %val_1, %val_2, %val_3)
-  %res_0 = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val_0, <4 x double> undef, i8 -1)
-  %res_1 = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val_1, <4 x double> undef, i8 -1)
-  %res_2 = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val_2, <4 x double> undef, i8 -1)
-  %res_3 = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val_3, <4 x double> undef, i8 -1)
+  %res_0 = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val_0, <4 x double> poison, i8 -1)
+  %res_1 = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val_1, <4 x double> poison, i8 -1)
+  %res_2 = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val_2, <4 x double> poison, i8 -1)
+  %res_3 = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val_3, <4 x double> poison, i8 -1)
   v4tov16(double, %res_0, %res_1, %res_2, %res_3, %res)
   ret <16 x double> %res
 }
@@ -1080,8 +1080,8 @@ rsqrt14_uniform()
 declare <8 x float> @llvm.x86.avx512.rsqrt14.ps.256(<8 x float>,  <8 x float>,  i8) nounwind readnone
 define <16 x float> @__rsqrt_fast_varying_float(<16 x float> %v) nounwind readonly alwaysinline {
   v16tov8(float, %v, %val_lo, %val_hi)
-  %ret_lo = call <8 x float> @llvm.x86.avx512.rsqrt14.ps.256(<8 x float> %val_lo,  <8 x float> undef,  i8 -1)
-  %ret_hi = call <8 x float> @llvm.x86.avx512.rsqrt14.ps.256(<8 x float> %val_hi,  <8 x float> undef,  i8 -1)
+  %ret_lo = call <8 x float> @llvm.x86.avx512.rsqrt14.ps.256(<8 x float> %val_lo,  <8 x float> poison,  i8 -1)
+  %ret_hi = call <8 x float> @llvm.x86.avx512.rsqrt14.ps.256(<8 x float> %val_hi,  <8 x float> poison,  i8 -1)
   v8tov16(float, %ret_lo, %ret_hi, %ret)
   ret <16 x float> %ret
 }
@@ -1108,10 +1108,10 @@ define <16 x float> @__rsqrt_varying_float(<16 x float> %v) nounwind readonly al
 declare <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double>,  <4 x double>,  i8) nounwind readnone
 define <16 x double> @__rsqrt_fast_varying_double(<16 x double> %val) nounwind readonly alwaysinline {
   v16tov4(double, %val, %val_0, %val_1, %val_2, %val_3)
-  %res_0 = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val_0, <4 x double> undef, i8 -1)
-  %res_1 = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val_1, <4 x double> undef, i8 -1)
-  %res_2 = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val_2, <4 x double> undef, i8 -1)
-  %res_3 = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val_3, <4 x double> undef, i8 -1)
+  %res_0 = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val_0, <4 x double> poison, i8 -1)
+  %res_1 = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val_1, <4 x double> poison, i8 -1)
+  %res_2 = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val_2, <4 x double> poison, i8 -1)
+  %res_3 = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val_3, <4 x double> poison, i8 -1)
   v4tov16(double, %res_0, %res_1, %res_2, %res_3, %res)
   ret <16 x double> %res
 }

--- a/builtins/target-avx512skx-x16.ll
+++ b/builtins/target-avx512skx-x16.ll
@@ -179,10 +179,10 @@ declare <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16>) nounwind readnone
 declare <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float>, i32) nounwind readnone
 
 define <16 x float> @__half_to_float_varying(<16 x i16> %v) nounwind readnone {
-  %r_0 = shufflevector <16 x i16> %v, <16 x i16> undef,
+  %r_0 = shufflevector <16 x i16> %v, <16 x i16> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %vr_0 = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %r_0)
-  %r_1 = shufflevector <16 x i16> %v, <16 x i16> undef,
+  %r_1 = shufflevector <16 x i16> %v, <16 x i16> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %vr_1 = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %r_1)
   %r = shufflevector <8 x float> %vr_0, <8 x float> %vr_1,
@@ -192,10 +192,10 @@ define <16 x float> @__half_to_float_varying(<16 x i16> %v) nounwind readnone {
 }
 
 define <16 x i16> @__float_to_half_varying(<16 x float> %v) nounwind readnone {
-  %r_0 = shufflevector <16 x float> %v, <16 x float> undef,
+  %r_0 = shufflevector <16 x float> %v, <16 x float> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %vr_0 = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %r_0, i32 0)
-  %r_1 = shufflevector <16 x float> %v, <16 x float> undef,
+  %r_1 = shufflevector <16 x float> %v, <16 x float> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %vr_1 = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %r_1, i32 0)
   %r = shufflevector <8 x i16> %vr_0, <8 x i16> %vr_1,
@@ -214,10 +214,10 @@ declare <8 x i64> @llvm.x86.avx512.mask.pmins.q.512(<8 x i64>, <8 x i64>, <8 x i
 declare <8 x i64> @llvm.x86.avx512.mask.pminu.q.512(<8 x i64>, <8 x i64>, <8 x i64>, i8)
 
 define <16 x i64> @__max_varying_int64(<16 x i64>, <16 x i64>) nounwind readonly alwaysinline {
-  %v0_lo = shufflevector <16 x i64> %0, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v0_hi = shufflevector <16 x i64> %0, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %v1_lo = shufflevector <16 x i64> %1, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v1_hi = shufflevector <16 x i64> %1, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %v0_lo = shufflevector <16 x i64> %0, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %v0_hi = shufflevector <16 x i64> %0, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %v1_lo = shufflevector <16 x i64> %1, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %v1_hi = shufflevector <16 x i64> %1, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %r0 = call <8 x i64> @llvm.x86.avx512.mask.pmaxs.q.512(<8 x i64> %v0_lo, <8 x i64> %v1_lo, <8 x i64>zeroinitializer, i8 -1)
   %r1 = call <8 x i64> @llvm.x86.avx512.mask.pmaxs.q.512(<8 x i64> %v0_hi, <8 x i64> %v1_hi, <8 x i64>zeroinitializer, i8 -1)
   %res = shufflevector <8 x i64> %r0, <8 x i64> %r1, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
@@ -226,10 +226,10 @@ define <16 x i64> @__max_varying_int64(<16 x i64>, <16 x i64>) nounwind readonly
 }
 
 define <16 x i64> @__max_varying_uint64(<16 x i64>, <16 x i64>) nounwind readonly alwaysinline {
-  %v0_lo = shufflevector <16 x i64> %0, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v0_hi = shufflevector <16 x i64> %0, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %v1_lo = shufflevector <16 x i64> %1, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v1_hi = shufflevector <16 x i64> %1, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %v0_lo = shufflevector <16 x i64> %0, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %v0_hi = shufflevector <16 x i64> %0, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %v1_lo = shufflevector <16 x i64> %1, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %v1_hi = shufflevector <16 x i64> %1, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 
   %r0 = call <8 x i64> @llvm.x86.avx512.mask.pmaxu.q.512(<8 x i64> %v0_lo, <8 x i64> %v1_lo, <8 x i64>zeroinitializer, i8 -1)
   %r1 = call <8 x i64> @llvm.x86.avx512.mask.pmaxu.q.512(<8 x i64> %v0_hi, <8 x i64> %v1_hi, <8 x i64>zeroinitializer, i8 -1)
@@ -239,10 +239,10 @@ define <16 x i64> @__max_varying_uint64(<16 x i64>, <16 x i64>) nounwind readonl
 }
 
 define <16 x i64> @__min_varying_int64(<16 x i64>, <16 x i64>) nounwind readonly alwaysinline {
-  %v0_lo = shufflevector <16 x i64> %0, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v0_hi = shufflevector <16 x i64> %0, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %v1_lo = shufflevector <16 x i64> %1, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v1_hi = shufflevector <16 x i64> %1, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %v0_lo = shufflevector <16 x i64> %0, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %v0_hi = shufflevector <16 x i64> %0, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %v1_lo = shufflevector <16 x i64> %1, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %v1_hi = shufflevector <16 x i64> %1, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 
   %r0 = call <8 x i64> @llvm.x86.avx512.mask.pmins.q.512(<8 x i64> %v0_lo, <8 x i64> %v1_lo, <8 x i64>zeroinitializer, i8 -1)
   %r1 = call <8 x i64> @llvm.x86.avx512.mask.pmins.q.512(<8 x i64> %v0_hi, <8 x i64> %v1_hi, <8 x i64>zeroinitializer, i8 -1)
@@ -252,10 +252,10 @@ define <16 x i64> @__min_varying_int64(<16 x i64>, <16 x i64>) nounwind readonly
 }
 
 define <16 x i64> @__min_varying_uint64(<16 x i64>, <16 x i64>) nounwind readonly alwaysinline {
-  %v0_lo = shufflevector <16 x i64> %0, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v0_hi = shufflevector <16 x i64> %0, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %v1_lo = shufflevector <16 x i64> %1, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v1_hi = shufflevector <16 x i64> %1, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %v0_lo = shufflevector <16 x i64> %0, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %v0_hi = shufflevector <16 x i64> %0, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %v1_lo = shufflevector <16 x i64> %1, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %v1_hi = shufflevector <16 x i64> %1, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 
   %r0 = call <8 x i64> @llvm.x86.avx512.mask.pminu.q.512(<8 x i64> %v0_lo, <8 x i64> %v1_lo, <8 x i64>zeroinitializer, i8 -1)
   %r1 = call <8 x i64> @llvm.x86.avx512.mask.pminu.q.512(<8 x i64> %v0_hi, <8 x i64> %v1_hi, <8 x i64>zeroinitializer, i8 -1)
@@ -322,15 +322,15 @@ declare <8 x double> @llvm.x86.avx512.mask.max.pd.512(<8 x double>, <8 x double>
                     <8 x double>, i8, i32)
 
 define <16 x double> @__min_varying_double(<16 x double>, <16 x double>) nounwind readnone alwaysinline {
-  %a_0 = shufflevector <16 x double> %0, <16 x double> undef,
+  %a_0 = shufflevector <16 x double> %0, <16 x double> poison,
                        <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %a_1 = shufflevector <16 x double> %1, <16 x double> undef,
+  %a_1 = shufflevector <16 x double> %1, <16 x double> poison,
                        <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %res_a = call <8 x double> @llvm.x86.avx512.mask.min.pd.512(<8 x double> %a_0, <8 x double> %a_1,
                 <8 x double> zeroinitializer, i8 -1, i32 4)
-  %b_0 = shufflevector <16 x double> %0, <16 x double> undef,
+  %b_0 = shufflevector <16 x double> %0, <16 x double> poison,
                        <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %b_1 = shufflevector <16 x double> %1, <16 x double> undef,
+  %b_1 = shufflevector <16 x double> %1, <16 x double> poison,
                        <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %res_b = call <8 x double> @llvm.x86.avx512.mask.min.pd.512(<8 x double> %b_0, <8 x double> %b_1,
                 <8 x double> zeroinitializer, i8 -1, i32 4)
@@ -341,15 +341,15 @@ define <16 x double> @__min_varying_double(<16 x double>, <16 x double>) nounwin
 }
 
 define <16 x double> @__max_varying_double(<16 x double>, <16 x double>) nounwind readnone alwaysinline {
-  %a_0 = shufflevector <16 x double> %0, <16 x double> undef,
+  %a_0 = shufflevector <16 x double> %0, <16 x double> poison,
                        <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %a_1 = shufflevector <16 x double> %1, <16 x double> undef,
+  %a_1 = shufflevector <16 x double> %1, <16 x double> poison,
                        <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %res_a = call <8 x double> @llvm.x86.avx512.mask.max.pd.512(<8 x double> %a_0, <8 x double> %a_1,
                 <8 x double> zeroinitializer, i8 -1, i32 4)
-  %b_0 = shufflevector <16 x double> %0, <16 x double> undef,
+  %b_0 = shufflevector <16 x double> %0, <16 x double> poison,
                        <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %b_1 = shufflevector <16 x double> %1, <16 x double> undef,
+  %b_1 = shufflevector <16 x double> %1, <16 x double> poison,
                        <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %res_b = call <8 x double> @llvm.x86.avx512.mask.max.pd.512(<8 x double> %b_0, <8 x double> %b_1,
                 <8 x double> zeroinitializer, i8 -1, i32 4)
@@ -382,9 +382,9 @@ define double @__sqrt_uniform_double(double) nounwind alwaysinline {
 declare <8 x double> @llvm.x86.avx512.mask.sqrt.pd.512(<8 x double>, <8 x double>, i8, i32) nounwind readnone
 
 define <16 x double> @__sqrt_varying_double(<16 x double>) nounwind alwaysinline {
-  %v0 = shufflevector <16 x double> %0, <16 x double> undef,
+  %v0 = shufflevector <16 x double> %0, <16 x double> poison,
                       <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v1 = shufflevector <16 x double> %0, <16 x double> undef,
+  %v1 = shufflevector <16 x double> %0, <16 x double> poison,
                       <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %r0 = call <8 x double> @llvm.x86.avx512.mask.sqrt.pd.512(<8 x double> %v0,  <8 x double> zeroinitializer, i8 -1, i32 4)
   %r1 = call <8 x double> @llvm.x86.avx512.mask.sqrt.pd.512(<8 x double> %v1,  <8 x double> zeroinitializer, i8 -1, i32 4)
@@ -427,9 +427,9 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 declare <8 x float> @llvm.x86.avx.hadd.ps.256(<8 x float>, <8 x float>) nounwind readnone
 
 define float @__reduce_add_float(<16 x float>) nounwind readonly alwaysinline {
-  %va = shufflevector <16 x float> %0, <16 x float> undef,
+  %va = shufflevector <16 x float> %0, <16 x float> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vb = shufflevector <16 x float> %0, <16 x float> undef,
+  %vb = shufflevector <16 x float> %0, <16 x float> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %v1 = call <8 x float> @llvm.x86.avx.hadd.ps.256(<8 x float> %va, <8 x float> %vb)
   %v2 = call <8 x float> @llvm.x86.avx.hadd.ps.256(<8 x float> %v1, <8 x float> %v1)
@@ -476,13 +476,13 @@ define i32 @__reduce_max_uint32(<16 x i32>) nounwind readnone alwaysinline {
 declare <4 x double> @llvm.x86.avx.hadd.pd.256(<4 x double>, <4 x double>) nounwind readnone
 
 define double @__reduce_add_double(<16 x double>) nounwind readonly alwaysinline {
-  %va = shufflevector <16 x double> %0, <16 x double> undef,
+  %va = shufflevector <16 x double> %0, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vb = shufflevector <16 x double> %0, <16 x double> undef,
+  %vb = shufflevector <16 x double> %0, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %vc = shufflevector <16 x double> %0, <16 x double> undef,
+  %vc = shufflevector <16 x double> %0, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %vd = shufflevector <16 x double> %0, <16 x double> undef,
+  %vd = shufflevector <16 x double> %0, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
   %vab = fadd <4 x double> %va, %vb
   %vcd = fadd <4 x double> %vc, %vd
@@ -631,9 +631,9 @@ define void @__masked_store_i64(<16 x i64>* nocapture, <16 x i64> %v, <WIDTH x M
   %ptr_lo = getelementptr PTR_OP_ARGS(`<16 x i64>') %0, i32 0, i32 8
   %ptr_lo_i8 = bitcast i64* %ptr_lo to i8*
 
-  %v_lo = shufflevector <16 x i64> %v, <16 x i64> undef,
+  %v_lo = shufflevector <16 x i64> %v, <16 x i64> poison,
                         <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v_hi = shufflevector <16 x i64> %v, <16 x i64> undef,
+  %v_hi = shufflevector <16 x i64> %v, <16 x i64> poison,
                         <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 
   call void @llvm.x86.avx512.mask.storeu.q.512(i8* %ptr_i8, <8 x i64> %v_lo, i8 %mask_lo_i8)
@@ -659,9 +659,9 @@ define void @__masked_store_double(<16 x double>* nocapture, <16 x double> %v, <
   %ptr_lo = getelementptr PTR_OP_ARGS(`<16 x double>') %0, i32 0, i32 8
   %ptr_lo_i8 = bitcast double* %ptr_lo to i8*
 
-  %v_lo = shufflevector <16 x double> %v, <16 x double> undef,
+  %v_lo = shufflevector <16 x double> %v, <16 x double> poison,
                         <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %v_hi = shufflevector <16 x double> %v, <16 x double> undef,
+  %v_hi = shufflevector <16 x double> %v, <16 x double> poison,
                         <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 
   call void @llvm.x86.avx512.mask.storeu.pd.512(i8* %ptr_i8, <8 x double> %v_lo, i8 %mask_lo_i8)
@@ -704,10 +704,10 @@ define <16 x i32>
 declare <8 x i32> @llvm.x86.avx512.mask.gather.qpi.512 (<8 x i32>, i8*, <8 x i64>, <8 x i1>, i32)
 define <16 x i32>
 @__gather_base_offsets64_i32(i8 * %ptr, i32 %offset_scale, <16 x i64> %offsets, <16 x i1> %vecmask) nounwind readonly alwaysinline {
-  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   convert_scale_to_const_gather(res1, llvm.x86.avx512.mask.gather.qpi.512, 8, i32, ptr, offsets_lo, i64, vecmask_lo, <8 x i1>, offset_scale)
   convert_scale_to_const_gather(res2, llvm.x86.avx512.mask.gather.qpi.512, 8, i32, ptr, offsets_hi, i64, vecmask_hi, <8 x i1>, offset_scale)
   %res = shufflevector <8 x i32> %res1, <8 x i32> %res2 , <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
@@ -730,10 +730,10 @@ define <16 x i32>
 declare <8 x i64> @llvm.x86.avx512.mask.gather.dpq.512(<8 x i64>, i8*, <8 x i32>, <8 x i1>, i32)
 define <16 x i64>
 @__gather_base_offsets32_i64(i8 * %ptr, i32 %offset_scale, <16 x i32> %offsets, <16 x i1> %vecmask) nounwind readonly alwaysinline {
-  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %offsets_lo = shufflevector <16 x i32> %offsets, <16 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %offsets_hi = shufflevector <16 x i32> %offsets, <16 x i32> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %offsets_lo = shufflevector <16 x i32> %offsets, <16 x i32> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %offsets_hi = shufflevector <16 x i32> %offsets, <16 x i32> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   convert_scale_to_const_gather(res1, llvm.x86.avx512.mask.gather.dpq.512, 8, i64, ptr, offsets_lo, i32, vecmask_lo, <8 x i1>, offset_scale)
   convert_scale_to_const_gather(res2, llvm.x86.avx512.mask.gather.dpq.512, 8, i64, ptr, offsets_hi, i32, vecmask_hi, <8 x i1>, offset_scale)
   %res = shufflevector <8 x i64> %res1, <8 x i64> %res2 , <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
@@ -743,10 +743,10 @@ define <16 x i64>
 declare <8 x i64> @llvm.x86.avx512.mask.gather.qpq.512 (<8 x i64>, i8*, <8 x i64>, <8 x i1>, i32)
 define <16 x i64>
 @__gather_base_offsets64_i64(i8 * %ptr, i32 %offset_scale, <16 x i64> %offsets, <16 x i1> %vecmask) nounwind readonly alwaysinline {
-  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   convert_scale_to_const_gather(res1, llvm.x86.avx512.mask.gather.qpq.512, 8, i64, ptr, offsets_lo, i64, vecmask_lo, <8 x i1>, offset_scale)
   convert_scale_to_const_gather(res2, llvm.x86.avx512.mask.gather.qpq.512, 8, i64, ptr, offsets_hi, i64, vecmask_hi, <8 x i1>, offset_scale)
   %res = shufflevector <8 x i64> %res1, <8 x i64> %res2 , <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
@@ -776,10 +776,10 @@ define <16 x float>
 declare <8 x float> @llvm.x86.avx512.mask.gather.qps.512 (<8 x float>, i8*, <8 x i64>, <8 x i1>, i32)
 define <16 x float>
 @__gather_base_offsets64_float(i8 * %ptr, i32 %offset_scale, <16 x i64> %offsets, <16 x i1> %vecmask) nounwind readonly alwaysinline {
-  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   convert_scale_to_const_gather(res_lo, llvm.x86.avx512.mask.gather.qps.512, 8, float, ptr, offsets_lo, i64, vecmask_lo, <8 x i1>, offset_scale)
   convert_scale_to_const_gather(res_hi, llvm.x86.avx512.mask.gather.qps.512, 8, float, ptr, offsets_hi, i64, vecmask_hi, <8 x i1>, offset_scale)
   %res = shufflevector <8 x float> %res_lo, <8 x float> %res_hi, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
@@ -802,10 +802,10 @@ define <16 x float>
 declare <8 x double> @llvm.x86.avx512.mask.gather.dpd.512(<8 x double>, i8*, <8 x i32>, <8 x i1>, i32)
 define <16 x double>
 @__gather_base_offsets32_double(i8 * %ptr, i32 %offset_scale, <16 x i32> %offsets, <16 x i1> %vecmask) nounwind readonly alwaysinline {
-  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %offsets_lo = shufflevector <16 x i32> %offsets, <16 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %offsets_hi = shufflevector <16 x i32> %offsets, <16 x i32> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %offsets_lo = shufflevector <16 x i32> %offsets, <16 x i32> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %offsets_hi = shufflevector <16 x i32> %offsets, <16 x i32> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   convert_scale_to_const_gather(res1, llvm.x86.avx512.mask.gather.dpd.512, 8, double, ptr, offsets_lo, i32, vecmask_lo, <8 x i1>, offset_scale)
   convert_scale_to_const_gather(res2, llvm.x86.avx512.mask.gather.dpd.512, 8, double, ptr, offsets_hi, i32, vecmask_hi, <8 x i1>, offset_scale)
   %res = shufflevector <8 x double> %res1, <8 x double> %res2 , <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
@@ -815,10 +815,10 @@ define <16 x double>
 declare <8 x double> @llvm.x86.avx512.mask.gather.qpd.512 (<8 x double>, i8*, <8 x i64>, <8 x i1>, i32)
 define <16 x double>
 @__gather_base_offsets64_double(i8 * %ptr, i32 %offset_scale, <16 x i64> %offsets, <16 x i1> %vecmask) nounwind readonly alwaysinline {
-  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   convert_scale_to_const_gather(res1, llvm.x86.avx512.mask.gather.qpd.512, 8, double, ptr, offsets_lo, i64, vecmask_lo, <8 x i1>, offset_scale)
   convert_scale_to_const_gather(res2, llvm.x86.avx512.mask.gather.qpd.512, 8, double, ptr, offsets_hi, i64, vecmask_hi, <8 x i1>, offset_scale)
   %res = shufflevector <8 x double> %res1, <8 x double> %res2 , <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
@@ -886,12 +886,12 @@ define void
 declare void @llvm.x86.avx512.mask.scatter.qpi.512 (i8*, <8 x i1>, <8 x i64>, <8 x i32>, i32)
 define void
 @__scatter_base_offsets64_i32(i8* %ptr, i32 %offset_scale, <16 x i64> %offsets, <16 x i32> %vals, <WIDTH x MASK> %vecmask) nounwind {
-  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %res_lo = shufflevector <16 x i32> %vals, <16 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %res_hi = shufflevector <16 x i32> %vals, <16 x i32> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %res_lo = shufflevector <16 x i32> %vals, <16 x i32> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %res_hi = shufflevector <16 x i32> %vals, <16 x i32> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatter.qpi.512, 8, res_lo, i32, ptr, offsets_lo, i64, vecmask_lo, <8 x i1>, offset_scale);
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatter.qpi.512, 8, res_hi, i32, ptr, offsets_hi, i64, vecmask_hi, <8 x i1>, offset_scale);
   ret void
@@ -913,12 +913,12 @@ define void
 declare void @llvm.x86.avx512.mask.scatter.dpq.512 (i8*, <8 x i1>, <8 x i32>, <8 x i64>, i32)
 define void
 @__scatter_base_offsets32_i64(i8* %ptr, i32 %offset_scale, <16 x i32> %offsets, <16 x i64> %vals, <WIDTH x MASK> %vecmask) nounwind {
-  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %offsets_lo = shufflevector <16 x i32> %offsets, <16 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %offsets_hi = shufflevector <16 x i32> %offsets, <16 x i32> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %res_lo = shufflevector <16 x i64> %vals, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %res_hi = shufflevector <16 x i64> %vals, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %offsets_lo = shufflevector <16 x i32> %offsets, <16 x i32> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %offsets_hi = shufflevector <16 x i32> %offsets, <16 x i32> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %res_lo = shufflevector <16 x i64> %vals, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %res_hi = shufflevector <16 x i64> %vals, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatter.dpq.512, 8, res_lo, i64, ptr, offsets_lo, i32, vecmask_lo, <8 x i1>, offset_scale);
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatter.dpq.512, 8, res_hi, i64, ptr, offsets_hi, i32, vecmask_hi, <8 x i1>, offset_scale);
   ret void
@@ -927,12 +927,12 @@ define void
 declare void @llvm.x86.avx512.mask.scatter.qpq.512 (i8*, <8 x i1>, <8 x i64>, <8 x i64>, i32)
 define void
 @__scatter_base_offsets64_i64(i8* %ptr, i32 %offset_scale, <16 x i64> %offsets, <16 x i64> %vals, <WIDTH x MASK> %vecmask) nounwind {
-  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %res_lo = shufflevector <16 x i64> %vals, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %res_hi = shufflevector <16 x i64> %vals, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %res_lo = shufflevector <16 x i64> %vals, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %res_hi = shufflevector <16 x i64> %vals, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatter.qpq.512, 8, res_lo, i64, ptr, offsets_lo, i64, vecmask_lo, <8 x i1>, offset_scale);
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatter.qpq.512, 8, res_hi, i64, ptr, offsets_hi, i64, vecmask_hi, <8 x i1>, offset_scale);
   ret void
@@ -961,12 +961,12 @@ define void
 declare void @llvm.x86.avx512.mask.scatter.qps.512 (i8*, <8 x i1>, <8 x i64>, <8 x float>, i32)
 define void
 @__scatter_base_offsets64_float(i8* %ptr, i32 %offset_scale, <16 x i64> %offsets, <16 x float> %vals, <WIDTH x MASK> %vecmask) nounwind {
-  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %res_lo = shufflevector <16 x float> %vals, <16 x float> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %res_hi = shufflevector <16 x float> %vals, <16 x float> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %res_lo = shufflevector <16 x float> %vals, <16 x float> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %res_hi = shufflevector <16 x float> %vals, <16 x float> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatter.qps.512, 8, res_lo, float, ptr, offsets_lo, i64, vecmask_lo, <8 x i1>, offset_scale);
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatter.qps.512, 8, res_hi, float, ptr, offsets_hi, i64, vecmask_hi, <8 x i1>, offset_scale);
   ret void
@@ -988,12 +988,12 @@ define void
 declare void @llvm.x86.avx512.mask.scatter.dpd.512 (i8*, <8 x i1>, <8 x i32>, <8 x double>, i32)
 define void
 @__scatter_base_offsets32_double(i8* %ptr, i32 %offset_scale, <16 x i32> %offsets, <16 x double> %vals, <WIDTH x MASK> %vecmask) nounwind {
-  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %offsets_lo = shufflevector <16 x i32> %offsets, <16 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %offsets_hi = shufflevector <16 x i32> %offsets, <16 x i32> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %res_lo = shufflevector <16 x double> %vals, <16 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %res_hi = shufflevector <16 x double> %vals, <16 x double> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %offsets_lo = shufflevector <16 x i32> %offsets, <16 x i32> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %offsets_hi = shufflevector <16 x i32> %offsets, <16 x i32> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %res_lo = shufflevector <16 x double> %vals, <16 x double> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %res_hi = shufflevector <16 x double> %vals, <16 x double> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatter.dpd.512, 8, res_lo, double, ptr, offsets_lo, i32, vecmask_lo, <8 x i1>, offset_scale);
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatter.dpd.512, 8, res_hi, double, ptr, offsets_hi, i32, vecmask_hi, <8 x i1>, offset_scale);
   ret void
@@ -1002,12 +1002,12 @@ define void
 declare void @llvm.x86.avx512.mask.scatter.qpd.512 (i8*, <8 x i1>, <8 x i64>, <8 x double>, i32)
 define void
 @__scatter_base_offsets64_double(i8* %ptr, i32 %offset_scale, <16 x i64> %offsets, <16 x double> %vals, <WIDTH x MASK> %vecmask) nounwind {
-  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %res_lo = shufflevector <16 x double> %vals, <16 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %res_hi = shufflevector <16 x double> %vals, <16 x double> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %vecmask_lo = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %vecmask_hi = shufflevector <16 x i1> %vecmask, <16 x i1> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %offsets_lo = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %offsets_hi = shufflevector <16 x i64> %offsets, <16 x i64> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %res_lo = shufflevector <16 x double> %vals, <16 x double> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %res_hi = shufflevector <16 x double> %vals, <16 x double> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatter.qpd.512, 8, res_lo, double, ptr, offsets_lo, i64, vecmask_lo, <8 x i1>, offset_scale);
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatter.qpd.512, 8, res_hi, double, ptr, offsets_hi, i64, vecmask_hi, <8 x i1>, offset_scale);
   ret void
@@ -1061,7 +1061,7 @@ rcp14_uniform()
 ;; rcp float
 declare <16 x float> @llvm.x86.avx512.rcp14.ps.512(<16 x float>, <16 x float>, i16) nounwind readnone
 define <16 x float> @__rcp_fast_varying_float(<16 x float>) nounwind readonly alwaysinline {
-  %ret = call <16 x float> @llvm.x86.avx512.rcp14.ps.512(<16 x float> %0, <16 x float> undef, i16 -1)
+  %ret = call <16 x float> @llvm.x86.avx512.rcp14.ps.512(<16 x float> %0, <16 x float> poison, i16 -1)
   ret <16 x float> %ret
 }
 define <16 x float> @__rcp_varying_float(<16 x float>) nounwind readonly alwaysinline {
@@ -1081,10 +1081,10 @@ define <16 x float> @__rcp_varying_float(<16 x float>) nounwind readonly alwaysi
 ;; rcp double
 declare <8 x double> @llvm.x86.avx512.rcp14.pd.512(<8 x double>, <8 x double>, i8) nounwind readnone
 define <16 x double> @__rcp_fast_varying_double(<16 x double> %val) nounwind readonly alwaysinline {
-  %val_lo = shufflevector <16 x double> %val, <16 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %val_hi = shufflevector <16 x double> %val, <16 x double> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %res_lo = call <8 x double> @llvm.x86.avx512.rcp14.pd.512(<8 x double> %val_lo, <8 x double> undef, i8 -1)
-  %res_hi = call <8 x double> @llvm.x86.avx512.rcp14.pd.512(<8 x double> %val_hi, <8 x double> undef, i8 -1)
+  %val_lo = shufflevector <16 x double> %val, <16 x double> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %val_hi = shufflevector <16 x double> %val, <16 x double> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %res_lo = call <8 x double> @llvm.x86.avx512.rcp14.pd.512(<8 x double> %val_lo, <8 x double> poison, i8 -1)
+  %res_hi = call <8 x double> @llvm.x86.avx512.rcp14.pd.512(<8 x double> %val_hi, <8 x double> poison, i8 -1)
   %res = shufflevector <8 x double> %res_lo, <8 x double> %res_hi, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   ret <16 x double> %res
 }
@@ -1106,7 +1106,7 @@ rsqrt14_uniform()
 ;; rsqrt float
 declare <16 x float> @llvm.x86.avx512.rsqrt14.ps.512(<16 x float>,  <16 x float>,  i16) nounwind readnone
 define <16 x float> @__rsqrt_fast_varying_float(<16 x float> %v) nounwind readonly alwaysinline {
-  %ret = call <16 x float> @llvm.x86.avx512.rsqrt14.ps.512(<16 x float> %v,  <16 x float> undef,  i16 -1)
+  %ret = call <16 x float> @llvm.x86.avx512.rsqrt14.ps.512(<16 x float> %v,  <16 x float> poison,  i16 -1)
   ret <16 x float> %ret
 }
 define <16 x float> @__rsqrt_varying_float(<16 x float> %v) nounwind readonly alwaysinline {
@@ -1131,18 +1131,18 @@ define <16 x float> @__rsqrt_varying_float(<16 x float> %v) nounwind readonly al
 ;; rsqrt double
 declare <8 x double> @llvm.x86.avx512.rsqrt14.pd.512(<8 x double>,  <8 x double>,  i8) nounwind readnone
 define <16 x double> @__rsqrt_fast_varying_double(<16 x double> %val) nounwind readonly alwaysinline {
-  %val_lo = shufflevector <16 x double> %val, <16 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %val_hi = shufflevector <16 x double> %val, <16 x double> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %res_lo = call <8 x double> @llvm.x86.avx512.rsqrt14.pd.512(<8 x double> %val_lo, <8 x double> undef, i8 -1)
-  %res_hi = call <8 x double> @llvm.x86.avx512.rsqrt14.pd.512(<8 x double> %val_hi, <8 x double> undef, i8 -1)
+  %val_lo = shufflevector <16 x double> %val, <16 x double> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %val_hi = shufflevector <16 x double> %val, <16 x double> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %res_lo = call <8 x double> @llvm.x86.avx512.rsqrt14.pd.512(<8 x double> %val_lo, <8 x double> poison, i8 -1)
+  %res_hi = call <8 x double> @llvm.x86.avx512.rsqrt14.pd.512(<8 x double> %val_hi, <8 x double> poison, i8 -1)
   %res = shufflevector <8 x double> %res_lo, <8 x double> %res_hi, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   ret <16 x double> %res
 }
 declare <8 x i1> @llvm.x86.avx512.fpclass.pd.512(<8 x double>, i32)
 define <16 x double> @__rsqrt_varying_double(<16 x double> %v) nounwind readonly alwaysinline {
   ; detect +/-0 and +inf to deal with them differently.
-  %val_lo = shufflevector <16 x double> %v, <16 x double> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %val_hi = shufflevector <16 x double> %v, <16 x double> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %val_lo = shufflevector <16 x double> %v, <16 x double> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %val_hi = shufflevector <16 x double> %v, <16 x double> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %corner_cases_lo = call <8 x i1> @llvm.x86.avx512.fpclass.pd.512(<8 x double> %val_lo, i32 14)
   %corner_cases_hi = call <8 x i1> @llvm.x86.avx512.fpclass.pd.512(<8 x double> %val_hi, i32 14)
   %corner_cases = shufflevector <8 x i1> %corner_cases_lo, <8 x i1> %corner_cases_hi, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>

--- a/builtins/target-avx512skx-x32.ll
+++ b/builtins/target-avx512skx-x32.ll
@@ -116,7 +116,7 @@ define <32 x i64> @__shuffle_i64(<32 x i64> %input, <32 x i32> %perm) nounwind r
 
   ; Create base pointer vector for gather operation
   %base_ptr_scalar = bitcast [32 x i64]* %input_alloca to i64*
-  %base_ptr_vec = insertelement <32 x i64*> undef, i64* %base_ptr_scalar, i32 0
+  %base_ptr_vec = insertelement <32 x i64*> poison, i64* %base_ptr_scalar, i32 0
   %base_ptr_broadcast = shufflevector <32 x i64*> %base_ptr_vec, <32 x i64*> zeroinitializer, <32 x i32> zeroinitializer
 
   ; Create pointer vector
@@ -124,7 +124,7 @@ define <32 x i64> @__shuffle_i64(<32 x i64> %input, <32 x i32> %perm) nounwind r
   %ptrs = getelementptr i64, <32 x i64*> %base_ptr_broadcast, <32 x i64> %perm_i64
 
   ; Create mask for gather (all true)
-  %true_val = insertelement <32 x i1> undef, i1 true, i32 0
+  %true_val = insertelement <32 x i1> poison, i1 true, i32 0
   %mask_all = shufflevector <32 x i1> %true_val, <32 x i1> zeroinitializer, <32 x i32> zeroinitializer
 
   ; Perform the single gather operation
@@ -195,9 +195,9 @@ declare <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float>, i32) nounwind readnone
 
 define float @__half_to_float_uniform(i16 %v) nounwind readnone alwaysinline {
   %v1 = bitcast i16 %v to <1 x i16>
-  %vv = shufflevector <1 x i16> %v1, <1 x i16> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x i16> %v1, <1 x i16> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %rv = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %vv)
   %r = extractelement <8 x float> %rv, i32 0
   ret float %r
@@ -205,9 +205,9 @@ define float @__half_to_float_uniform(i16 %v) nounwind readnone alwaysinline {
 
 define i16 @__float_to_half_uniform(float %v) nounwind readnone alwaysinline {
   %v1 = bitcast float %v to <1 x float>
-  %vv = shufflevector <1 x float> %v1, <1 x float> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x float> %v1, <1 x float> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   ; round to nearest even
   %rv = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %vv, i32 0)
   %r = extractelement <8 x i16> %rv, i32 0
@@ -219,16 +219,16 @@ declare <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %source, i32
 
 define <32 x float> @__half_to_float_varying(<32 x i16> %v) nounwind readnone alwaysinline {
   v32tov16(i16, %v, %v0, %v1)
-  %r0 = call <16 x float> @llvm.x86.avx512.mask.vcvtph2ps.512(<16 x i16> %v0, <16 x float> undef, i16 -1, i32 4)
-  %r1 = call <16 x float> @llvm.x86.avx512.mask.vcvtph2ps.512(<16 x i16> %v1, <16 x float> undef, i16 -1, i32 4)
+  %r0 = call <16 x float> @llvm.x86.avx512.mask.vcvtph2ps.512(<16 x i16> %v0, <16 x float> poison, i16 -1, i32 4)
+  %r1 = call <16 x float> @llvm.x86.avx512.mask.vcvtph2ps.512(<16 x i16> %v1, <16 x float> poison, i16 -1, i32 4)
   v16tov32(float, %r0, %r1, %r)
   ret <32 x float> %r
 }
 
 define <32 x i16> @__float_to_half_varying(<32 x float> %v) nounwind readnone alwaysinline {
   v32tov16(float, %v, %v0, %v1)
-  %r0 = call <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %v0, i32 0, <16 x i16> undef, i16 -1)
-  %r1 = call <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %v1, i32 0, <16 x i16> undef, i16 -1)
+  %r0 = call <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %v0, i32 0, <16 x i16> poison, i16 -1)
+  %r1 = call <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %v1, i32 0, <16 x i16> poison, i16 -1)
   v16tov32(i16, %r0, %r1, %r)
   ret <32 x i16> %r
 }

--- a/builtins/target-avx512skx-x4.ll
+++ b/builtins/target-avx512skx-x4.ll
@@ -212,7 +212,7 @@ define <4 x float> @__half_to_float_varying(<4 x i16> %v) nounwind readnone {
 
 define <4 x i16> @__float_to_half_varying(<4 x float> %v) nounwind readnone {
   %r = call <8 x i16> @llvm.x86.vcvtps2ph.128(<4 x float> %v, i32 0)
-  %res = shufflevector <8 x i16> %r, <8 x i16> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %res = shufflevector <8 x i16> %r, <8 x i16> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   ret <4 x i16> %res
 }
 
@@ -842,7 +842,7 @@ rcp14_uniform()
 ;; rcp float
 declare <4 x float> @llvm.x86.avx512.rcp14.ps.128(<4 x float>, <4 x float>, i8) nounwind readnone
 define <4 x float> @__rcp_fast_varying_float(<4 x float>) nounwind readonly alwaysinline {
-  %ret = call <4 x float> @llvm.x86.avx512.rcp14.ps.128(<4 x float> %0, <4 x float> undef, i8 -1)
+  %ret = call <4 x float> @llvm.x86.avx512.rcp14.ps.128(<4 x float> %0, <4 x float> poison, i8 -1)
   ret <4 x float> %ret
 }
 define <4 x float> @__rcp_varying_float(<4 x float>) nounwind readonly alwaysinline {
@@ -859,7 +859,7 @@ define <4 x float> @__rcp_varying_float(<4 x float>) nounwind readonly alwaysinl
 ;; rcp double
 declare <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double>, <4 x double>, i8) nounwind readnone
 define <4 x double> @__rcp_fast_varying_double(<4 x double> %val) nounwind readonly alwaysinline {
-  %res = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val, <4 x double> undef, i8 -1)
+  %res = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val, <4 x double> poison, i8 -1)
   ret <4 x double> %res
 }
 define <4 x double> @__rcp_varying_double(<4 x double>) nounwind readonly alwaysinline {
@@ -877,7 +877,7 @@ rsqrt14_uniform()
 ;; rsqrt float
 declare <4 x float> @llvm.x86.avx512.rsqrt14.ps.128(<4 x float>,  <4 x float>,  i8) nounwind readnone
 define <4 x float> @__rsqrt_fast_varying_float(<4 x float> %v) nounwind readonly alwaysinline {
-  %ret = call <4 x float> @llvm.x86.avx512.rsqrt14.ps.128(<4 x float> %v,  <4 x float> undef,  i8 -1)
+  %ret = call <4 x float> @llvm.x86.avx512.rsqrt14.ps.128(<4 x float> %v,  <4 x float> poison,  i8 -1)
   ret <4 x float> %ret
 }
 define <4 x float> @__rsqrt_varying_float(<4 x float> %v) nounwind readonly alwaysinline {
@@ -896,7 +896,7 @@ define <4 x float> @__rsqrt_varying_float(<4 x float> %v) nounwind readonly alwa
 ;; rsqrt double
 declare <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double>,  <4 x double>,  i8) nounwind readnone
 define <4 x double> @__rsqrt_fast_varying_double(<4 x double> %val) nounwind readonly alwaysinline {
-  %res = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val, <4 x double> undef, i8 -1)
+  %res = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val, <4 x double> poison, i8 -1)
   ret <4 x double> %res
 }
 declare <4 x i1> @llvm.x86.avx512.fpclass.pd.256(<4 x double>, i32)

--- a/builtins/target-avx512skx-x64.ll
+++ b/builtins/target-avx512skx-x64.ll
@@ -93,14 +93,14 @@ define <64 x i32> @__shuffle_i32(<64 x i32> %input, <64 x i32> %perm) nounwind r
 
   ; Create base pointer vector for gather operation
   %base_ptr_scalar = bitcast [64 x i32]* %input_alloca to i32*
-  %base_ptr_vec = insertelement <64 x i32*> undef, i32* %base_ptr_scalar, i32 0
+  %base_ptr_vec = insertelement <64 x i32*> poison, i32* %base_ptr_scalar, i32 0
   %base_ptr_broadcast = shufflevector <64 x i32*> %base_ptr_vec, <64 x i32*> zeroinitializer, <64 x i32> zeroinitializer
 
   ; Create pointer vector
   %ptrs = getelementptr i32, <64 x i32*> %base_ptr_broadcast, <64 x i32> %perm
 
   ; Create mask for gather (all true)
-  %true_val = insertelement <64 x i1> undef, i1 true, i32 0
+  %true_val = insertelement <64 x i1> poison, i1 true, i32 0
   %mask_all = shufflevector <64 x i1> %true_val, <64 x i1> zeroinitializer, <64 x i32> zeroinitializer
 
   ; Perform the single gather operation
@@ -125,7 +125,7 @@ define <64 x i64> @__shuffle_i64(<64 x i64> %input, <64 x i32> %perm) nounwind r
 
   ; Create base pointer vector for gather operation
   %base_ptr_scalar = bitcast [64 x i64]* %input_alloca to i64*
-  %base_ptr_vec = insertelement <64 x i64*> undef, i64* %base_ptr_scalar, i32 0
+  %base_ptr_vec = insertelement <64 x i64*> poison, i64* %base_ptr_scalar, i32 0
   %base_ptr_broadcast = shufflevector <64 x i64*> %base_ptr_vec, <64 x i64*> zeroinitializer, <64 x i32> zeroinitializer
 
   ; Create pointer vector
@@ -133,7 +133,7 @@ define <64 x i64> @__shuffle_i64(<64 x i64> %input, <64 x i32> %perm) nounwind r
   %ptrs = getelementptr i64, <64 x i64*> %base_ptr_broadcast, <64 x i64> %perm_i64
 
   ; Create mask for gather (all true)
-  %true_val = insertelement <64 x i1> undef, i1 true, i32 0
+  %true_val = insertelement <64 x i1> poison, i1 true, i32 0
   %mask_all = shufflevector <64 x i1> %true_val, <64 x i1> zeroinitializer, <64 x i32> zeroinitializer
 
   ; Perform the single gather operation
@@ -169,9 +169,9 @@ declare <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float>, i32) nounwind readnone
 
 define float @__half_to_float_uniform(i16 %v) nounwind readnone alwaysinline {
   %v1 = bitcast i16 %v to <1 x i16>
-  %vv = shufflevector <1 x i16> %v1, <1 x i16> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x i16> %v1, <1 x i16> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %rv = call <8 x float> @llvm.x86.vcvtph2ps.256(<8 x i16> %vv)
   %r = extractelement <8 x float> %rv, i32 0
   ret float %r
@@ -179,9 +179,9 @@ define float @__half_to_float_uniform(i16 %v) nounwind readnone alwaysinline {
 
 define i16 @__float_to_half_uniform(float %v) nounwind readnone alwaysinline {
   %v1 = bitcast float %v to <1 x float>
-  %vv = shufflevector <1 x float> %v1, <1 x float> undef,
-           <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vv = shufflevector <1 x float> %v1, <1 x float> poison,
+           <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   ; round to nearest even
   %rv = call <8 x i16> @llvm.x86.vcvtps2ph.256(<8 x float> %vv, i32 0)
   %r = extractelement <8 x i16> %rv, i32 0
@@ -193,20 +193,20 @@ declare <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %source, i32
 
 define <64 x float> @__half_to_float_varying(<64 x i16> %v) nounwind readnone alwaysinline {
   v64tov16(i16, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <16 x float> @llvm.x86.avx512.mask.vcvtph2ps.512(<16 x i16> %v0, <16 x float> undef, i16 -1, i32 4)
-  %r1 = call <16 x float> @llvm.x86.avx512.mask.vcvtph2ps.512(<16 x i16> %v1, <16 x float> undef, i16 -1, i32 4)
-  %r2 = call <16 x float> @llvm.x86.avx512.mask.vcvtph2ps.512(<16 x i16> %v2, <16 x float> undef, i16 -1, i32 4)
-  %r3 = call <16 x float> @llvm.x86.avx512.mask.vcvtph2ps.512(<16 x i16> %v3, <16 x float> undef, i16 -1, i32 4)
+  %r0 = call <16 x float> @llvm.x86.avx512.mask.vcvtph2ps.512(<16 x i16> %v0, <16 x float> poison, i16 -1, i32 4)
+  %r1 = call <16 x float> @llvm.x86.avx512.mask.vcvtph2ps.512(<16 x i16> %v1, <16 x float> poison, i16 -1, i32 4)
+  %r2 = call <16 x float> @llvm.x86.avx512.mask.vcvtph2ps.512(<16 x i16> %v2, <16 x float> poison, i16 -1, i32 4)
+  %r3 = call <16 x float> @llvm.x86.avx512.mask.vcvtph2ps.512(<16 x i16> %v3, <16 x float> poison, i16 -1, i32 4)
   v16tov64(float, %r0, %r1, %r2, %r3, %r)
   ret <64 x float> %r
 }
 
 define <64 x i16> @__float_to_half_varying(<64 x float> %v) nounwind readnone alwaysinline {
   v64tov16(float, %v, %v0, %v1, %v2, %v3)
-  %r0 = call <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %v0, i32 0, <16 x i16> undef, i16 -1)
-  %r1 = call <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %v1, i32 0, <16 x i16> undef, i16 -1)
-  %r2 = call <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %v2, i32 0, <16 x i16> undef, i16 -1)
-  %r3 = call <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %v3, i32 0, <16 x i16> undef, i16 -1)
+  %r0 = call <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %v0, i32 0, <16 x i16> poison, i16 -1)
+  %r1 = call <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %v1, i32 0, <16 x i16> poison, i16 -1)
+  %r2 = call <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %v2, i32 0, <16 x i16> poison, i16 -1)
+  %r3 = call <16 x i16> @llvm.x86.avx512.mask.vcvtps2ph.512(<16 x float> %v3, i32 0, <16 x i16> poison, i16 -1)
   v16tov64(i16, %r0, %r1, %r2, %r3, %r)
   ret <64 x i16> %r
 }

--- a/builtins/target-avx512skx-x8.ll
+++ b/builtins/target-avx512skx-x8.ll
@@ -201,10 +201,10 @@ declare <4 x i64> @llvm.x86.avx512.mask.pmins.q.256(<4 x i64>, <4 x i64>, <4 x i
 declare <4 x i64> @llvm.x86.avx512.mask.pminu.q.256(<4 x i64>, <4 x i64>, <4 x i64>, i8)
 
 define <8 x i64> @__max_varying_int64(<8 x i64>, <8 x i64>) nounwind readonly alwaysinline {
-  %v0_lo = shufflevector <8 x i64> %0, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0_hi = shufflevector <8 x i64> %0, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1_lo = shufflevector <8 x i64> %1, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1_hi = shufflevector <8 x i64> %1, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %v0_lo = shufflevector <8 x i64> %0, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %v0_hi = shufflevector <8 x i64> %0, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %v1_lo = shufflevector <8 x i64> %1, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %v1_hi = shufflevector <8 x i64> %1, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %r0 = call <4 x i64> @llvm.x86.avx512.mask.pmaxs.q.256(<4 x i64> %v0_lo, <4 x i64> %v1_lo, <4 x i64>zeroinitializer, i8 -1)
   %r1 = call <4 x i64> @llvm.x86.avx512.mask.pmaxs.q.256(<4 x i64> %v0_hi, <4 x i64> %v1_hi, <4 x i64>zeroinitializer, i8 -1)
   %res = shufflevector <4 x i64> %r0, <4 x i64> %r1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -212,10 +212,10 @@ define <8 x i64> @__max_varying_int64(<8 x i64>, <8 x i64>) nounwind readonly al
 }
 
 define <8 x i64> @__max_varying_uint64(<8 x i64>, <8 x i64>) nounwind readonly alwaysinline {
-  %v0_lo = shufflevector <8 x i64> %0, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0_hi = shufflevector <8 x i64> %0, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1_lo = shufflevector <8 x i64> %1, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1_hi = shufflevector <8 x i64> %1, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %v0_lo = shufflevector <8 x i64> %0, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %v0_hi = shufflevector <8 x i64> %0, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %v1_lo = shufflevector <8 x i64> %1, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %v1_hi = shufflevector <8 x i64> %1, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   %r0 = call <4 x i64> @llvm.x86.avx512.mask.pmaxu.q.256(<4 x i64> %v0_lo, <4 x i64> %v1_lo, <4 x i64>zeroinitializer, i8 -1)
   %r1 = call <4 x i64> @llvm.x86.avx512.mask.pmaxu.q.256(<4 x i64> %v0_hi, <4 x i64> %v1_hi, <4 x i64>zeroinitializer, i8 -1)
@@ -224,10 +224,10 @@ define <8 x i64> @__max_varying_uint64(<8 x i64>, <8 x i64>) nounwind readonly a
 }
 
 define <8 x i64> @__min_varying_int64(<8 x i64>, <8 x i64>) nounwind readonly alwaysinline {
-  %v0_lo = shufflevector <8 x i64> %0, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0_hi = shufflevector <8 x i64> %0, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1_lo = shufflevector <8 x i64> %1, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1_hi = shufflevector <8 x i64> %1, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %v0_lo = shufflevector <8 x i64> %0, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %v0_hi = shufflevector <8 x i64> %0, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %v1_lo = shufflevector <8 x i64> %1, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %v1_hi = shufflevector <8 x i64> %1, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   %r0 = call <4 x i64> @llvm.x86.avx512.mask.pmins.q.256(<4 x i64> %v0_lo, <4 x i64> %v1_lo, <4 x i64>zeroinitializer, i8 -1)
   %r1 = call <4 x i64> @llvm.x86.avx512.mask.pmins.q.256(<4 x i64> %v0_hi, <4 x i64> %v1_hi, <4 x i64>zeroinitializer, i8 -1)
@@ -236,10 +236,10 @@ define <8 x i64> @__min_varying_int64(<8 x i64>, <8 x i64>) nounwind readonly al
 }
 
 define <8 x i64> @__min_varying_uint64(<8 x i64>, <8 x i64>) nounwind readonly alwaysinline {
-  %v0_lo = shufflevector <8 x i64> %0, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0_hi = shufflevector <8 x i64> %0, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1_lo = shufflevector <8 x i64> %1, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1_hi = shufflevector <8 x i64> %1, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %v0_lo = shufflevector <8 x i64> %0, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %v0_hi = shufflevector <8 x i64> %0, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %v1_lo = shufflevector <8 x i64> %1, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %v1_hi = shufflevector <8 x i64> %1, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   %r0 = call <4 x i64> @llvm.x86.avx512.mask.pminu.q.256(<4 x i64> %v0_lo, <4 x i64> %v1_lo, <4 x i64>zeroinitializer, i8 -1)
   %r1 = call <4 x i64> @llvm.x86.avx512.mask.pminu.q.256(<4 x i64> %v0_hi, <4 x i64> %v1_hi, <4 x i64>zeroinitializer, i8 -1)
@@ -305,15 +305,15 @@ declare <4 x double> @llvm.x86.avx512.mask.max.pd.256(<4 x double>, <4 x double>
                     <4 x double>, i8)
 
 define <8 x double> @__min_varying_double(<8 x double>, <8 x double>) nounwind readnone alwaysinline {
-  %a_0 = shufflevector <8 x double> %0, <8 x double> undef,
+  %a_0 = shufflevector <8 x double> %0, <8 x double> poison,
                        <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %a_1 = shufflevector <8 x double> %1, <8 x double> undef,
+  %a_1 = shufflevector <8 x double> %1, <8 x double> poison,
                        <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %res_a = call <4 x double> @llvm.x86.avx512.mask.min.pd.256(<4 x double> %a_0, <4 x double> %a_1,
                 <4 x double> zeroinitializer, i8 -1)
-  %b_0 = shufflevector <8 x double> %0, <8 x double> undef,
+  %b_0 = shufflevector <8 x double> %0, <8 x double> poison,
                        <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %b_1 = shufflevector <8 x double> %1, <8 x double> undef,
+  %b_1 = shufflevector <8 x double> %1, <8 x double> poison,
                        <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %res_b = call <4 x double> @llvm.x86.avx512.mask.min.pd.256(<4 x double> %b_0, <4 x double> %b_1,
                 <4 x double> zeroinitializer, i8 -1)
@@ -323,15 +323,15 @@ define <8 x double> @__min_varying_double(<8 x double>, <8 x double>) nounwind r
 }
 
 define <8 x double> @__max_varying_double(<8 x double>, <8 x double>) nounwind readnone alwaysinline {
-  %a_0 = shufflevector <8 x double> %0, <8 x double> undef,
+  %a_0 = shufflevector <8 x double> %0, <8 x double> poison,
                        <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %a_1 = shufflevector <8 x double> %1, <8 x double> undef,
+  %a_1 = shufflevector <8 x double> %1, <8 x double> poison,
                        <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %res_a = call <4 x double> @llvm.x86.avx512.mask.max.pd.256(<4 x double> %a_0, <4 x double> %a_1,
                 <4 x double> zeroinitializer, i8 -1)
-  %b_0 = shufflevector <8 x double> %0, <8 x double> undef,
+  %b_0 = shufflevector <8 x double> %0, <8 x double> poison,
                        <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %b_1 = shufflevector <8 x double> %1, <8 x double> undef,
+  %b_1 = shufflevector <8 x double> %1, <8 x double> poison,
                        <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %res_b = call <4 x double> @llvm.x86.avx512.mask.max.pd.256(<4 x double> %b_0, <4 x double> %b_1,
                 <4 x double> zeroinitializer, i8 -1)
@@ -363,9 +363,9 @@ define double @__sqrt_uniform_double(double) nounwind alwaysinline {
 declare <4 x double> @llvm.x86.avx512.mask.sqrt.pd.256(<4 x double>, <4 x double>, i8) nounwind readnone
 
 define <8 x double> @__sqrt_varying_double(<8 x double>) nounwind alwaysinline {
-  %v0 = shufflevector <8 x double> %0, <8 x double> undef,
+  %v0 = shufflevector <8 x double> %0, <8 x double> poison,
                       <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1 = shufflevector <8 x double> %0, <8 x double> undef,
+  %v1 = shufflevector <8 x double> %0, <8 x double> poison,
                       <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %r0 = call <4 x double> @llvm.x86.avx512.mask.sqrt.pd.256(<4 x double> %v0,  <4 x double> zeroinitializer, i8 -1)
   %r1 = call <4 x double> @llvm.x86.avx512.mask.sqrt.pd.256(<4 x double> %v1,  <4 x double> zeroinitializer, i8 -1)
@@ -457,9 +457,9 @@ define i32 @__reduce_max_uint32(<8 x i32>) nounwind readnone alwaysinline {
 declare <4 x double> @llvm.x86.avx.hadd.pd.256(<4 x double>, <4 x double>) nounwind readnone
 
 define double @__reduce_add_double(<8 x double>) nounwind readonly alwaysinline {
-  %va = shufflevector <8 x double> %0, <8 x double> undef,
+  %va = shufflevector <8 x double> %0, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vb = shufflevector <8 x double> %0, <8 x double> undef,
+  %vb = shufflevector <8 x double> %0, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %vab = fadd <4 x double> %va, %vb
   %sum0 = call <4 x double> @llvm.x86.avx.hadd.pd.256(<4 x double> %vab, <4 x double> %vab)
@@ -589,9 +589,9 @@ define void @__masked_store_i64(<8 x i64>* nocapture, <8 x i64> %v, <WIDTH x MAS
   %ptr_lo = getelementptr PTR_OP_ARGS(`<8 x i64>') %0, i32 0, i32 4
   %ptr_lo_i8 = bitcast i64* %ptr_lo to i8*
 
-  %v_lo = shufflevector <8 x i64> %v, <8 x i64> undef,
+  %v_lo = shufflevector <8 x i64> %v, <8 x i64> poison,
                         <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v_hi = shufflevector <8 x i64> %v, <8 x i64> undef,
+  %v_hi = shufflevector <8 x i64> %v, <8 x i64> poison,
                         <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   call void @llvm.x86.avx512.mask.storeu.q.256(i8* %ptr_i8, <4 x i64> %v_lo, i8 %mask_i8)
@@ -617,9 +617,9 @@ define void @__masked_store_double(<8 x double>* nocapture, <8 x double> %v, <WI
   %ptr_lo = getelementptr PTR_OP_ARGS(`<8 x double>') %0, i32 0, i32 4
   %ptr_lo_i8 = bitcast double* %ptr_lo to i8*
 
-  %v_lo = shufflevector <8 x double> %v, <8 x double> undef,
+  %v_lo = shufflevector <8 x double> %v, <8 x double> poison,
                         <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v_hi = shufflevector <8 x double> %v, <8 x double> undef,
+  %v_hi = shufflevector <8 x double> %v, <8 x double> poison,
                         <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   call void @llvm.x86.avx512.mask.storeu.pd.256(i8* %ptr_i8, <4 x double> %v_lo, i8 %mask_i8)
@@ -664,10 +664,10 @@ define <8 x i32>
 declare <4 x i32> @llvm.x86.avx512.mask.gather3div8.si(<4 x i32>, i8*, <4 x i64>, <4 x i1>, i32)
 define <8 x i32>
 @__gather_base_offsets64_i32(i8 * %ptr, i32 %offset_scale, <8 x i64> %offsets, <8 x i1> %vecmask) nounwind readonly alwaysinline {
-  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   convert_scale_to_const_gather(res1, llvm.x86.avx512.mask.gather3div8.si, 4, i32, ptr, offsets_lo, i64, vecmask_lo, <4 x i1>, offset_scale)
   convert_scale_to_const_gather(res2, llvm.x86.avx512.mask.gather3div8.si, 4, i32, ptr, offsets_hi, i64, vecmask_hi, <4 x i1>, offset_scale)
   %res = shufflevector <4 x i32> %res1, <4 x i32> %res2 , <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -690,10 +690,10 @@ define <8 x i32>
 declare <4 x i64> @llvm.x86.avx512.mask.gather3siv4.di(<4 x i64>, i8*, <4 x i32>, <4 x i1>, i32)
 define <8 x i64>
 @__gather_base_offsets32_i64(i8 * %ptr, i32 %offset_scale, <8 x i32> %offsets, <8 x i1> %vecmask) nounwind readonly alwaysinline {
-  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %offsets_lo = shufflevector <8 x i32> %offsets, <8 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %offsets_hi = shufflevector <8 x i32> %offsets, <8 x i32> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %offsets_lo = shufflevector <8 x i32> %offsets, <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %offsets_hi = shufflevector <8 x i32> %offsets, <8 x i32> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   convert_scale_to_const_gather(res1, llvm.x86.avx512.mask.gather3siv4.di, 4, i64, ptr, offsets_lo, i32, vecmask_lo, <4 x i1>, offset_scale)
   convert_scale_to_const_gather(res2, llvm.x86.avx512.mask.gather3siv4.di, 4, i64, ptr, offsets_hi, i32, vecmask_hi, <4 x i1>, offset_scale)
   %res = shufflevector <4 x i64> %res1, <4 x i64> %res2 , <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -703,10 +703,10 @@ define <8 x i64>
 declare <4 x i64> @llvm.x86.avx512.mask.gather3div4.di(<4 x i64>, i8*, <4 x i64>, <4 x i1>, i32)
 define <8 x i64>
 @__gather_base_offsets64_i64(i8 * %ptr, i32 %offset_scale, <8 x i64> %offsets, <8 x i1> %vecmask) nounwind readonly alwaysinline {
-  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   convert_scale_to_const_gather(res1, llvm.x86.avx512.mask.gather3div4.di, 4, i64, ptr, offsets_lo, i64, vecmask_lo, <4 x i1>, offset_scale)
   convert_scale_to_const_gather(res2, llvm.x86.avx512.mask.gather3div4.di, 4, i64, ptr, offsets_hi, i64, vecmask_hi, <4 x i1>, offset_scale)
   %res = shufflevector <4 x i64> %res1, <4 x i64> %res2 , <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -736,10 +736,10 @@ define <8 x float>
 declare <4 x float> @llvm.x86.avx512.mask.gather3div8.sf(<4 x float>, i8*, <4 x i64>, <4 x i1>, i32)
 define <8 x float>
 @__gather_base_offsets64_float(i8 * %ptr, i32 %offset_scale, <8 x i64> %offsets, <8 x i1> %vecmask) nounwind readonly alwaysinline {
-  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   convert_scale_to_const_gather(res_lo, llvm.x86.avx512.mask.gather3div8.sf, 4, float, ptr, offsets_lo, i64, vecmask_lo, <4 x i1>, offset_scale)
   convert_scale_to_const_gather(res_hi, llvm.x86.avx512.mask.gather3div8.sf, 4, float, ptr, offsets_hi, i64, vecmask_hi, <4 x i1>, offset_scale)
   %res = shufflevector <4 x float> %res_lo, <4 x float> %res_hi, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -762,10 +762,10 @@ define <8 x float>
 declare <4 x double> @llvm.x86.avx512.mask.gather3siv4.df(<4 x double>, i8*, <4 x i32>, <4 x i1>, i32)
 define <8 x double>
 @__gather_base_offsets32_double(i8 * %ptr, i32 %offset_scale, <8 x i32> %offsets, <8 x i1> %vecmask) nounwind readonly alwaysinline {
-  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %offsets_lo = shufflevector <8 x i32> %offsets, <8 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %offsets_hi = shufflevector <8 x i32> %offsets, <8 x i32> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %offsets_lo = shufflevector <8 x i32> %offsets, <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %offsets_hi = shufflevector <8 x i32> %offsets, <8 x i32> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   convert_scale_to_const_gather(res1, llvm.x86.avx512.mask.gather3siv4.df, 4, double, ptr, offsets_lo, i32, vecmask_lo, <4 x i1>, offset_scale)
   convert_scale_to_const_gather(res2, llvm.x86.avx512.mask.gather3siv4.df, 4, double, ptr, offsets_hi, i32, vecmask_hi, <4 x i1>, offset_scale)
   %res = shufflevector <4 x double> %res1, <4 x double> %res2 , <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -775,10 +775,10 @@ define <8 x double>
 declare <4 x double> @llvm.x86.avx512.mask.gather3div4.df(<4 x double>, i8*, <4 x i64>, <4 x i1>, i32)
 define <8 x double>
 @__gather_base_offsets64_double(i8 * %ptr, i32 %offset_scale, <8 x i64> %offsets, <8 x i1> %vecmask) nounwind readonly alwaysinline {
-  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   convert_scale_to_const_gather(res1, llvm.x86.avx512.mask.gather3div4.df, 4, double, ptr, offsets_lo, i64, vecmask_lo, <4 x i1>, offset_scale)
   convert_scale_to_const_gather(res2, llvm.x86.avx512.mask.gather3div4.df, 4, double, ptr, offsets_hi, i64, vecmask_hi, <4 x i1>, offset_scale)
   %res = shufflevector <4 x double> %res1, <4 x double> %res2 , <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -846,12 +846,12 @@ define void
 declare void @llvm.x86.avx512.mask.scatterdiv8.si(i8*, <4 x i1>, <4 x i64>, <4 x i32>, i32)
 define void
 @__scatter_base_offsets64_i32(i8* %ptr, i32 %offset_scale, <8 x i64> %offsets, <8 x i32> %vals, <8 x i1> %vecmask) nounwind {
-  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %res_lo = shufflevector <8 x i32> %vals, <8 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %res_hi = shufflevector <8 x i32> %vals, <8 x i32> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %res_lo = shufflevector <8 x i32> %vals, <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %res_hi = shufflevector <8 x i32> %vals, <8 x i32> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatterdiv8.si, 4, res_lo, i32, ptr, offsets_lo, i64, vecmask_lo, <4 x i1>, offset_scale);
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatterdiv8.si, 4, res_hi, i32, ptr, offsets_hi, i64, vecmask_hi, <4 x i1>, offset_scale);
   ret void
@@ -873,12 +873,12 @@ define void
 declare void @llvm.x86.avx512.mask.scattersiv4.di(i8*, <4 x i1>, <4 x i32>, <4 x i64>, i32)
 define void
 @__scatter_base_offsets32_i64(i8* %ptr, i32 %offset_scale, <8 x i32> %offsets, <8 x i64> %vals, <8 x i1> %vecmask) nounwind {
-  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %offsets_lo = shufflevector <8 x i32> %offsets, <8 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %offsets_hi = shufflevector <8 x i32> %offsets, <8 x i32> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %res_lo = shufflevector <8 x i64> %vals, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %res_hi = shufflevector <8 x i64> %vals, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %offsets_lo = shufflevector <8 x i32> %offsets, <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %offsets_hi = shufflevector <8 x i32> %offsets, <8 x i32> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %res_lo = shufflevector <8 x i64> %vals, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %res_hi = shufflevector <8 x i64> %vals, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scattersiv4.di, 4, res_lo, i64, ptr, offsets_lo, i32, vecmask_lo, <4 x i1>, offset_scale);
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scattersiv4.di, 4, res_hi, i64, ptr, offsets_hi, i32, vecmask_hi, <4 x i1>, offset_scale);
   ret void
@@ -887,12 +887,12 @@ define void
 declare void @llvm.x86.avx512.mask.scatterdiv4.di(i8*, <4 x i1>, <4 x i64>, <4 x i64>, i32)
 define void
 @__scatter_base_offsets64_i64(i8* %ptr, i32 %offset_scale, <8 x i64> %offsets, <8 x i64> %vals, <8 x i1> %vecmask) nounwind {
-  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %res_lo = shufflevector <8 x i64> %vals, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %res_hi = shufflevector <8 x i64> %vals, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %res_lo = shufflevector <8 x i64> %vals, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %res_hi = shufflevector <8 x i64> %vals, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatterdiv4.di, 4, res_lo, i64, ptr, offsets_lo, i64, vecmask_lo, <4 x i1>, offset_scale);
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatterdiv4.di, 4, res_hi, i64, ptr, offsets_hi, i64, vecmask_hi, <4 x i1>, offset_scale);
   ret void
@@ -921,12 +921,12 @@ define void
 declare void @llvm.x86.avx512.mask.scatterdiv8.sf(i8*, <4 x i1>, <4 x i64>, <4 x float>, i32)
 define void
 @__scatter_base_offsets64_float(i8* %ptr, i32 %offset_scale, <8 x i64> %offsets, <8 x float> %vals, <8 x i1> %vecmask) nounwind {
-  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %res_lo = shufflevector <8 x float> %vals, <8 x float> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %res_hi = shufflevector <8 x float> %vals, <8 x float> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %res_lo = shufflevector <8 x float> %vals, <8 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %res_hi = shufflevector <8 x float> %vals, <8 x float> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatterdiv8.sf, 4, res_lo, float, ptr, offsets_lo, i64, vecmask_lo, <4 x i1>, offset_scale);
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatterdiv8.sf, 4, res_hi, float, ptr, offsets_hi, i64, vecmask_hi, <4 x i1>, offset_scale);
   ret void
@@ -948,12 +948,12 @@ define void
 declare void @llvm.x86.avx512.mask.scattersiv4.df(i8*, <4 x i1>, <4 x i32>, <4 x double>, i32)
 define void
 @__scatter_base_offsets32_double(i8* %ptr, i32 %offset_scale, <8 x i32> %offsets, <8 x double> %vals, <8 x i1> %vecmask) nounwind {
-  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %offsets_lo = shufflevector <8 x i32> %offsets, <8 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %offsets_hi = shufflevector <8 x i32> %offsets, <8 x i32> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %res_lo = shufflevector <8 x double> %vals, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %res_hi = shufflevector <8 x double> %vals, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %offsets_lo = shufflevector <8 x i32> %offsets, <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %offsets_hi = shufflevector <8 x i32> %offsets, <8 x i32> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %res_lo = shufflevector <8 x double> %vals, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %res_hi = shufflevector <8 x double> %vals, <8 x double> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scattersiv4.df, 4, res_lo, double, ptr, offsets_lo, i32, vecmask_lo, <4 x i1>, offset_scale);
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scattersiv4.df, 4, res_hi, double, ptr, offsets_hi, i32, vecmask_hi, <4 x i1>, offset_scale);
   ret void
@@ -962,12 +962,12 @@ define void
 declare void @llvm.x86.avx512.mask.scatterdiv4.df(i8*, <4 x i1>, <4 x i64>, <4 x double>, i32)
 define void
 @__scatter_base_offsets64_double(i8* %ptr, i32 %offset_scale, <8 x i64> %offsets, <8 x double> %vals, <8 x i1> %vecmask) nounwind {
-  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %res_lo = shufflevector <8 x double> %vals, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %res_hi = shufflevector <8 x double> %vals, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %vecmask_lo = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %vecmask_hi = shufflevector <8 x i1> %vecmask, <8 x i1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %offsets_lo = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %offsets_hi = shufflevector <8 x i64> %offsets, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %res_lo = shufflevector <8 x double> %vals, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %res_hi = shufflevector <8 x double> %vals, <8 x double> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatterdiv4.df, 4, res_lo, double, ptr, offsets_lo, i64, vecmask_lo, <4 x i1>, offset_scale);
   convert_scale_to_const_scatter(llvm.x86.avx512.mask.scatterdiv4.df, 4, res_hi, double, ptr, offsets_hi, i64, vecmask_hi, <4 x i1>, offset_scale);
   ret void
@@ -1011,7 +1011,7 @@ rcp14_uniform()
 ;; rcp float
 declare <8 x float> @llvm.x86.avx512.rcp14.ps.256(<8 x float>, <8 x float>, i8) nounwind readnone
 define <8 x float> @__rcp_fast_varying_float(<8 x float>) nounwind readonly alwaysinline {
-  %ret = call <8 x float> @llvm.x86.avx512.rcp14.ps.256(<8 x float> %0, <8 x float> undef, i8 -1)
+  %ret = call <8 x float> @llvm.x86.avx512.rcp14.ps.256(<8 x float> %0, <8 x float> poison, i8 -1)
   ret <8 x float> %ret
 }
 define <8 x float> @__rcp_varying_float(<8 x float>) nounwind readonly alwaysinline {
@@ -1029,10 +1029,10 @@ define <8 x float> @__rcp_varying_float(<8 x float>) nounwind readonly alwaysinl
 ;; rcp double
 declare <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double>, <4 x double>, i8) nounwind readnone
 define <8 x double> @__rcp_fast_varying_double(<8 x double> %val) nounwind readonly alwaysinline {
-  %val_lo = shufflevector <8 x double> %val, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %val_hi = shufflevector <8 x double> %val, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %res_lo = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val_lo, <4 x double> undef, i8 -1)
-  %res_hi = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val_hi, <4 x double> undef, i8 -1)
+  %val_lo = shufflevector <8 x double> %val, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %val_hi = shufflevector <8 x double> %val, <8 x double> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %res_lo = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val_lo, <4 x double> poison, i8 -1)
+  %res_hi = call <4 x double> @llvm.x86.avx512.rcp14.pd.256(<4 x double> %val_hi, <4 x double> poison, i8 -1)
   %res = shufflevector <4 x double> %res_lo, <4 x double> %res_hi, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x double> %res
 }
@@ -1052,7 +1052,7 @@ rsqrt14_uniform()
 ;; rsqrt float
 declare <8 x float> @llvm.x86.avx512.rsqrt14.ps.256(<8 x float>,  <8 x float>,  i8) nounwind readnone
 define <8 x float> @__rsqrt_varying_float(<8 x float> %v) nounwind readonly alwaysinline {
-  %is = call <8 x float> @llvm.x86.avx512.rsqrt14.ps.256(<8 x float> %v,  <8 x float> undef,  i8 -1)
+  %is = call <8 x float> @llvm.x86.avx512.rsqrt14.ps.256(<8 x float> %v,  <8 x float> poison,  i8 -1)
   ; Newton-Raphson iteration to improve precision
   ;  float is = __rsqrt_v(v);
   ;  return 0.5 * is * (3. - (v * is) * is);
@@ -1066,25 +1066,25 @@ define <8 x float> @__rsqrt_varying_float(<8 x float> %v) nounwind readonly alwa
   ret <8 x float> %half_scale
 }
 define <8 x float> @__rsqrt_fast_varying_float(<8 x float> %v) nounwind readonly alwaysinline {
-  %ret = call <8 x float> @llvm.x86.avx512.rsqrt14.ps.256(<8 x float> %v,  <8 x float> undef,  i8 -1)
+  %ret = call <8 x float> @llvm.x86.avx512.rsqrt14.ps.256(<8 x float> %v,  <8 x float> poison,  i8 -1)
   ret <8 x float> %ret
 }
 
 ;; rsqrt double
 declare <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double>,  <4 x double>,  i8) nounwind readnone
 define <8 x double> @__rsqrt_fast_varying_double(<8 x double> %val) nounwind readonly alwaysinline {
-  %val_lo = shufflevector <8 x double> %val, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %val_hi = shufflevector <8 x double> %val, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %res_lo = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val_lo, <4 x double> undef, i8 -1)
-  %res_hi = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val_hi, <4 x double> undef, i8 -1)
+  %val_lo = shufflevector <8 x double> %val, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %val_hi = shufflevector <8 x double> %val, <8 x double> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %res_lo = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val_lo, <4 x double> poison, i8 -1)
+  %res_hi = call <4 x double> @llvm.x86.avx512.rsqrt14.pd.256(<4 x double> %val_hi, <4 x double> poison, i8 -1)
   %res = shufflevector <4 x double> %res_lo, <4 x double> %res_hi, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x double> %res
 }
 declare <4 x i1> @llvm.x86.avx512.fpclass.pd.256(<4 x double>, i32)
 define <8 x double> @__rsqrt_varying_double(<8 x double> %v) nounwind readonly alwaysinline {
   ; detect +/-0 and +inf to deal with them differently.
-  %val_lo = shufflevector <8 x double> %v, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %val_hi = shufflevector <8 x double> %v, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %val_lo = shufflevector <8 x double> %v, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %val_hi = shufflevector <8 x double> %v, <8 x double> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %corner_cases_lo = call <4 x i1> @llvm.x86.avx512.fpclass.pd.256(<4 x double> %val_lo, i32 14)
   %corner_cases_hi = call <4 x i1> @llvm.x86.avx512.fpclass.pd.256(<4 x double> %val_hi, i32 14)
   %corner_cases = shufflevector <4 x i1> %corner_cases_lo, <4 x i1> %corner_cases_hi, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>

--- a/builtins/target-neon-common.ll
+++ b/builtins/target-neon-common.ll
@@ -57,7 +57,7 @@ declare <4 x float> @NEON_PREFIX.vcvthf2fp(<4 x i16>) nounwind readnone
 
 define float @__half_to_float_uniform(i16 %v) nounwind readnone alwaysinline {
   %v1 = bitcast i16 %v to <1 x i16>
-  %vec = shufflevector <1 x i16> %v1, <1 x i16> undef,
+  %vec = shufflevector <1 x i16> %v1, <1 x i16> poison,
            <4 x i32> <i32 0, i32 0, i32 0, i32 0>
   %h = call <4 x float> @NEON_PREFIX.vcvthf2fp(<4 x i16> %vec)
   %r = extractelement <4 x float> %h, i32 0
@@ -66,7 +66,7 @@ define float @__half_to_float_uniform(i16 %v) nounwind readnone alwaysinline {
 
 define i16 @__float_to_half_uniform(float %v) nounwind readnone alwaysinline {
   %v1 = bitcast float %v to <1 x float>
-  %vec = shufflevector <1 x float> %v1, <1 x float> undef,
+  %vec = shufflevector <1 x float> %v1, <1 x float> poison,
            <4 x i32> <i32 0, i32 0, i32 0, i32 0>
   %h = call <4 x i16> @NEON_PREFIX.vcvtfp2hf(<4 x float> %vec)
   %r = extractelement <4 x i16> %h, i32 0

--- a/builtins/target-neon-i16x8.ll
+++ b/builtins/target-neon-i16x8.ll
@@ -104,14 +104,14 @@ define <WIDTH x float> @__rsqrt_fast_varying_float(<WIDTH x float> %d) nounwind 
 }
 
 define float @__rsqrt_uniform_float(float) nounwind readnone alwaysinline {
-  %vs = insertelement <8 x float> undef, float %0, i32 0
+  %vs = insertelement <8 x float> poison, float %0, i32 0
   %vr = call <8 x float> @__rsqrt_varying_float(<8 x float> %vs)
   %r = extractelement <8 x float> %vr, i32 0
   ret float %r
 }
 
 define float @__rsqrt_fast_uniform_float(float) nounwind readnone alwaysinline {
-  %vs = insertelement <8 x float> undef, float %0, i32 0
+  %vs = insertelement <8 x float> poison, float %0, i32 0
   %vr = call <8 x float> @__rsqrt_fast_varying_float(<8 x float> %vs)
   %r = extractelement <8 x float> %vr, i32 0
   ret float %r
@@ -119,9 +119,9 @@ define float @__rsqrt_fast_uniform_float(float) nounwind readnone alwaysinline {
 
 define float @__rcp_uniform_float(float) nounwind readnone alwaysinline {
   %v1 = bitcast float %0 to <1 x float>
-  %vs = shufflevector <1 x float> %v1, <1 x float> undef,
-          <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vs = shufflevector <1 x float> %v1, <1 x float> poison,
+          <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %vr = call <8 x float> @__rcp_varying_float(<8 x float> %vs)
   %r = extractelement <8 x float> %vr, i32 0
   ret float %r
@@ -129,9 +129,9 @@ define float @__rcp_uniform_float(float) nounwind readnone alwaysinline {
 
 define float @__rcp_fast_uniform_float(float) nounwind readnone alwaysinline {
   %v1 = bitcast float %0 to <1 x float>
-  %vs = shufflevector <1 x float> %v1, <1 x float> undef,
-          <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vs = shufflevector <1 x float> %v1, <1 x float> poison,
+          <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %vr = call <8 x float> @__rcp_fast_varying_float(<8 x float> %vs)
   %r = extractelement <8 x float> %vr, i32 0
   ret float %r

--- a/builtins/target-neon-i32x4.ll
+++ b/builtins/target-neon-i32x4.ll
@@ -88,8 +88,8 @@ define <WIDTH x float> @__rsqrt_varying_float(<WIDTH x float> %d) nounwind readn
 
 define float @__rsqrt_uniform_float(float) nounwind readnone alwaysinline {
   %v1 = bitcast float %0 to <1 x float>
-  %vs = shufflevector <1 x float> %v1, <1 x float> undef,
-          <4 x i32> <i32 0, i32 undef, i32 undef, i32 undef>
+  %vs = shufflevector <1 x float> %v1, <1 x float> poison,
+          <4 x i32> <i32 0, i32 poison, i32 poison, i32 poison>
   %vr = call <4 x float> @__rsqrt_varying_float(<4 x float> %vs)
   %r = extractelement <4 x float> %vr, i32 0
   ret float %r
@@ -101,7 +101,7 @@ define <WIDTH x float> @__rsqrt_fast_varying_float(<WIDTH x float> %d) nounwind 
 }
 
 define float @__rsqrt_fast_uniform_float(float) nounwind readnone alwaysinline {
-  %vs = insertelement <4 x float> undef, float %0, i32 0
+  %vs = insertelement <4 x float> poison, float %0, i32 0
   %vr = call <4 x float> @__rsqrt_fast_varying_float(<4 x float> %vs)
   %r = extractelement <4 x float> %vr, i32 0
   ret float %r
@@ -109,15 +109,15 @@ define float @__rsqrt_fast_uniform_float(float) nounwind readnone alwaysinline {
 
 define float @__rcp_uniform_float(float) nounwind readnone alwaysinline {
   %v1 = bitcast float %0 to <1 x float>
-  %vs = shufflevector <1 x float> %v1, <1 x float> undef,
-          <4 x i32> <i32 0, i32 undef, i32 undef, i32 undef>
+  %vs = shufflevector <1 x float> %v1, <1 x float> poison,
+          <4 x i32> <i32 0, i32 poison, i32 poison, i32 poison>
   %vr = call <4 x float> @__rcp_varying_float(<4 x float> %vs)
   %r = extractelement <4 x float> %vr, i32 0
   ret float %r
 }
 
 define float @__rcp_fast_uniform_float(float) nounwind readnone alwaysinline {
-  %vs = insertelement <4 x float> undef, float %0, i32 0
+  %vs = insertelement <4 x float> poison, float %0, i32 0
   %vr = call <4 x float> @__rcp_fast_varying_float(<4 x float> %vs)
   %r = extractelement <4 x float> %vr, i32 0
   ret float %r

--- a/builtins/target-neon-i32x8.ll
+++ b/builtins/target-neon-i32x8.ll
@@ -98,9 +98,9 @@ define <8 x float> @__rsqrt_fast_varying_float(<8 x float> %d) nounwind readnone
 
 define float @__rsqrt_uniform_float(float) nounwind readnone alwaysinline {
   %v1 = bitcast float %0 to <1 x float>
-  %vs = shufflevector <1 x float> %v1, <1 x float> undef,
-          <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vs = shufflevector <1 x float> %v1, <1 x float> poison,
+          <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %vr = call <8 x float> @__rsqrt_varying_float(<8 x float> %vs)
   %r = extractelement <8 x float> %vr, i32 0
   ret float %r
@@ -108,23 +108,23 @@ define float @__rsqrt_uniform_float(float) nounwind readnone alwaysinline {
 
 define float @__rcp_uniform_float(float) nounwind readnone alwaysinline {
   %v1 = bitcast float %0 to <1 x float>
-  %vs = shufflevector <1 x float> %v1, <1 x float> undef,
-          <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vs = shufflevector <1 x float> %v1, <1 x float> poison,
+          <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %vr = call <8 x float> @__rcp_varying_float(<8 x float> %vs)
   %r = extractelement <8 x float> %vr, i32 0
   ret float %r
 }
 
 define float @__rsqrt_fast_uniform_float(float) nounwind readnone alwaysinline {
-  %vs = insertelement <8 x float> undef, float %0, i32 0
+  %vs = insertelement <8 x float> poison, float %0, i32 0
   %vr = call <8 x float> @__rsqrt_fast_varying_float(<8 x float> %vs)
   %r = extractelement <8 x float> %vr, i32 0
   ret float %r
 }
 
 define float @__rcp_fast_uniform_float(float) nounwind readnone alwaysinline {
-  %vs = insertelement <8 x float> undef, float %0, i32 0
+  %vs = insertelement <8 x float> poison, float %0, i32 0
   %vr = call <8 x float> @__rcp_fast_varying_float(<8 x float> %vs)
   %r = extractelement <8 x float> %vr, i32 0
   ret float %r

--- a/builtins/target-neon-i8x16.ll
+++ b/builtins/target-neon-i8x16.ll
@@ -113,18 +113,18 @@ define <WIDTH x float> @__rsqrt_fast_varying_float(<WIDTH x float> %d) nounwind 
 
 define float @__rsqrt_uniform_float(float) nounwind readnone alwaysinline {
   %v1 = bitcast float %0 to <1 x float>
-  %vs = shufflevector <1 x float> %v1, <1 x float> undef,
-          <16 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vs = shufflevector <1 x float> %v1, <1 x float> poison,
+          <16 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %vr = call <16 x float> @__rsqrt_varying_float(<16 x float> %vs)
   %r = extractelement <16 x float> %vr, i32 0
   ret float %r
 }
 
 define float @__rsqrt_fast_uniform_float(float) nounwind readnone alwaysinline {
-  %vs = insertelement <16 x float> undef, float %0, i32 0
+  %vs = insertelement <16 x float> poison, float %0, i32 0
   %vr = call <16 x float> @__rsqrt_fast_varying_float(<16 x float> %vs)
   %r = extractelement <16 x float> %vr, i32 0
   ret float %r
@@ -132,18 +132,18 @@ define float @__rsqrt_fast_uniform_float(float) nounwind readnone alwaysinline {
 
 define float @__rcp_uniform_float(float) nounwind readnone alwaysinline {
   %v1 = bitcast float %0 to <1 x float>
-  %vs = shufflevector <1 x float> %v1, <1 x float> undef,
-          <16 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef>
+  %vs = shufflevector <1 x float> %v1, <1 x float> poison,
+          <16 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison>
   %vr = call <16 x float> @__rcp_varying_float(<16 x float> %vs)
   %r = extractelement <16 x float> %vr, i32 0
   ret float %r
 }
 
 define float @__rcp_fast_uniform_float(float) nounwind readnone alwaysinline {
-  %vs = insertelement <16 x float> undef, float %0, i32 0
+  %vs = insertelement <16 x float> poison, float %0, i32 0
   %vr = call <16 x float> @__rcp_fast_varying_float(<16 x float> %vs)
   %r = extractelement <16 x float> %vr, i32 0
   ret float %r

--- a/builtins/target-sse2-common.ll
+++ b/builtins/target-sse2-common.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2025, Intel Corporation
+;;  Copyright (c) 2010-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -16,7 +16,7 @@ declare <4 x float> @llvm.x86.sse.rcp.ss(<4 x float>) nounwind readnone
 
 define float @__rcp_uniform_float(float) nounwind readonly alwaysinline {
   ; do the rcpss call
-  %vecval = insertelement <4 x float> undef, float %0, i32 0
+  %vecval = insertelement <4 x float> poison, float %0, i32 0
   %call = call <4 x float> @llvm.x86.sse.rcp.ss(<4 x float> %vecval)
   %scall = extractelement <4 x float> %call, i32 0
 
@@ -29,7 +29,7 @@ define float @__rcp_uniform_float(float) nounwind readonly alwaysinline {
 
 define float @__rcp_fast_uniform_float(float) nounwind readonly alwaysinline {
   ; do the rcpss call
-  %vecval = insertelement <4 x float> undef, float %0, i32 0
+  %vecval = insertelement <4 x float> poison, float %0, i32 0
   %call = call <4 x float> @llvm.x86.sse.rcp.ss(<4 x float> %vecval)
   %scall = extractelement <4 x float> %call, i32 0
   ret float %scall
@@ -43,7 +43,7 @@ declare <4 x float> @llvm.x86.sse.rsqrt.ss(<4 x float>) nounwind readnone
 
 define float @__rsqrt_uniform_float(float) nounwind readonly alwaysinline {
   ;  uniform float is = extract(__rsqrt_u(v), 0);
-  %v = insertelement <4 x float> undef, float %0, i32 0
+  %v = insertelement <4 x float> poison, float %0, i32 0
   %vis = call <4 x float> @llvm.x86.sse.rsqrt.ss(<4 x float> %v)
   %is = extractelement <4 x float> %vis, i32 0
 
@@ -59,7 +59,7 @@ define float @__rsqrt_uniform_float(float) nounwind readonly alwaysinline {
 
 define float @__rsqrt_fast_uniform_float(float) nounwind readonly alwaysinline {
   ;  uniform float is = extract(__rsqrt_u(v), 0);
-  %v = insertelement <4 x float> undef, float %0, i32 0
+  %v = insertelement <4 x float> poison, float %0, i32 0
   %vis = call <4 x float> @llvm.x86.sse.rsqrt.ss(<4 x float> %v)
   %is = extractelement <4 x float> %vis, i32 0
   ret float %is

--- a/builtins/target-sse2-i32x4.ll
+++ b/builtins/target-sse2-i32x4.ll
@@ -153,8 +153,8 @@ define i1 @__none(<4 x i32>) nounwind readnone alwaysinline {
 }
 
 define float @__reduce_add_float(<4 x float> %v) nounwind readonly alwaysinline {
-  %v1 = shufflevector <4 x float> %v, <4 x float> undef,
-                      <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
+  %v1 = shufflevector <4 x float> %v, <4 x float> poison,
+                      <4 x i32> <i32 2, i32 3, i32 poison, i32 poison>
   %m1 = fadd <4 x float> %v1, %v
   %m1a = extractelement <4 x float> %m1, i32 0
   %m1b = extractelement <4 x float> %m1, i32 1
@@ -188,9 +188,9 @@ define i32 @__reduce_max_uint32(<4 x i32>) nounwind readnone {
 
 
 define double @__reduce_add_double(<4 x double>) nounwind readnone {
-  %v0 = shufflevector <4 x double> %0, <4 x double> undef,
+  %v0 = shufflevector <4 x double> %0, <4 x double> poison,
                       <2 x i32> <i32 0, i32 1>
-  %v1 = shufflevector <4 x double> %0, <4 x double> undef,
+  %v1 = shufflevector <4 x double> %0, <4 x double> poison,
                       <2 x i32> <i32 2, i32 3>
   %sum = fadd <2 x double> %v0, %v1
   %e0 = extractelement <2 x double> %sum, i32 0

--- a/builtins/target-sse2-i32x8.ll
+++ b/builtins/target-sse2-i32x8.ll
@@ -110,10 +110,10 @@ declare i32 @llvm.x86.sse.movmsk.ps(<4 x float>) nounwind readnone
 define i64 @__movmsk(<8 x i32>) nounwind readnone alwaysinline {
   ; first do two 4-wide movmsk calls
   %floatmask = bitcast <8 x i32> %0 to <8 x float>
-  %m0 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m0 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v0 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m0) nounwind readnone
-  %m1 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m1 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v1 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m1) nounwind readnone
 
@@ -128,10 +128,10 @@ define i64 @__movmsk(<8 x i32>) nounwind readnone alwaysinline {
 define i1 @__any(<8 x i32>) nounwind readnone alwaysinline {
   ; first do two 4-wide movmsk calls
   %floatmask = bitcast <8 x i32> %0 to <8 x float>
-  %m0 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m0 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v0 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m0) nounwind readnone
-  %m1 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m1 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v1 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m1) nounwind readnone
 
@@ -146,10 +146,10 @@ define i1 @__any(<8 x i32>) nounwind readnone alwaysinline {
 define i1 @__all(<8 x i32>) nounwind readnone alwaysinline {
   ; first do two 4-wide movmsk calls
   %floatmask = bitcast <8 x i32> %0 to <8 x float>
-  %m0 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m0 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v0 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m0) nounwind readnone
-  %m1 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m1 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v1 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m1) nounwind readnone
 
@@ -164,10 +164,10 @@ define i1 @__all(<8 x i32>) nounwind readnone alwaysinline {
 define i1 @__none(<8 x i32>) nounwind readnone alwaysinline {
   ; first do two 4-wide movmsk calls
   %floatmask = bitcast <8 x i32> %0 to <8 x float>
-  %m0 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m0 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v0 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m0) nounwind readnone
-  %m1 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m1 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v1 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m1) nounwind readnone
 

--- a/builtins/target-sse4-common.ll
+++ b/builtins/target-sse4-common.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2025, Intel Corporation
+;;  Copyright (c) 2010-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 
@@ -34,7 +34,7 @@ define float @__round_uniform_float(float) nounwind readonly alwaysinline {
   ;  It doesn't matter what we pass as a, since we only need the r0 value
   ;  here.  So we pass the same register for both.  Further, only the 0th
   ;  element of the b parameter matters
-  %xi = insertelement <4 x float> undef, float %0, i32 0
+  %xi = insertelement <4 x float> poison, float %0, i32 0
   %xr = call <4 x float> @llvm.x86.sse41.round.ss(<4 x float> %xi, <4 x float> %xi, i32 8)
   %rs = extractelement <4 x float> %xr, i32 0
   ret float %rs
@@ -42,7 +42,7 @@ define float @__round_uniform_float(float) nounwind readonly alwaysinline {
 
 define float @__floor_uniform_float(float) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <4 x float> undef, float %0, i32 0
+  %xi = insertelement <4 x float> poison, float %0, i32 0
   ; roundps, round down 0b01 | don't signal precision exceptions 0b1001 = 9
   %xr = call <4 x float> @llvm.x86.sse41.round.ss(<4 x float> %xi, <4 x float> %xi, i32 9)
   %rs = extractelement <4 x float> %xr, i32 0
@@ -51,7 +51,7 @@ define float @__floor_uniform_float(float) nounwind readonly alwaysinline {
 
 define float @__ceil_uniform_float(float) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <4 x float> undef, float %0, i32 0
+  %xi = insertelement <4 x float> poison, float %0, i32 0
   ; roundps, round up 0b10 | don't signal precision exceptions 0b1010 = 10
   %xr = call <4 x float> @llvm.x86.sse41.round.ss(<4 x float> %xi, <4 x float> %xi, i32 10)
   %rs = extractelement <4 x float> %xr, i32 0
@@ -64,7 +64,7 @@ define float @__ceil_uniform_float(float) nounwind readonly alwaysinline {
 declare <2 x double> @llvm.x86.sse41.round.sd(<2 x double>, <2 x double>, i32) nounwind readnone
 
 define double @__round_uniform_double(double) nounwind readonly alwaysinline {
-  %xi = insertelement <2 x double> undef, double %0, i32 0
+  %xi = insertelement <2 x double> poison, double %0, i32 0
   %xr = call <2 x double> @llvm.x86.sse41.round.sd(<2 x double> %xi, <2 x double> %xi, i32 8)
   %rs = extractelement <2 x double> %xr, i32 0
   ret double %rs
@@ -72,7 +72,7 @@ define double @__round_uniform_double(double) nounwind readonly alwaysinline {
 
 define double @__floor_uniform_double(double) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <2 x double> undef, double %0, i32 0
+  %xi = insertelement <2 x double> poison, double %0, i32 0
   ; roundsd, round down 0b01 | don't signal precision exceptions 0b1001 = 9
   %xr = call <2 x double> @llvm.x86.sse41.round.sd(<2 x double> %xi, <2 x double> %xi, i32 9)
   %rs = extractelement <2 x double> %xr, i32 0
@@ -81,7 +81,7 @@ define double @__floor_uniform_double(double) nounwind readonly alwaysinline {
 
 define double @__ceil_uniform_double(double) nounwind readonly alwaysinline {
   ; see above for round_ss instrinsic discussion...
-  %xi = insertelement <2 x double> undef, double %0, i32 0
+  %xi = insertelement <2 x double> poison, double %0, i32 0
   ; roundsd, round up 0b10 | don't signal precision exceptions 0b1010 = 10
   %xr = call <2 x double> @llvm.x86.sse41.round.sd(<2 x double> %xi, <2 x double> %xi, i32 10)
   %rs = extractelement <2 x double> %xr, i32 0
@@ -97,7 +97,7 @@ define float @__rcp_uniform_float(float) nounwind readonly alwaysinline {
   ; do the rcpss call
   ;    uniform float iv = extract(__rcp_u(v), 0);
   ;    return iv * (2. - v * iv);
-  %vecval = insertelement <4 x float> undef, float %0, i32 0
+  %vecval = insertelement <4 x float> poison, float %0, i32 0
   %call = call <4 x float> @llvm.x86.sse.rcp.ss(<4 x float> %vecval)
   %scall = extractelement <4 x float> %call, i32 0
 
@@ -112,7 +112,7 @@ define float @__rcp_fast_uniform_float(float) nounwind readonly alwaysinline {
   ; do the rcpss call
   ;    uniform float iv = extract(__rcp_u(v), 0);
   ;    return iv;
-  %vecval = insertelement <4 x float> undef, float %0, i32 0
+  %vecval = insertelement <4 x float> poison, float %0, i32 0
   %call = call <4 x float> @llvm.x86.sse.rcp.ss(<4 x float> %vecval)
   %scall = extractelement <4 x float> %call, i32 0
   ret float %scall
@@ -125,7 +125,7 @@ declare <4 x float> @llvm.x86.sse.rsqrt.ss(<4 x float>) nounwind readnone
 
 define float @__rsqrt_uniform_float(float) nounwind readonly alwaysinline {
   ;  uniform float is = extract(__rsqrt_u(v), 0);
-  %v = insertelement <4 x float> undef, float %0, i32 0
+  %v = insertelement <4 x float> poison, float %0, i32 0
   %vis = call <4 x float> @llvm.x86.sse.rsqrt.ss(<4 x float> %v)
   %is = extractelement <4 x float> %vis, i32 0
 
@@ -141,7 +141,7 @@ define float @__rsqrt_uniform_float(float) nounwind readonly alwaysinline {
 
 define float @__rsqrt_fast_uniform_float(float) nounwind readonly alwaysinline {
   ;  uniform float is = extract(__rsqrt_u(v), 0);
-  %v = insertelement <4 x float> undef, float %0, i32 0
+  %v = insertelement <4 x float> poison, float %0, i32 0
   %vis = call <4 x float> @llvm.x86.sse.rsqrt.ss(<4 x float> %v)
   %is = extractelement <4 x float> %vis, i32 0
   ret float %is

--- a/builtins/target-sse4-i16x8.ll
+++ b/builtins/target-sse4-i16x8.ll
@@ -391,16 +391,16 @@ gen_scatter(double)
 declare <16 x i8> @llvm.x86.sse2.pavg.b(<16 x i8>, <16 x i8>) nounwind readnone
 
 define <8 x i8> @__avg_up_uint8(<8 x i8>, <8 x i8>) {
-  %v0 = shufflevector <8 x i8> %0, <8 x i8> undef,
+  %v0 = shufflevector <8 x i8> %0, <8 x i8> poison,
     <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef>
-  %v1 = shufflevector <8 x i8> %1, <8 x i8> undef,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison>
+  %v1 = shufflevector <8 x i8> %1, <8 x i8> poison,
     <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef>
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison>
   %r16 = call <16 x i8> @llvm.x86.sse2.pavg.b(<16 x i8> %v0, <16 x i8> %v1)
-  %r = shufflevector <16 x i8> %r16, <16 x i8> undef,
+  %r = shufflevector <16 x i8> %r16, <16 x i8> poison,
     <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x i8> %r
 }

--- a/builtins/target-sse4-i32x4.ll
+++ b/builtins/target-sse4-i32x4.ll
@@ -258,9 +258,9 @@ define float @__reduce_max_float(<4 x float>) nounwind readnone alwaysinline {
 ;; horizontal double ops
 
 define double @__reduce_add_double(<4 x double>) nounwind readnone alwaysinline {
-  %v0 = shufflevector <4 x double> %0, <4 x double> undef,
+  %v0 = shufflevector <4 x double> %0, <4 x double> poison,
                       <2 x i32> <i32 0, i32 1>
-  %v1 = shufflevector <4 x double> %0, <4 x double> undef,
+  %v1 = shufflevector <4 x double> %0, <4 x double> poison,
                       <2 x i32> <i32 2, i32 3>
   %sum = fadd <2 x double> %v0, %v1
   %e0 = extractelement <2 x double> %sum, i32 0
@@ -374,14 +374,14 @@ define void @__masked_store_blend_i64(<4 x i64>* nocapture %ptr, <4 x i64> %new,
   ; are actually bitcast <2 x i64> values
   ;
   ; set up the first two 64-bit values
-  %old01  = shufflevector <4 x i64> %oldValue, <4 x i64> undef,
+  %old01  = shufflevector <4 x i64> %oldValue, <4 x i64> poison,
                           <2 x i32> <i32 0, i32 1>
   %old01f = bitcast <2 x i64> %old01 to <4 x float>
-  %new01  = shufflevector <4 x i64> %new, <4 x i64> undef,
+  %new01  = shufflevector <4 x i64> %new, <4 x i64> poison,
                           <2 x i32> <i32 0, i32 1>
   %new01f = bitcast <2 x i64> %new01 to <4 x float>
   ; compute mask--note that the indices 0 and 1 are doubled-up
-  %mask01 = shufflevector <4 x float> %mask, <4 x float> undef,
+  %mask01 = shufflevector <4 x float> %mask, <4 x float> poison,
                           <4 x i32> <i32 0, i32 0, i32 1, i32 1>
   ; and blend the two of the values
   %result01f = call <4 x float> @llvm.x86.sse41.blendvps(<4 x float> %old01f,
@@ -390,14 +390,14 @@ define void @__masked_store_blend_i64(<4 x i64>* nocapture %ptr, <4 x i64> %new,
   %result01 = bitcast <4 x float> %result01f to <2 x i64>
 
   ; and again
-  %old23  = shufflevector <4 x i64> %oldValue, <4 x i64> undef,
+  %old23  = shufflevector <4 x i64> %oldValue, <4 x i64> poison,
                           <2 x i32> <i32 2, i32 3>
   %old23f = bitcast <2 x i64> %old23 to <4 x float>
-  %new23  = shufflevector <4 x i64> %new, <4 x i64> undef,
+  %new23  = shufflevector <4 x i64> %new, <4 x i64> poison,
                           <2 x i32> <i32 2, i32 3>
   %new23f = bitcast <2 x i64> %new23 to <4 x float>
   ; compute mask--note that the values 2 and 3 are doubled-up
-  %mask23 = shufflevector <4 x float> %mask, <4 x float> undef,
+  %mask23 = shufflevector <4 x float> %mask, <4 x float> poison,
                           <4 x i32> <i32 2, i32 2, i32 3, i32 3>
   ; and blend the two of the values
   %result23f = call <4 x float> @llvm.x86.sse41.blendvps(<4 x float> %old23f,

--- a/builtins/target-sse4-i32x8.ll
+++ b/builtins/target-sse4-i32x8.ll
@@ -138,10 +138,10 @@ declare i32 @llvm.x86.sse.movmsk.ps(<4 x float>) nounwind readnone
 define i64 @__movmsk(<8 x i32>) nounwind readnone alwaysinline {
   ; first do two 4-wide movmsk calls
   %floatmask = bitcast <8 x i32> %0 to <8 x float>
-  %m0 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m0 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v0 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m0) nounwind readnone
-  %m1 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m1 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v1 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m1) nounwind readnone
 
@@ -156,10 +156,10 @@ define i64 @__movmsk(<8 x i32>) nounwind readnone alwaysinline {
 define i1 @__any(<8 x i32>) nounwind readnone alwaysinline {
   ; first do two 4-wide movmsk calls
   %floatmask = bitcast <8 x i32> %0 to <8 x float>
-  %m0 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m0 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v0 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m0) nounwind readnone
-  %m1 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m1 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v1 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m1) nounwind readnone
 
@@ -174,10 +174,10 @@ define i1 @__any(<8 x i32>) nounwind readnone alwaysinline {
 define i1 @__all(<8 x i32>) nounwind readnone alwaysinline {
   ; first do two 4-wide movmsk calls
   %floatmask = bitcast <8 x i32> %0 to <8 x float>
-  %m0 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m0 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v0 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m0) nounwind readnone
-  %m1 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m1 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v1 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m1) nounwind readnone
 
@@ -192,10 +192,10 @@ define i1 @__all(<8 x i32>) nounwind readnone alwaysinline {
 define i1 @__none(<8 x i32>) nounwind readnone alwaysinline {
   ; first do two 4-wide movmsk calls
   %floatmask = bitcast <8 x i32> %0 to <8 x float>
-  %m0 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m0 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v0 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m0) nounwind readnone
-  %m1 = shufflevector <8 x float> %floatmask, <8 x float> undef,
+  %m1 = shufflevector <8 x float> %floatmask, <8 x float> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v1 = call i32 @llvm.x86.sse.movmsk.ps(<4 x float> %m1) nounwind readnone
 
@@ -353,9 +353,9 @@ truncate()
 declare <4 x float> @llvm.x86.sse3.hadd.ps(<4 x float>, <4 x float>) nounwind readnone
 
 define float @__reduce_add_float(<8 x float>) nounwind readonly alwaysinline {
-  %a = shufflevector <8 x float> %0, <8 x float> undef,
+  %a = shufflevector <8 x float> %0, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %b = shufflevector <8 x float> %0, <8 x float> undef,
+  %b = shufflevector <8 x float> %0, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %ab = fadd <4 x float> %a, %b
   %hab = call <4 x float> @llvm.x86.sse3.hadd.ps(<4 x float> %ab, <4 x float> %ab)
@@ -383,20 +383,20 @@ define void @__masked_store_blend_i32(<8 x i32>* nocapture, <8 x i32>,
                                       <8 x i32> %mask) nounwind alwaysinline {
   ; do two 4-wide blends with blendvps
   %mask_as_float = bitcast <8 x i32> %mask to <8 x float>
-  %mask_a = shufflevector <8 x float> %mask_as_float, <8 x float> undef,
+  %mask_a = shufflevector <8 x float> %mask_as_float, <8 x float> poison,
                 <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %mask_b = shufflevector <8 x float> %mask_as_float, <8 x float> undef,
+  %mask_b = shufflevector <8 x float> %mask_as_float, <8 x float> poison,
                 <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %oldValue = load PTR_OP_ARGS(`<8 x i32>')  %0, align 4
   %oldAsFloat = bitcast <8 x i32> %oldValue to <8 x float>
   %newAsFloat = bitcast <8 x i32> %1 to <8 x float>
-  %old_a = shufflevector <8 x float> %oldAsFloat, <8 x float> undef,
+  %old_a = shufflevector <8 x float> %oldAsFloat, <8 x float> poison,
                 <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %old_b = shufflevector <8 x float> %oldAsFloat, <8 x float> undef,
+  %old_b = shufflevector <8 x float> %oldAsFloat, <8 x float> poison,
                 <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %new_a = shufflevector <8 x float> %newAsFloat, <8 x float> undef,
+  %new_a = shufflevector <8 x float> %newAsFloat, <8 x float> poison,
                 <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %new_b = shufflevector <8 x float> %newAsFloat, <8 x float> undef,
+  %new_b = shufflevector <8 x float> %newAsFloat, <8 x float> poison,
                 <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %blend_a = call <4 x float> @llvm.x86.sse41.blendvps(<4 x float> %old_a, <4 x float> %new_a,
                                                        <4 x float> %mask_a)
@@ -419,12 +419,12 @@ define void @__masked_store_blend_i64(<8 x i64>* nocapture %ptr, <8 x i64> %new,
   %old = load PTR_OP_ARGS(`<8 x i64>')  %ptr, align 8
 
   ; set up the first two 64-bit values
-  %old01 = shufflevector <8 x i64> %old, <8 x i64> undef, <2 x i32> <i32 0, i32 1>
+  %old01 = shufflevector <8 x i64> %old, <8 x i64> poison, <2 x i32> <i32 0, i32 1>
   %old01f = bitcast <2 x i64> %old01 to <4 x float>
-  %new01  = shufflevector <8 x i64> %new, <8 x i64> undef, <2 x i32> <i32 0, i32 1>
+  %new01  = shufflevector <8 x i64> %new, <8 x i64> poison, <2 x i32> <i32 0, i32 1>
   %new01f = bitcast <2 x i64> %new01 to <4 x float>
   ; compute mask--note that the values mask0 and mask1 are doubled-up
-  %mask01 = shufflevector <8 x float> %mask_as_float, <8 x float> undef,
+  %mask01 = shufflevector <8 x float> %mask_as_float, <8 x float> poison,
                           <4 x i32> <i32 0, i32 0, i32 1, i32 1>
   ; and blend the two of them values
   %result01f = call <4 x float> @llvm.x86.sse41.blendvps(<4 x float> %old01f,
@@ -433,33 +433,33 @@ define void @__masked_store_blend_i64(<8 x i64>* nocapture %ptr, <8 x i64> %new,
   %result01 = bitcast <4 x float> %result01f to <2 x i64>
 
   ; and again
-  %old23 = shufflevector <8 x i64> %old, <8 x i64> undef, <2 x i32> <i32 2, i32 3>
+  %old23 = shufflevector <8 x i64> %old, <8 x i64> poison, <2 x i32> <i32 2, i32 3>
   %old23f = bitcast <2 x i64> %old23 to <4 x float>
-  %new23  = shufflevector <8 x i64> %new, <8 x i64> undef, <2 x i32> <i32 2, i32 3>
+  %new23  = shufflevector <8 x i64> %new, <8 x i64> poison, <2 x i32> <i32 2, i32 3>
   %new23f = bitcast <2 x i64> %new23 to <4 x float>
-  %mask23 = shufflevector <8 x float> %mask_as_float, <8 x float> undef,
+  %mask23 = shufflevector <8 x float> %mask_as_float, <8 x float> poison,
                           <4 x i32> <i32 2, i32 2, i32 3, i32 3>
   %result23f = call <4 x float> @llvm.x86.sse41.blendvps(<4 x float> %old23f,
                                                          <4 x float> %new23f,
                                                          <4 x float> %mask23)
   %result23 = bitcast <4 x float> %result23f to <2 x i64>
 
-  %old45 = shufflevector <8 x i64> %old, <8 x i64> undef, <2 x i32> <i32 4, i32 5>
+  %old45 = shufflevector <8 x i64> %old, <8 x i64> poison, <2 x i32> <i32 4, i32 5>
   %old45f = bitcast <2 x i64> %old45 to <4 x float>
-  %new45  = shufflevector <8 x i64> %new, <8 x i64> undef, <2 x i32> <i32 4, i32 5>
+  %new45  = shufflevector <8 x i64> %new, <8 x i64> poison, <2 x i32> <i32 4, i32 5>
   %new45f = bitcast <2 x i64> %new45 to <4 x float>
-  %mask45 = shufflevector <8 x float> %mask_as_float, <8 x float> undef,
+  %mask45 = shufflevector <8 x float> %mask_as_float, <8 x float> poison,
                           <4 x i32> <i32 4, i32 4, i32 5, i32 5>
   %result45f = call <4 x float> @llvm.x86.sse41.blendvps(<4 x float> %old45f,
                                                          <4 x float> %new45f,
                                                          <4 x float> %mask45)
   %result45 = bitcast <4 x float> %result45f to <2 x i64>
 
-  %old67 = shufflevector <8 x i64> %old, <8 x i64> undef, <2 x i32> <i32 6, i32 7>
+  %old67 = shufflevector <8 x i64> %old, <8 x i64> poison, <2 x i32> <i32 6, i32 7>
   %old67f = bitcast <2 x i64> %old67 to <4 x float>
-  %new67  = shufflevector <8 x i64> %new, <8 x i64> undef, <2 x i32> <i32 6, i32 7>
+  %new67  = shufflevector <8 x i64> %new, <8 x i64> poison, <2 x i32> <i32 6, i32 7>
   %new67f = bitcast <2 x i64> %new67 to <4 x float>
-  %mask67 = shufflevector <8 x float> %mask_as_float, <8 x float> undef,
+  %mask67 = shufflevector <8 x float> %mask_as_float, <8 x float> poison,
                           <4 x i32> <i32 6, i32 6, i32 7, i32 7>
   %result67f = call <4 x float> @llvm.x86.sse41.blendvps(<4 x float> %old67f,
                                                          <4 x float> %new67f,

--- a/builtins/target-wasm-i32x4.ll
+++ b/builtins/target-wasm-i32x4.ll
@@ -96,11 +96,11 @@ define double @__doublebits_uniform_int64(i64) nounwind readnone alwaysinline {
 }
 
 define <WIDTH x float> @__undef_varying() nounwind readnone alwaysinline {
-  ret <WIDTH x float> undef
+  ret <WIDTH x float> poison
 }
 
 define float @__undef_uniform() nounwind readnone alwaysinline {
-  ret float undef
+  ret float poison
 }
 
 ;; rcp/rsqrt for double
@@ -591,11 +591,11 @@ define <4 x float> @__max_varying_float(<4 x float> %0, <4 x float> %1) unnamed_
 
 define <4 x double> @__max_varying_double(<4 x double> %a, <4 x double> %b) {
 entry:
-  %vecinit2 = shufflevector <4 x double> %a, <4 x double> undef, <2 x i32> <i32 0, i32 1>
-  %vecinit7 = shufflevector <4 x double> %b, <4 x double> undef, <2 x i32> <i32 0, i32 1>
+  %vecinit2 = shufflevector <4 x double> %a, <4 x double> poison, <2 x i32> <i32 0, i32 1>
+  %vecinit7 = shufflevector <4 x double> %b, <4 x double> poison, <2 x i32> <i32 0, i32 1>
   %0 = tail call <2 x double> @llvm.maximum.v2f64(<2 x double> %vecinit2, <2 x double> %vecinit7) #5
-  %vecinit12 = shufflevector <4 x double> %a, <4 x double> undef, <2 x i32> <i32 2, i32 3>
-  %vecinit17 = shufflevector <4 x double> %b, <4 x double> undef, <2 x i32> <i32 2, i32 3>
+  %vecinit12 = shufflevector <4 x double> %a, <4 x double> poison, <2 x i32> <i32 2, i32 3>
+  %vecinit17 = shufflevector <4 x double> %b, <4 x double> poison, <2 x i32> <i32 2, i32 3>
   %1 = tail call <2 x double> @llvm.maximum.v2f64(<2 x double> %vecinit12, <2 x double> %vecinit17) #5
   %vecinit6.i = shufflevector <2 x double> %0, <2 x double> %1, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   ret <4 x double> %vecinit6.i
@@ -603,11 +603,11 @@ entry:
 
 define <4 x double> @__min_varying_double(<4 x double> %a, <4 x double> %b) {
 entry:
-  %vecinit2 = shufflevector <4 x double> %a, <4 x double> undef, <2 x i32> <i32 0, i32 1>
-  %vecinit7 = shufflevector <4 x double> %b, <4 x double> undef, <2 x i32> <i32 0, i32 1>
+  %vecinit2 = shufflevector <4 x double> %a, <4 x double> poison, <2 x i32> <i32 0, i32 1>
+  %vecinit7 = shufflevector <4 x double> %b, <4 x double> poison, <2 x i32> <i32 0, i32 1>
   %0 = tail call <2 x double> @llvm.minimum.v2f64(<2 x double> %vecinit2, <2 x double> %vecinit7) #5
-  %vecinit12 = shufflevector <4 x double> %a, <4 x double> undef, <2 x i32> <i32 2, i32 3>
-  %vecinit17 = shufflevector <4 x double> %b, <4 x double> undef, <2 x i32> <i32 2, i32 3>
+  %vecinit12 = shufflevector <4 x double> %a, <4 x double> poison, <2 x i32> <i32 2, i32 3>
+  %vecinit17 = shufflevector <4 x double> %b, <4 x double> poison, <2 x i32> <i32 2, i32 3>
   %1 = tail call <2 x double> @llvm.minimum.v2f64(<2 x double> %vecinit12, <2 x double> %vecinit17) #5
   %vecinit6.i = shufflevector <2 x double> %0, <2 x double> %1, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   ret <4 x double> %vecinit6.i
@@ -662,8 +662,8 @@ packed_load_and_store(FALSE)
 define_prefetches()
 
 define float @__reduce_add_float(<4 x float> %v) nounwind readonly alwaysinline {
-  %v1 = shufflevector <4 x float> %v, <4 x float> undef,
-                      <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
+  %v1 = shufflevector <4 x float> %v, <4 x float> poison,
+                      <4 x i32> <i32 2, i32 3, i32 poison, i32 poison>
   %m1 = fadd <4 x float> %v1, %v
   %m1a = extractelement <4 x float> %m1, i32 0
   %m1b = extractelement <4 x float> %m1, i32 1
@@ -680,9 +680,9 @@ define float @__reduce_max_float(<4 x float>) nounwind readnone {
 }
 
 define double @__reduce_add_double(<4 x double>) nounwind readnone {
-  %v0 = shufflevector <4 x double> %0, <4 x double> undef,
+  %v0 = shufflevector <4 x double> %0, <4 x double> poison,
                       <2 x i32> <i32 0, i32 1>
-  %v1 = shufflevector <4 x double> %0, <4 x double> undef,
+  %v1 = shufflevector <4 x double> %0, <4 x double> poison,
                       <2 x i32> <i32 2, i32 3>
   %sum = fadd <2 x double> %v0, %v1
   %e0 = extractelement <2 x double> %sum, i32 0

--- a/builtins/target-xe.ll
+++ b/builtins/target-xe.ll
@@ -471,7 +471,7 @@ define i32 @__task_count()  nounwind readnone alwaysinline {
   %l_size_x = trunc i64 %l_size_x_ to i32
   %l_size_y = trunc i64 %l_size_y_ to i32
   %l_size_z = trunc i64 %l_size_z_ to i32
-  %l_size_1 = insertelement <3 x i32> undef, i32 %l_size_x, i32 0
+  %l_size_1 = insertelement <3 x i32> poison, i32 %l_size_x, i32 0
   %l_size_2 = insertelement <3 x i32> %l_size_1, i32 %l_size_y, i32 1
   %l_size_3 = insertelement <3 x i32> %l_size_2, i32 %l_size_z, i32 2
   %gr_count_x_ = call i64 @__spirv_BuiltInNumWorkgroups(i32 0)
@@ -480,7 +480,7 @@ define i32 @__task_count()  nounwind readnone alwaysinline {
   %gr_count_x = trunc i64 %gr_count_x_ to i32
   %gr_count_y = trunc i64 %gr_count_y_ to i32
   %gr_count_z = trunc i64 %gr_count_z_ to i32
-  %gr_count_1 = insertelement <3 x i32> undef, i32 %gr_count_x, i32 0
+  %gr_count_1 = insertelement <3 x i32> poison, i32 %gr_count_x, i32 0
   %gr_count_2 = insertelement <3 x i32> %gr_count_1, i32 %gr_count_y, i32 1
   %gr_count_3 = insertelement <3 x i32> %gr_count_2, i32 %gr_count_z, i32 2
   %size_gr = mul <3 x i32> %l_size_3, %gr_count_3
@@ -699,17 +699,17 @@ define <WIDTH x float> @__ceil_varying_float(<WIDTH x float>) nounwind readonly 
 define <WIDTH x double> @__round_varying_double(<WIDTH x double>) nounwind readonly alwaysinline {
   %float_to_int_bitcast.i.i.i.i = bitcast <WIDTH x double> %0 to <WIDTH x i64>
   ; create vector of literals
-  %vec_lit.i = insertelement <1 x i64> undef, i64 -9223372036854775808, i32 0
-  %vec_lit = shufflevector <1 x i64> %vec_lit.i, <1 x i64> undef, <WIDTH x i32> zeroinitializer
+  %vec_lit.i = insertelement <1 x i64> poison, i64 -9223372036854775808, i32 0
+  %vec_lit = shufflevector <1 x i64> %vec_lit.i, <1 x i64> poison, <WIDTH x i32> zeroinitializer
   %bitop.i.i = and <WIDTH x i64> %float_to_int_bitcast.i.i.i.i, %vec_lit
   %bitop.i = xor <WIDTH x i64> %float_to_int_bitcast.i.i.i.i, %bitop.i.i
   %int_to_float_bitcast.i.i40.i = bitcast <WIDTH x i64> %bitop.i to <WIDTH x double>
   ; create vector of float literals
-  %vec_lit_pos.i = insertelement <1 x double> undef, double 4.5036e+15, i32 0
-  %vec_lit_pos = shufflevector <1 x double> %vec_lit_pos.i, <1 x double> undef, <WIDTH x i32> zeroinitializer
+  %vec_lit_pos.i = insertelement <1 x double> poison, double 4.5036e+15, i32 0
+  %vec_lit_pos = shufflevector <1 x double> %vec_lit_pos.i, <1 x double> poison, <WIDTH x i32> zeroinitializer
   ; create vector of float literals
-  %vec_lit_neg.i = insertelement <1 x double> undef, double -4.5036e+15, i32 0
-  %vec_lit_neg = shufflevector <1 x double> %vec_lit_neg.i, <1 x double> undef, <WIDTH x i32> zeroinitializer
+  %vec_lit_neg.i = insertelement <1 x double> poison, double -4.5036e+15, i32 0
+  %vec_lit_neg = shufflevector <1 x double> %vec_lit_neg.i, <1 x double> poison, <WIDTH x i32> zeroinitializer
   %binop.i = fadd <WIDTH x double> %int_to_float_bitcast.i.i40.i, %vec_lit_pos
   %binop21.i = fadd <WIDTH x double> %binop.i, %vec_lit_neg
   %float_to_int_bitcast.i.i.i = bitcast <WIDTH x double> %binop21.i to <WIDTH x i64>
@@ -723,8 +723,8 @@ define <WIDTH x double> @__floor_varying_double(<WIDTH x double>) nounwind reado
   %bincmp.i = fcmp ogt <WIDTH x double> %calltmp.i, %0
   %val_to_boolvec32.i = sext <WIDTH x i1> %bincmp.i to <WIDTH x i64>
   ; create vector of literals
-  %vec_lit.i = insertelement <1 x i64> undef, i64 -4616189618054758400, i32 0
-  %vec_lit = shufflevector <1 x i64> %vec_lit.i, <1 x i64> undef, <WIDTH x i32> zeroinitializer
+  %vec_lit.i = insertelement <1 x i64> poison, i64 -4616189618054758400, i32 0
+  %vec_lit = shufflevector <1 x i64> %vec_lit.i, <1 x i64> poison, <WIDTH x i32> zeroinitializer
   %bitop.i = and <WIDTH x i64> %val_to_boolvec32.i, %vec_lit
   %int_to_float_bitcast.i.i.i = bitcast <WIDTH x i64> %bitop.i to <WIDTH x double>
   %binop.i = fadd <WIDTH x double> %calltmp.i, %int_to_float_bitcast.i.i.i
@@ -736,8 +736,8 @@ define <WIDTH x double> @__ceil_varying_double(<WIDTH x double>) nounwind readon
   %bincmp.i = fcmp olt <WIDTH x double> %calltmp.i, %0
   %val_to_boolvec32.i = sext <WIDTH x i1> %bincmp.i to <WIDTH x i64>
   ; create vector of literals
-  %vec_lit.i = insertelement <1 x i64> undef, i64 4607182418800017408, i32 0
-  %vec_lit = shufflevector <1 x i64> %vec_lit.i, <1 x i64> undef, <WIDTH x i32> zeroinitializer
+  %vec_lit.i = insertelement <1 x i64> poison, i64 4607182418800017408, i32 0
+  %vec_lit = shufflevector <1 x i64> %vec_lit.i, <1 x i64> poison, <WIDTH x i32> zeroinitializer
   %bitop.i = and <WIDTH x i64> %val_to_boolvec32.i, %vec_lit
   %int_to_float_bitcast.i.i.i = bitcast <WIDTH x i64> %bitop.i to <WIDTH x double>
   %binop.i = fadd <WIDTH x double> %calltmp.i, %int_to_float_bitcast.i.i.i
@@ -990,8 +990,8 @@ xe_masked_store_blend(i64)
 define(`xe_masked_store', `
 define void @__masked_store_$1(<WIDTH x $1>* nocapture, <WIDTH x $1>, <WIDTH x MASK> %mask) nounwind alwaysinline {
   %ptr = bitcast <WIDTH x $1>* %0 to i8*
-  %broadcast_init = insertelement <WIDTH x i32> undef, i32 SIZEOF($1), i32 0
-  %shuffle = shufflevector <WIDTH x i32> %broadcast_init, <WIDTH x i32> undef, <WIDTH x i32> zeroinitializer
+  %broadcast_init = insertelement <WIDTH x i32> poison, i32 SIZEOF($1), i32 0
+  %shuffle = shufflevector <WIDTH x i32> %broadcast_init, <WIDTH x i32> poison, <WIDTH x i32> zeroinitializer
   %offsets = mul LINEAR_VECTOR(i32), %shuffle
 ifelse(RUNTIME, `32',
 `
@@ -1021,7 +1021,7 @@ define(`xe_masked_load', `
 define <WIDTH x $1> @__masked_load_blend_$1(i8 *, <WIDTH x MASK> %mask) nounwind alwaysinline {
   %bitptr = bitcast i8* %0 to <WIDTH x $1>*
   %res = load PTR_OP_ARGS(`<WIDTH x $1> ') %bitptr, align SIZEOF($1)
-  %res_masked = select <WIDTH x MASK> %mask, <WIDTH x $1> %res, <WIDTH x $1> undef
+  %res_masked = select <WIDTH x MASK> %mask, <WIDTH x $1> %res, <WIDTH x $1> poison
   ret <WIDTH x $1> %res_masked
 }
 
@@ -1080,8 +1080,8 @@ vload:
 
 
 vgather:
-  %broadcast_init = insertelement <WIDTH x i32> undef, i32 SIZEOF($1), i32 0
-  %shuffle = shufflevector <WIDTH x i32> %broadcast_init, <WIDTH x i32> undef, <WIDTH x i32> zeroinitializer
+  %broadcast_init = insertelement <WIDTH x i32> poison, i32 SIZEOF($1), i32 0
+  %shuffle = shufflevector <WIDTH x i32> %broadcast_init, <WIDTH x i32> poison, <WIDTH x i32> zeroinitializer
   %offsets = mul LINEAR_VECTOR(i32), %shuffle
   ifelse(RUNTIME, `32',
   `
@@ -1119,12 +1119,12 @@ ifelse(WIDTH, 32,`
 
 define <WIDTH x $1>
 @__gather_base_offsets32_$1(i8 * %ptr, i32 %offset_scale, <WIDTH x i32> %offsets, <WIDTH x MASK> %vecmask) nounwind readonly alwaysinline {
-  %scale = insertelement <WIDTH x i32> undef, i32 %offset_scale, i32 0
-  %scale_shuffle = shufflevector <WIDTH x i32> %scale, <WIDTH x i32> undef, <WIDTH x i32> zeroinitializer
+  %scale = insertelement <WIDTH x i32> poison, i32 %offset_scale, i32 0
+  %scale_shuffle = shufflevector <WIDTH x i32> %scale, <WIDTH x i32> poison, <WIDTH x i32> zeroinitializer
   %new_offsets_scaled = mul <WIDTH x i32> %offsets, %scale_shuffle
   %ptr_to_int = ptrtoint i8* %ptr to i32
-  %base = insertelement <WIDTH x i32> undef, i32 %ptr_to_int, i32 0
-  %shuffle = shufflevector <WIDTH x i32> %base, <WIDTH x i32> undef, <WIDTH x i32> zeroinitializer
+  %base = insertelement <WIDTH x i32> poison, i32 %ptr_to_int, i32 0
+  %shuffle = shufflevector <WIDTH x i32> %base, <WIDTH x i32> poison, <WIDTH x i32> zeroinitializer
   %new_offsets = add <WIDTH x i32> %new_offsets_scaled, %shuffle
   %res = call <WIDTH x $1> @__gather32_$1(<WIDTH x i32> %new_offsets, <WIDTH x MASK> %vecmask)
   ret <WIDTH x $1> %res
@@ -1133,12 +1133,12 @@ define <WIDTH x $1>
 define <WIDTH x $1>
 @__gather_base_offsets64_$1(i8 * %ptr, i32 %offset_scale, <WIDTH x i64> %offsets, <WIDTH x MASK> %vecmask) nounwind readonly alwaysinline {
   %offset_scale64 = zext i32 %offset_scale to i64
-  %scale = insertelement <WIDTH x i64> undef, i64 %offset_scale64, i32 0
-  %scale_shuffle = shufflevector <WIDTH x i64> %scale, <WIDTH x i64> undef, <WIDTH x i32> zeroinitializer
+  %scale = insertelement <WIDTH x i64> poison, i64 %offset_scale64, i32 0
+  %scale_shuffle = shufflevector <WIDTH x i64> %scale, <WIDTH x i64> poison, <WIDTH x i32> zeroinitializer
   %new_offsets_scaled = mul <WIDTH x i64> %offsets, %scale_shuffle
   %ptr_to_int = ptrtoint i8* %ptr to i64
-  %base = insertelement <WIDTH x i64> undef, i64 %ptr_to_int, i32 0
-  %shuffle = shufflevector <WIDTH x i64> %base, <WIDTH x i64> undef, <WIDTH x i32> zeroinitializer
+  %base = insertelement <WIDTH x i64> poison, i64 %ptr_to_int, i32 0
+  %shuffle = shufflevector <WIDTH x i64> %base, <WIDTH x i64> poison, <WIDTH x i32> zeroinitializer
   %new_offsets = add <WIDTH x i64> %new_offsets_scaled, %shuffle
   %res = call <WIDTH x $1> @__gather64_$1(<WIDTH x i64> %new_offsets, <WIDTH x MASK> %vecmask)
   ret <WIDTH x $1> %res
@@ -1154,37 +1154,37 @@ define <WIDTH x $1>
 define <WIDTH x $1>
 @__gather64_$1(<WIDTH x i64> %offsets, <WIDTH x MASK> %vecmask) nounwind readonly alwaysinline {
   ifelse(WIDTH,32,`
-   %offsets1 = shufflevector <WIDTH x i64> %offsets, <WIDTH x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-   %offsets2 = shufflevector <WIDTH x i64> %offsets, <WIDTH x i64> undef, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-   %vecmask1 = shufflevector <WIDTH x MASK> %vecmask, <WIDTH x MASK> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-   %vecmask2 = shufflevector <WIDTH x MASK> %vecmask, <WIDTH x MASK> undef, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+   %offsets1 = shufflevector <WIDTH x i64> %offsets, <WIDTH x i64> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+   %offsets2 = shufflevector <WIDTH x i64> %offsets, <WIDTH x i64> poison, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+   %vecmask1 = shufflevector <WIDTH x MASK> %vecmask, <WIDTH x MASK> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+   %vecmask2 = shufflevector <WIDTH x MASK> %vecmask, <WIDTH x MASK> poison, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
    ifelse($1, i8,`
-      %res64_1 = call <64 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1, 64).XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16)(<16 x MASK> %vecmask1, i32 0, <16 x i64> %offsets1, <16 x $1> undef)
-      %res_1 = call <16 x $1> @llvm.genx.rdregioni.XE_SUFFIXN($1,16).XE_SUFFIXN($1, 64).i16(<64 x $1> %res64_1, i32 0, i32 16, i32 4, i16 0, i32 undef)
-      %res64_2 = call <64 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1, 64).XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16)(<16 x MASK> %vecmask2, i32 0, <16 x i64> %offsets2, <16 x $1> undef)
-      %res_2 = call <16 x $1> @llvm.genx.rdregioni.XE_SUFFIXN($1,16).XE_SUFFIXN($1, 64).i16(<64 x $1> %res64_2, i32 0, i32 16, i32 4, i16 0, i32 undef)
+      %res64_1 = call <64 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1, 64).XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16)(<16 x MASK> %vecmask1, i32 0, <16 x i64> %offsets1, <16 x $1> poison)
+      %res_1 = call <16 x $1> @llvm.genx.rdregioni.XE_SUFFIXN($1,16).XE_SUFFIXN($1, 64).i16(<64 x $1> %res64_1, i32 0, i32 16, i32 4, i16 0, i32 poison)
+      %res64_2 = call <64 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1, 64).XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16)(<16 x MASK> %vecmask2, i32 0, <16 x i64> %offsets2, <16 x $1> poison)
+      %res_2 = call <16 x $1> @llvm.genx.rdregioni.XE_SUFFIXN($1,16).XE_SUFFIXN($1, 64).i16(<64 x $1> %res64_2, i32 0, i32 16, i32 4, i16 0, i32 poison)
       %res = shufflevector <16 x $1> %res_1, <16 x $1> %res_2, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
     ', $1,i16, `
-      %res64_1 = call <32 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1, 32).XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16)(<16 x MASK> %vecmask1, i32 1, <16 x i64> %offsets1, <16 x $1> undef)
-      %res_1 = call <16 x $1> @llvm.genx.rdregioni.XE_SUFFIXN($1,16).XE_SUFFIXN($1, 32).i16(<32 x $1> %res64_1, i32 0, i32 16, i32 2, i16 0, i32 undef)
-      %res64_2 = call <32 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1, 32).XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16)(<16 x MASK> %vecmask2, i32 1, <16 x i64> %offsets2, <16 x $1> undef)
-      %res_2 = call <16 x $1> @llvm.genx.rdregioni.XE_SUFFIXN($1,16).XE_SUFFIXN($1, 32).i16(<32 x $1> %res64_2, i32 0, i32 16, i32 2, i16 0, i32 undef)
+      %res64_1 = call <32 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1, 32).XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16)(<16 x MASK> %vecmask1, i32 1, <16 x i64> %offsets1, <16 x $1> poison)
+      %res_1 = call <16 x $1> @llvm.genx.rdregioni.XE_SUFFIXN($1,16).XE_SUFFIXN($1, 32).i16(<32 x $1> %res64_1, i32 0, i32 16, i32 2, i16 0, i32 poison)
+      %res64_2 = call <32 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1, 32).XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16)(<16 x MASK> %vecmask2, i32 1, <16 x i64> %offsets2, <16 x $1> poison)
+      %res_2 = call <16 x $1> @llvm.genx.rdregioni.XE_SUFFIXN($1,16).XE_SUFFIXN($1, 32).i16(<32 x $1> %res64_2, i32 0, i32 16, i32 2, i16 0, i32 poison)
       %res = shufflevector <16 x $1> %res_1, <16 x $1> %res_2, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
     ',`
-      %res1 = call <16 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1,16).XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16)(<16 x MASK> %vecmask1, i32 0, <16 x i64> %offsets1, <16 x $1> undef)
-      %res2 = call <16 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1,16).XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16)(<16 x MASK> %vecmask2, i32 0, <16 x i64> %offsets2, <16 x $1> undef)
+      %res1 = call <16 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1,16).XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16)(<16 x MASK> %vecmask1, i32 0, <16 x i64> %offsets1, <16 x $1> poison)
+      %res2 = call <16 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1,16).XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16)(<16 x MASK> %vecmask2, i32 0, <16 x i64> %offsets2, <16 x $1> poison)
       %res = shufflevector <16 x $1> %res1, <16 x $1> %res2, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
     ')
       ret <WIDTH x $1> %res
   ',`
     ifelse($1, i8,`
-        %res64 = call <WIDTH_X4 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1, WIDTH_X4).XE_SUFFIX(i1).XE_SUFFIX(i64)(<WIDTH x MASK> %vecmask, i32 0, <WIDTH x i64> %offsets, <WIDTH x $1> undef)
-        %res = call <WIDTH x $1> @llvm.genx.rdregioni.XE_SUFFIX($1).XE_SUFFIXN($1, WIDTH_X4).i16(<WIDTH_X4 x $1> %res64, i32 0, i32 WIDTH, i32 4, i16 0, i32 undef)
+        %res64 = call <WIDTH_X4 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1, WIDTH_X4).XE_SUFFIX(i1).XE_SUFFIX(i64)(<WIDTH x MASK> %vecmask, i32 0, <WIDTH x i64> %offsets, <WIDTH x $1> poison)
+        %res = call <WIDTH x $1> @llvm.genx.rdregioni.XE_SUFFIX($1).XE_SUFFIXN($1, WIDTH_X4).i16(<WIDTH_X4 x $1> %res64, i32 0, i32 WIDTH, i32 4, i16 0, i32 poison)
       ', $1,i16, `
-        %res64 = call <WIDTH_X2 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1, WIDTH_X2).XE_SUFFIX(i1).XE_SUFFIX(i64)(<WIDTH x MASK> %vecmask, i32 1, <WIDTH x i64> %offsets, <WIDTH x $1> undef)
-        %res = call <WIDTH x $1> @llvm.genx.rdregioni.XE_SUFFIX($1).XE_SUFFIXN($1, WIDTH_X2).i16(<WIDTH_X2 x $1> %res64, i32 0, i32 WIDTH, i32 2, i16 0, i32 undef)
+        %res64 = call <WIDTH_X2 x $1> @llvm.genx.svm.gather.XE_SUFFIXN($1, WIDTH_X2).XE_SUFFIX(i1).XE_SUFFIX(i64)(<WIDTH x MASK> %vecmask, i32 1, <WIDTH x i64> %offsets, <WIDTH x $1> poison)
+        %res = call <WIDTH x $1> @llvm.genx.rdregioni.XE_SUFFIX($1).XE_SUFFIXN($1, WIDTH_X2).i16(<WIDTH_X2 x $1> %res64, i32 0, i32 WIDTH, i32 2, i16 0, i32 poison)
       ',`
-        %res = call <WIDTH x $1> @llvm.genx.svm.gather.XE_SUFFIX($1).XE_SUFFIX(i1).XE_SUFFIX(i64)(<WIDTH x MASK> %vecmask, i32 0, <WIDTH x i64> %offsets, <WIDTH x $1> undef)
+        %res = call <WIDTH x $1> @llvm.genx.svm.gather.XE_SUFFIX($1).XE_SUFFIX(i1).XE_SUFFIX(i64)(<WIDTH x MASK> %vecmask, i32 0, <WIDTH x i64> %offsets, <WIDTH x $1> poison)
       ')
       ret <WIDTH x $1> %res
   ')
@@ -1215,12 +1215,12 @@ ifelse(WIDTH, 32,`
 ')
 define void
 @__scatter_base_offsets32_$1(i8* %ptr, i32 %offset_scale, <WIDTH x i32> %offsets, <WIDTH x $1> %vals, <WIDTH x MASK> %vecmask) nounwind {
-  %scale = insertelement <WIDTH x i32> undef, i32 %offset_scale, i32 0
-  %scale_shuffle = shufflevector <WIDTH x i32> %scale, <WIDTH x i32> undef, <WIDTH x i32> zeroinitializer
+  %scale = insertelement <WIDTH x i32> poison, i32 %offset_scale, i32 0
+  %scale_shuffle = shufflevector <WIDTH x i32> %scale, <WIDTH x i32> poison, <WIDTH x i32> zeroinitializer
   %new_offsets_scaled = mul <WIDTH x i32> %offsets, %scale_shuffle
   %ptr_to_int = ptrtoint i8* %ptr to i32
-  %base = insertelement <WIDTH x i32> undef, i32 %ptr_to_int, i32 0
-  %shuffle = shufflevector <WIDTH x i32> %base, <WIDTH x i32> undef, <WIDTH x i32> zeroinitializer
+  %base = insertelement <WIDTH x i32> poison, i32 %ptr_to_int, i32 0
+  %shuffle = shufflevector <WIDTH x i32> %base, <WIDTH x i32> poison, <WIDTH x i32> zeroinitializer
   %new_offsets = add <WIDTH x i32> %new_offsets_scaled, %shuffle
   call void @__scatter32_$1(<WIDTH x i32> %new_offsets, <WIDTH x $1> %vals, <WIDTH x MASK> %vecmask)
   ret void
@@ -1229,12 +1229,12 @@ define void
 define void
 @__scatter_base_offsets64_$1(i8* %ptr, i32 %offset_scale, <WIDTH x i64> %offsets, <WIDTH x $1> %vals, <WIDTH x MASK> %vecmask) nounwind {
   %offset_scale64 = zext i32 %offset_scale to i64
-  %scale = insertelement <WIDTH x i64> undef, i64 %offset_scale64, i32 0
-  %scale_shuffle = shufflevector <WIDTH x i64> %scale, <WIDTH x i64> undef, <WIDTH x i32> zeroinitializer
+  %scale = insertelement <WIDTH x i64> poison, i64 %offset_scale64, i32 0
+  %scale_shuffle = shufflevector <WIDTH x i64> %scale, <WIDTH x i64> poison, <WIDTH x i32> zeroinitializer
   %new_offsets_scaled = mul <WIDTH x i64> %offsets, %scale_shuffle
   %ptr_to_int = ptrtoint i8* %ptr to i64
-  %base = insertelement <WIDTH x i64> undef, i64 %ptr_to_int, i32 0
-  %shuffle = shufflevector <WIDTH x i64> %base, <WIDTH x i64> undef, <WIDTH x i32> zeroinitializer
+  %base = insertelement <WIDTH x i64> poison, i64 %ptr_to_int, i32 0
+  %shuffle = shufflevector <WIDTH x i64> %base, <WIDTH x i64> poison, <WIDTH x i32> zeroinitializer
   %new_offsets = add <WIDTH x i64> %new_offsets_scaled, %shuffle
   call void @__scatter64_$1(<WIDTH x i64> %new_offsets, <WIDTH x $1> %vals, <WIDTH x MASK> %vecmask)
   ret void
@@ -1250,21 +1250,21 @@ define void
 define void
 @__scatter64_$1(<WIDTH x i64> %ptrs, <WIDTH x $1> %values, <WIDTH x MASK> %vecmask) nounwind alwaysinline {
    ifelse(WIDTH,32,`
-    %ptrs1 = shufflevector <WIDTH x i64> %ptrs, <WIDTH x i64> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-    %ptrs2 = shufflevector <WIDTH x i64> %ptrs, <WIDTH x i64> undef, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-    %values1 = shufflevector <WIDTH x $1> %values, <WIDTH x $1> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-    %values2 = shufflevector <WIDTH x $1> %values, <WIDTH x $1> undef, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-    %vecmask1 = shufflevector <WIDTH x MASK> %vecmask, <WIDTH x MASK> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-    %vecmask2 = shufflevector <WIDTH x MASK> %vecmask, <WIDTH x MASK> undef, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+    %ptrs1 = shufflevector <WIDTH x i64> %ptrs, <WIDTH x i64> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+    %ptrs2 = shufflevector <WIDTH x i64> %ptrs, <WIDTH x i64> poison, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+    %values1 = shufflevector <WIDTH x $1> %values, <WIDTH x $1> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+    %values2 = shufflevector <WIDTH x $1> %values, <WIDTH x $1> poison, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+    %vecmask1 = shufflevector <WIDTH x MASK> %vecmask, <WIDTH x MASK> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+    %vecmask2 = shufflevector <WIDTH x MASK> %vecmask, <WIDTH x MASK> poison, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
     ifelse($1,i8, `
-      %res1 = tail call <64 x $1> @llvm.genx.wrregioni.XE_SUFFIXN($1, 64).XE_SUFFIXN($1,16).i16.XE_SUFFIXN(i1,16)(<64 x $1> undef, <16 x $1> %values1, i32 0, i32 16, i32 4, i16 0, i32 0, <16 x MASK> %vecmask1)
+      %res1 = tail call <64 x $1> @llvm.genx.wrregioni.XE_SUFFIXN($1, 64).XE_SUFFIXN($1,16).i16.XE_SUFFIXN(i1,16)(<64 x $1> poison, <16 x $1> %values1, i32 0, i32 16, i32 4, i16 0, i32 0, <16 x MASK> %vecmask1)
       call void @llvm.genx.svm.scatter.XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16).XE_SUFFIXN($1, 64)(<16 x MASK> %vecmask1, i32 0, <16 x i64> %ptrs1, <64 x $1> %res1)
-      %res2 = tail call <64 x $1> @llvm.genx.wrregioni.XE_SUFFIXN($1, 64).XE_SUFFIXN($1,16).i16.XE_SUFFIXN(i1,16)(<64 x $1> undef, <16 x $1> %values2, i32 0, i32 16, i32 4, i16 0, i32 0, <16 x MASK> %vecmask2)
+      %res2 = tail call <64 x $1> @llvm.genx.wrregioni.XE_SUFFIXN($1, 64).XE_SUFFIXN($1,16).i16.XE_SUFFIXN(i1,16)(<64 x $1> poison, <16 x $1> %values2, i32 0, i32 16, i32 4, i16 0, i32 0, <16 x MASK> %vecmask2)
       call void @llvm.genx.svm.scatter.XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16).XE_SUFFIXN($1, 64)(<16 x MASK> %vecmask2, i32 0, <16 x i64> %ptrs2, <64 x $1> %res2)
     ', $1,i16, `
-      %res1 = tail call <32 x $1> @llvm.genx.wrregioni.XE_SUFFIXN($1, 32).XE_SUFFIXN($1,16).i16.XE_SUFFIXN(i1,16)(<32 x $1> undef, <16 x $1> %values1, i32 0, i32 16, i32 2, i16 0, i32 0, <16 x MASK> %vecmask1)
+      %res1 = tail call <32 x $1> @llvm.genx.wrregioni.XE_SUFFIXN($1, 32).XE_SUFFIXN($1,16).i16.XE_SUFFIXN(i1,16)(<32 x $1> poison, <16 x $1> %values1, i32 0, i32 16, i32 2, i16 0, i32 0, <16 x MASK> %vecmask1)
       call void @llvm.genx.svm.scatter.XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16).XE_SUFFIXN($1, 32)(<16 x MASK> %vecmask1, i32 1, <16 x i64> %ptrs1, <32 x $1> %res1)
-      %res2 = tail call <32 x $1> @llvm.genx.wrregioni.XE_SUFFIXN($1, 32).XE_SUFFIXN($1,16).i16.XE_SUFFIXN(i1,16)(<32 x $1> undef, <16 x $1> %values2, i32 0, i32 16, i32 2, i16 0, i32 0, <16 x MASK> %vecmask2)
+      %res2 = tail call <32 x $1> @llvm.genx.wrregioni.XE_SUFFIXN($1, 32).XE_SUFFIXN($1,16).i16.XE_SUFFIXN(i1,16)(<32 x $1> poison, <16 x $1> %values2, i32 0, i32 16, i32 2, i16 0, i32 0, <16 x MASK> %vecmask2)
       call void @llvm.genx.svm.scatter.XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16).XE_SUFFIXN($1, 32)(<16 x MASK> %vecmask2, i32 1, <16 x i64> %ptrs2, <32 x $1> %res2)
     ',`
       call void @llvm.genx.svm.scatter.XE_SUFFIXN(i1,16).XE_SUFFIXN(i64,16).XE_SUFFIXN($1,16)(<16 x MASK> %vecmask1, i32 0, <16 x i64> %ptrs1, <16 x $1> %values1)
@@ -1272,10 +1272,10 @@ define void
     ')
   ',`
     ifelse($1,i8, `
-      %res = tail call <WIDTH_X4 x $1> @llvm.genx.wrregioni.XE_SUFFIXN($1, WIDTH_X4).XE_SUFFIX($1).i16.XE_SUFFIX(i1)(<WIDTH_X4 x $1> undef, <WIDTH x $1> %values, i32 0, i32 WIDTH, i32 4, i16 0, i32 0, <WIDTH x MASK> %vecmask)
+      %res = tail call <WIDTH_X4 x $1> @llvm.genx.wrregioni.XE_SUFFIXN($1, WIDTH_X4).XE_SUFFIX($1).i16.XE_SUFFIX(i1)(<WIDTH_X4 x $1> poison, <WIDTH x $1> %values, i32 0, i32 WIDTH, i32 4, i16 0, i32 0, <WIDTH x MASK> %vecmask)
       call void @llvm.genx.svm.scatter.XE_SUFFIX(i1).XE_SUFFIX(i64).XE_SUFFIXN(i8, WIDTH_X4)(<WIDTH x MASK> %vecmask, i32 0, <WIDTH x i64> %ptrs, <WIDTH_X4 x $1> %res)
     ', $1,i16, `
-      %res = tail call <WIDTH_X2 x $1> @llvm.genx.wrregioni.XE_SUFFIXN($1, WIDTH_X2).XE_SUFFIX($1).i16.XE_SUFFIX(i1)(<WIDTH_X2 x $1> undef, <WIDTH x $1> %values, i32 0, i32 WIDTH, i32 2, i16 0, i32 0, <WIDTH x MASK> %vecmask)
+      %res = tail call <WIDTH_X2 x $1> @llvm.genx.wrregioni.XE_SUFFIXN($1, WIDTH_X2).XE_SUFFIX($1).i16.XE_SUFFIX(i1)(<WIDTH_X2 x $1> poison, <WIDTH x $1> %values, i32 0, i32 WIDTH, i32 2, i16 0, i32 0, <WIDTH x MASK> %vecmask)
       call void @llvm.genx.svm.scatter.XE_SUFFIX(i1).XE_SUFFIX(i64).XE_SUFFIXN($1, WIDTH_X2)(<WIDTH x MASK> %vecmask, i32 1, <WIDTH x i64> %ptrs, <WIDTH_X2 x $1> %res)
     ',`
       call void @llvm.genx.svm.scatter.XE_SUFFIX(i1).XE_SUFFIX(i64).XE_SUFFIX($1)(<WIDTH x MASK> %vecmask, i32 0, <WIDTH x i64> %ptrs, <WIDTH x $1> %values)
@@ -1328,8 +1328,8 @@ define float @__log_uniform_float(float) nounwind readnone {
 declare <WIDTH x float> @__spirv_ocl_native_log2_DvWIDTHf(<WIDTH x float>) nounwind readnone
 define <WIDTH x float> @__log_varying_float(<WIDTH x float>) nounwind readnone {
   %res2base = call <WIDTH x float> @__spirv_ocl_native_log2_DvWIDTHf(<WIDTH x float> %0)
-  %log2e = insertelement <WIDTH x float> undef, float LOG2E, i32 0
-  %log2e_shuffle = shufflevector <WIDTH x float> %log2e, <WIDTH x float> undef, <WIDTH x i32> zeroinitializer
+  %log2e = insertelement <WIDTH x float> poison, float LOG2E, i32 0
+  %log2e_shuffle = shufflevector <WIDTH x float> %log2e, <WIDTH x float> poison, <WIDTH x i32> zeroinitializer
   %res = fdiv <WIDTH x float> %res2base, %log2e_shuffle
   ret <WIDTH x float> %res
 }
@@ -1347,8 +1347,8 @@ define half @__log_uniform_half(half) nounwind readnone {
 declare <WIDTH x half> @__spirv_ocl_native_log2_DvWIDTHDh(<WIDTH x half>) nounwind readnone
 define <WIDTH x half> @__log_varying_half(<WIDTH x half>) nounwind readnone {
   %res2base = call <WIDTH x half> @__spirv_ocl_native_log2_DvWIDTHDh(<WIDTH x half> %0)
-  %log2e = insertelement <WIDTH x half> undef, half LOG2EF16, i32 0
-  %log2e_shuffle = shufflevector <WIDTH x half> %log2e, <WIDTH x half> undef, <WIDTH x i32> zeroinitializer
+  %log2e = insertelement <WIDTH x half> poison, half LOG2EF16, i32 0
+  %log2e_shuffle = shufflevector <WIDTH x half> %log2e, <WIDTH x half> poison, <WIDTH x i32> zeroinitializer
   %res = fdiv <WIDTH x half> %res2base, %log2e_shuffle
   ret <WIDTH x half> %res
 }
@@ -1383,8 +1383,8 @@ define float @__exp_uniform_float(float) nounwind readnone {
 }
 
 define <WIDTH x float> @__exp_varying_float(<WIDTH x float>) nounwind readnone {
-  %exp = insertelement <WIDTH x float> undef, float EXP, i32 0
-  %exp_shuffle = shufflevector <WIDTH x float> %exp, <WIDTH x float> undef, <WIDTH x i32> zeroinitializer
+  %exp = insertelement <WIDTH x float> poison, float EXP, i32 0
+  %exp_shuffle = shufflevector <WIDTH x float> %exp, <WIDTH x float> poison, <WIDTH x i32> zeroinitializer
   %res = call <WIDTH x float> @__spirv_ocl_native_powr_DvWIDTHf(<WIDTH x float> %exp_shuffle, <WIDTH x float> %0)
   ret <WIDTH x float> %res
 }
@@ -1395,8 +1395,8 @@ define half @__exp_uniform_half(half) nounwind readnone {
 }
 
 define <WIDTH x half> @__exp_varying_half(<WIDTH x half>) nounwind readnone {
-  %exp = insertelement <WIDTH x half> undef, half EXPF16, i32 0
-  %exp_shuffle = shufflevector <WIDTH x half> %exp, <WIDTH x half> undef, <WIDTH x i32> zeroinitializer
+  %exp = insertelement <WIDTH x half> poison, half EXPF16, i32 0
+  %exp_shuffle = shufflevector <WIDTH x half> %exp, <WIDTH x half> poison, <WIDTH x i32> zeroinitializer
   %res = call <WIDTH x half> @__spirv_ocl_native_powr_DvWIDTHDh(<WIDTH x half> %exp_shuffle, <WIDTH x half> %0)
   ret <WIDTH x half> %res
 }
@@ -1418,8 +1418,8 @@ ifelse(WIDTH,32,`
 ')
 define <WIDTH x double> @__$1_varying_double(<WIDTH x double>) nounwind readnone {
   ifelse(WIDTH,32,`
-    %in1 = shufflevector <32 x double> %0, <32 x double> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-    %in2 = shufflevector <32 x double> %0, <32 x double> undef, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+    %in1 = shufflevector <32 x double> %0, <32 x double> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+    %in2 = shufflevector <32 x double> %0, <32 x double> poison, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
     %res1 = call <16 x double> @__spirv_ocl_$1_DvWIDTHd(<16 x double> %in1)
     %res2 = call <16 x double> @__spirv_ocl_$1_DvWIDTHd(<16 x double> %in2)
     %res = shufflevector <16 x double> %res1, <16 x double> %res2, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
@@ -1460,8 +1460,8 @@ define void @__sincos_varying_double(<WIDTH x double>, i8*, i8*) nounwind {
   %ptr1 = bitcast i8* %1 to <WIDTH x double>*
   %ptr2 = bitcast i8* %2 to <WIDTH x double>*
   ifelse(WIDTH,32,`
-    %in0_1 = shufflevector <32 x double> %0, <32 x double> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-    %in0_2 = shufflevector <32 x double> %0, <32 x double> undef, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+    %in0_1 = shufflevector <32 x double> %0, <32 x double> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+    %in0_2 = shufflevector <32 x double> %0, <32 x double> poison, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
     %ptr2_16_1 = bitcast <32 x double>* %ptr2 to <16 x double>*
     %ptrtoint = ptrtoint <32 x double>* %ptr2 to i64
     %ptrtoint_add = add i64 %ptrtoint, 128
@@ -1489,10 +1489,10 @@ ifelse(WIDTH,32,`
 ')
 define <WIDTH x double> @__pow_varying_double(<WIDTH x double>, <WIDTH x double>) nounwind {
   ifelse(WIDTH,32,`
-    %in1_1 = shufflevector <32 x double> %0, <32 x double> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-    %in1_2 = shufflevector <32 x double> %0, <32 x double> undef, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-    %in2_1 = shufflevector <32 x double> %1, <32 x double> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-    %in2_2 = shufflevector <32 x double> %1, <32 x double> undef, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+    %in1_1 = shufflevector <32 x double> %0, <32 x double> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+    %in1_2 = shufflevector <32 x double> %0, <32 x double> poison, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+    %in2_1 = shufflevector <32 x double> %1, <32 x double> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+    %in2_2 = shufflevector <32 x double> %1, <32 x double> poison, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
     %res1 = call <16 x double> @__spirv_ocl_pow_DvWIDTHd(<16 x double> %in1_1, <16 x double> %in2_1)
     %res2 = call <16 x double> @__spirv_ocl_pow_DvWIDTHd(<16 x double> %in1_2, <16 x double> %in2_2)
     %res = shufflevector <16 x double> %res1, <16 x double> %res2, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
@@ -1517,10 +1517,10 @@ ifelse(WIDTH,32,`
 
 define <WIDTH x double> @__atan2_varying_double(<WIDTH x double>, <WIDTH x double>) nounwind {
   ifelse(WIDTH,32,`
-    %in1_1 = shufflevector <32 x double> %0, <32 x double> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-    %in1_2 = shufflevector <32 x double> %0, <32 x double> undef, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-    %in2_1 = shufflevector <32 x double> %1, <32 x double> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-    %in2_2 = shufflevector <32 x double> %1, <32 x double> undef, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+    %in1_1 = shufflevector <32 x double> %0, <32 x double> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+    %in1_2 = shufflevector <32 x double> %0, <32 x double> poison, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+    %in2_1 = shufflevector <32 x double> %1, <32 x double> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+    %in2_2 = shufflevector <32 x double> %1, <32 x double> poison, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
     %res1 = call <16 x double> @__spirv_ocl_atan2_DvWIDTHd(<16 x double> %in1_1, <16 x double> %in2_1)
     %res2 = call <16 x double> @__spirv_ocl_atan2_DvWIDTHd(<16 x double> %in1_2, <16 x double> %in2_2)
     %res = shufflevector <16 x double> %res1, <16 x double> %res2, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>

--- a/builtins/util-xe.m4
+++ b/builtins/util-xe.m4
@@ -69,117 +69,117 @@ define(`MfORi32',
 
 
 define(`convert1to8', `
-  $3 = shufflevector <1 x $1> $2, <1 x $1> undef,
-  <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-             i32 undef, i32 undef, i32 undef, i32 undef>
+  $3 = shufflevector <1 x $1> $2, <1 x $1> poison,
+  <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+             i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 
 define(`convert1to16', `
-  $3 = shufflevector <1 x $1> $2, <1 x $1> undef,
-  <16 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef>
+  $3 = shufflevector <1 x $1> $2, <1 x $1> poison,
+  <16 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert4to8', `
-  $3 = shufflevector <4 x $1> $2, <4 x $1> undef,
+  $3 = shufflevector <4 x $1> $2, <4 x $1> poison,
   <8 x i32> <i32 0, i32 1, i32 2, i32 3,
-             i32 undef, i32 undef, i32 undef, i32 undef>
+             i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert4to16', `
-  $3 = shufflevector <4 x $1> $2, <4 x $1> undef,
+  $3 = shufflevector <4 x $1> $2, <4 x $1> poison,
   <16 x i32> <i32 0, i32 1, i32 2, i32 3,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef>
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert8to16', `
-  $3 = shufflevector <8 x $1> $2, <8 x $1> undef,
+  $3 = shufflevector <8 x $1> $2, <8 x $1> poison,
   <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef>
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert4to32', `
-  $3 = shufflevector <4 x $1> $2, <4 x $1> undef,
+  $3 = shufflevector <4 x $1> $2, <4 x $1> poison,
   <32 x i32> <i32 0, i32 1, i32 2, i32 3,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef>
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert8to32', `
-  $3 = shufflevector <4 x $1> $2, <4 x $1> undef,
+  $3 = shufflevector <4 x $1> $2, <4 x $1> poison,
   <32 x i32> <i32 0, i32 1, i32 2, i32 3,
               i32 4, i32 5, i32 6, i32 7,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef>
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert16to32', `
-  $3 = shufflevector <4 x $1> $2, <4 x $1> undef,
+  $3 = shufflevector <4 x $1> $2, <4 x $1> poison,
   <32 x i32> <i32  0, i32 1,  i32  2, i32  3,
               i32  4, i32 5,  i32  6, i32  7,
               i32  8, i32 9,  i32 10, i32 11,
               i32 12, i32 13, i32 14, i32 15
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef>
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert8to1', `
-  $3 = shufflevector <8 x $1> $2, <8 x $1> undef,
+  $3 = shufflevector <8 x $1> $2, <8 x $1> poison,
     <1 x i32> <i32 0>
 ')
 
 
 define(`convert16to1', `
-  $3 = shufflevector <16 x $1> $2, <16 x $1> undef,
+  $3 = shufflevector <16 x $1> $2, <16 x $1> poison,
     <1 x i32> <i32 0>
 ')
 
 define(`convert8to4', `
-  $3 = shufflevector <8 x $1> $2, <8 x $1> undef,
+  $3 = shufflevector <8 x $1> $2, <8 x $1> poison,
     <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ')
 
 
 define(`convert16to4', `
-  $3 = shufflevector <16 x $1> $2, <16 x $1> undef,
+  $3 = shufflevector <16 x $1> $2, <16 x $1> poison,
     <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ')
 
 define(`convert16to8', `
-  $3 = shufflevector <16 x $1> $2, <16 x $1> undef,
+  $3 = shufflevector <16 x $1> $2, <16 x $1> poison,
   <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
 ')
 
 define(`convert32to4', `
-  $3 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $3 = shufflevector <32 x $1> $2, <32 x $1> poison,
     <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ')
 
 define(`convert32to8', `
-  $3 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $3 = shufflevector <32 x $1> $2, <32 x $1> poison,
     <8 x i32> <i32 0, i32 1, i32 2, i32 3,
                i32 4, i32 5, i32 6, i32 7>
 ')
 
 define(`convert32to16', `
-  $3 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $3 = shufflevector <32 x $1> $2, <32 x $1> poison,
     <16 x i32> <i32  0, i32 1,  i32  2, i32  3,
                 i32  4, i32 5,  i32  6, i32  7,
                 i32  8, i32 9,  i32 10, i32 11,
@@ -187,7 +187,7 @@ define(`convert32to16', `
 ')
 
 define(`convert32to64', `
-  $3 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $3 = shufflevector <32 x $1> $2, <32 x $1> poison,
     <64 x i32> <i32  0, i32 1,  i32  2, i32  3,
                 i32  4, i32 5,  i32  6, i32  7,
                 i32  8, i32 9,  i32 10, i32 11,
@@ -196,18 +196,18 @@ define(`convert32to64', `
                 i32 20, i32 21, i32 22, i32 23,
                 i32 24, i32 25, i32 26, i32 27,
                 i32 28, i32 29, i32 30, i32 31,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef>
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert64to32', `
-  $3 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $3 = shufflevector <64 x $1> $2, <64 x $1> poison,
     <32 x i32> <i32 0, i32 1, i32 2, i32 3,
                 i32  4, i32 5,  i32  6, i32  7,
                 i32  8, i32 9,  i32 10, i32 11,
@@ -380,36 +380,36 @@ saturation_arithmetic_sub_u(i64)
 ;; $4: second 4-wide vector
 
 define(`v8tov4', `
-  $3 = shufflevector <8 x $1> $2, <8 x $1> undef,
+  $3 = shufflevector <8 x $1> $2, <8 x $1> poison,
     <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  $4 = shufflevector <8 x $1> $2, <8 x $1> undef,
+  $4 = shufflevector <8 x $1> $2, <8 x $1> poison,
     <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 ')
 
 define(`v16tov8', `
-  $3 = shufflevector <16 x $1> $2, <16 x $1> undef,
+  $3 = shufflevector <16 x $1> $2, <16 x $1> poison,
     <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  $4 = shufflevector <16 x $1> $2, <16 x $1> undef,
+  $4 = shufflevector <16 x $1> $2, <16 x $1> poison,
     <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 ')
 
 define(`v4tov2', `
-  $3 = shufflevector <4 x $1> $2, <4 x $1> undef, <2 x i32> <i32 0, i32 1>
-  $4 = shufflevector <4 x $1> $2, <4 x $1> undef, <2 x i32> <i32 2, i32 3>
+  $3 = shufflevector <4 x $1> $2, <4 x $1> poison, <2 x i32> <i32 0, i32 1>
+  $4 = shufflevector <4 x $1> $2, <4 x $1> poison, <2 x i32> <i32 2, i32 3>
 ')
 
 define(`v8tov2', `
-  $3 = shufflevector <8 x $1> $2, <8 x $1> undef, <2 x i32> <i32 0, i32 1>
-  $4 = shufflevector <8 x $1> $2, <8 x $1> undef, <2 x i32> <i32 2, i32 3>
-  $5 = shufflevector <8 x $1> $2, <8 x $1> undef, <2 x i32> <i32 4, i32 5>
-  $6 = shufflevector <8 x $1> $2, <8 x $1> undef, <2 x i32> <i32 6, i32 7>
+  $3 = shufflevector <8 x $1> $2, <8 x $1> poison, <2 x i32> <i32 0, i32 1>
+  $4 = shufflevector <8 x $1> $2, <8 x $1> poison, <2 x i32> <i32 2, i32 3>
+  $5 = shufflevector <8 x $1> $2, <8 x $1> poison, <2 x i32> <i32 4, i32 5>
+  $6 = shufflevector <8 x $1> $2, <8 x $1> poison, <2 x i32> <i32 6, i32 7>
 ')
 
 define(`v16tov4', `
-  $3 = shufflevector <16 x $1> $2, <16 x $1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  $4 = shufflevector <16 x $1> $2, <16 x $1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  $5 = shufflevector <16 x $1> $2, <16 x $1> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  $6 = shufflevector <16 x $1> $2, <16 x $1> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  $3 = shufflevector <16 x $1> $2, <16 x $1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  $4 = shufflevector <16 x $1> $2, <16 x $1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  $5 = shufflevector <16 x $1> $2, <16 x $1> poison, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  $6 = shufflevector <16 x $1> $2, <16 x $1> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 ')
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -440,7 +440,7 @@ define(`v8tov16', `
 ;;  sse_unary_scalar(ret, 4, float, @llvm.x86.sse.sqrt.ss, %0)
 
 define(`sse_unary_scalar', `
-  %$1_vec = insertelement <$2 x $3> undef, $3 $5, i32 0
+  %$1_vec = insertelement <$2 x $3> poison, $3 $5, i32 0
   %$1_val = call <$2 x $3> $4(<$2 x $3> %$1_vec)
   %$1 = extractelement <$2 x $3> %$1_val, i32 0
 ')
@@ -455,8 +455,8 @@ define(`sse_unary_scalar', `
 ;; $6 : variable name that has the second scalar operand
 
 define(`sse_binary_scalar', `
-  %$1_veca = insertelement <$2 x $3> undef, $3 $5, i32 0
-  %$1_vecb = insertelement <$2 x $3> undef, $3 $6, i32 0
+  %$1_veca = insertelement <$2 x $3> poison, $3 $5, i32 0
+  %$1_vecb = insertelement <$2 x $3> poison, $3 $6, i32 0
   %$1_val = call <$2 x $3> $4(<$2 x $3> %$1_veca, <$2 x $3> %$1_vecb)
   %$1 = extractelement <$2 x $3> %$1_val, i32 0
 ')
@@ -469,11 +469,11 @@ define(`sse_binary_scalar', `
 ;;     the final reduction
 ;; $4: input vector
 define(`reduce8', `
-  %v1 = shufflevector <8 x $1> $4, <8 x $1> undef,
-        <8 x i32> <i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef>
+  %v1 = shufflevector <8 x $1> $4, <8 x $1> poison,
+        <8 x i32> <i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison>
   %m1 = call <8 x $1> $2(<8 x $1> %v1, <8 x $1> $4)
-  %v2 = shufflevector <8 x $1> %m1, <8 x $1> undef,
-        <8 x i32> <i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %v2 = shufflevector <8 x $1> %m1, <8 x $1> poison,
+        <8 x i32> <i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m2 = call <8 x $1> $2(<8 x $1> %v2, <8 x $1> %m1)
   %m2a = extractelement <8 x $1> %m2, i32 0
   %m2b = extractelement <8 x $1> %m2, i32 1
@@ -491,22 +491,22 @@ define(`reduce8', `
 ;; $4: input vector
 
 define(`reduce16', `
-  %v1 = shufflevector <16 x $1> $4, <16 x $1> undef,
+  %v1 = shufflevector <16 x $1> $4, <16 x $1> poison,
         <16 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
-                    i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef>
+                    i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison>
   %m1 = call <16 x $1> $2(<16 x $1> %v1, <16 x $1> $4)
-  %v2 = shufflevector <16 x $1> %m1, <16 x $1> undef,
+  %v2 = shufflevector <16 x $1> %m1, <16 x $1> poison,
         <16 x i32> <i32 4, i32 5, i32 6, i32 7,
-                    i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef>
+                    i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison>
   %m2 = call <16 x $1> $2(<16 x $1> %v2, <16 x $1> %m1)
-  %v3 = shufflevector <16 x $1> %m2, <16 x $1> undef,
-        <16 x i32> <i32 2, i32 3, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef>
+  %v3 = shufflevector <16 x $1> %m2, <16 x $1> poison,
+        <16 x i32> <i32 2, i32 3, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison>
   %m3 = call <16 x $1> $2(<16 x $1> %v3, <16 x $1> %m2)
 
   %m3a = extractelement <16 x $1> %m3, i32 0
@@ -525,29 +525,29 @@ define(`reduce16', `
 ;; $4: input vector
 
 define(`reduce32', `
-  %v0 = shufflevector <32 x $1> $4, <32 x $1> undef,
+  %v0 = shufflevector <32 x $1> $4, <32 x $1> poison,
         <32 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23,
                     i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m0 = call <32 x $1> $2(<32 x $1> %v0, <32 x $1> $4)
-  %v1 = shufflevector <32 x $1> %m0, <32 x $1> undef,
+  %v1 = shufflevector <32 x $1> %m0, <32 x $1> poison,
         <32 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m1 = call <32 x $1> $2(<32 x $1> %v1, <32 x $1> %m0)
-  %v2 = shufflevector <32 x $1> %m1, <32 x $1> undef,
-        <32 x i32> <i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %v2 = shufflevector <32 x $1> %m1, <32 x $1> poison,
+        <32 x i32> <i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m2 = call <32 x $1> $2(<32 x $1> %v2, <32 x $1> %m1)
-  %v3 = shufflevector <32 x $1> %m2, <32 x $1> undef,
-        <32 x i32> <i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %v3 = shufflevector <32 x $1> %m2, <32 x $1> poison,
+        <32 x i32> <i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m3 = call <32 x $1> $2(<32 x $1> %v3, <32 x $1> %m2)
 
   %m3a = extractelement <32 x $1> %m3, i32 0
@@ -565,12 +565,12 @@ define(`reduce32', `
 ;; $5: scale
 define(`reducexe8', `
   %scale2 = mul i16 $5, 4
-  %v3 = call <4 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 8).i16(<8 x $1> $4, i32 0, i32 4, i32 1, i16 0, i32 undef)
-  %v4 = call <4 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 8).i16(<8 x $1> $4, i32 0, i32 4, i32 1, i16 %scale2, i32 undef)
+  %v3 = call <4 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 8).i16(<8 x $1> $4, i32 0, i32 4, i32 1, i16 0, i32 poison)
+  %v4 = call <4 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 8).i16(<8 x $1> $4, i32 0, i32 4, i32 1, i16 %scale2, i32 poison)
   %m2 = call <4 x $1> @llvm.genx.$2.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 4)(<4 x $1> %v3, <4 x $1> %v4)
   %scale3 = mul i16 $5, 2
-  %v5 = call <2 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 4).i16(<4 x $1> %m2, i32 0, i32 2, i32 1, i16 0, i32 undef)
-  %v6 = call <2 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 4).i16(<4 x $1> %m2, i32 0, i32 2, i32 1, i16 %scale3, i32 undef)
+  %v5 = call <2 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 4).i16(<4 x $1> %m2, i32 0, i32 2, i32 1, i16 0, i32 poison)
+  %v6 = call <2 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 4).i16(<4 x $1> %m2, i32 0, i32 2, i32 1, i16 %scale3, i32 poison)
   %m3 = call <2 x $1> @llvm.genx.$2.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 2)(<2 x $1> %v5, <2 x $1> %v6)
   %m3a = extractelement <2 x $1> %m3, i32 0
   %m3b = extractelement <2 x $1> %m3, i32 1
@@ -587,16 +587,16 @@ define(`reducexe8', `
 ;; $5: scale
 define(`reducexe16', `
   %scale1 = mul i16 $5, 8
-  %v1 = call <8 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 8).XE_SUFFIX($1).i16(<16 x $1> $4, i32 0, i32 8, i32 1, i16 0, i32 undef)
-  %v2 = call <8 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 8).XE_SUFFIX($1).i16(<16 x $1> $4, i32 0, i32 8, i32 1, i16 %scale1, i32 undef)
+  %v1 = call <8 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 8).XE_SUFFIX($1).i16(<16 x $1> $4, i32 0, i32 8, i32 1, i16 0, i32 poison)
+  %v2 = call <8 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 8).XE_SUFFIX($1).i16(<16 x $1> $4, i32 0, i32 8, i32 1, i16 %scale1, i32 poison)
   %m1 = call <8 x $1> @llvm.genx.$2.XE_SUFFIXN($1, 8).XE_SUFFIXN($1, 8)(<8 x $1> %v1, <8 x $1> %v2)
   %scale2 = mul i16 $5, 4
-  %v3 = call <4 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 8).i16(<8 x $1> %m1, i32 0, i32 4, i32 1, i16 0, i32 undef)
-  %v4 = call <4 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 8).i16(<8 x $1> %m1, i32 0, i32 4, i32 1, i16 %scale2, i32 undef)
+  %v3 = call <4 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 8).i16(<8 x $1> %m1, i32 0, i32 4, i32 1, i16 0, i32 poison)
+  %v4 = call <4 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 8).i16(<8 x $1> %m1, i32 0, i32 4, i32 1, i16 %scale2, i32 poison)
   %m2 = call <4 x $1> @llvm.genx.$2.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 4)(<4 x $1> %v3, <4 x $1> %v4)
   %scale3 = mul i16 $5, 2
-  %v5 = call <2 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 4).i16(<4 x $1> %m2, i32 0, i32 2, i32 1, i16 0, i32 undef)
-  %v6 = call <2 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 4).i16(<4 x $1> %m2, i32 0, i32 2, i32 1, i16 %scale3, i32 undef)
+  %v5 = call <2 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 4).i16(<4 x $1> %m2, i32 0, i32 2, i32 1, i16 0, i32 poison)
+  %v6 = call <2 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 4).i16(<4 x $1> %m2, i32 0, i32 2, i32 1, i16 %scale3, i32 poison)
   %m3 = call <2 x $1> @llvm.genx.$2.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 2)(<2 x $1> %v5, <2 x $1> %v6)
   %m3a = extractelement <2 x $1> %m3, i32 0
   %m3b = extractelement <2 x $1> %m3, i32 1
@@ -613,20 +613,20 @@ define(`reducexe16', `
 ;; $5: scale
 define(`reducexe32', `
   %scale1 = mul i16 $5, 16
-  %v1 = call <16 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 16).XE_SUFFIX($1).i16(<32 x $1> $4, i32 0, i32 16, i32 1, i16 0, i32 undef)
-  %v2 = call <16 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 16).XE_SUFFIX($1).i16(<32 x $1> $4, i32 0, i32 16, i32 1, i16 %scale1, i32 undef)
+  %v1 = call <16 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 16).XE_SUFFIX($1).i16(<32 x $1> $4, i32 0, i32 16, i32 1, i16 0, i32 poison)
+  %v2 = call <16 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 16).XE_SUFFIX($1).i16(<32 x $1> $4, i32 0, i32 16, i32 1, i16 %scale1, i32 poison)
   %m1 = call <16 x $1> @llvm.genx.$2.XE_SUFFIXN($1, 16).XE_SUFFIXN($1, 16)(<16 x $1> %v1, <16 x $1> %v2)
   %scale2 = mul i16 $5, 8
-  %v3 = call <8 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 8).XE_SUFFIXN($1, 16).i16(<16 x $1> %m1, i32 0, i32 8, i32 1, i16 0, i32 undef)
-  %v4 = call <8 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 8).XE_SUFFIXN($1, 16).i16(<16 x $1> %m1, i32 0, i32 8, i32 1, i16 %scale2, i32 undef)
+  %v3 = call <8 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 8).XE_SUFFIXN($1, 16).i16(<16 x $1> %m1, i32 0, i32 8, i32 1, i16 0, i32 poison)
+  %v4 = call <8 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 8).XE_SUFFIXN($1, 16).i16(<16 x $1> %m1, i32 0, i32 8, i32 1, i16 %scale2, i32 poison)
   %m2 = call <8 x $1> @llvm.genx.$2.XE_SUFFIXN($1, 8).XE_SUFFIXN($1, 8)(<8 x $1> %v3, <8 x $1> %v4)
   %scale3 = mul i16 $5, 4
-  %v5 = call <4 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 8).i16(<8 x $1> %m2, i32 0, i32 4, i32 1, i16 0, i32 undef)
-  %v6 = call <4 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 8).i16(<8 x $1> %m2, i32 0, i32 4, i32 1, i16 %scale3, i32 undef)
+  %v5 = call <4 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 8).i16(<8 x $1> %m2, i32 0, i32 4, i32 1, i16 0, i32 poison)
+  %v6 = call <4 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 8).i16(<8 x $1> %m2, i32 0, i32 4, i32 1, i16 %scale3, i32 poison)
   %m3 = call <4 x $1> @llvm.genx.$2.XE_SUFFIXN($1, 4).XE_SUFFIXN($1, 4)(<4 x $1> %v5, <4 x $1> %v6)
   %scale4 = mul i16 $5, 2
-  %v7 = call <2 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 4).i16(<4 x $1> %m3, i32 0, i32 2, i32 1, i16 0, i32 undef)
-  %v8 = call <2 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 4).i16(<4 x $1> %m3, i32 0, i32 2, i32 1, i16 %scale4, i32 undef)
+  %v7 = call <2 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 4).i16(<4 x $1> %m3, i32 0, i32 2, i32 1, i16 0, i32 poison)
+  %v8 = call <2 x $1> @llvm.genx.$3.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 4).i16(<4 x $1> %m3, i32 0, i32 2, i32 1, i16 %scale4, i32 poison)
   %m4 = call <2 x $1> @llvm.genx.$2.XE_SUFFIXN($1, 2).XE_SUFFIXN($1, 2)(<2 x $1> %v7, <2 x $1> %v8)
   %m4a = extractelement <2 x $1> %m4, i32 0
   %m4b = extractelement <2 x $1> %m4, i32 1
@@ -642,7 +642,7 @@ define(`reducexe32', `
 define(`unary1to4', `
   %v_0 = extractelement <4 x $1> %0, i32 0
   %r_0 = call $1 $2($1 %v_0)
-  %ret_0 = insertelement <4 x $1> undef, $1 %r_0, i32 0
+  %ret_0 = insertelement <4 x $1> poison, $1 %r_0, i32 0
   %v_1 = extractelement <4 x $1> %0, i32 1
   %r_1 = call $1 $2($1 %v_1)
   %ret_1 = insertelement <4 x $1> %ret_0, $1 %r_1, i32 1
@@ -658,7 +658,7 @@ define(`unary1to4', `
 define(`unary1to8', `
   %v_0 = extractelement <8 x $1> %0, i32 0
   %r_0 = call $1 $2($1 %v_0)
-  %ret_0 = insertelement <8 x $1> undef, $1 %r_0, i32 0
+  %ret_0 = insertelement <8 x $1> poison, $1 %r_0, i32 0
   %v_1 = extractelement <8 x $1> %0, i32 1
   %r_1 = call $1 $2($1 %v_1)
   %ret_1 = insertelement <8 x $1> %ret_0, $1 %r_1, i32 1
@@ -692,9 +692,9 @@ define(`unary1to8', `
 ;; $4: 4-wide operand value
 
 define(`unary2to4', `
-  %$1_0 = shufflevector <4 x $2> $4, <4 x $2> undef, <2 x i32> <i32 0, i32 1>
+  %$1_0 = shufflevector <4 x $2> $4, <4 x $2> poison, <2 x i32> <i32 0, i32 1>
   %v$1_0 = call <2 x $2> $3(<2 x $2> %$1_0)
-  %$1_1 = shufflevector <4 x $2> $4, <4 x $2> undef, <2 x i32> <i32 2, i32 3>
+  %$1_1 = shufflevector <4 x $2> $4, <4 x $2> poison, <2 x i32> <i32 2, i32 3>
   %v$1_1 = call <2 x $2> $3(<2 x $2> %$1_1)
   %$1 = shufflevector <2 x $2> %v$1_0, <2 x $2> %v$1_1,
            <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -710,11 +710,11 @@ define(`unary2to4', `
 ;; $5: Second 4-wide operand value
 
 define(`binary2to4', `
-%$1_0a = shufflevector <4 x $2> $4, <4 x $2> undef, <2 x i32> <i32 0, i32 1>
-%$1_0b = shufflevector <4 x $2> $5, <4 x $2> undef, <2 x i32> <i32 0, i32 1>
+%$1_0a = shufflevector <4 x $2> $4, <4 x $2> poison, <2 x i32> <i32 0, i32 1>
+%$1_0b = shufflevector <4 x $2> $5, <4 x $2> poison, <2 x i32> <i32 0, i32 1>
 %v$1_0 = call <2 x $2> $3(<2 x $2> %$1_0a, <2 x $2> %$1_0b)
-%$1_1a = shufflevector <4 x $2> $4, <4 x $2> undef, <2 x i32> <i32 2, i32 3>
-%$1_1b = shufflevector <4 x $2> $5, <4 x $2> undef, <2 x i32> <i32 2, i32 3>
+%$1_1a = shufflevector <4 x $2> $4, <4 x $2> poison, <2 x i32> <i32 2, i32 3>
+%$1_1b = shufflevector <4 x $2> $5, <4 x $2> poison, <2 x i32> <i32 2, i32 3>
 %v$1_1 = call <2 x $2> $3(<2 x $2> %$1_1a, <2 x $2> %$1_1b)
 %$1 = shufflevector <2 x $2> %v$1_0, <2 x $2> %v$1_1,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -729,9 +729,9 @@ define(`binary2to4', `
 ;; $4: 8-wide operand value
 
 define(`unary4to8', `
-  %__$1_0 = shufflevector <8 x $2> $4, <8 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %__$1_0 = shufflevector <8 x $2> $4, <8 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %__v$1_0 = call <4 x $2> $3(<4 x $2> %__$1_0)
-  %__$1_1 = shufflevector <8 x $2> $4, <8 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %__$1_1 = shufflevector <8 x $2> $4, <8 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %__v$1_1 = call <4 x $2> $3(<4 x $2> %__$1_1)
   %$1 = shufflevector <4 x $2> %__v$1_0, <4 x $2> %__v$1_1,
            <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -745,9 +745,9 @@ define(`unary4to8', `
 ;; $5: 8-wide operand value
 
 define(`unary4to8conv', `
-  %$1_0 = shufflevector <8 x $2> $5, <8 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %$1_0 = shufflevector <8 x $2> $5, <8 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v$1_0 = call <4 x $3> $4(<4 x $2> %$1_0)
-  %$1_1 = shufflevector <8 x $2> $5, <8 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %$1_1 = shufflevector <8 x $2> $5, <8 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v$1_1 = call <4 x $3> $4(<4 x $2> %$1_1)
   %$1 = shufflevector <4 x $3> %v$1_0, <4 x $3> %v$1_1,
            <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -755,13 +755,13 @@ define(`unary4to8conv', `
 )
 
 define(`unary4to16', `
-  %__$1_0 = shufflevector <16 x $2> $4, <16 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %__$1_0 = shufflevector <16 x $2> $4, <16 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %__v$1_0 = call <4 x $2> $3(<4 x $2> %__$1_0)
-  %__$1_1 = shufflevector <16 x $2> $4, <16 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %__$1_1 = shufflevector <16 x $2> $4, <16 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %__v$1_1 = call <4 x $2> $3(<4 x $2> %__$1_1)
-  %__$1_2 = shufflevector <16 x $2> $4, <16 x $2> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  %__$1_2 = shufflevector <16 x $2> $4, <16 x $2> poison, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
   %__v$1_2 = call <4 x $2> $3(<4 x $2> %__$1_2)
-  %__$1_3 = shufflevector <16 x $2> $4, <16 x $2> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  %__$1_3 = shufflevector <16 x $2> $4, <16 x $2> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
   %__v$1_3 = call <4 x $2> $3(<4 x $2> %__$1_3)
 
   %__$1a = shufflevector <4 x $2> %__v$1_0, <4 x $2> %__v$1_1,
@@ -775,13 +775,13 @@ define(`unary4to16', `
 )
 
 define(`unary4to16conv', `
-  %$1_0 = shufflevector <16 x $2> $5, <16 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %$1_0 = shufflevector <16 x $2> $5, <16 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v$1_0 = call <4 x $3> $4(<4 x $2> %$1_0)
-  %$1_1 = shufflevector <16 x $2> $5, <16 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %$1_1 = shufflevector <16 x $2> $5, <16 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v$1_1 = call <4 x $3> $4(<4 x $2> %$1_1)
-  %$1_2 = shufflevector <16 x $2> $5, <16 x $2> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  %$1_2 = shufflevector <16 x $2> $5, <16 x $2> poison, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
   %v$1_2 = call <4 x $3> $4(<4 x $2> %$1_2)
-  %$1_3 = shufflevector <16 x $2> $5, <16 x $2> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  %$1_3 = shufflevector <16 x $2> $5, <16 x $2> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
   %v$1_3 = call <4 x $3> $4(<4 x $2> %$1_3)
 
   %$1a = shufflevector <4 x $3> %v$1_0, <4 x $3> %v$1_1,
@@ -801,10 +801,10 @@ define(`unary4to16conv', `
 ;; $4: 16-wide operand value
 
 define(`unary8to16', `
-  %$1_0 = shufflevector <16 x $2> $4, <16 x $2> undef,
+  %$1_0 = shufflevector <16 x $2> $4, <16 x $2> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %v$1_0 = call <8 x $2> $3(<8 x $2> %$1_0)
-  %$1_1 = shufflevector <16 x $2> $4, <16 x $2> undef,
+  %$1_1 = shufflevector <16 x $2> $4, <16 x $2> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %v$1_1 = call <8 x $2> $3(<8 x $2> %$1_1)
   %$1 = shufflevector <8 x $2> %v$1_0, <8 x $2> %v$1_1,
@@ -822,11 +822,11 @@ define(`unary8to16', `
 ;; $5: Second 8-wide operand value
 
 define(`binary4to8', `
-%$1_0a = shufflevector <8 x $2> $4, <8 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-%$1_0b = shufflevector <8 x $2> $5, <8 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+%$1_0a = shufflevector <8 x $2> $4, <8 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+%$1_0b = shufflevector <8 x $2> $5, <8 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 %v$1_0 = call <4 x $2> $3(<4 x $2> %$1_0a, <4 x $2> %$1_0b)
-%$1_1a = shufflevector <8 x $2> $4, <8 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-%$1_1b = shufflevector <8 x $2> $5, <8 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+%$1_1a = shufflevector <8 x $2> $4, <8 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+%$1_1b = shufflevector <8 x $2> $5, <8 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 %v$1_1 = call <4 x $2> $3(<4 x $2> %$1_1a, <4 x $2> %$1_1b)
 %$1 = shufflevector <4 x $2> %v$1_0, <4 x $2> %v$1_1,
          <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -834,14 +834,14 @@ define(`binary4to8', `
 )
 
 define(`binary8to16', `
-%$1_0a = shufflevector <16 x $2> $4, <16 x $2> undef,
+%$1_0a = shufflevector <16 x $2> $4, <16 x $2> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-%$1_0b = shufflevector <16 x $2> $5, <16 x $2> undef,
+%$1_0b = shufflevector <16 x $2> $5, <16 x $2> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
 %v$1_0 = call <8 x $2> $3(<8 x $2> %$1_0a, <8 x $2> %$1_0b)
-%$1_1a = shufflevector <16 x $2> $4, <16 x $2> undef,
+%$1_1a = shufflevector <16 x $2> $4, <16 x $2> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-%$1_1b = shufflevector <16 x $2> $5, <16 x $2> undef,
+%$1_1b = shufflevector <16 x $2> $5, <16 x $2> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 %v$1_1 = call <8 x $2> $3(<8 x $2> %$1_1a, <8 x $2> %$1_1b)
 %$1 = shufflevector <8 x $2> %v$1_0, <8 x $2> %v$1_1,
@@ -851,27 +851,27 @@ define(`binary8to16', `
 )
 
 define(`binary4to16', `
-%$1_0a = shufflevector <16 x $2> $4, <16 x $2> undef,
+%$1_0a = shufflevector <16 x $2> $4, <16 x $2> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-%$1_0b = shufflevector <16 x $2> $5, <16 x $2> undef,
+%$1_0b = shufflevector <16 x $2> $5, <16 x $2> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 %r$1_0 = call <4 x $2> $3(<4 x $2> %$1_0a, <4 x $2> %$1_0b)
 
-%$1_1a = shufflevector <16 x $2> $4, <16 x $2> undef,
+%$1_1a = shufflevector <16 x $2> $4, <16 x $2> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-%$1_1b = shufflevector <16 x $2> $5, <16 x $2> undef,
+%$1_1b = shufflevector <16 x $2> $5, <16 x $2> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 %r$1_1 = call <4 x $2> $3(<4 x $2> %$1_1a, <4 x $2> %$1_1b)
 
-%$1_2a = shufflevector <16 x $2> $4, <16 x $2> undef,
+%$1_2a = shufflevector <16 x $2> $4, <16 x $2> poison,
           <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-%$1_2b = shufflevector <16 x $2> $5, <16 x $2> undef,
+%$1_2b = shufflevector <16 x $2> $5, <16 x $2> poison,
           <4 x i32> <i32 8, i32 9, i32 10, i32 11>
 %r$1_2 = call <4 x $2> $3(<4 x $2> %$1_2a, <4 x $2> %$1_2b)
 
-%$1_3a = shufflevector <16 x $2> $4, <16 x $2> undef,
+%$1_3a = shufflevector <16 x $2> $4, <16 x $2> poison,
           <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-%$1_3b = shufflevector <16 x $2> $5, <16 x $2> undef,
+%$1_3b = shufflevector <16 x $2> $5, <16 x $2> poison,
           <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 %r$1_3 = call <4 x $2> $3(<4 x $2> %$1_3a, <4 x $2> %$1_3b)
 
@@ -893,13 +893,13 @@ define(`binary4to16', `
 ;; $4: 8-wide operand value
 
 define(`unary2to8', `
-  %$1_0 = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 0, i32 1>
+  %$1_0 = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 0, i32 1>
   %v$1_0 = call <2 x $2> $3(<2 x $2> %$1_0)
-  %$1_1 = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 2, i32 3>
+  %$1_1 = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 2, i32 3>
   %v$1_1 = call <2 x $2> $3(<2 x $2> %$1_1)
-  %$1_2 = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 4, i32 5>
+  %$1_2 = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 4, i32 5>
   %v$1_2 = call <2 x $2> $3(<2 x $2> %$1_2)
-  %$1_3 = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 6, i32 7>
+  %$1_3 = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 6, i32 7>
   %v$1_3 = call <2 x $2> $3(<2 x $2> %$1_3)
   %$1a = shufflevector <2 x $2> %v$1_0, <2 x $2> %v$1_1,
            <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -911,21 +911,21 @@ define(`unary2to8', `
 )
 
 define(`unary2to16', `
-  %$1_0 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 0, i32 1>
+  %$1_0 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 0, i32 1>
   %v$1_0 = call <2 x $2> $3(<2 x $2> %$1_0)
-  %$1_1 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 2, i32 3>
+  %$1_1 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 2, i32 3>
   %v$1_1 = call <2 x $2> $3(<2 x $2> %$1_1)
-  %$1_2 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 4, i32 5>
+  %$1_2 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 4, i32 5>
   %v$1_2 = call <2 x $2> $3(<2 x $2> %$1_2)
-  %$1_3 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 6, i32 7>
+  %$1_3 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 6, i32 7>
   %v$1_3 = call <2 x $2> $3(<2 x $2> %$1_3)
-  %$1_4 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 8, i32 9>
+  %$1_4 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 8, i32 9>
   %v$1_4 = call <2 x $2> $3(<2 x $2> %$1_4)
-  %$1_5 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 10, i32 11>
+  %$1_5 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 10, i32 11>
   %v$1_5 = call <2 x $2> $3(<2 x $2> %$1_5)
-  %$1_6 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 12, i32 13>
+  %$1_6 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 12, i32 13>
   %v$1_6 = call <2 x $2> $3(<2 x $2> %$1_6)
-  %$1_7 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 14, i32 15>
+  %$1_7 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 14, i32 15>
   %v$1_7 = call <2 x $2> $3(<2 x $2> %$1_7)
   %$1a = shufflevector <2 x $2> %v$1_0, <2 x $2> %v$1_1,
            <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -954,17 +954,17 @@ define(`unary2to16', `
 ;; $5: Second 8-wide operand value
 
 define(`binary2to8', `
-  %$1_0a = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 0, i32 1>
-  %$1_0b = shufflevector <8 x $2> $5, <8 x $2> undef, <2 x i32> <i32 0, i32 1>
+  %$1_0a = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 0, i32 1>
+  %$1_0b = shufflevector <8 x $2> $5, <8 x $2> poison, <2 x i32> <i32 0, i32 1>
   %v$1_0 = call <2 x $2> $3(<2 x $2> %$1_0a, <2 x $2> %$1_0b)
-  %$1_1a = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 2, i32 3>
-  %$1_1b = shufflevector <8 x $2> $5, <8 x $2> undef, <2 x i32> <i32 2, i32 3>
+  %$1_1a = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 2, i32 3>
+  %$1_1b = shufflevector <8 x $2> $5, <8 x $2> poison, <2 x i32> <i32 2, i32 3>
   %v$1_1 = call <2 x $2> $3(<2 x $2> %$1_1a, <2 x $2> %$1_1b)
-  %$1_2a = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 4, i32 5>
-  %$1_2b = shufflevector <8 x $2> $5, <8 x $2> undef, <2 x i32> <i32 4, i32 5>
+  %$1_2a = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 4, i32 5>
+  %$1_2b = shufflevector <8 x $2> $5, <8 x $2> poison, <2 x i32> <i32 4, i32 5>
   %v$1_2 = call <2 x $2> $3(<2 x $2> %$1_2a, <2 x $2> %$1_2b)
-  %$1_3a = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 6, i32 7>
-  %$1_3b = shufflevector <8 x $2> $5, <8 x $2> undef, <2 x i32> <i32 6, i32 7>
+  %$1_3a = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 6, i32 7>
+  %$1_3b = shufflevector <8 x $2> $5, <8 x $2> poison, <2 x i32> <i32 6, i32 7>
   %v$1_3 = call <2 x $2> $3(<2 x $2> %$1_3a, <2 x $2> %$1_3b)
 
   %$1a = shufflevector <2 x $2> %v$1_0, <2 x $2> %v$1_1,
@@ -977,29 +977,29 @@ define(`binary2to8', `
 )
 
 define(`binary2to16', `
-  %$1_0a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 0, i32 1>
-  %$1_0b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 0, i32 1>
+  %$1_0a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 0, i32 1>
+  %$1_0b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 0, i32 1>
   %v$1_0 = call <2 x $2> $3(<2 x $2> %$1_0a, <2 x $2> %$1_0b)
-  %$1_1a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 2, i32 3>
-  %$1_1b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 2, i32 3>
+  %$1_1a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 2, i32 3>
+  %$1_1b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 2, i32 3>
   %v$1_1 = call <2 x $2> $3(<2 x $2> %$1_1a, <2 x $2> %$1_1b)
-  %$1_2a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 4, i32 5>
-  %$1_2b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 4, i32 5>
+  %$1_2a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 4, i32 5>
+  %$1_2b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 4, i32 5>
   %v$1_2 = call <2 x $2> $3(<2 x $2> %$1_2a, <2 x $2> %$1_2b)
-  %$1_3a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 6, i32 7>
-  %$1_3b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 6, i32 7>
+  %$1_3a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 6, i32 7>
+  %$1_3b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 6, i32 7>
   %v$1_3 = call <2 x $2> $3(<2 x $2> %$1_3a, <2 x $2> %$1_3b)
-  %$1_4a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 8, i32 9>
-  %$1_4b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 8, i32 9>
+  %$1_4a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 8, i32 9>
+  %$1_4b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 8, i32 9>
   %v$1_4 = call <2 x $2> $3(<2 x $2> %$1_4a, <2 x $2> %$1_4b)
-  %$1_5a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 10, i32 11>
-  %$1_5b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 10, i32 11>
+  %$1_5a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 10, i32 11>
+  %$1_5b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 10, i32 11>
   %v$1_5 = call <2 x $2> $3(<2 x $2> %$1_5a, <2 x $2> %$1_5b)
-  %$1_6a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 12, i32 13>
-  %$1_6b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 12, i32 13>
+  %$1_6a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 12, i32 13>
+  %$1_6b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 12, i32 13>
   %v$1_6 = call <2 x $2> $3(<2 x $2> %$1_6a, <2 x $2> %$1_6b)
-  %$1_7a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 14, i32 15>
-  %$1_7b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 14, i32 15>
+  %$1_7a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 14, i32 15>
+  %$1_7b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 14, i32 15>
   %v$1_7 = call <2 x $2> $3(<2 x $2> %$1_7a, <2 x $2> %$1_7b)
 
   %$1a = shufflevector <2 x $2> %v$1_0, <2 x $2> %v$1_1,
@@ -1031,8 +1031,8 @@ define(`binary2to16', `
 ;; which is inconsistent with the macros above
 
 define(`round4to8', `
-%v0 = shufflevector <8 x float> $1, <8 x float> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-%v1 = shufflevector <8 x float> $1, <8 x float> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+%v0 = shufflevector <8 x float> $1, <8 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+%v1 = shufflevector <8 x float> $1, <8 x float> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 %r0 = call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %v0, i32 $2)
 %r1 = call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %v1, i32 $2)
 %ret = shufflevector <4 x float> %r0, <4 x float> %r1,
@@ -1042,10 +1042,10 @@ ret <8 x float> %ret
 )
 
 define(`round4to16', `
-%v0 = shufflevector <16 x float> $1, <16 x float> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-%v1 = shufflevector <16 x float> $1, <16 x float> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-%v2 = shufflevector <16 x float> $1, <16 x float> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-%v3 = shufflevector <16 x float> $1, <16 x float> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+%v0 = shufflevector <16 x float> $1, <16 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+%v1 = shufflevector <16 x float> $1, <16 x float> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+%v2 = shufflevector <16 x float> $1, <16 x float> poison, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+%v3 = shufflevector <16 x float> $1, <16 x float> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 %r0 = call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %v0, i32 $2)
 %r1 = call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %v1, i32 $2)
 %r2 = call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %v2, i32 $2)
@@ -1062,9 +1062,9 @@ ret <16 x float> %ret
 )
 
 define(`round8to16', `
-%v0 = shufflevector <16 x float> $1, <16 x float> undef,
+%v0 = shufflevector <16 x float> $1, <16 x float> poison,
         <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-%v1 = shufflevector <16 x float> $1, <16 x float> undef,
+%v1 = shufflevector <16 x float> $1, <16 x float> poison,
         <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 %r0 = call <8 x float> @llvm.x86.avx.round.ps.256(<8 x float> %v0, i32 $2)
 %r1 = call <8 x float> @llvm.x86.avx.round.ps.256(<8 x float> %v1, i32 $2)
@@ -1076,8 +1076,8 @@ ret <16 x float> %ret
 )
 
 define(`round4to8double', `
-%v0 = shufflevector <8 x double> $1, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-%v1 = shufflevector <8 x double> $1, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+%v0 = shufflevector <8 x double> $1, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+%v1 = shufflevector <8 x double> $1, <8 x double> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 %r0 = call <4 x double> @llvm.x86.avx.round.pd.256(<4 x double> %v0, i32 $2)
 %r1 = call <4 x double> @llvm.x86.avx.round.pd.256(<4 x double> %v1, i32 $2)
 %ret = shufflevector <4 x double> %r0, <4 x double> %r1,
@@ -1089,8 +1089,8 @@ ret <8 x double> %ret
 ; and similarly for doubles...
 
 define(`round2to4double', `
-%v0 = shufflevector <4 x double> $1, <4 x double> undef, <2 x i32> <i32 0, i32 1>
-%v1 = shufflevector <4 x double> $1, <4 x double> undef, <2 x i32> <i32 2, i32 3>
+%v0 = shufflevector <4 x double> $1, <4 x double> poison, <2 x i32> <i32 0, i32 1>
+%v1 = shufflevector <4 x double> $1, <4 x double> poison, <2 x i32> <i32 2, i32 3>
 %r0 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v0, i32 $2)
 %r1 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v1, i32 $2)
 %ret = shufflevector <2 x double> %r0, <2 x double> %r1,
@@ -1100,10 +1100,10 @@ ret <4 x double> %ret
 )
 
 define(`round2to8double', `
-%v0 = shufflevector <8 x double> $1, <8 x double> undef, <2 x i32> <i32 0, i32 1>
-%v1 = shufflevector <8 x double> $1, <8 x double> undef, <2 x i32> <i32 2, i32 3>
-%v2 = shufflevector <8 x double> $1, <8 x double> undef, <2 x i32> <i32 4, i32 5>
-%v3 = shufflevector <8 x double> $1, <8 x double> undef, <2 x i32> <i32 6, i32 7>
+%v0 = shufflevector <8 x double> $1, <8 x double> poison, <2 x i32> <i32 0, i32 1>
+%v1 = shufflevector <8 x double> $1, <8 x double> poison, <2 x i32> <i32 2, i32 3>
+%v2 = shufflevector <8 x double> $1, <8 x double> poison, <2 x i32> <i32 4, i32 5>
+%v3 = shufflevector <8 x double> $1, <8 x double> poison, <2 x i32> <i32 6, i32 7>
 %r0 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v0, i32 $2)
 %r1 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v1, i32 $2)
 %r2 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v2, i32 $2)
@@ -1119,14 +1119,14 @@ ret <8 x double> %ret
 )
 
 define(`round2to16double', `
-%v0 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 0,  i32 1>
-%v1 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 2,  i32 3>
-%v2 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 4,  i32 5>
-%v3 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 6,  i32 7>
-%v4 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 8,  i32 9>
-%v5 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 10, i32 11>
-%v6 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 12, i32 13>
-%v7 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 14, i32 15>
+%v0 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 0,  i32 1>
+%v1 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 2,  i32 3>
+%v2 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 4,  i32 5>
+%v3 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 6,  i32 7>
+%v4 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 8,  i32 9>
+%v5 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 10, i32 11>
+%v6 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 12, i32 13>
+%v7 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 14, i32 15>
 %r0 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v0, i32 $2)
 %r1 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v1, i32 $2)
 %r2 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v2, i32 $2)
@@ -1155,13 +1155,13 @@ ret <16 x double> %ret
 )
 
 define(`round4to16double', `
-%v0 = shufflevector <16 x double> $1, <16 x double> undef,
+%v0 = shufflevector <16 x double> $1, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-%v1 = shufflevector <16 x double> $1, <16 x double> undef,
+%v1 = shufflevector <16 x double> $1, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-%v2 = shufflevector <16 x double> $1, <16 x double> undef,
+%v2 = shufflevector <16 x double> $1, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-%v3 = shufflevector <16 x double> $1, <16 x double> undef,
+%v3 = shufflevector <16 x double> $1, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 %r0 = call <4 x double> @llvm.x86.avx.round.pd.256(<4 x double> %v0, i32 $2)
 %r1 = call <4 x double> @llvm.x86.avx.round.pd.256(<4 x double> %v1, i32 $2)
@@ -1291,8 +1291,8 @@ define <WIDTH x double> @__trunc_varying_double(<WIDTH x double> %val) {
 define(`shuffles', `
 define <WIDTH x $1> @__broadcast_$1(<WIDTH x $1>, i32) nounwind readnone alwaysinline {
   %v = extractelement <WIDTH x $1> %0, i32 %1
-  %broadcast_init = insertelement <WIDTH x $1> undef, $1 %v, i32 0
-  %broadcast = shufflevector <WIDTH x $1> %broadcast_init, <WIDTH x $1> undef, <WIDTH x i32> zeroinitializer
+  %broadcast_init = insertelement <WIDTH x $1> poison, $1 %v, i32 0
+  %broadcast = shufflevector <WIDTH x $1> %broadcast_init, <WIDTH x $1> poison, <WIDTH x i32> zeroinitializer
   ret <WIDTH x $1> %broadcast
 }
 
@@ -1308,7 +1308,7 @@ forloop(i, 0, eval(WIDTH-1), `
   %delta_clamped_`'i = and i32 %delta_`'i, eval(WIDTH-1)
   %v_`'i = extractelement <WIDTH x $1> %0, i32 %delta_clamped_`'i')
 
-  %ret_0 = insertelement <WIDTH x $1> undef, $1 %v_0, i32 0
+  %ret_0 = insertelement <WIDTH x $1> poison, $1 %v_0, i32 0
 forloop(i, 1, eval(WIDTH-1), `  %ret_`'i = insertelement <WIDTH x $1> %ret_`'eval(i-1), $1 %v_`'i, i32 i
 ')
   ret <WIDTH x $1> %ret_`'eval(WIDTH-1)
@@ -1353,7 +1353,7 @@ forloop(i, 0, eval(WIDTH-1), `
 forloop(i, 0, eval(WIDTH-1), `
   %v_`'i = extractelement <WIDTH x $1> %0, i32 %index_`'i')
 
-  %ret_0 = insertelement <WIDTH x $1> undef, $1 %v_0, i32 0
+  %ret_0 = insertelement <WIDTH x $1> poison, $1 %v_0, i32 0
 forloop(i, 1, eval(WIDTH-1), `  %ret_`'i = insertelement <WIDTH x $1> %ret_`'eval(i-1), $1 %v_`'i, i32 i
 ')
   ret <WIDTH x $1> %ret_`'eval(WIDTH-1)
@@ -1376,7 +1376,7 @@ is_const:
 forloop(i, 0, eval(WIDTH-1), `
   %v_`'i = extractelement <eval(2*WIDTH) x $1> %v2, i32 %index_`'i')
 
-  %ret_0 = insertelement <WIDTH x $1> undef, $1 %v_0, i32 0
+  %ret_0 = insertelement <WIDTH x $1> poison, $1 %v_0, i32 0
 forloop(i, 1, eval(WIDTH-1), `  %ret_`'i = insertelement <WIDTH x $1> %ret_`'eval(i-1), $1 %v_`'i, i32 i
 ')
   ret <WIDTH x $1> %ret_`'eval(WIDTH-1)
@@ -1389,7 +1389,7 @@ not_const:
 
   %ptr_0 = getelementptr PTR_OP_ARGS(`$1') %baseptr, i32 %index_0
   %val_0 = load PTR_OP_ARGS(`$1 ')  %ptr_0
-  %result_0 = insertelement <WIDTH x $1> undef, $1 %val_0, i32 0
+  %result_0 = insertelement <WIDTH x $1> poison, $1 %val_0, i32 0
 
 forloop(i, 1, eval(WIDTH-1), `
   %ptr_`'i = getelementptr PTR_OP_ARGS(`$1') %baseptr, i32 %index_`'i
@@ -1514,8 +1514,8 @@ define <$1 x $3> @__atomic_$2_$4_global(i8* %ptr, <$1 x $3> %val,
     %dst = alloca <$1 x $3>
     %dst_load = load <$1 x $3>, <$1 x $3>* %dst
     %ptr_to_int = ptrtoint i8* %ptr to i64
-    %base = insertelement <WIDTH x i64> undef, i64 %ptr_to_int, i32 0
-    %shuffle = shufflevector <WIDTH x i64> %base, <WIDTH x i64> undef, <WIDTH x i32> zeroinitializer
+    %base = insertelement <WIDTH x i64> poison, i64 %ptr_to_int, i32 0
+    %shuffle = shufflevector <WIDTH x i64> %base, <WIDTH x i64> poison, <WIDTH x i32> zeroinitializer
     %res = call <$1 x $3> @llvm.genx.svm.atomic.$2.XE_SUFFIX($3).XE_SUFFIX(i1).XE_SUFFIX(i64)(<$1 x i1> %m, <$1 x i64> %shuffle, <$1 x $3> %val, <$1 x $3> %dst_load)
   ',`
     %ret_ptr = alloca <$1 x $3>
@@ -1629,8 +1629,8 @@ define <$1 x $2> @__atomic_compare_exchange_$3_global(i8* %ptr, <$1 x $2> %cmp,
     %dst = alloca <$1 x $2>
     %dst_load = load <$1 x $2>, <$1 x $2>* %dst
     %ptr_to_int = ptrtoint i8* %ptr to i64
-    %base = insertelement <WIDTH x i64> undef, i64 %ptr_to_int, i32 0
-    %shuffle = shufflevector <WIDTH x i64> %base, <WIDTH x i64> undef, <WIDTH x i32> zeroinitializer
+    %base = insertelement <WIDTH x i64> poison, i64 %ptr_to_int, i32 0
+    %shuffle = shufflevector <WIDTH x i64> %base, <WIDTH x i64> poison, <WIDTH x i32> zeroinitializer
     %res = call <$1 x $2> @llvm.genx.svm.atomic.cmpxchg.XE_SUFFIX($2).XE_SUFFIX(i1).XE_SUFFIX(i64)(<$1 x i1> %mask, <$1 x i64> %shuffle, <$1 x $2> %val, <$1 x $2> %cmp, <$1 x $2> %dst_load)
   ',`
     %ret_ptr = alloca <$1 x $2>
@@ -1991,7 +1991,7 @@ define void
   store <4 x float> %r1, <4 x float> * %out1
 
   %t2 = shufflevector <4 x float> %v0, <4 x float> %v1, ; z0 z1 x x
-    <4 x i32> <i32 2, i32 5, i32 undef, i32 undef>
+    <4 x i32> <i32 2, i32 5, i32 poison, i32 poison>
 
   %r2 = shufflevector <4 x float> %t2, <4 x float> %v2, ; z0 z1 z2 z3
     <4 x i32> <i32 0, i32 1, i32 4, i32 7>
@@ -2021,7 +2021,7 @@ define void
   store <4 x float> %r1, <4 x float> * %out1
 
   %t2 = shufflevector <4 x float> %v0, <4 x float> %v1, ; x3 y3 x x
-    <4 x i32> <i32 3, i32 7, i32 undef, i32 undef>
+    <4 x i32> <i32 3, i32 7, i32 poison, i32 poison>
 
   %r2 = shufflevector <4 x float> %t2, <4 x float> %v2, ; z2 x3 y3 z3
     <4 x i32> <i32 6, i32 0, i32 1, i32 7>
@@ -2047,7 +2047,7 @@ define void
   store <4 x double> %r1, <4 x double> * %out1
 
   %t2 = shufflevector <4 x double> %v0, <4 x double> %v1, ; z0 z1 x x
-    <4 x i32> <i32 2, i32 5, i32 undef, i32 undef>
+    <4 x i32> <i32 2, i32 5, i32 poison, i32 poison>
 
   %r2 = shufflevector <4 x double> %t2, <4 x double> %v2, ; z0 z1 z2 z3
     <4 x i32> <i32 0, i32 1, i32 4, i32 7>
@@ -2072,7 +2072,7 @@ define void
   store <4 x double> %r1, <4 x double> * %out1
 
   %t2 = shufflevector <4 x double> %v0, <4 x double> %v1, ; x3 y3 x x
-    <4 x i32> <i32 3, i32 7, i32 undef, i32 undef>
+    <4 x i32> <i32 3, i32 7, i32 poison, i32 poison>
 
   %r2 = shufflevector <4 x double> %t2, <4 x double> %v2, ; z2 x3 y3 z3
     <4 x i32> <i32 6, i32 0, i32 1, i32 7>
@@ -2158,21 +2158,21 @@ define void
         <8 x float> * noalias %out1, <8 x float> * noalias %out2,
         <8 x float> * noalias %out3) nounwind alwaysinline {
   ;; Split each 8-vector into 2 4-vectors
-  %v0a = shufflevector <8 x float> %v0, <8 x float> undef,
+  %v0a = shufflevector <8 x float> %v0, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <8 x float> %v0, <8 x float> undef,
+  %v0b = shufflevector <8 x float> %v0, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1a = shufflevector <8 x float> %v1, <8 x float> undef,
+  %v1a = shufflevector <8 x float> %v1, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <8 x float> %v1, <8 x float> undef,
+  %v1b = shufflevector <8 x float> %v1, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2a = shufflevector <8 x float> %v2, <8 x float> undef,
+  %v2a = shufflevector <8 x float> %v2, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <8 x float> %v2, <8 x float> undef,
+  %v2b = shufflevector <8 x float> %v2, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v3a = shufflevector <8 x float> %v3, <8 x float> undef,
+  %v3a = shufflevector <8 x float> %v3, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v3b = shufflevector <8 x float> %v3, <8 x float> undef,
+  %v3b = shufflevector <8 x float> %v3, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   ;; Similarly for the output pointers
@@ -2208,21 +2208,21 @@ define void
         <8 x float> * noalias %out1, <8 x float> * noalias %out2,
         <8 x float> * noalias %out3) nounwind alwaysinline {
   ;; As above, split into 4-vectors and 4-wide outputs...
-  %v0a = shufflevector <8 x float> %v0, <8 x float> undef,
+  %v0a = shufflevector <8 x float> %v0, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <8 x float> %v0, <8 x float> undef,
+  %v0b = shufflevector <8 x float> %v0, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1a = shufflevector <8 x float> %v1, <8 x float> undef,
+  %v1a = shufflevector <8 x float> %v1, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <8 x float> %v1, <8 x float> undef,
+  %v1b = shufflevector <8 x float> %v1, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2a = shufflevector <8 x float> %v2, <8 x float> undef,
+  %v2a = shufflevector <8 x float> %v2, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <8 x float> %v2, <8 x float> undef,
+  %v2b = shufflevector <8 x float> %v2, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v3a = shufflevector <8 x float> %v3, <8 x float> undef,
+  %v3a = shufflevector <8 x float> %v3, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v3b = shufflevector <8 x float> %v3, <8 x float> undef,
+  %v3b = shufflevector <8 x float> %v3, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   %out0a = bitcast <8 x float> * %out0 to <4 x float> *
@@ -2256,21 +2256,21 @@ define void
         <8 x double> * noalias %out1, <8 x double> * noalias %out2,
         <8 x double> * noalias %out3) nounwind alwaysinline {
   ;; Split each 8-vector into 2 4-vectors
-  %v0a = shufflevector <8 x double> %v0, <8 x double> undef,
+  %v0a = shufflevector <8 x double> %v0, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <8 x double> %v0, <8 x double> undef,
+  %v0b = shufflevector <8 x double> %v0, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1a = shufflevector <8 x double> %v1, <8 x double> undef,
+  %v1a = shufflevector <8 x double> %v1, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <8 x double> %v1, <8 x double> undef,
+  %v1b = shufflevector <8 x double> %v1, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2a = shufflevector <8 x double> %v2, <8 x double> undef,
+  %v2a = shufflevector <8 x double> %v2, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <8 x double> %v2, <8 x double> undef,
+  %v2b = shufflevector <8 x double> %v2, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v3a = shufflevector <8 x double> %v3, <8 x double> undef,
+  %v3a = shufflevector <8 x double> %v3, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v3b = shufflevector <8 x double> %v3, <8 x double> undef,
+  %v3b = shufflevector <8 x double> %v3, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   ;; Similarly for the output pointers
@@ -2305,21 +2305,21 @@ define void
         <8 x double> * noalias %out1, <8 x double> * noalias %out2,
         <8 x double> * noalias %out3) nounwind alwaysinline {
   ;; As above, split into 4-vectors and 4-wide outputs...
-  %v0a = shufflevector <8 x double> %v0, <8 x double> undef,
+  %v0a = shufflevector <8 x double> %v0, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <8 x double> %v0, <8 x double> undef,
+  %v0b = shufflevector <8 x double> %v0, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1a = shufflevector <8 x double> %v1, <8 x double> undef,
+  %v1a = shufflevector <8 x double> %v1, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <8 x double> %v1, <8 x double> undef,
+  %v1b = shufflevector <8 x double> %v1, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2a = shufflevector <8 x double> %v2, <8 x double> undef,
+  %v2a = shufflevector <8 x double> %v2, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <8 x double> %v2, <8 x double> undef,
+  %v2b = shufflevector <8 x double> %v2, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v3a = shufflevector <8 x double> %v3, <8 x double> undef,
+  %v3a = shufflevector <8 x double> %v3, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v3b = shufflevector <8 x double> %v3, <8 x double> undef,
+  %v3b = shufflevector <8 x double> %v3, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   %out0a = bitcast <8 x double> * %out0 to <4 x double> *
@@ -2351,17 +2351,17 @@ define void
 @__aos_to_soa3_float8(<8 x float> %v0, <8 x float> %v1, <8 x float> %v2,
         <8 x float> * noalias %out0, <8 x float> * noalias %out1,
         <8 x float> * noalias %out2) nounwind alwaysinline {
-  %v0a = shufflevector <8 x float> %v0, <8 x float> undef,
+  %v0a = shufflevector <8 x float> %v0, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <8 x float> %v0, <8 x float> undef,
+  %v0b = shufflevector <8 x float> %v0, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1a = shufflevector <8 x float> %v1, <8 x float> undef,
+  %v1a = shufflevector <8 x float> %v1, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <8 x float> %v1, <8 x float> undef,
+  %v1b = shufflevector <8 x float> %v1, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2a = shufflevector <8 x float> %v2, <8 x float> undef,
+  %v2a = shufflevector <8 x float> %v2, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <8 x float> %v2, <8 x float> undef,
+  %v2b = shufflevector <8 x float> %v2, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   %out0a = bitcast <8 x float> * %out0 to <4 x float> *
@@ -2385,17 +2385,17 @@ define void
 @__soa_to_aos3_float8(<8 x float> %v0, <8 x float> %v1, <8 x float> %v2,
         <8 x float> * noalias %out0, <8 x float> * noalias %out1,
         <8 x float> * noalias %out2) nounwind alwaysinline {
-  %v0a = shufflevector <8 x float> %v0, <8 x float> undef,
+  %v0a = shufflevector <8 x float> %v0, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <8 x float> %v0, <8 x float> undef,
+  %v0b = shufflevector <8 x float> %v0, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1a = shufflevector <8 x float> %v1, <8 x float> undef,
+  %v1a = shufflevector <8 x float> %v1, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <8 x float> %v1, <8 x float> undef,
+  %v1b = shufflevector <8 x float> %v1, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2a = shufflevector <8 x float> %v2, <8 x float> undef,
+  %v2a = shufflevector <8 x float> %v2, <8 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <8 x float> %v2, <8 x float> undef,
+  %v2b = shufflevector <8 x float> %v2, <8 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   %out0a = bitcast <8 x float> * %out0 to <4 x float> *
@@ -2419,17 +2419,17 @@ define void
 @__aos_to_soa3_double8(<8 x double> %v0, <8 x double> %v1, <8 x double> %v2,
         <8 x double> * noalias %out0, <8 x double> * noalias %out1,
         <8 x double> * noalias %out2) nounwind alwaysinline {
-  %v0a = shufflevector <8 x double> %v0, <8 x double> undef,
+  %v0a = shufflevector <8 x double> %v0, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <8 x double> %v0, <8 x double> undef,
+  %v0b = shufflevector <8 x double> %v0, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1a = shufflevector <8 x double> %v1, <8 x double> undef,
+  %v1a = shufflevector <8 x double> %v1, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <8 x double> %v1, <8 x double> undef,
+  %v1b = shufflevector <8 x double> %v1, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2a = shufflevector <8 x double> %v2, <8 x double> undef,
+  %v2a = shufflevector <8 x double> %v2, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <8 x double> %v2, <8 x double> undef,
+  %v2b = shufflevector <8 x double> %v2, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   %out0a = bitcast <8 x double> * %out0 to <4 x double> *
@@ -2453,17 +2453,17 @@ define void
 @__soa_to_aos3_double8(<8 x double> %v0, <8 x double> %v1, <8 x double> %v2,
         <8 x double> * noalias %out0, <8 x double> * noalias %out1,
         <8 x double> * noalias %out2) nounwind alwaysinline {
-  %v0a = shufflevector <8 x double> %v0, <8 x double> undef,
+  %v0a = shufflevector <8 x double> %v0, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <8 x double> %v0, <8 x double> undef,
+  %v0b = shufflevector <8 x double> %v0, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1a = shufflevector <8 x double> %v1, <8 x double> undef,
+  %v1a = shufflevector <8 x double> %v1, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <8 x double> %v1, <8 x double> undef,
+  %v1b = shufflevector <8 x double> %v1, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2a = shufflevector <8 x double> %v2, <8 x double> undef,
+  %v2a = shufflevector <8 x double> %v2, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <8 x double> %v2, <8 x double> undef,
+  %v2b = shufflevector <8 x double> %v2, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   %out0a = bitcast <8 x double> * %out0 to <4 x double> *
@@ -2577,37 +2577,37 @@ define void
         <16 x float> %v3, <16 x float> * noalias %out0,
         <16 x float> * noalias %out1, <16 x float> * noalias %out2,
         <16 x float> * noalias %out3) nounwind alwaysinline {
-  %v0a = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0a = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0b = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v0c = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0c = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v0d = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0d = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v1a = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1a = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1b = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1c = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1c = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v1d = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1d = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v2a = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2a = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2b = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2c = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2c = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v2d = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2d = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v3a = shufflevector <16 x float> %v3, <16 x float> undef,
+  %v3a = shufflevector <16 x float> %v3, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v3b = shufflevector <16 x float> %v3, <16 x float> undef,
+  %v3b = shufflevector <16 x float> %v3, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v3c = shufflevector <16 x float> %v3, <16 x float> undef,
+  %v3c = shufflevector <16 x float> %v3, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v3d = shufflevector <16 x float> %v3, <16 x float> undef,
+  %v3d = shufflevector <16 x float> %v3, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 
   %out0a = bitcast <16 x float> * %out0 to <4 x float> *
@@ -2648,37 +2648,37 @@ define void
         <16 x float> %v3, <16 x float> * noalias %out0,
         <16 x float> * noalias %out1, <16 x float> * noalias %out2,
         <16 x float> * noalias %out3) nounwind alwaysinline {
-  %v0a = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0a = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0b = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v0c = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0c = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v0d = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0d = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v1a = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1a = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1b = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1c = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1c = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v1d = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1d = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v2a = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2a = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2b = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2c = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2c = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v2d = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2d = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v3a = shufflevector <16 x float> %v3, <16 x float> undef,
+  %v3a = shufflevector <16 x float> %v3, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v3b = shufflevector <16 x float> %v3, <16 x float> undef,
+  %v3b = shufflevector <16 x float> %v3, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v3c = shufflevector <16 x float> %v3, <16 x float> undef,
+  %v3c = shufflevector <16 x float> %v3, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v3d = shufflevector <16 x float> %v3, <16 x float> undef,
+  %v3d = shufflevector <16 x float> %v3, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 
   %out0a = bitcast <16 x float> * %out0 to <4 x float> *
@@ -2719,37 +2719,37 @@ define void
         <16 x double> %v3, <16 x double> * noalias %out0,
         <16 x double> * noalias %out1, <16 x double> * noalias %out2,
         <16 x double> * noalias %out3) nounwind alwaysinline {
-  %v0a = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0a = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0b = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v0c = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0c = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v0d = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0d = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v1a = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1a = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1b = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1c = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1c = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v1d = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1d = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v2a = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2a = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2b = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2c = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2c = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v2d = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2d = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v3a = shufflevector <16 x double> %v3, <16 x double> undef,
+  %v3a = shufflevector <16 x double> %v3, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v3b = shufflevector <16 x double> %v3, <16 x double> undef,
+  %v3b = shufflevector <16 x double> %v3, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v3c = shufflevector <16 x double> %v3, <16 x double> undef,
+  %v3c = shufflevector <16 x double> %v3, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v3d = shufflevector <16 x double> %v3, <16 x double> undef,
+  %v3d = shufflevector <16 x double> %v3, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 
   %out0a = bitcast <16 x double> * %out0 to <4 x double> *
@@ -2789,37 +2789,37 @@ define void
         <16 x double> %v3, <16 x double> * noalias %out0,
         <16 x double> * noalias %out1, <16 x double> * noalias %out2,
         <16 x double> * noalias %out3) nounwind alwaysinline {
-  %v0a = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0a = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0b = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v0c = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0c = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v0d = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0d = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v1a = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1a = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1b = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1c = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1c = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v1d = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1d = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v2a = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2a = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2b = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2c = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2c = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v2d = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2d = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v3a = shufflevector <16 x double> %v3, <16 x double> undef,
+  %v3a = shufflevector <16 x double> %v3, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v3b = shufflevector <16 x double> %v3, <16 x double> undef,
+  %v3b = shufflevector <16 x double> %v3, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v3c = shufflevector <16 x double> %v3, <16 x double> undef,
+  %v3c = shufflevector <16 x double> %v3, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v3d = shufflevector <16 x double> %v3, <16 x double> undef,
+  %v3d = shufflevector <16 x double> %v3, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 
   %out0a = bitcast <16 x double> * %out0 to <4 x double> *
@@ -2858,29 +2858,29 @@ define void
 @__aos_to_soa3_float16(<16 x float> %v0, <16 x float> %v1, <16 x float> %v2,
         <16 x float> * noalias %out0, <16 x float> * noalias %out1,
         <16 x float> * noalias %out2) nounwind alwaysinline {
-  %v0a = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0a = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0b = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v0c = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0c = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v0d = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0d = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v1a = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1a = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1b = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1c = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1c = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v1d = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1d = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v2a = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2a = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2b = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2c = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2c = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v2d = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2d = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 
   %out0a = bitcast <16 x float> * %out0 to <4 x float> *
@@ -2916,29 +2916,29 @@ define void
 @__soa_to_aos3_float16(<16 x float> %v0, <16 x float> %v1, <16 x float> %v2,
         <16 x float> * noalias %out0, <16 x float> * noalias %out1,
         <16 x float> * noalias %out2) nounwind alwaysinline {
-  %v0a = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0a = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0b = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v0c = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0c = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v0d = shufflevector <16 x float> %v0, <16 x float> undef,
+  %v0d = shufflevector <16 x float> %v0, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v1a = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1a = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1b = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1c = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1c = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v1d = shufflevector <16 x float> %v1, <16 x float> undef,
+  %v1d = shufflevector <16 x float> %v1, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v2a = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2a = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2b = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2c = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2c = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v2d = shufflevector <16 x float> %v2, <16 x float> undef,
+  %v2d = shufflevector <16 x float> %v2, <16 x float> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 
   %out0a = bitcast <16 x float> * %out0 to <4 x float> *
@@ -2974,29 +2974,29 @@ define void
 @__aos_to_soa3_double16(<16 x double> %v0, <16 x double> %v1, <16 x double> %v2,
         <16 x double> * noalias %out0, <16 x double> * noalias %out1,
         <16 x double> * noalias %out2) nounwind alwaysinline {
-  %v0a = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0a = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0b = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v0c = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0c = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v0d = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0d = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v1a = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1a = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1b = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1c = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1c = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v1d = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1d = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v2a = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2a = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2b = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2c = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2c = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v2d = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2d = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 
   %out0a = bitcast <16 x double> * %out0 to <4 x double> *
@@ -3032,29 +3032,29 @@ define void
 @__soa_to_aos3_double16(<16 x double> %v0, <16 x double> %v1, <16 x double> %v2,
         <16 x double> * noalias %out0, <16 x double> * noalias %out1,
         <16 x double> * noalias %out2) nounwind alwaysinline {
-  %v0a = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0a = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0b = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v0c = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0c = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v0d = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0d = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v1a = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1a = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1b = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1c = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1c = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v1d = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1d = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v2a = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2a = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2b = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2c = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2c = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v2d = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2d = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 
   %out0a = bitcast <16 x double> * %out0 to <4 x double> *
@@ -3415,10 +3415,10 @@ define void
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
   store <32 x float> %r1, <32 x float> * %out1
 
-  ;; t2 = <c0 ... c20 undef ... undef>
+  ;; t2 = <c0 ... c20 poison ... poison>
   %t2 = shufflevector <32 x float> %v0, <32 x float> %v1,
           <32 x i32> <i32 2, i32 5, i32 8, i32 11, i32 14, i32 17, i32 20, i32 23, i32 26, i32 29, i32 32, i32 35, i32 38, i32 41, i32 44, i32 47,
-                      i32 50, i32 53, i32 56, i32 59, i32 62, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 50, i32 53, i32 56, i32 59, i32 62, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 
   ;; Produce output vector
   %r2 = shufflevector <32 x float> %t2, <32 x float> %v2,
@@ -3460,10 +3460,10 @@ define void
                       i32 16, i32 38, i32 59, i32 17, i32 39, i32 60, i32 18, i32 40, i32 61, i32 19, i32 41, i32 62, i32 20, i32 42, i32 63, i32 21>
   store <32 x float> %r1, <32 x float> * %out1
 
-  ;; t2 = <a22 ... a31 b21 ... b31 undef ... undef>
+  ;; t2 = <a22 ... a31 b21 ... b31 poison ... poison>
   %t2 = shufflevector <32 x float> %v0, <32 x float> %v1,
           <32 x i32> <i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58,
-                      i32 59, i32 60, i32 61, i32 62, i32 63, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 59, i32 60, i32 61, i32 62, i32 63, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   ;; Produce output vector
   %r2 = shufflevector <32 x float> %t2, <32 x float> %v2,
           <32 x i32> <i32 10, i32 53, i32 0, i32 11, i32 54, i32 1, i32 12, i32 55, i32 2, i32 13, i32 56, i32 3, i32 14, i32 57, i32 4, i32 15,
@@ -3504,10 +3504,10 @@ define void
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
   store <32 x double> %r1, <32 x double> * %out1
 
-  ;; t2 = <c0 ... c20 undef ... undef>
+  ;; t2 = <c0 ... c20 poison ... poison>
   %t2 = shufflevector <32 x double> %v0, <32 x double> %v1,
           <32 x i32> <i32 2, i32 5, i32 8, i32 11, i32 14, i32 17, i32 20, i32 23, i32 26, i32 29, i32 32, i32 35, i32 38, i32 41, i32 44, i32 47,
-                      i32 50, i32 53, i32 56, i32 59, i32 62, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 50, i32 53, i32 56, i32 59, i32 62, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 
   ;; Produce output vector
   %r2 = shufflevector <32 x double> %t2, <32 x double> %v2,
@@ -3549,10 +3549,10 @@ define void
                       i32 16, i32 38, i32 59, i32 17, i32 39, i32 60, i32 18, i32 40, i32 61, i32 19, i32 41, i32 62, i32 20, i32 42, i32 63, i32 21>
   store <32 x double> %r1, <32 x double> * %out1
 
-  ;; t2 = <a22 ... a31 b21 ... b31 undef ... undef>
+  ;; t2 = <a22 ... a31 b21 ... b31 poison ... poison>
   %t2 = shufflevector <32 x double> %v0, <32 x double> %v1,
           <32 x i32> <i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58,
-                      i32 59, i32 60, i32 61, i32 62, i32 63, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 59, i32 60, i32 61, i32 62, i32 63, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   ;; Produce output vector
   %r2 = shufflevector <32 x double> %t2, <32 x double> %v2,
           <32 x i32> <i32 10, i32 53, i32 0, i32 11, i32 54, i32 1, i32 12, i32 55, i32 2, i32 13, i32 56, i32 3, i32 14, i32 57, i32 4, i32 15,
@@ -4008,11 +4008,11 @@ define double @__doublebits_uniform_int64(i64) nounwind readnone alwaysinline {
 }
 
 define <WIDTH x float> @__undef_varying() nounwind readnone alwaysinline {
-  ret <WIDTH x float> undef
+  ret <WIDTH x float> poison
 }
 
 define float @__undef_uniform() nounwind readnone alwaysinline {
-  ret float undef
+  ret float poison
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -5291,9 +5291,9 @@ domixed:
   %first = call i64 @__count_trailing_zeros_uniform_i64(i64 %mm)
   %first32 = trunc i64 %first to i32
   %baseval = extractelement <$1 x $2> %v, i32 %first32
-  %basev1 = insertelement <$1 x $2> undef, $2 %baseval, i32 0
+  %basev1 = insertelement <$1 x $2> poison, $2 %baseval, i32 0
   ; get a vector that is that value smeared across all elements
-  %basesmear = shufflevector <$1 x $2> %basev1, <$1 x $2> undef,
+  %basesmear = shufflevector <$1 x $2> %basev1, <$1 x $2> poison,
         <$1 x i32> < forloop(i, 0, eval($1-2), `i32 0, ') i32 0 >
 
   ; now to a blend of that vector with the original vector, such that the
@@ -5378,7 +5378,7 @@ define <$1 x $2> @__exclusive_scan_$6(<$1 x $2> %v,
   ; first, set the value of any off lanes to the identity value
   %ptr = alloca <$1 x $2>
   %idvec1 = bitcast $2 $5 to <1 x $2>
-  %idvec = shufflevector <1 x $2> %idvec1, <1 x $2> undef,
+  %idvec = shufflevector <1 x $2> %idvec1, <1 x $2> poison,
       <$1 x i32> < forloop(i, 0, eval($1-2), `i32 0, ') i32 0 >
   store <$1 x $2> %idvec, <$1 x $2> * %ptr
   %ptr`'$3 = bitcast <$1 x $2> * %ptr to <$1 x i`'$3> *
@@ -5401,7 +5401,7 @@ define <$1 x $2> @__exclusive_scan_$6(<$1 x $2> %v,
   %s`'i = $4 $2 %s`'eval(i-1), %v`'eval(i-1)')
 
   ; and fill in the result vector
-  %r0 = insertelement <$1 x $2> undef, $2 $5, i32 0  ; 0th element gets identity
+  %r0 = insertelement <$1 x $2> poison, $2 $5, i32 0  ; 0th element gets identity
   forloop(i, 1, eval($1-1), `
   %r`'i = insertelement <$1 x $2> %r`'eval(i-1), $2 %s`'i, i32 i')
 
@@ -5644,7 +5644,7 @@ define <WIDTH x $1> @__gather_factored_base_offsets32_$1(i8 * %ptr, <WIDTH x i32
 
   %ret0 = call <WIDTH x $1> @__gather_elt32_$1(i8 * %ptr, <WIDTH x i32> %newOffsets,
                                             i32 %offset_scale, <WIDTH x i32> %newDelta,
-                                            <WIDTH x $1> undef, i32 0)
+                                            <WIDTH x $1> poison, i32 0)
   forloop(lane, 1, eval(WIDTH-1),
           `patsubst(patsubst(`%retLANE = call <WIDTH x $1> @__gather_elt32_$1(i8 * %ptr,
                                 <WIDTH x i32> %newOffsets, i32 %offset_scale, <WIDTH x i32> %newDelta,
@@ -5675,7 +5675,7 @@ define <WIDTH x $1> @__gather_factored_base_offsets64_$1(i8 * %ptr, <WIDTH x i64
 
   %ret0 = call <WIDTH x $1> @__gather_elt64_$1(i8 * %ptr, <WIDTH x i64> %newOffsets,
                                             i32 %offset_scale, <WIDTH x i64> %newDelta,
-                                            <WIDTH x $1> undef, i32 0)
+                                            <WIDTH x $1> poison, i32 0)
   forloop(lane, 1, eval(WIDTH-1),
           `patsubst(patsubst(`%retLANE = call <WIDTH x $1> @__gather_elt64_$1(i8 * %ptr,
                                 <WIDTH x i64> %newOffsets, i32 %offset_scale, <WIDTH x i64> %newDelta,
@@ -5708,7 +5708,7 @@ define <WIDTH x $1>
                            <WIDTH x i32> %offsets,
                            <WIDTH x MASK> %vecmask) nounwind readonly alwaysinline {
   %scale_vec = bitcast i32 %offset_scale to <1 x i32>
-  %smear_scale = shufflevector <1 x i32> %scale_vec, <1 x i32> undef,
+  %smear_scale = shufflevector <1 x i32> %scale_vec, <1 x i32> poison,
      <WIDTH x i32> < forloop(i, 1, eval(WIDTH-1), `i32 0, ') i32 0 >
   %scaled_offsets = mul <WIDTH x i32> %smear_scale, %offsets
   %v = call <WIDTH x $1> @__gather_factored_base_offsets32_$1(i8 * %ptr, <WIDTH x i32> %scaled_offsets, i32 1,
@@ -5722,7 +5722,7 @@ define <WIDTH x $1>
                             <WIDTH x MASK> %vecmask) nounwind readonly alwaysinline {
   %scale64 = zext i32 %offset_scale to i64
   %scale_vec = bitcast i64 %scale64 to <1 x i64>
-  %smear_scale = shufflevector <1 x i64> %scale_vec, <1 x i64> undef,
+  %smear_scale = shufflevector <1 x i64> %scale_vec, <1 x i64> poison,
      <WIDTH x i32> < forloop(i, 1, eval(WIDTH-1), `i32 0, ') i32 0 >
   %scaled_offsets = mul <WIDTH x i64> %smear_scale, %offsets
   %v = call <WIDTH x $1> @__gather_factored_base_offsets64_$1(i8 * %ptr, <WIDTH x i64> %scaled_offsets,

--- a/builtins/util.m4
+++ b/builtins/util.m4
@@ -95,117 +95,117 @@ define(`reduce_func',
 
 
 define(`convert1to8', `
-  $3 = shufflevector <1 x $1> $2, <1 x $1> undef,
-  <8 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-             i32 undef, i32 undef, i32 undef, i32 undef>
+  $3 = shufflevector <1 x $1> $2, <1 x $1> poison,
+  <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+             i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 
 define(`convert1to16', `
-  $3 = shufflevector <1 x $1> $2, <1 x $1> undef,
-  <16 x i32> <i32 0, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef>
+  $3 = shufflevector <1 x $1> $2, <1 x $1> poison,
+  <16 x i32> <i32 0, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert4to8', `
-  $3 = shufflevector <4 x $1> $2, <4 x $1> undef,
+  $3 = shufflevector <4 x $1> $2, <4 x $1> poison,
   <8 x i32> <i32 0, i32 1, i32 2, i32 3,
-             i32 undef, i32 undef, i32 undef, i32 undef>
+             i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert4to16', `
-  $3 = shufflevector <4 x $1> $2, <4 x $1> undef,
+  $3 = shufflevector <4 x $1> $2, <4 x $1> poison,
   <16 x i32> <i32 0, i32 1, i32 2, i32 3,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef>
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert8to16', `
-  $3 = shufflevector <8 x $1> $2, <8 x $1> undef,
+  $3 = shufflevector <8 x $1> $2, <8 x $1> poison,
   <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef>
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert4to32', `
-  $3 = shufflevector <4 x $1> $2, <4 x $1> undef,
+  $3 = shufflevector <4 x $1> $2, <4 x $1> poison,
   <32 x i32> <i32 0, i32 1, i32 2, i32 3,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef>
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert8to32', `
-  $3 = shufflevector <4 x $1> $2, <4 x $1> undef,
+  $3 = shufflevector <4 x $1> $2, <4 x $1> poison,
   <32 x i32> <i32 0, i32 1, i32 2, i32 3,
               i32 4, i32 5, i32 6, i32 7,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef>
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert16to32', `
-  $3 = shufflevector <4 x $1> $2, <4 x $1> undef,
+  $3 = shufflevector <4 x $1> $2, <4 x $1> poison,
   <32 x i32> <i32  0, i32 1,  i32  2, i32  3,
               i32  4, i32 5,  i32  6, i32  7,
               i32  8, i32 9,  i32 10, i32 11,
               i32 12, i32 13, i32 14, i32 15
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef,
-              i32 undef, i32 undef, i32 undef, i32 undef>
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison,
+              i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert8to1', `
-  $3 = shufflevector <8 x $1> $2, <8 x $1> undef,
+  $3 = shufflevector <8 x $1> $2, <8 x $1> poison,
     <1 x i32> <i32 0>
 ')
 
 
 define(`convert16to1', `
-  $3 = shufflevector <16 x $1> $2, <16 x $1> undef,
+  $3 = shufflevector <16 x $1> $2, <16 x $1> poison,
     <1 x i32> <i32 0>
 ')
 
 define(`convert8to4', `
-  $3 = shufflevector <8 x $1> $2, <8 x $1> undef,
+  $3 = shufflevector <8 x $1> $2, <8 x $1> poison,
     <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ')
 
 
 define(`convert16to4', `
-  $3 = shufflevector <16 x $1> $2, <16 x $1> undef,
+  $3 = shufflevector <16 x $1> $2, <16 x $1> poison,
     <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ')
 
 define(`convert16to8', `
-  $3 = shufflevector <16 x $1> $2, <16 x $1> undef,
+  $3 = shufflevector <16 x $1> $2, <16 x $1> poison,
   <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
 ')
 
 define(`convert32to4', `
-  $3 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $3 = shufflevector <32 x $1> $2, <32 x $1> poison,
     <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ')
 
 define(`convert32to8', `
-  $3 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $3 = shufflevector <32 x $1> $2, <32 x $1> poison,
     <8 x i32> <i32 0, i32 1, i32 2, i32 3,
                i32 4, i32 5, i32 6, i32 7>
 ')
 
 define(`convert32to16', `
-  $3 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $3 = shufflevector <32 x $1> $2, <32 x $1> poison,
     <16 x i32> <i32  0, i32 1,  i32  2, i32  3,
                 i32  4, i32 5,  i32  6, i32  7,
                 i32  8, i32 9,  i32 10, i32 11,
@@ -213,7 +213,7 @@ define(`convert32to16', `
 ')
 
 define(`convert32to64', `
-  $3 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $3 = shufflevector <32 x $1> $2, <32 x $1> poison,
     <64 x i32> <i32  0, i32 1,  i32  2, i32  3,
                 i32  4, i32 5,  i32  6, i32  7,
                 i32  8, i32 9,  i32 10, i32 11,
@@ -222,18 +222,18 @@ define(`convert32to64', `
                 i32 20, i32 21, i32 22, i32 23,
                 i32 24, i32 25, i32 26, i32 27,
                 i32 28, i32 29, i32 30, i32 31,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef,
-                i32 undef, i32 undef, i32 undef, i32 undef>
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison,
+                i32 poison, i32 poison, i32 poison, i32 poison>
 ')
 
 define(`convert64to32', `
-  $3 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $3 = shufflevector <64 x $1> $2, <64 x $1> poison,
     <32 x i32> <i32 0, i32 1, i32 2, i32 3,
                 i32  4, i32 5,  i32  6, i32  7,
                 i32  8, i32 9,  i32 10, i32 11,
@@ -585,29 +585,29 @@ define <16 x i16> @__psubus_vi16(<16 x i16> %a0, <16 x i16> %a1) {
 ;; $4: second 4-wide vector
 
 define(`v8tov4', `
-  $3 = shufflevector <8 x $1> $2, <8 x $1> undef,
+  $3 = shufflevector <8 x $1> $2, <8 x $1> poison,
     <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  $4 = shufflevector <8 x $1> $2, <8 x $1> undef,
+  $4 = shufflevector <8 x $1> $2, <8 x $1> poison,
     <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 ')
 
 define(`v16tov8', `
-  $3 = shufflevector <16 x $1> $2, <16 x $1> undef,
+  $3 = shufflevector <16 x $1> $2, <16 x $1> poison,
     <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  $4 = shufflevector <16 x $1> $2, <16 x $1> undef,
+  $4 = shufflevector <16 x $1> $2, <16 x $1> poison,
     <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 ')
 
 define(`v4tov2', `
-  $3 = shufflevector <4 x $1> $2, <4 x $1> undef, <2 x i32> <i32 0, i32 1>
-  $4 = shufflevector <4 x $1> $2, <4 x $1> undef, <2 x i32> <i32 2, i32 3>
+  $3 = shufflevector <4 x $1> $2, <4 x $1> poison, <2 x i32> <i32 0, i32 1>
+  $4 = shufflevector <4 x $1> $2, <4 x $1> poison, <2 x i32> <i32 2, i32 3>
 ')
 
 define(`v8tov2', `
-  $3 = shufflevector <8 x $1> $2, <8 x $1> undef, <2 x i32> <i32 0, i32 1>
-  $4 = shufflevector <8 x $1> $2, <8 x $1> undef, <2 x i32> <i32 2, i32 3>
-  $5 = shufflevector <8 x $1> $2, <8 x $1> undef, <2 x i32> <i32 4, i32 5>
-  $6 = shufflevector <8 x $1> $2, <8 x $1> undef, <2 x i32> <i32 6, i32 7>
+  $3 = shufflevector <8 x $1> $2, <8 x $1> poison, <2 x i32> <i32 0, i32 1>
+  $4 = shufflevector <8 x $1> $2, <8 x $1> poison, <2 x i32> <i32 2, i32 3>
+  $5 = shufflevector <8 x $1> $2, <8 x $1> poison, <2 x i32> <i32 4, i32 5>
+  $6 = shufflevector <8 x $1> $2, <8 x $1> poison, <2 x i32> <i32 6, i32 7>
 ')
 
 ;; $1: vector element type
@@ -618,19 +618,19 @@ define(`v4tov8', `
 ')
 
 define(`v16tov4', `
-  $3 = shufflevector <16 x $1> $2, <16 x $1> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  $4 = shufflevector <16 x $1> $2, <16 x $1> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  $5 = shufflevector <16 x $1> $2, <16 x $1> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  $6 = shufflevector <16 x $1> $2, <16 x $1> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  $3 = shufflevector <16 x $1> $2, <16 x $1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  $4 = shufflevector <16 x $1> $2, <16 x $1> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  $5 = shufflevector <16 x $1> $2, <16 x $1> poison, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  $6 = shufflevector <16 x $1> $2, <16 x $1> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 ')
 
 ;; $1: vector element type
 ;; $2: input 32-wide vector
 ;; $3-$4: 2 output 16-wide vectors
 define(`v32tov16', `
-  $3 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $3 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  $4 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $4 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
 ')
 
@@ -638,13 +638,13 @@ define(`v32tov16', `
 ;; $2: input 32-wide vector
 ;; $3-$6: 4 output 8-wide vectors
 define(`v32tov8', `
-  $3 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $3 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  $4 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $4 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  $5 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $5 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <8 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  $6 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $6 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <8 x i32> <i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
 ')
 
@@ -652,21 +652,21 @@ define(`v32tov8', `
 ;; $2: input 32-wide vector
 ;; $3-$10: 8 output 4-wide vectors
 define(`v32tov4', `
-  $3 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $3 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  $4 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $4 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  $5 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $5 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  $6 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $6 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  $7 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $7 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <4 x i32> <i32 16, i32 17, i32 18, i32 19>
-  $8 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $8 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <4 x i32> <i32 20, i32 21, i32 22, i32 23>
-  $9 = shufflevector <32 x $1> $2, <32 x $1> undef,
+  $9 = shufflevector <32 x $1> $2, <32 x $1> poison,
           <4 x i32> <i32 24, i32 25, i32 26, i32 27>
-  argn(`10',$@) = shufflevector <32 x $1> $2, <32 x $1> undef,
+  argn(`10',$@) = shufflevector <32 x $1> $2, <32 x $1> poison,
                     <4 x i32> <i32 28, i32 29, i32 30, i32 31>
 ')
 
@@ -674,13 +674,13 @@ define(`v32tov4', `
 ;; $2: input 64-wide vector
 ;; $3-$6: 4 output 16-wide vectors
 define(`v64tov16', `
-  $3 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $3 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  $4 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $4 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  $5 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $5 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <16 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  $6 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $6 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <16 x i32> <i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
 ')
 
@@ -688,21 +688,21 @@ define(`v64tov16', `
 ;; $2: input 64-wide vector
 ;; $3-$10: 8 output 8-wide vectors
 define(`v64tov8', `
-  $3 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $3 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  $4 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $4 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  $5 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $5 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <8 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  $6 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $6 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <8 x i32> <i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  $7 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $7 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <8 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39>
-  $8 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $8 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <8 x i32> <i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  $9 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $9 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <8 x i32> <i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55>
-  argn(`10',$@) = shufflevector <64 x $1> $2, <64 x $1> undef,
+  argn(`10',$@) = shufflevector <64 x $1> $2, <64 x $1> poison,
                     <8 x i32> <i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
 ')
 
@@ -771,10 +771,10 @@ define(`v32tov64', `
 ;; $2: input 64-wide vector
 ;; $3-$4: 2 output 32-wide vectors
 define(`v64tov32', `
-  $3 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $3 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                       i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  $4 = shufflevector <64 x $1> $2, <64 x $1> undef,
+  $4 = shufflevector <64 x $1> $2, <64 x $1> poison,
           <32 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47,
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
 ')
@@ -867,19 +867,19 @@ define(`convert_scale_to_const', `
                                                 i32 8, label %on_eight_$1]
 
 on_one_$1:
-  %$1_1 = call <$3 x $4> @$2(<$3 x $4> undef, i8 * %$5, <$3 x $7> %$6, <$3 x $9> %$8, argn(`11',$@) 1)
+  %$1_1 = call <$3 x $4> @$2(<$3 x $4> poison, i8 * %$5, <$3 x $7> %$6, <$3 x $9> %$8, argn(`11',$@) 1)
   br label %end_bb_$1
 
 on_two_$1:
-  %$1_2 = call <$3 x $4> @$2(<$3 x $4> undef, i8 * %$5, <$3 x $7> %$6, <$3 x $9> %$8, argn(`11',$@) 2)
+  %$1_2 = call <$3 x $4> @$2(<$3 x $4> poison, i8 * %$5, <$3 x $7> %$6, <$3 x $9> %$8, argn(`11',$@) 2)
   br label %end_bb_$1
 
 on_four_$1:
-  %$1_4 = call <$3 x $4> @$2(<$3 x $4> undef, i8 * %$5, <$3 x $7> %$6, <$3 x $9> %$8, argn(`11',$@) 4)
+  %$1_4 = call <$3 x $4> @$2(<$3 x $4> poison, i8 * %$5, <$3 x $7> %$6, <$3 x $9> %$8, argn(`11',$@) 4)
   br label %end_bb_$1
 
 on_eight_$1:
-  %$1_8 = call <$3 x $4> @$2(<$3 x $4> undef, i8 * %$5, <$3 x $7> %$6, <$3 x $9> %$8, argn(`11',$@) 8)
+  %$1_8 = call <$3 x $4> @$2(<$3 x $4> poison, i8 * %$5, <$3 x $7> %$6, <$3 x $9> %$8, argn(`11',$@) 8)
   br label %end_bb_$1
 
 default_$1:
@@ -904,7 +904,7 @@ end_bb_$1:
 ;;  sse_unary_scalar(ret, 4, float, @llvm.x86.sse.sqrt.ss, %0)
 
 define(`sse_unary_scalar', `
-  %$1_vec = insertelement <$2 x $3> undef, $3 $5, i32 0
+  %$1_vec = insertelement <$2 x $3> poison, $3 $5, i32 0
   %$1_val = call <$2 x $3> $4(<$2 x $3> %$1_vec)
   %$1 = extractelement <$2 x $3> %$1_val, i32 0
 ')
@@ -919,8 +919,8 @@ define(`sse_unary_scalar', `
 ;; $6 : variable name that has the second scalar operand
 
 define(`sse_binary_scalar', `
-  %$1_veca = insertelement <$2 x $3> undef, $3 $5, i32 0
-  %$1_vecb = insertelement <$2 x $3> undef, $3 $6, i32 0
+  %$1_veca = insertelement <$2 x $3> poison, $3 $5, i32 0
+  %$1_vecb = insertelement <$2 x $3> poison, $3 $6, i32 0
   %$1_val = call <$2 x $3> $4(<$2 x $3> %$1_veca, <$2 x $3> %$1_vecb)
   %$1 = extractelement <$2 x $3> %$1_val, i32 0
 ')
@@ -933,8 +933,8 @@ define(`sse_binary_scalar', `
 ;;     the final reduction
 
 define(`reduce4', `
-  %v1 = shufflevector <4 x $1> %0, <4 x $1> undef,
-                      <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
+  %v1 = shufflevector <4 x $1> %0, <4 x $1> poison,
+                      <4 x i32> <i32 2, i32 3, i32 poison, i32 poison>
   %m1 = call <4 x $1> $2(<4 x $1> %v1, <4 x $1> %0)
   %m1a = extractelement <4 x $1> %m1, i32 0
   %m1b = extractelement <4 x $1> %m1, i32 1
@@ -951,11 +951,11 @@ define(`reduce4', `
 ;;     the final reduction
 
 define(`reduce8', `
-  %v1 = shufflevector <8 x $1> %0, <8 x $1> undef,
-        <8 x i32> <i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef>
+  %v1 = shufflevector <8 x $1> %0, <8 x $1> poison,
+        <8 x i32> <i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison>
   %m1 = call <8 x $1> $2(<8 x $1> %v1, <8 x $1> %0)
-  %v2 = shufflevector <8 x $1> %m1, <8 x $1> undef,
-        <8 x i32> <i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %v2 = shufflevector <8 x $1> %m1, <8 x $1> poison,
+        <8 x i32> <i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m2 = call <8 x $1> $2(<8 x $1> %v2, <8 x $1> %m1)
   %m2a = extractelement <8 x $1> %m2, i32 0
   %m2b = extractelement <8 x $1> %m2, i32 1
@@ -972,22 +972,22 @@ define(`reduce8', `
 ;;     the final reduction
 
 define(`reduce16', `
-  %v1 = shufflevector <16 x $1> %0, <16 x $1> undef,
+  %v1 = shufflevector <16 x $1> %0, <16 x $1> poison,
         <16 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
-                    i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef>
+                    i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison>
   %m1 = call <16 x $1> $2(<16 x $1> %v1, <16 x $1> %0)
-  %v2 = shufflevector <16 x $1> %m1, <16 x $1> undef,
+  %v2 = shufflevector <16 x $1> %m1, <16 x $1> poison,
         <16 x i32> <i32 4, i32 5, i32 6, i32 7,
-                    i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef>
+                    i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison>
   %m2 = call <16 x $1> $2(<16 x $1> %v2, <16 x $1> %m1)
-  %v3 = shufflevector <16 x $1> %m2, <16 x $1> undef,
-        <16 x i32> <i32 2, i32 3, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef>
+  %v3 = shufflevector <16 x $1> %m2, <16 x $1> poison,
+        <16 x i32> <i32 2, i32 3, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison>
   %m3 = call <16 x $1> $2(<16 x $1> %v3, <16 x $1> %m2)
 
   %m3a = extractelement <16 x $1> %m3, i32 0
@@ -1005,29 +1005,29 @@ define(`reduce16', `
 ;;     the final reduction
 
 define(`reduce32', `
-  %v1 = shufflevector <32 x $1> %0, <32 x $1> undef,
+  %v1 = shufflevector <32 x $1> %0, <32 x $1> poison,
         <32 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23,
                     i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m1 = call <32 x $1> $2(<32 x $1> %v1, <32 x $1> %0)
-  %v2 = shufflevector <32 x $1> %m1, <32 x $1> undef,
+  %v2 = shufflevector <32 x $1> %m1, <32 x $1> poison,
         <32 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m2 = call <32 x $1> $2(<32 x $1> %v2, <32 x $1> %m1)
-  %v3 = shufflevector <32 x $1> %m2, <32 x $1> undef,
-        <32 x i32> <i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %v3 = shufflevector <32 x $1> %m2, <32 x $1> poison,
+        <32 x i32> <i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m3 = call <32 x $1> $2(<32 x $1> %v3, <32 x $1> %m2)
-  %v4 = shufflevector <32 x $1> %m3, <32 x $1> undef,
-        <32 x i32> <i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %v4 = shufflevector <32 x $1> %m3, <32 x $1> poison,
+        <32 x i32> <i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m4 = call <32 x $1> $2(<32 x $1> %v4, <32 x $1> %m3)
 
   %m4a = extractelement <32 x $1> %m4, i32 0
@@ -1045,55 +1045,55 @@ define(`reduce32', `
 ;;     the final reduction
 
 define(`reduce64', `
-  %v1 = shufflevector <64 x $1> %0, <64 x $1> undef,
+  %v1 = shufflevector <64 x $1> %0, <64 x $1> poison,
         <64 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39,
                     i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47,
                     i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55,
                     i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m1 = call <64 x $1> $2(<64 x $1> %v1, <64 x $1> %0)
-  %v2 = shufflevector <64 x $1> %m1, <64 x $1> undef,
+  %v2 = shufflevector <64 x $1> %m1, <64 x $1> poison,
         <64 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23,
                     i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m2 = call <64 x $1> $2(<64 x $1> %v2, <64 x $1> %m1)
-  %v3 = shufflevector <64 x $1> %m2, <64 x $1> undef,
+  %v3 = shufflevector <64 x $1> %m2, <64 x $1> poison,
         <64 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m3 = call <64 x $1> $2(<64 x $1> %v3, <64 x $1> %m2)
-  %v4 = shufflevector <64 x $1> %m3, <64 x $1> undef,
-        <64 x i32> <i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %v4 = shufflevector <64 x $1> %m3, <64 x $1> poison,
+        <64 x i32> <i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m4 = call <64 x $1> $2(<64 x $1> %v4, <64 x $1> %m3)
-  %v5 = shufflevector <64 x $1> %m4, <64 x $1> undef,
-        <64 x i32> <i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                    i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %v5 = shufflevector <64 x $1> %m4, <64 x $1> poison,
+        <64 x i32> <i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                    i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %m5 = call <64 x $1> $2(<64 x $1> %v5, <64 x $1> %m4)
 
   %m5a = extractelement <64 x $1> %m5, i32 0
@@ -1115,8 +1115,8 @@ define(`reduce64', `
 define(`reduce8by4', `
   v8tov4($1, %0, %v1, %v2)
   %m1 = call <4 x $1> $2(<4 x $1> %v1, <4 x $1> %v2)
-  %v3 = shufflevector <4 x $1> %m1, <4 x $1> undef,
-        <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
+  %v3 = shufflevector <4 x $1> %m1, <4 x $1> poison,
+        <4 x i32> <i32 2, i32 3, i32 poison, i32 poison>
   %m2 = call <4 x $1> $2(<4 x $1> %v3, <4 x $1> %m1)
   %m2a = extractelement <4 x $1> %m2, i32 0
   %m2b = extractelement <4 x $1> %m2, i32 1
@@ -1133,7 +1133,7 @@ define(`reduce8by4', `
 define(`unary1to4', `
   %v_0 = extractelement <4 x $1> %0, i32 0
   %r_0 = call $1 $2($1 %v_0)
-  %ret_0 = insertelement <4 x $1> undef, $1 %r_0, i32 0
+  %ret_0 = insertelement <4 x $1> poison, $1 %r_0, i32 0
   %v_1 = extractelement <4 x $1> %0, i32 1
   %r_1 = call $1 $2($1 %v_1)
   %ret_1 = insertelement <4 x $1> %ret_0, $1 %r_1, i32 1
@@ -1149,7 +1149,7 @@ define(`unary1to4', `
 define(`unary1to8', `
   %v_0 = extractelement <8 x $1> %0, i32 0
   %r_0 = call $1 $2($1 %v_0)
-  %ret_0 = insertelement <8 x $1> undef, $1 %r_0, i32 0
+  %ret_0 = insertelement <8 x $1> poison, $1 %r_0, i32 0
   %v_1 = extractelement <8 x $1> %0, i32 1
   %r_1 = call $1 $2($1 %v_1)
   %ret_1 = insertelement <8 x $1> %ret_0, $1 %r_1, i32 1
@@ -1183,9 +1183,9 @@ define(`unary1to8', `
 ;; $4: 4-wide operand value
 
 define(`unary2to4', `
-  %$1_0 = shufflevector <4 x $2> $4, <4 x $2> undef, <2 x i32> <i32 0, i32 1>
+  %$1_0 = shufflevector <4 x $2> $4, <4 x $2> poison, <2 x i32> <i32 0, i32 1>
   %v$1_0 = call <2 x $2> $3(<2 x $2> %$1_0)
-  %$1_1 = shufflevector <4 x $2> $4, <4 x $2> undef, <2 x i32> <i32 2, i32 3>
+  %$1_1 = shufflevector <4 x $2> $4, <4 x $2> poison, <2 x i32> <i32 2, i32 3>
   %v$1_1 = call <2 x $2> $3(<2 x $2> %$1_1)
   %$1 = shufflevector <2 x $2> %v$1_0, <2 x $2> %v$1_1,
            <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -1201,11 +1201,11 @@ define(`unary2to4', `
 ;; $5: Second 4-wide operand value
 
 define(`binary2to4', `
-%$1_0a = shufflevector <4 x $2> $4, <4 x $2> undef, <2 x i32> <i32 0, i32 1>
-%$1_0b = shufflevector <4 x $2> $5, <4 x $2> undef, <2 x i32> <i32 0, i32 1>
+%$1_0a = shufflevector <4 x $2> $4, <4 x $2> poison, <2 x i32> <i32 0, i32 1>
+%$1_0b = shufflevector <4 x $2> $5, <4 x $2> poison, <2 x i32> <i32 0, i32 1>
 %v$1_0 = call <2 x $2> $3(<2 x $2> %$1_0a, <2 x $2> %$1_0b)
-%$1_1a = shufflevector <4 x $2> $4, <4 x $2> undef, <2 x i32> <i32 2, i32 3>
-%$1_1b = shufflevector <4 x $2> $5, <4 x $2> undef, <2 x i32> <i32 2, i32 3>
+%$1_1a = shufflevector <4 x $2> $4, <4 x $2> poison, <2 x i32> <i32 2, i32 3>
+%$1_1b = shufflevector <4 x $2> $5, <4 x $2> poison, <2 x i32> <i32 2, i32 3>
 %v$1_1 = call <2 x $2> $3(<2 x $2> %$1_1a, <2 x $2> %$1_1b)
 %$1 = shufflevector <2 x $2> %v$1_0, <2 x $2> %v$1_1,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -1220,9 +1220,9 @@ define(`binary2to4', `
 ;; $4: 8-wide operand value
 
 define(`unary4to8', `
-  %__$1_0 = shufflevector <8 x $2> $4, <8 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %__$1_0 = shufflevector <8 x $2> $4, <8 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %__v$1_0 = call <4 x $2> $3(<4 x $2> %__$1_0)
-  %__$1_1 = shufflevector <8 x $2> $4, <8 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %__$1_1 = shufflevector <8 x $2> $4, <8 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %__v$1_1 = call <4 x $2> $3(<4 x $2> %__$1_1)
   %$1 = shufflevector <4 x $2> %__v$1_0, <4 x $2> %__v$1_1,
            <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -1236,9 +1236,9 @@ define(`unary4to8', `
 ;; $5: 8-wide operand value
 
 define(`unary4to8conv', `
-  %$1_0 = shufflevector <8 x $2> $5, <8 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %$1_0 = shufflevector <8 x $2> $5, <8 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v$1_0 = call <4 x $3> $4(<4 x $2> %$1_0)
-  %$1_1 = shufflevector <8 x $2> $5, <8 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %$1_1 = shufflevector <8 x $2> $5, <8 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v$1_1 = call <4 x $3> $4(<4 x $2> %$1_1)
   %$1 = shufflevector <4 x $3> %v$1_0, <4 x $3> %v$1_1,
            <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -1246,13 +1246,13 @@ define(`unary4to8conv', `
 )
 
 define(`unary4to16', `
-  %__$1_0 = shufflevector <16 x $2> $4, <16 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %__$1_0 = shufflevector <16 x $2> $4, <16 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %__v$1_0 = call <4 x $2> $3(<4 x $2> %__$1_0)
-  %__$1_1 = shufflevector <16 x $2> $4, <16 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %__$1_1 = shufflevector <16 x $2> $4, <16 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %__v$1_1 = call <4 x $2> $3(<4 x $2> %__$1_1)
-  %__$1_2 = shufflevector <16 x $2> $4, <16 x $2> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  %__$1_2 = shufflevector <16 x $2> $4, <16 x $2> poison, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
   %__v$1_2 = call <4 x $2> $3(<4 x $2> %__$1_2)
-  %__$1_3 = shufflevector <16 x $2> $4, <16 x $2> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  %__$1_3 = shufflevector <16 x $2> $4, <16 x $2> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
   %__v$1_3 = call <4 x $2> $3(<4 x $2> %__$1_3)
 
   %__$1a = shufflevector <4 x $2> %__v$1_0, <4 x $2> %__v$1_1,
@@ -1266,13 +1266,13 @@ define(`unary4to16', `
 )
 
 define(`unary4to16conv', `
-  %$1_0 = shufflevector <16 x $2> $5, <16 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %$1_0 = shufflevector <16 x $2> $5, <16 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v$1_0 = call <4 x $3> $4(<4 x $2> %$1_0)
-  %$1_1 = shufflevector <16 x $2> $5, <16 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %$1_1 = shufflevector <16 x $2> $5, <16 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v$1_1 = call <4 x $3> $4(<4 x $2> %$1_1)
-  %$1_2 = shufflevector <16 x $2> $5, <16 x $2> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  %$1_2 = shufflevector <16 x $2> $5, <16 x $2> poison, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
   %v$1_2 = call <4 x $3> $4(<4 x $2> %$1_2)
-  %$1_3 = shufflevector <16 x $2> $5, <16 x $2> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  %$1_3 = shufflevector <16 x $2> $5, <16 x $2> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
   %v$1_3 = call <4 x $3> $4(<4 x $2> %$1_3)
 
   %$1a = shufflevector <4 x $3> %v$1_0, <4 x $3> %v$1_1,
@@ -1286,21 +1286,21 @@ define(`unary4to16conv', `
 )
 
 define(`unary4to32conv', `
-  %$1_0 = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %$1_0 = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %v$1_0 = call <4 x $3> $4(<4 x $2> %$1_0)
-  %$1_1 = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %$1_1 = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
   %v$1_1 = call <4 x $3> $4(<4 x $2> %$1_1)
-  %$1_2 = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  %$1_2 = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
   %v$1_2 = call <4 x $3> $4(<4 x $2> %$1_2)
-  %$1_3 = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  %$1_3 = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
   %v$1_3 = call <4 x $3> $4(<4 x $2> %$1_3)
-  %$1_4 = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 16, i32 17, i32 18, i32 19>
+  %$1_4 = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 16, i32 17, i32 18, i32 19>
   %v$1_4 = call <4 x $3> $4(<4 x $2> %$1_4)
-  %$1_5 = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 20, i32 21, i32 22, i32 23>
+  %$1_5 = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 20, i32 21, i32 22, i32 23>
   %v$1_5 = call <4 x $3> $4(<4 x $2> %$1_5)
-  %$1_6 = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 24, i32 25, i32 26, i32 27>
+  %$1_6 = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 24, i32 25, i32 26, i32 27>
   %v$1_6 = call <4 x $3> $4(<4 x $2> %$1_6)
-  %$1_7 = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 28, i32 29, i32 30, i32 31>
+  %$1_7 = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 28, i32 29, i32 30, i32 31>
   %v$1_7 = call <4 x $3> $4(<4 x $2> %$1_7)
 
   %$1a = shufflevector <4 x $3> %v$1_0, <4 x $3> %v$1_1,
@@ -1332,21 +1332,21 @@ define(`unary4to32conv', `
 ;; $4: 32-wide operand value
 
 define(`unary4to32', `
-  %$1_0 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_0 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %$1_1 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_1 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %$1_2 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_2 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %$1_3 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_3 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %$1_4 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_4 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <4 x i32> <i32 16, i32 17, i32 18, i32 19>
-  %$1_5 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_5 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <4 x i32> <i32 20, i32 21, i32 22, i32 23>
-  %$1_6 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_6 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <4 x i32> <i32 24, i32 25, i32 26, i32 27>
-  %$1_7 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_7 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <4 x i32> <i32 28, i32 29, i32 30, i32 31>
   %v$1_0 = call <4 x $2> $3(<4 x $2> %$1_0)
   %v$1_1 = call <4 x $2> $3(<4 x $2> %$1_1)
@@ -1383,22 +1383,22 @@ define(`unary4to32', `
 ;; $5: second 32-wide operand value
 
 define(`binary4to32', `
-  %$1_0a = shufflevector <32 x $2> $4, <32 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %$1_0b = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %$1_1a = shufflevector <32 x $2> $4, <32 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %$1_1b = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %$1_2a = shufflevector <32 x $2> $4, <32 x $2> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %$1_2b = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %$1_3a = shufflevector <32 x $2> $4, <32 x $2> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %$1_3b = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %$1_4a = shufflevector <32 x $2> $4, <32 x $2> undef, <4 x i32> <i32 16, i32 17, i32 18, i32 19>
-  %$1_4b = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 16, i32 17, i32 18, i32 19>
-  %$1_5a = shufflevector <32 x $2> $4, <32 x $2> undef, <4 x i32> <i32 20, i32 21, i32 22, i32 23>
-  %$1_5b = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 20, i32 21, i32 22, i32 23>
-  %$1_6a = shufflevector <32 x $2> $4, <32 x $2> undef, <4 x i32> <i32 24, i32 25, i32 26, i32 27>
-  %$1_6b = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 24, i32 25, i32 26, i32 27>
-  %$1_7a = shufflevector <32 x $2> $4, <32 x $2> undef, <4 x i32> <i32 28, i32 29, i32 30, i32 31>
-  %$1_7b = shufflevector <32 x $2> $5, <32 x $2> undef, <4 x i32> <i32 28, i32 29, i32 30, i32 31>
+  %$1_0a = shufflevector <32 x $2> $4, <32 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %$1_0b = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %$1_1a = shufflevector <32 x $2> $4, <32 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %$1_1b = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %$1_2a = shufflevector <32 x $2> $4, <32 x $2> poison, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  %$1_2b = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  %$1_3a = shufflevector <32 x $2> $4, <32 x $2> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  %$1_3b = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  %$1_4a = shufflevector <32 x $2> $4, <32 x $2> poison, <4 x i32> <i32 16, i32 17, i32 18, i32 19>
+  %$1_4b = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 16, i32 17, i32 18, i32 19>
+  %$1_5a = shufflevector <32 x $2> $4, <32 x $2> poison, <4 x i32> <i32 20, i32 21, i32 22, i32 23>
+  %$1_5b = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 20, i32 21, i32 22, i32 23>
+  %$1_6a = shufflevector <32 x $2> $4, <32 x $2> poison, <4 x i32> <i32 24, i32 25, i32 26, i32 27>
+  %$1_6b = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 24, i32 25, i32 26, i32 27>
+  %$1_7a = shufflevector <32 x $2> $4, <32 x $2> poison, <4 x i32> <i32 28, i32 29, i32 30, i32 31>
+  %$1_7b = shufflevector <32 x $2> $5, <32 x $2> poison, <4 x i32> <i32 28, i32 29, i32 30, i32 31>
   %v$1_0 = call <4 x $2> $3(<4 x $2> %$1_0a, <4 x $2> %$1_0b)
   %v$1_1 = call <4 x $2> $3(<4 x $2> %$1_1a, <4 x $2> %$1_1b)
   %v$1_2 = call <4 x $2> $3(<4 x $2> %$1_2a, <4 x $2> %$1_2b)
@@ -1434,10 +1434,10 @@ define(`binary4to32', `
 ;; $4: 16-wide operand value
 
 define(`unary8to16', `
-  %$1_0 = shufflevector <16 x $2> $4, <16 x $2> undef,
+  %$1_0 = shufflevector <16 x $2> $4, <16 x $2> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %v$1_0 = call <8 x $2> $3(<8 x $2> %$1_0)
-  %$1_1 = shufflevector <16 x $2> $4, <16 x $2> undef,
+  %$1_1 = shufflevector <16 x $2> $4, <16 x $2> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %v$1_1 = call <8 x $2> $3(<8 x $2> %$1_1)
   %$1 = shufflevector <8 x $2> %v$1_0, <8 x $2> %v$1_1,
@@ -1452,13 +1452,13 @@ define(`unary8to16', `
 ;; $4: 32-wide operand value
 
 define(`unary8to32', `
-  %$1_0 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_0 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %$1_1 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_1 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %$1_2 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_2 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <8 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  %$1_3 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_3 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <8 x i32> <i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   %v$1_0 = call <8 x $2> $3(<8 x $2> %$1_0)
   %v$1_1 = call <8 x $2> $3(<8 x $2> %$1_1)
@@ -1482,21 +1482,21 @@ define(`unary8to32', `
 ;; $4: 64-wide operand value
 
 define(`unary8to64', `
-  %$1_0 = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_0 = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %$1_1 = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_1 = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %$1_2 = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_2 = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  %$1_3 = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_3 = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  %$1_4 = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_4 = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39>
-  %$1_5 = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_5 = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  %$1_6 = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_6 = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55>
-  %$1_7 = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_7 = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
   %v$1_0 = call <8 x $2> $3(<8 x $2> %$1_0)
   %v$1_1 = call <8 x $2> $3(<8 x $2> %$1_1)
@@ -1539,21 +1539,21 @@ define(`unary8to64', `
 ;; $5: second 32-wide operand value
 
 define(`binary8to32', `
-  %$1_0a = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_0a = shufflevector <32 x $2> $4, <32 x $2> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %$1_0b = shufflevector <32 x $2> $5, <32 x $2> undef,
+  %$1_0b = shufflevector <32 x $2> $5, <32 x $2> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %$1_1a = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_1a = shufflevector <32 x $2> $4, <32 x $2> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %$1_1b = shufflevector <32 x $2> $5, <32 x $2> undef,
+  %$1_1b = shufflevector <32 x $2> $5, <32 x $2> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %$1_2a = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_2a = shufflevector <32 x $2> $4, <32 x $2> poison,
              <8 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  %$1_2b = shufflevector <32 x $2> $5, <32 x $2> undef,
+  %$1_2b = shufflevector <32 x $2> $5, <32 x $2> poison,
              <8 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  %$1_3a = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_3a = shufflevector <32 x $2> $4, <32 x $2> poison,
              <8 x i32> <i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  %$1_3b = shufflevector <32 x $2> $5, <32 x $2> undef,
+  %$1_3b = shufflevector <32 x $2> $5, <32 x $2> poison,
              <8 x i32> <i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   %v$1_0 = call <8 x $2> $3(<8 x $2> %$1_0a, <8 x $2> %$1_0b)
   %v$1_1 = call <8 x $2> $3(<8 x $2> %$1_1a, <8 x $2> %$1_1b)
@@ -1578,37 +1578,37 @@ define(`binary8to32', `
 ;; $5: second 64-wide operand value
 
 define(`binary8to64', `
-  %$1_0a = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_0a = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %$1_0b = shufflevector <64 x $2> $5, <64 x $2> undef,
+  %$1_0b = shufflevector <64 x $2> $5, <64 x $2> poison,
              <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  %$1_1a = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_1a = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %$1_1b = shufflevector <64 x $2> $5, <64 x $2> undef,
+  %$1_1b = shufflevector <64 x $2> $5, <64 x $2> poison,
              <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %$1_2a = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_2a = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  %$1_2b = shufflevector <64 x $2> $5, <64 x $2> undef,
+  %$1_2b = shufflevector <64 x $2> $5, <64 x $2> poison,
              <8 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
-  %$1_3a = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_3a = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  %$1_3b = shufflevector <64 x $2> $5, <64 x $2> undef,
+  %$1_3b = shufflevector <64 x $2> $5, <64 x $2> poison,
              <8 x i32> <i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  %$1_4a = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_4a = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39>
-  %$1_4b = shufflevector <64 x $2> $5, <64 x $2> undef,
+  %$1_4b = shufflevector <64 x $2> $5, <64 x $2> poison,
              <8 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39>
-  %$1_5a = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_5a = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  %$1_5b = shufflevector <64 x $2> $5, <64 x $2> undef,
+  %$1_5b = shufflevector <64 x $2> $5, <64 x $2> poison,
              <8 x i32> <i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  %$1_6a = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_6a = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55>
-  %$1_6b = shufflevector <64 x $2> $5, <64 x $2> undef,
+  %$1_6b = shufflevector <64 x $2> $5, <64 x $2> poison,
              <8 x i32> <i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55>
-  %$1_7a = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_7a = shufflevector <64 x $2> $4, <64 x $2> poison,
              <8 x i32> <i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-  %$1_7b = shufflevector <64 x $2> $5, <64 x $2> undef,
+  %$1_7b = shufflevector <64 x $2> $5, <64 x $2> poison,
              <8 x i32> <i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
   %v$1_0 = call <8 x $2> $3(<8 x $2> %$1_0a, <8 x $2> %$1_0b)
   %v$1_1 = call <8 x $2> $3(<8 x $2> %$1_1a, <8 x $2> %$1_1b)
@@ -1650,9 +1650,9 @@ define(`binary8to64', `
 ;; $4: 32-wide operand value
 
 define(`unary16to32', `
-  %$1_0 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_0 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %$1_1 = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_1 = shufflevector <32 x $2> $4, <32 x $2> poison,
              <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   %v$1_0 = call <16 x $2> $3(<16 x $2> %$1_0)
   %v$1_1 = call <16 x $2> $3(<16 x $2> %$1_1)
@@ -1668,13 +1668,13 @@ define(`unary16to32', `
 ;; $4: 64-wide operand value
 
 define(`unary16to64', `
-  %$1_0 = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_0 = shufflevector <64 x $2> $4, <64 x $2> poison,
              <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %$1_1 = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_1 = shufflevector <64 x $2> $4, <64 x $2> poison,
              <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  %$1_2 = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_2 = shufflevector <64 x $2> $4, <64 x $2> poison,
              <16 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  %$1_3 = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_3 = shufflevector <64 x $2> $4, <64 x $2> poison,
              <16 x i32> <i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
   %v$1_0 = call <16 x $2> $3(<16 x $2> %$1_0)
   %v$1_1 = call <16 x $2> $3(<16 x $2> %$1_1)
@@ -1700,13 +1700,13 @@ define(`unary16to64', `
 ;; $4: First 32-wide operand value
 ;; $5: Second 32-wide operand value
 define(`binary16to32', `
-  %$1_0a = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_0a = shufflevector <32 x $2> $4, <32 x $2> poison,
              <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %$1_0b = shufflevector <32 x $2> $5, <32 x $2> undef,
+  %$1_0b = shufflevector <32 x $2> $5, <32 x $2> poison,
              <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %$1_1a = shufflevector <32 x $2> $4, <32 x $2> undef,
+  %$1_1a = shufflevector <32 x $2> $4, <32 x $2> poison,
              <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  %$1_1b = shufflevector <32 x $2> $5, <32 x $2> undef,
+  %$1_1b = shufflevector <32 x $2> $5, <32 x $2> poison,
              <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   %v$1_0 = call <16 x $2> $3(<16 x $2> %$1_0a, <16 x $2> %$1_0b)
   %v$1_1 = call <16 x $2> $3(<16 x $2> %$1_1a, <16 x $2> %$1_1b)
@@ -1722,21 +1722,21 @@ define(`binary16to32', `
 ;; $4: First 64-wide operand value
 ;; $5: Second 64-wide operand value
 define(`binary16to64', `
-  %$1_0a = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_0a = shufflevector <64 x $2> $4, <64 x $2> poison,
              <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %$1_0b = shufflevector <64 x $2> $5, <64 x $2> undef,
+  %$1_0b = shufflevector <64 x $2> $5, <64 x $2> poison,
              <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %$1_1a = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_1a = shufflevector <64 x $2> $4, <64 x $2> poison,
              <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  %$1_1b = shufflevector <64 x $2> $5, <64 x $2> undef,
+  %$1_1b = shufflevector <64 x $2> $5, <64 x $2> poison,
              <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  %$1_2a = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_2a = shufflevector <64 x $2> $4, <64 x $2> poison,
              <16 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  %$1_2b = shufflevector <64 x $2> $5, <64 x $2> undef,
+  %$1_2b = shufflevector <64 x $2> $5, <64 x $2> poison,
              <16 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47>
-  %$1_3a = shufflevector <64 x $2> $4, <64 x $2> undef,
+  %$1_3a = shufflevector <64 x $2> $4, <64 x $2> poison,
              <16 x i32> <i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-  %$1_3b = shufflevector <64 x $2> $5, <64 x $2> undef,
+  %$1_3b = shufflevector <64 x $2> $5, <64 x $2> poison,
              <16 x i32> <i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
   %v$1_0 = call <16 x $2> $3(<16 x $2> %$1_0a, <16 x $2> %$1_0b)
   %v$1_1 = call <16 x $2> $3(<16 x $2> %$1_1a, <16 x $2> %$1_1b)
@@ -1765,11 +1765,11 @@ define(`binary16to64', `
 ;; $5: Second 8-wide operand value
 
 define(`binary4to8', `
-%$1_0a = shufflevector <8 x $2> $4, <8 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-%$1_0b = shufflevector <8 x $2> $5, <8 x $2> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+%$1_0a = shufflevector <8 x $2> $4, <8 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+%$1_0b = shufflevector <8 x $2> $5, <8 x $2> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 %v$1_0 = call <4 x $2> $3(<4 x $2> %$1_0a, <4 x $2> %$1_0b)
-%$1_1a = shufflevector <8 x $2> $4, <8 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-%$1_1b = shufflevector <8 x $2> $5, <8 x $2> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+%$1_1a = shufflevector <8 x $2> $4, <8 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+%$1_1b = shufflevector <8 x $2> $5, <8 x $2> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 %v$1_1 = call <4 x $2> $3(<4 x $2> %$1_1a, <4 x $2> %$1_1b)
 %$1 = shufflevector <4 x $2> %v$1_0, <4 x $2> %v$1_1,
          <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
@@ -1777,14 +1777,14 @@ define(`binary4to8', `
 )
 
 define(`binary8to16', `
-%$1_0a = shufflevector <16 x $2> $4, <16 x $2> undef,
+%$1_0a = shufflevector <16 x $2> $4, <16 x $2> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-%$1_0b = shufflevector <16 x $2> $5, <16 x $2> undef,
+%$1_0b = shufflevector <16 x $2> $5, <16 x $2> poison,
           <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
 %v$1_0 = call <8 x $2> $3(<8 x $2> %$1_0a, <8 x $2> %$1_0b)
-%$1_1a = shufflevector <16 x $2> $4, <16 x $2> undef,
+%$1_1a = shufflevector <16 x $2> $4, <16 x $2> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-%$1_1b = shufflevector <16 x $2> $5, <16 x $2> undef,
+%$1_1b = shufflevector <16 x $2> $5, <16 x $2> poison,
           <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 %v$1_1 = call <8 x $2> $3(<8 x $2> %$1_1a, <8 x $2> %$1_1b)
 %$1 = shufflevector <8 x $2> %v$1_0, <8 x $2> %v$1_1,
@@ -1794,27 +1794,27 @@ define(`binary8to16', `
 )
 
 define(`binary4to16', `
-%$1_0a = shufflevector <16 x $2> $4, <16 x $2> undef,
+%$1_0a = shufflevector <16 x $2> $4, <16 x $2> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-%$1_0b = shufflevector <16 x $2> $5, <16 x $2> undef,
+%$1_0b = shufflevector <16 x $2> $5, <16 x $2> poison,
           <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 %r$1_0 = call <4 x $2> $3(<4 x $2> %$1_0a, <4 x $2> %$1_0b)
 
-%$1_1a = shufflevector <16 x $2> $4, <16 x $2> undef,
+%$1_1a = shufflevector <16 x $2> $4, <16 x $2> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-%$1_1b = shufflevector <16 x $2> $5, <16 x $2> undef,
+%$1_1b = shufflevector <16 x $2> $5, <16 x $2> poison,
           <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 %r$1_1 = call <4 x $2> $3(<4 x $2> %$1_1a, <4 x $2> %$1_1b)
 
-%$1_2a = shufflevector <16 x $2> $4, <16 x $2> undef,
+%$1_2a = shufflevector <16 x $2> $4, <16 x $2> poison,
           <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-%$1_2b = shufflevector <16 x $2> $5, <16 x $2> undef,
+%$1_2b = shufflevector <16 x $2> $5, <16 x $2> poison,
           <4 x i32> <i32 8, i32 9, i32 10, i32 11>
 %r$1_2 = call <4 x $2> $3(<4 x $2> %$1_2a, <4 x $2> %$1_2b)
 
-%$1_3a = shufflevector <16 x $2> $4, <16 x $2> undef,
+%$1_3a = shufflevector <16 x $2> $4, <16 x $2> poison,
           <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-%$1_3b = shufflevector <16 x $2> $5, <16 x $2> undef,
+%$1_3b = shufflevector <16 x $2> $5, <16 x $2> poison,
           <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 %r$1_3 = call <4 x $2> $3(<4 x $2> %$1_3a, <4 x $2> %$1_3b)
 
@@ -1836,13 +1836,13 @@ define(`binary4to16', `
 ;; $4: 8-wide operand value
 
 define(`unary2to8', `
-  %$1_0 = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 0, i32 1>
+  %$1_0 = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 0, i32 1>
   %v$1_0 = call <2 x $2> $3(<2 x $2> %$1_0)
-  %$1_1 = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 2, i32 3>
+  %$1_1 = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 2, i32 3>
   %v$1_1 = call <2 x $2> $3(<2 x $2> %$1_1)
-  %$1_2 = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 4, i32 5>
+  %$1_2 = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 4, i32 5>
   %v$1_2 = call <2 x $2> $3(<2 x $2> %$1_2)
-  %$1_3 = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 6, i32 7>
+  %$1_3 = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 6, i32 7>
   %v$1_3 = call <2 x $2> $3(<2 x $2> %$1_3)
   %$1a = shufflevector <2 x $2> %v$1_0, <2 x $2> %v$1_1,
            <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -1854,21 +1854,21 @@ define(`unary2to8', `
 )
 
 define(`unary2to16', `
-  %$1_0 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 0, i32 1>
+  %$1_0 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 0, i32 1>
   %v$1_0 = call <2 x $2> $3(<2 x $2> %$1_0)
-  %$1_1 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 2, i32 3>
+  %$1_1 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 2, i32 3>
   %v$1_1 = call <2 x $2> $3(<2 x $2> %$1_1)
-  %$1_2 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 4, i32 5>
+  %$1_2 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 4, i32 5>
   %v$1_2 = call <2 x $2> $3(<2 x $2> %$1_2)
-  %$1_3 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 6, i32 7>
+  %$1_3 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 6, i32 7>
   %v$1_3 = call <2 x $2> $3(<2 x $2> %$1_3)
-  %$1_4 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 8, i32 9>
+  %$1_4 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 8, i32 9>
   %v$1_4 = call <2 x $2> $3(<2 x $2> %$1_4)
-  %$1_5 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 10, i32 11>
+  %$1_5 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 10, i32 11>
   %v$1_5 = call <2 x $2> $3(<2 x $2> %$1_5)
-  %$1_6 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 12, i32 13>
+  %$1_6 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 12, i32 13>
   %v$1_6 = call <2 x $2> $3(<2 x $2> %$1_6)
-  %$1_7 = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 14, i32 15>
+  %$1_7 = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 14, i32 15>
   %v$1_7 = call <2 x $2> $3(<2 x $2> %$1_7)
   %$1a = shufflevector <2 x $2> %v$1_0, <2 x $2> %v$1_1,
            <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -1897,17 +1897,17 @@ define(`unary2to16', `
 ;; $5: Second 8-wide operand value
 
 define(`binary2to8', `
-  %$1_0a = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 0, i32 1>
-  %$1_0b = shufflevector <8 x $2> $5, <8 x $2> undef, <2 x i32> <i32 0, i32 1>
+  %$1_0a = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 0, i32 1>
+  %$1_0b = shufflevector <8 x $2> $5, <8 x $2> poison, <2 x i32> <i32 0, i32 1>
   %v$1_0 = call <2 x $2> $3(<2 x $2> %$1_0a, <2 x $2> %$1_0b)
-  %$1_1a = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 2, i32 3>
-  %$1_1b = shufflevector <8 x $2> $5, <8 x $2> undef, <2 x i32> <i32 2, i32 3>
+  %$1_1a = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 2, i32 3>
+  %$1_1b = shufflevector <8 x $2> $5, <8 x $2> poison, <2 x i32> <i32 2, i32 3>
   %v$1_1 = call <2 x $2> $3(<2 x $2> %$1_1a, <2 x $2> %$1_1b)
-  %$1_2a = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 4, i32 5>
-  %$1_2b = shufflevector <8 x $2> $5, <8 x $2> undef, <2 x i32> <i32 4, i32 5>
+  %$1_2a = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 4, i32 5>
+  %$1_2b = shufflevector <8 x $2> $5, <8 x $2> poison, <2 x i32> <i32 4, i32 5>
   %v$1_2 = call <2 x $2> $3(<2 x $2> %$1_2a, <2 x $2> %$1_2b)
-  %$1_3a = shufflevector <8 x $2> $4, <8 x $2> undef, <2 x i32> <i32 6, i32 7>
-  %$1_3b = shufflevector <8 x $2> $5, <8 x $2> undef, <2 x i32> <i32 6, i32 7>
+  %$1_3a = shufflevector <8 x $2> $4, <8 x $2> poison, <2 x i32> <i32 6, i32 7>
+  %$1_3b = shufflevector <8 x $2> $5, <8 x $2> poison, <2 x i32> <i32 6, i32 7>
   %v$1_3 = call <2 x $2> $3(<2 x $2> %$1_3a, <2 x $2> %$1_3b)
 
   %$1a = shufflevector <2 x $2> %v$1_0, <2 x $2> %v$1_1,
@@ -1920,29 +1920,29 @@ define(`binary2to8', `
 )
 
 define(`binary2to16', `
-  %$1_0a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 0, i32 1>
-  %$1_0b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 0, i32 1>
+  %$1_0a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 0, i32 1>
+  %$1_0b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 0, i32 1>
   %v$1_0 = call <2 x $2> $3(<2 x $2> %$1_0a, <2 x $2> %$1_0b)
-  %$1_1a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 2, i32 3>
-  %$1_1b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 2, i32 3>
+  %$1_1a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 2, i32 3>
+  %$1_1b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 2, i32 3>
   %v$1_1 = call <2 x $2> $3(<2 x $2> %$1_1a, <2 x $2> %$1_1b)
-  %$1_2a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 4, i32 5>
-  %$1_2b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 4, i32 5>
+  %$1_2a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 4, i32 5>
+  %$1_2b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 4, i32 5>
   %v$1_2 = call <2 x $2> $3(<2 x $2> %$1_2a, <2 x $2> %$1_2b)
-  %$1_3a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 6, i32 7>
-  %$1_3b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 6, i32 7>
+  %$1_3a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 6, i32 7>
+  %$1_3b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 6, i32 7>
   %v$1_3 = call <2 x $2> $3(<2 x $2> %$1_3a, <2 x $2> %$1_3b)
-  %$1_4a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 8, i32 9>
-  %$1_4b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 8, i32 9>
+  %$1_4a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 8, i32 9>
+  %$1_4b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 8, i32 9>
   %v$1_4 = call <2 x $2> $3(<2 x $2> %$1_4a, <2 x $2> %$1_4b)
-  %$1_5a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 10, i32 11>
-  %$1_5b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 10, i32 11>
+  %$1_5a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 10, i32 11>
+  %$1_5b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 10, i32 11>
   %v$1_5 = call <2 x $2> $3(<2 x $2> %$1_5a, <2 x $2> %$1_5b)
-  %$1_6a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 12, i32 13>
-  %$1_6b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 12, i32 13>
+  %$1_6a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 12, i32 13>
+  %$1_6b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 12, i32 13>
   %v$1_6 = call <2 x $2> $3(<2 x $2> %$1_6a, <2 x $2> %$1_6b)
-  %$1_7a = shufflevector <16 x $2> $4, <16 x $2> undef, <2 x i32> <i32 14, i32 15>
-  %$1_7b = shufflevector <16 x $2> $5, <16 x $2> undef, <2 x i32> <i32 14, i32 15>
+  %$1_7a = shufflevector <16 x $2> $4, <16 x $2> poison, <2 x i32> <i32 14, i32 15>
+  %$1_7b = shufflevector <16 x $2> $5, <16 x $2> poison, <2 x i32> <i32 14, i32 15>
   %v$1_7 = call <2 x $2> $3(<2 x $2> %$1_7a, <2 x $2> %$1_7b)
 
   %$1a = shufflevector <2 x $2> %v$1_0, <2 x $2> %v$1_1,
@@ -1974,8 +1974,8 @@ define(`binary2to16', `
 ;; which is inconsistent with the macros above
 
 define(`round4to8', `
-%v0 = shufflevector <8 x float> $1, <8 x float> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-%v1 = shufflevector <8 x float> $1, <8 x float> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+%v0 = shufflevector <8 x float> $1, <8 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+%v1 = shufflevector <8 x float> $1, <8 x float> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 %r0 = call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %v0, i32 $2)
 %r1 = call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %v1, i32 $2)
 %ret = shufflevector <4 x float> %r0, <4 x float> %r1,
@@ -1985,10 +1985,10 @@ ret <8 x float> %ret
 )
 
 define(`round4to16', `
-%v0 = shufflevector <16 x float> $1, <16 x float> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-%v1 = shufflevector <16 x float> $1, <16 x float> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-%v2 = shufflevector <16 x float> $1, <16 x float> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-%v3 = shufflevector <16 x float> $1, <16 x float> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+%v0 = shufflevector <16 x float> $1, <16 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+%v1 = shufflevector <16 x float> $1, <16 x float> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+%v2 = shufflevector <16 x float> $1, <16 x float> poison, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+%v3 = shufflevector <16 x float> $1, <16 x float> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 %r0 = call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %v0, i32 $2)
 %r1 = call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %v1, i32 $2)
 %r2 = call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %v2, i32 $2)
@@ -2005,9 +2005,9 @@ ret <16 x float> %ret
 )
 
 define(`round8to16', `
-%v0 = shufflevector <16 x float> $1, <16 x float> undef,
+%v0 = shufflevector <16 x float> $1, <16 x float> poison,
         <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-%v1 = shufflevector <16 x float> $1, <16 x float> undef,
+%v1 = shufflevector <16 x float> $1, <16 x float> poison,
         <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 %r0 = call <8 x float> @llvm.x86.avx.round.ps.256(<8 x float> %v0, i32 $2)
 %r1 = call <8 x float> @llvm.x86.avx.round.ps.256(<8 x float> %v1, i32 $2)
@@ -2019,8 +2019,8 @@ ret <16 x float> %ret
 )
 
 define(`round4to8double', `
-%v0 = shufflevector <8 x double> $1, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-%v1 = shufflevector <8 x double> $1, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+%v0 = shufflevector <8 x double> $1, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+%v1 = shufflevector <8 x double> $1, <8 x double> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 %r0 = call <4 x double> @llvm.x86.avx.round.pd.256(<4 x double> %v0, i32 $2)
 %r1 = call <4 x double> @llvm.x86.avx.round.pd.256(<4 x double> %v1, i32 $2)
 %ret = shufflevector <4 x double> %r0, <4 x double> %r1,
@@ -2032,8 +2032,8 @@ ret <8 x double> %ret
 ; and similarly for doubles...
 
 define(`round2to4double', `
-%v0 = shufflevector <4 x double> $1, <4 x double> undef, <2 x i32> <i32 0, i32 1>
-%v1 = shufflevector <4 x double> $1, <4 x double> undef, <2 x i32> <i32 2, i32 3>
+%v0 = shufflevector <4 x double> $1, <4 x double> poison, <2 x i32> <i32 0, i32 1>
+%v1 = shufflevector <4 x double> $1, <4 x double> poison, <2 x i32> <i32 2, i32 3>
 %r0 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v0, i32 $2)
 %r1 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v1, i32 $2)
 %ret = shufflevector <2 x double> %r0, <2 x double> %r1,
@@ -2043,10 +2043,10 @@ ret <4 x double> %ret
 )
 
 define(`round2to8double', `
-%v0 = shufflevector <8 x double> $1, <8 x double> undef, <2 x i32> <i32 0, i32 1>
-%v1 = shufflevector <8 x double> $1, <8 x double> undef, <2 x i32> <i32 2, i32 3>
-%v2 = shufflevector <8 x double> $1, <8 x double> undef, <2 x i32> <i32 4, i32 5>
-%v3 = shufflevector <8 x double> $1, <8 x double> undef, <2 x i32> <i32 6, i32 7>
+%v0 = shufflevector <8 x double> $1, <8 x double> poison, <2 x i32> <i32 0, i32 1>
+%v1 = shufflevector <8 x double> $1, <8 x double> poison, <2 x i32> <i32 2, i32 3>
+%v2 = shufflevector <8 x double> $1, <8 x double> poison, <2 x i32> <i32 4, i32 5>
+%v3 = shufflevector <8 x double> $1, <8 x double> poison, <2 x i32> <i32 6, i32 7>
 %r0 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v0, i32 $2)
 %r1 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v1, i32 $2)
 %r2 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v2, i32 $2)
@@ -2062,14 +2062,14 @@ ret <8 x double> %ret
 )
 
 define(`round2to16double', `
-%v0 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 0,  i32 1>
-%v1 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 2,  i32 3>
-%v2 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 4,  i32 5>
-%v3 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 6,  i32 7>
-%v4 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 8,  i32 9>
-%v5 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 10, i32 11>
-%v6 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 12, i32 13>
-%v7 = shufflevector <16 x double> $1, <16 x double> undef, <2 x i32> <i32 14, i32 15>
+%v0 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 0,  i32 1>
+%v1 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 2,  i32 3>
+%v2 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 4,  i32 5>
+%v3 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 6,  i32 7>
+%v4 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 8,  i32 9>
+%v5 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 10, i32 11>
+%v6 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 12, i32 13>
+%v7 = shufflevector <16 x double> $1, <16 x double> poison, <2 x i32> <i32 14, i32 15>
 %r0 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v0, i32 $2)
 %r1 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v1, i32 $2)
 %r2 = call <2 x double> @llvm.x86.sse41.round.pd(<2 x double> %v2, i32 $2)
@@ -2098,13 +2098,13 @@ ret <16 x double> %ret
 )
 
 define(`round4to16double', `
-%v0 = shufflevector <16 x double> $1, <16 x double> undef,
+%v0 = shufflevector <16 x double> $1, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-%v1 = shufflevector <16 x double> $1, <16 x double> undef,
+%v1 = shufflevector <16 x double> $1, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-%v2 = shufflevector <16 x double> $1, <16 x double> undef,
+%v2 = shufflevector <16 x double> $1, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-%v3 = shufflevector <16 x double> $1, <16 x double> undef,
+%v3 = shufflevector <16 x double> $1, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 %r0 = call <4 x double> @llvm.x86.avx.round.pd.256(<4 x double> %v0, i32 $2)
 %r1 = call <4 x double> @llvm.x86.avx.round.pd.256(<4 x double> %v1, i32 $2)
@@ -2190,7 +2190,7 @@ forloop(i, 0, eval(WIDTH-1), `
 forloop(i, 0, eval(WIDTH-1), `
   %v_`'i = extractelement <WIDTH x $1> %0, i32 %index_`'i')
 
-  %ret_0 = insertelement <WIDTH x $1> undef, $1 %v_0, i32 0
+  %ret_0 = insertelement <WIDTH x $1> poison, $1 %v_0, i32 0
 forloop(i, 1, eval(WIDTH-1), `  %ret_`'i = insertelement <WIDTH x $1> %ret_`'eval(i-1), $1 %v_`'i, i32 i
 ')
   ret <WIDTH x $1> %ret_`'eval(WIDTH-1)
@@ -2247,7 +2247,7 @@ not_const:
 
   %ptr_0 = getelementptr PTR_OP_ARGS(`$1') %baseptr, i32 %index_0
   %val_0 = load PTR_OP_ARGS(`$1 ')  %ptr_0
-  %result_0 = insertelement <WIDTH x $1> undef, $1 %val_0, i32 0
+  %result_0 = insertelement <WIDTH x $1> poison, $1 %val_0, i32 0
 
 forloop(i, 1, eval(WIDTH-1), `
   %ptr_`'i = getelementptr PTR_OP_ARGS(`$1') %baseptr, i32 %index_`'i
@@ -2265,8 +2265,8 @@ forloop(i, 1, eval(WIDTH-1), `
 define(`vector_broadcast', `
 define <WIDTH x $1> @__broadcast_$1(<WIDTH x $1>, i32) nounwind readnone alwaysinline {
   %v = extractelement <WIDTH x $1> %0, i32 %1
-  %broadcast_init = insertelement <WIDTH x $1> undef, $1 %v, i32 0
-  %broadcast = shufflevector <WIDTH x $1> %broadcast_init, <WIDTH x $1> undef, <WIDTH x i32> zeroinitializer
+  %broadcast_init = insertelement <WIDTH x $1> poison, $1 %v, i32 0
+  %broadcast = shufflevector <WIDTH x $1> %broadcast_init, <WIDTH x $1> poison, <WIDTH x i32> zeroinitializer
   ret <WIDTH x $1> %broadcast
 }
 ')
@@ -2283,7 +2283,7 @@ forloop(i, 0, eval(WIDTH-1), `
   %delta_clamped_`'i = and i32 %delta_`'i, eval(WIDTH-1)
   %v_`'i = extractelement <WIDTH x $1> %0, i32 %delta_clamped_`'i')
 
-  %ret_0 = insertelement <WIDTH x $1> undef, $1 %v_0, i32 0
+  %ret_0 = insertelement <WIDTH x $1> poison, $1 %v_0, i32 0
 forloop(i, 1, eval(WIDTH-1), `  %ret_`'i = insertelement <WIDTH x $1> %ret_`'eval(i-1), $1 %v_`'i, i32 i
 ')
   ret <WIDTH x $1> %ret_`'eval(WIDTH-1)
@@ -2529,7 +2529,7 @@ define <$1 x $3> @__atomic_$2_$4_global(i8 * %ptr, <$1 x $3> %val,
   ; compute an identity vector that is zero in on lanes and has the identiy value
   ; in the off lanes
   %idv1 = bitcast $3 $5 to <1 x $3>
-  %idvec = shufflevector <1 x $3> %idv1, <1 x $3> undef,
+  %idvec = shufflevector <1 x $3> %idv1, <1 x $3> poison,
      <$1 x i32> < forloop(i, 1, eval($1-1), `i32 0, ') i32 0 >
   %notmask = xor <$1 x $3> %mask, < forloop(i, 1, eval($1-1), `$3 -1, ') $3 -1 >
   %idoff = and <$1 x $3> %idvec, %notmask
@@ -2541,7 +2541,7 @@ define <$1 x $3> @__atomic_$2_$4_global(i8 * %ptr, <$1 x $3> %val,
   ; %eltvec so that the 0th element is the identity, the first is val0,
   ; the second is (val0 op val1), ..
   %red0 = extractelement <$1 x $3> %valp, i32 0
-  %eltvec0 = insertelement <$1 x $3> undef, $3 $5, i32 0
+  %eltvec0 = insertelement <$1 x $3> poison, $3 $5, i32 0
 
   forloop(i, 1, eval($1-1), `
   %elt`'i = extractelement <$1 x $3> %valp, i32 i
@@ -2556,7 +2556,7 @@ define <$1 x $3> @__atomic_$2_$4_global(i8 * %ptr, <$1 x $3> %val,
   ; actual atomic call across the vector and applying the vector op to the
   ; %eltvec vector computed above..
   %finalv1 = bitcast $3 %final0 to <1 x $3>
-  %final_base = shufflevector <1 x $3> %finalv1, <1 x $3> undef,
+  %final_base = shufflevector <1 x $3> %finalv1, <1 x $3> poison,
      <$1 x i32> < forloop(i, 1, eval($1-1), `i32 0, ') i32 0 >
   %r = $2 <$1 x $3> %final_base, %eltvec`'eval($1-1)
 
@@ -2929,7 +2929,7 @@ define void
   store <4 x float> %r1, <4 x float> * %out1, align 4
 
   %t2 = shufflevector <4 x float> %v0, <4 x float> %v1, ; z0 z1 x x
-    <4 x i32> <i32 2, i32 5, i32 undef, i32 undef>
+    <4 x i32> <i32 2, i32 5, i32 poison, i32 poison>
 
   %r2 = shufflevector <4 x float> %t2, <4 x float> %v2, ; z0 z1 z2 z3
     <4 x i32> <i32 0, i32 1, i32 4, i32 7>
@@ -2959,7 +2959,7 @@ define void
   store <4 x float> %r1, <4 x float> * %out1, align 4
 
   %t2 = shufflevector <4 x float> %v0, <4 x float> %v1, ; x3 y3 x x
-    <4 x i32> <i32 3, i32 7, i32 undef, i32 undef>
+    <4 x i32> <i32 3, i32 7, i32 poison, i32 poison>
 
   %r2 = shufflevector <4 x float> %t2, <4 x float> %v2, ; z2 x3 y3 z3
     <4 x i32> <i32 6, i32 0, i32 1, i32 7>
@@ -2985,7 +2985,7 @@ define void
   store <4 x double> %r1, <4 x double> * %out1, align 4
 
   %t2 = shufflevector <4 x double> %v0, <4 x double> %v1, ; z0 z1 x x
-    <4 x i32> <i32 2, i32 5, i32 undef, i32 undef>
+    <4 x i32> <i32 2, i32 5, i32 poison, i32 poison>
 
   %r2 = shufflevector <4 x double> %t2, <4 x double> %v2, ; z0 z1 z2 z3
     <4 x i32> <i32 0, i32 1, i32 4, i32 7>
@@ -3010,7 +3010,7 @@ define void
   store <4 x double> %r1, <4 x double> * %out1, align 4
 
   %t2 = shufflevector <4 x double> %v0, <4 x double> %v1, ; x3 y3 x x
-    <4 x i32> <i32 3, i32 7, i32 undef, i32 undef>
+    <4 x i32> <i32 3, i32 7, i32 poison, i32 poison>
 
   %r2 = shufflevector <4 x double> %t2, <4 x double> %v2, ; z2 x3 y3 z3
     <4 x i32> <i32 6, i32 0, i32 1, i32 7>
@@ -3201,21 +3201,21 @@ define void
         <8 x double> * noalias %out1, <8 x double> * noalias %out2,
         <8 x double> * noalias %out3) nounwind alwaysinline {
   ;; As above, split into 4-vectors and 4-wide outputs...
-  %v0a = shufflevector <8 x double> %v0, <8 x double> undef,
+  %v0a = shufflevector <8 x double> %v0, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <8 x double> %v0, <8 x double> undef,
+  %v0b = shufflevector <8 x double> %v0, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1a = shufflevector <8 x double> %v1, <8 x double> undef,
+  %v1a = shufflevector <8 x double> %v1, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <8 x double> %v1, <8 x double> undef,
+  %v1b = shufflevector <8 x double> %v1, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2a = shufflevector <8 x double> %v2, <8 x double> undef,
+  %v2a = shufflevector <8 x double> %v2, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <8 x double> %v2, <8 x double> undef,
+  %v2b = shufflevector <8 x double> %v2, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v3a = shufflevector <8 x double> %v3, <8 x double> undef,
+  %v3a = shufflevector <8 x double> %v3, <8 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v3b = shufflevector <8 x double> %v3, <8 x double> undef,
+  %v3b = shufflevector <8 x double> %v3, <8 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   %out0a = bitcast <8 x double> * %out0 to <4 x double> *
@@ -3298,9 +3298,9 @@ define void
           <8 x i32> <i32 4, i32 5, i32 6, i32 7, i32 12, i32 13, i32 14, i32 15>
   store <8 x float> %r1, <8 x float> * %out1, align 4
 
-  ;; t2 = <c0 ... c4 undef ... undef>
+  ;; t2 = <c0 ... c4 poison ... poison>
   %t2 = shufflevector <8 x float> %v0, <8 x float> %v1,
-          <8 x i32> <i32 2, i32 5, i32 8, i32 11, i32 14, i32 undef, i32 undef, i32 undef>
+          <8 x i32> <i32 2, i32 5, i32 8, i32 11, i32 14, i32 poison, i32 poison, i32 poison>
 
   ;; Produce output vector
   %r2 = shufflevector <8 x float> %t2, <8 x float> %v2,
@@ -3329,9 +3329,9 @@ define void
           <8 x i32> <i32 13, i32 3, i32 9, i32 14, i32 4, i32 10, i32 15, i32 5>
   store <8 x float> %r1, <8 x float> * %out1, align 4
 
-  ;; t2 = <a6 ... a7 b5 ... b7 undef ... undef>
+  ;; t2 = <a6 ... a7 b5 ... b7 poison ... poison>
   %t2 = shufflevector <8 x float> %v0, <8 x float> %v1,
-          <8 x i32> <i32 6, i32 7, i32 13, i32 14, i32 15, i32 undef, i32 undef, i32 undef>
+          <8 x i32> <i32 6, i32 7, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison>
   ;; Produce output vector
   %r2 = shufflevector <8 x float> %t2, <8 x float> %v2,
           <8 x i32> <i32 2, i32 13, i32 0, i32 3, i32 14, i32 1, i32 4, i32 15>
@@ -3344,20 +3344,20 @@ define void
 @__aos_to_soa3_double8(<8 x double> %v0, <8 x double> %v1, <8 x double> %v2,
         <8 x double> * noalias %out0, <8 x double> * noalias %out1,
         <8 x double> * noalias %out2) nounwind alwaysinline {
-  %v0_0 = shufflevector <8 x double> %v0, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0_1 = shufflevector <8 x double> %v0, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1_0 = shufflevector <8 x double> %v1, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1_1 = shufflevector <8 x double> %v1, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2_0 = shufflevector <8 x double> %v2, <8 x double> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2_1 = shufflevector <8 x double> %v2, <8 x double> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %v0_0 = shufflevector <8 x double> %v0, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %v0_1 = shufflevector <8 x double> %v0, <8 x double> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %v1_0 = shufflevector <8 x double> %v1, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %v1_1 = shufflevector <8 x double> %v1, <8 x double> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %v2_0 = shufflevector <8 x double> %v2, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %v2_1 = shufflevector <8 x double> %v2, <8 x double> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 
   %t0 = shufflevector <4 x double> %v0_0, <4 x double> %v0_1, <4 x i32> <i32 0, i32 3, i32 1, i32 4>
   %t1 = shufflevector <4 x double> %v0_1, <4 x double> %v1_0, <4 x i32> <i32 2, i32 5, i32 3, i32 6>
-  %t2 = shufflevector <4 x double> %v0_0, <4 x double> %v0_1, <4 x i32> <i32 2, i32 5, i32 undef, i32 undef>
+  %t2 = shufflevector <4 x double> %v0_0, <4 x double> %v0_1, <4 x i32> <i32 2, i32 5, i32 poison, i32 poison>
 
   %s0 = shufflevector <4 x double> %v1_1, <4 x double> %v2_0, <4 x i32> <i32 0, i32 3, i32 1, i32 4>
   %s1 = shufflevector <4 x double> %v2_0, <4 x double> %v2_1, <4 x i32> <i32 2, i32 5, i32 3, i32 6>
-  %s2 = shufflevector <4 x double> %v1_1, <4 x double> %v2_0, <4 x i32> <i32 2, i32 5, i32 undef, i32 undef>
+  %s2 = shufflevector <4 x double> %v1_1, <4 x double> %v2_0, <4 x i32> <i32 2, i32 5, i32 poison, i32 poison>
 
   %a0 = shufflevector <4 x double> %t0, <4 x double> %t1, <4 x i32> <i32 0, i32 1, i32 4, i32 5>
   %b0 = shufflevector <4 x double> %t0, <4 x double> %t1, <4 x i32> <i32 2, i32 3, i32 6, i32 7>
@@ -3404,9 +3404,9 @@ define void
           <8 x i32> <i32 13, i32 3, i32 9, i32 14, i32 4, i32 10, i32 15, i32 5>
   store <8 x double> %r1, <8 x double> * %out1, align 4
 
-  ;; t2 = <a6 ... a7 b5 ... b7 undef ... undef>
+  ;; t2 = <a6 ... a7 b5 ... b7 poison ... poison>
   %t2 = shufflevector <8 x double> %v0, <8 x double> %v1,
-          <8 x i32> <i32 6, i32 7, i32 13, i32 14, i32 15, i32 undef, i32 undef, i32 undef>
+          <8 x i32> <i32 6, i32 7, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison>
   ;; Produce output vector
   %r2 = shufflevector <8 x double> %t2, <8 x double> %v2,
           <8 x i32> <i32 2, i32 13, i32 0, i32 3, i32 14, i32 1, i32 4, i32 15>
@@ -3639,37 +3639,37 @@ define void
         <16 x double> %v3, <16 x double> * noalias %out0,
         <16 x double> * noalias %out1, <16 x double> * noalias %out2,
         <16 x double> * noalias %out3) nounwind alwaysinline {
-  %v0a = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0a = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v0b = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0b = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v0c = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0c = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v0d = shufflevector <16 x double> %v0, <16 x double> undef,
+  %v0d = shufflevector <16 x double> %v0, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v1a = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1a = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v1b = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1b = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v1c = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1c = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v1d = shufflevector <16 x double> %v1, <16 x double> undef,
+  %v1d = shufflevector <16 x double> %v1, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v2a = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2a = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v2b = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2b = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v2c = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2c = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v2d = shufflevector <16 x double> %v2, <16 x double> undef,
+  %v2d = shufflevector <16 x double> %v2, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
-  %v3a = shufflevector <16 x double> %v3, <16 x double> undef,
+  %v3a = shufflevector <16 x double> %v3, <16 x double> poison,
          <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  %v3b = shufflevector <16 x double> %v3, <16 x double> undef,
+  %v3b = shufflevector <16 x double> %v3, <16 x double> poison,
          <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-  %v3c = shufflevector <16 x double> %v3, <16 x double> undef,
+  %v3c = shufflevector <16 x double> %v3, <16 x double> poison,
          <4 x i32> <i32 8, i32 9, i32 10, i32 11>
-  %v3d = shufflevector <16 x double> %v3, <16 x double> undef,
+  %v3d = shufflevector <16 x double> %v3, <16 x double> poison,
          <4 x i32> <i32 12, i32 13, i32 14, i32 15>
 
   %out0a = bitcast <16 x double> * %out0 to <4 x double> *
@@ -3771,10 +3771,10 @@ define void
                       i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   store <16 x float> %r1, <16 x float> * %out1, align 4
 
-  ;; t2 = <c0 ... c9 undef ... undef>
+  ;; t2 = <c0 ... c9 poison ... poison>
   %t2 = shufflevector <16 x float> %v0, <16 x float> %v1,
           <16 x i32> <i32 2, i32 5, i32 8, i32 11, i32 14, i32 17, i32 20, i32 23,
-                      i32 26, i32 29, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 26, i32 29, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 
   ;; Produce output vector
   %r2 = shufflevector <16 x float> %t2, <16 x float> %v2,
@@ -3808,10 +3808,10 @@ define void
                       i32 8, i32 19, i32 30, i32 9, i32 20, i32 31, i32 10, i32 21>
   store <16 x float> %r1, <16 x float> * %out1, align 4
 
-  ;; t2 = <a11 ... a15 b11 ... b15 undef ... undef>
+  ;; t2 = <a11 ... a15 b11 ... b15 poison ... poison>
   %t2 = shufflevector <16 x float> %v0, <16 x float> %v1,
           <16 x i32> <i32 11, i32 12, i32 13, i32 14, i32 15, i32 27, i32 28, i32 29,
-                      i32 30, i32 31, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 30, i32 31, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   ;; Produce output vector
   %r2 = shufflevector <16 x float> %t2, <16 x float> %v2,
           <16 x i32> <i32 26, i32 0, i32 5, i32 27, i32 1, i32 6, i32 28, i32 2,
@@ -3844,10 +3844,10 @@ define void
                       i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   store <16 x double> %r1, <16 x double> * %out1, align 4
 
-  ;; t2 = <c0 ... c9 undef ... undef>
+  ;; t2 = <c0 ... c9 poison ... poison>
   %t2 = shufflevector <16 x double> %v0, <16 x double> %v1,
           <16 x i32> <i32 2, i32 5, i32 8, i32 11, i32 14, i32 17, i32 20, i32 23,
-                      i32 26, i32 29, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 26, i32 29, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 
   ;; Produce output vector
   %r2 = shufflevector <16 x double> %t2, <16 x double> %v2,
@@ -3881,10 +3881,10 @@ define void
                       i32 8, i32 19, i32 30, i32 9, i32 20, i32 31, i32 10, i32 21>
   store <16 x double> %r1, <16 x double> * %out1, align 4
 
-  ;; t2 = <a11 ... a15 b11 ... b15 undef ... undef>
+  ;; t2 = <a11 ... a15 b11 ... b15 poison ... poison>
   %t2 = shufflevector <16 x double> %v0, <16 x double> %v1,
           <16 x i32> <i32 11, i32 12, i32 13, i32 14, i32 15, i32 27, i32 28, i32 29,
-                      i32 30, i32 31, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 30, i32 31, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   ;; Produce output vector
   %r2 = shufflevector <16 x double> %t2, <16 x double> %v2,
           <16 x i32> <i32 26, i32 0, i32 5, i32 27, i32 1, i32 6, i32 28, i32 2,
@@ -4223,10 +4223,10 @@ define void
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
   store <32 x float> %r1, <32 x float> * %out1, align 4
 
-  ;; t2 = <c0 ... c20 undef ... undef>
+  ;; t2 = <c0 ... c20 poison ... poison>
   %t2 = shufflevector <32 x float> %v0, <32 x float> %v1,
           <32 x i32> <i32 2, i32 5, i32 8, i32 11, i32 14, i32 17, i32 20, i32 23, i32 26, i32 29, i32 32, i32 35, i32 38, i32 41, i32 44, i32 47,
-                      i32 50, i32 53, i32 56, i32 59, i32 62, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 50, i32 53, i32 56, i32 59, i32 62, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 
   ;; Produce output vector
   %r2 = shufflevector <32 x float> %t2, <32 x float> %v2,
@@ -4268,10 +4268,10 @@ define void
                       i32 16, i32 38, i32 59, i32 17, i32 39, i32 60, i32 18, i32 40, i32 61, i32 19, i32 41, i32 62, i32 20, i32 42, i32 63, i32 21>
   store <32 x float> %r1, <32 x float> * %out1, align 4
 
-  ;; t2 = <a22 ... a31 b21 ... b31 undef ... undef>
+  ;; t2 = <a22 ... a31 b21 ... b31 poison ... poison>
   %t2 = shufflevector <32 x float> %v0, <32 x float> %v1,
           <32 x i32> <i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58,
-                      i32 59, i32 60, i32 61, i32 62, i32 63, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 59, i32 60, i32 61, i32 62, i32 63, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   ;; Produce output vector
   %r2 = shufflevector <32 x float> %t2, <32 x float> %v2,
           <32 x i32> <i32 10, i32 53, i32 0, i32 11, i32 54, i32 1, i32 12, i32 55, i32 2, i32 13, i32 56, i32 3, i32 14, i32 57, i32 4, i32 15,
@@ -4312,10 +4312,10 @@ define void
                       i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
   store <32 x double> %r1, <32 x double> * %out1, align 4
 
-  ;; t2 = <c0 ... c20 undef ... undef>
+  ;; t2 = <c0 ... c20 poison ... poison>
   %t2 = shufflevector <32 x double> %v0, <32 x double> %v1,
           <32 x i32> <i32 2, i32 5, i32 8, i32 11, i32 14, i32 17, i32 20, i32 23, i32 26, i32 29, i32 32, i32 35, i32 38, i32 41, i32 44, i32 47,
-                      i32 50, i32 53, i32 56, i32 59, i32 62, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 50, i32 53, i32 56, i32 59, i32 62, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 
   ;; Produce output vector
   %r2 = shufflevector <32 x double> %t2, <32 x double> %v2,
@@ -4357,10 +4357,10 @@ define void
                       i32 16, i32 38, i32 59, i32 17, i32 39, i32 60, i32 18, i32 40, i32 61, i32 19, i32 41, i32 62, i32 20, i32 42, i32 63, i32 21>
   store <32 x double> %r1, <32 x double> * %out1, align 4
 
-  ;; t2 = <a22 ... a31 b21 ... b31 undef ... undef>
+  ;; t2 = <a22 ... a31 b21 ... b31 poison ... poison>
   %t2 = shufflevector <32 x double> %v0, <32 x double> %v1,
           <32 x i32> <i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58,
-                      i32 59, i32 60, i32 61, i32 62, i32 63, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 59, i32 60, i32 61, i32 62, i32 63, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   ;; Produce output vector
   %r2 = shufflevector <32 x double> %t2, <32 x double> %v2,
           <32 x i32> <i32 10, i32 53, i32 0, i32 11, i32 54, i32 1, i32 12, i32 55, i32 2, i32 13, i32 56, i32 3, i32 14, i32 57, i32 4, i32 15,
@@ -4780,12 +4780,12 @@ define void
                       i32 112, i32 113, i32 114, i32 115, i32 116, i32 117, i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127>
   store <64 x float> %r1, <64 x float> * %out1, align 4
 
-  ;; t2 = <c0 ... c41 undef ... undef>
+  ;; t2 = <c0 ... c41 poison ... poison>
   %t2 = shufflevector <64 x float> %v0, <64 x float> %v1,
           <64 x i32> <i32 2, i32 5, i32 8, i32 11, i32 14, i32 17, i32 20, i32 23, i32 26, i32 29, i32 32, i32 35, i32 38, i32 41, i32 44, i32 47,
                       i32 50, i32 53, i32 56, i32 59, i32 62, i32 65, i32 68, i32 71, i32 74, i32 77, i32 80, i32 83, i32 86, i32 89, i32 92, i32 95,
-                      i32 98, i32 101, i32 104, i32 107, i32 110, i32 113, i32 116, i32 119, i32 122, i32 125, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 98, i32 101, i32 104, i32 107, i32 110, i32 113, i32 116, i32 119, i32 122, i32 125, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 
   ;; Produce output vector
   %r2 = shufflevector <64 x float> %t2, <64 x float> %v2,
@@ -4838,12 +4838,12 @@ define void
                       i32 80, i32 123, i32 38, i32 81, i32 124, i32 39, i32 82, i32 125, i32 40, i32 83, i32 126, i32 41, i32 84, i32 127, i32 42, i32 85>
   store <64 x float> %r1, <64 x float> * %out1, align 4
 
-  ;; t2 = <a43 ... a63 b43 ... b63 undef ... undef>
+  ;; t2 = <a43 ... a63 b43 ... b63 poison ... poison>
   %t2 = shufflevector <64 x float> %v0, <64 x float> %v1,
           <64 x i32> <i32 43, i32 44, i32 45, i32 46, i32 47, i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58,
                       i32 59, i32 60, i32 61, i32 62, i32 63, i32 107, i32 108, i32 109, i32 110, i32 111, i32 112, i32 113, i32 114, i32 115, i32 116, i32 117,
-                      i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   ;; Produce output vector
   %r2 = shufflevector <64 x float> %t2, <64 x float> %v2,
           <64 x i32> <i32 106, i32 0, i32 21, i32 107, i32 1, i32 22, i32 108, i32 2, i32 23, i32 109, i32 3, i32 24, i32 110, i32 4, i32 25, i32 111,
@@ -4895,12 +4895,12 @@ define void
                       i32 112, i32 113, i32 114, i32 115, i32 116, i32 117, i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127>
   store <64 x double> %r1, <64 x double> * %out1, align 4
 
-  ;; t3 = <c0 ... c41 undef ... undef>
+  ;; t3 = <c0 ... c41 poison ... poison>
   %t2 = shufflevector <64 x double> %v0, <64 x double> %v1,
           <64 x i32> <i32 2, i32 5, i32 8, i32 11, i32 14, i32 17, i32 20, i32 23, i32 26, i32 29, i32 32, i32 35, i32 38, i32 41, i32 44, i32 47,
                       i32 50, i32 53, i32 56, i32 59, i32 62, i32 65, i32 68, i32 71, i32 74, i32 77, i32 80, i32 83, i32 86, i32 89, i32 92, i32 95,
-                      i32 98, i32 101, i32 104, i32 107, i32 110, i32 113, i32 116, i32 119, i32 122, i32 125, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 98, i32 101, i32 104, i32 107, i32 110, i32 113, i32 116, i32 119, i32 122, i32 125, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 
   ;; Produce output vector
   %r2 = shufflevector <64 x double> %t2, <64 x double> %v2,
@@ -4953,12 +4953,12 @@ define void
                       i32 80, i32 123, i32 38, i32 81, i32 124, i32 39, i32 82, i32 125, i32 40, i32 83, i32 126, i32 41, i32 84, i32 127, i32 42, i32 85>
   store <64 x double> %r1, <64 x double> * %out1, align 4
 
-  ;; t2 = <a43 ... a63 b43 ... b63 undef ... undef>
+  ;; t2 = <a43 ... a63 b43 ... b63 poison ... poison>
   %t2 = shufflevector <64 x double> %v0, <64 x double> %v1, ; 21a[43:63] + 21b[43:63]
           <64 x i32> <i32 43, i32 44, i32 45, i32 46, i32 47, i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58,
                       i32 59, i32 60, i32 61, i32 62, i32 63, i32 107, i32 108, i32 109, i32 110, i32 111, i32 112, i32 113, i32 114, i32 115, i32 116, i32 117,
-                      i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
-                      i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+                      i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison,
+                      i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 
   ;; Produce output vector
   %r2 = shufflevector <64 x double> %t2, <64 x double> %v2, ; 21a[0:20] + 21b[21:41] + 22c[106:127]
@@ -6998,9 +6998,9 @@ domixed:
   %first = call i64 @llvm.cttz.i64(i64 %mm, i1 false)
   %first32 = trunc i64 %first to i32
   %baseval = extractelement <$1 x $2> %v, i32 %first32
-  %basev1 = insertelement <$1 x $2> undef, $2 %baseval, i32 0
+  %basev1 = insertelement <$1 x $2> poison, $2 %baseval, i32 0
   ; get a vector that is that value smeared across all elements
-  %basesmear = shufflevector <$1 x $2> %basev1, <$1 x $2> undef,
+  %basesmear = shufflevector <$1 x $2> %basev1, <$1 x $2> poison,
         <$1 x i32> < forloop(i, 0, eval($1-2), `i32 0, ') i32 0 >
 
   ; now to a blend of that vector with the original vector, such that the
@@ -7086,7 +7086,7 @@ define <$1 x $2> @__exclusive_scan_$6(<$1 x $2> %v,
   ; first, set the value of any off lanes to the identity value
   %ptr = alloca <$1 x $2>
   %idvec1 = bitcast $2 $5 to <1 x $2>
-  %idvec = shufflevector <1 x $2> %idvec1, <1 x $2> undef,
+  %idvec = shufflevector <1 x $2> %idvec1, <1 x $2> poison,
       <$1 x i32> < forloop(i, 0, eval($1-2), `i32 0, ') i32 0 >
   store <$1 x $2> %idvec, <$1 x $2> * %ptr
   %ptr`'$3 = bitcast <$1 x $2> * %ptr to <$1 x i`'$3> *
@@ -7109,7 +7109,7 @@ define <$1 x $2> @__exclusive_scan_$6(<$1 x $2> %v,
   %s`'i = $4 $2 %s`'eval(i-1), %v`'eval(i-1)')
 
   ; and fill in the result vector
-  %r0 = insertelement <$1 x $2> undef, $2 $5, i32 0  ; 0th element gets identity
+  %r0 = insertelement <$1 x $2> poison, $2 $5, i32 0  ; 0th element gets identity
   forloop(i, 1, eval($1-1), `
   %r`'i = insertelement <$1 x $2> %r`'eval(i-1), $2 %s`'i, i32 i')
 
@@ -7352,7 +7352,7 @@ define <WIDTH x $1> @__gather_factored_base_offsets32_$1(i8 * %ptr, <WIDTH x i32
 
   %ret0 = call <WIDTH x $1> @__gather_elt32_$1(i8 * %ptr, <WIDTH x i32> %newOffsets,
                                             i32 %offset_scale, <WIDTH x i32> %newDelta,
-                                            <WIDTH x $1> undef, i32 0)
+                                            <WIDTH x $1> poison, i32 0)
   forloop(lane, 1, eval(WIDTH-1),
           `patsubst(patsubst(`%retLANE = call <WIDTH x $1> @__gather_elt32_$1(i8 * %ptr,
                                 <WIDTH x i32> %newOffsets, i32 %offset_scale, <WIDTH x i32> %newDelta,
@@ -7383,7 +7383,7 @@ define <WIDTH x $1> @__gather_factored_base_offsets64_$1(i8 * %ptr, <WIDTH x i64
 
   %ret0 = call <WIDTH x $1> @__gather_elt64_$1(i8 * %ptr, <WIDTH x i64> %newOffsets,
                                             i32 %offset_scale, <WIDTH x i64> %newDelta,
-                                            <WIDTH x $1> undef, i32 0)
+                                            <WIDTH x $1> poison, i32 0)
   forloop(lane, 1, eval(WIDTH-1),
           `patsubst(patsubst(`%retLANE = call <WIDTH x $1> @__gather_elt64_$1(i8 * %ptr,
                                 <WIDTH x i64> %newOffsets, i32 %offset_scale, <WIDTH x i64> %newDelta,
@@ -7416,7 +7416,7 @@ define <WIDTH x $1>
                            <WIDTH x i32> %offsets,
                            <WIDTH x MASK> %vecmask) nounwind readonly alwaysinline {
   %scale_vec = bitcast i32 %offset_scale to <1 x i32>
-  %smear_scale = shufflevector <1 x i32> %scale_vec, <1 x i32> undef,
+  %smear_scale = shufflevector <1 x i32> %scale_vec, <1 x i32> poison,
      <WIDTH x i32> < forloop(i, 1, eval(WIDTH-1), `i32 0, ') i32 0 >
   %scaled_offsets = mul <WIDTH x i32> %smear_scale, %offsets
   %v = call <WIDTH x $1> @__gather_factored_base_offsets32_$1(i8 * %ptr, <WIDTH x i32> %scaled_offsets, i32 1,
@@ -7430,7 +7430,7 @@ define <WIDTH x $1>
                             <WIDTH x MASK> %vecmask) nounwind readonly alwaysinline {
   %scale64 = zext i32 %offset_scale to i64
   %scale_vec = bitcast i64 %scale64 to <1 x i64>
-  %smear_scale = shufflevector <1 x i64> %scale_vec, <1 x i64> undef,
+  %smear_scale = shufflevector <1 x i64> %scale_vec, <1 x i64> poison,
      <WIDTH x i32> < forloop(i, 1, eval(WIDTH-1), `i32 0, ') i32 0 >
   %scaled_offsets = mul <WIDTH x i64> %smear_scale, %offsets
   %v = call <WIDTH x $1> @__gather_factored_base_offsets64_$1(i8 * %ptr, <WIDTH x i64> %scaled_offsets,

--- a/tests/lit-tests/xe_vec_add.ispc
+++ b/tests/lit-tests/xe_vec_add.ispc
@@ -87,32 +87,32 @@ export void vadd(uniform int n, uniform T aIN[], uniform T bIN[], uniform T cOUT
   for (int i = 0; i < n; i += programCount) {
 // CHECK_VARYING: @llvm.genx.svm.gather
 // CHECK_VARYING_I8_SIMD16: call <64 x i8> @llvm.genx.svm.gather.v64i8.v16i1.v16i64(<16 x i1> {{.*}}, i32 0, {{.*}})
-// CHECK_VARYING_I8_SIMD16-NEXT: call <16 x i8> @llvm.genx.rdregioni.v16i8.v64i8.i16(<64 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 undef)
+// CHECK_VARYING_I8_SIMD16-NEXT: call <16 x i8> @llvm.genx.rdregioni.v16i8.v64i8.i16(<64 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 poison)
 // CHECK_VARYING_I8_SIMD8: call <32 x i8> @llvm.genx.svm.gather.v32i8.v8i1.v8i64(<8 x i1> {{.*}}, i32 0, {{.*}})
-// CHECK_VARYING_I8_SIMD8-NEXT: call <8 x i8> @llvm.genx.rdregioni.v8i8.v32i8.i16(<32 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 undef)
+// CHECK_VARYING_I8_SIMD8-NEXT: call <8 x i8> @llvm.genx.rdregioni.v8i8.v32i8.i16(<32 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 poison)
 // CHECK_VARYING_I16_SIMD16: call <32 x i16> @llvm.genx.svm.gather.v32i16.v16i1.v16i64(<16 x i1> {{.*}}, i32 1, {{.*}})
-// CHECK_VARYING_I16_SIMD16-NEXT: call <16 x i16> @llvm.genx.rdregioni.v16i16.v32i16.i16(<32 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 undef)
+// CHECK_VARYING_I16_SIMD16-NEXT: call <16 x i16> @llvm.genx.rdregioni.v16i16.v32i16.i16(<32 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 poison)
 // CHECK_VARYING_I16_SIMD8: call <16 x i16> @llvm.genx.svm.gather.v16i16.v8i1.v8i64(<8 x i1> {{.*}}, i32 1, {{.*}})
-// CHECK_VARYING_I16_SIMD8-NEXT: call <8 x i16> @llvm.genx.rdregioni.v8i16.v16i16.i16(<16 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 undef)
+// CHECK_VARYING_I16_SIMD8-NEXT: call <8 x i16> @llvm.genx.rdregioni.v8i16.v16i16.i16(<16 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 poison)
     T a = aIN[i + programIndex/2];
 // CHECK_VARYING: @llvm.genx.svm.gather
 // CHECK_VARYING_I8_SIMD16: call <64 x i8> @llvm.genx.svm.gather.v64i8.v16i1.v16i64(<16 x i1> {{.*}}, i32 0, {{.*}})
-// CHECK_VARYING_I8_SIMD16-NEXT: call <16 x i8> @llvm.genx.rdregioni.v16i8.v64i8.i16(<64 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 undef)
+// CHECK_VARYING_I8_SIMD16-NEXT: call <16 x i8> @llvm.genx.rdregioni.v16i8.v64i8.i16(<64 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 poison)
 // CHECK_VARYING_I8_SIMD8: call <32 x i8> @llvm.genx.svm.gather.v32i8.v8i1.v8i64(<8 x i1> {{.*}}, i32 0, {{.*}})
-// CHECK_VARYING_I8_SIMD8-NEXT: call <8 x i8> @llvm.genx.rdregioni.v8i8.v32i8.i16(<32 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 undef)
+// CHECK_VARYING_I8_SIMD8-NEXT: call <8 x i8> @llvm.genx.rdregioni.v8i8.v32i8.i16(<32 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 poison)
 // CHECK_VARYING_I16_SIMD16: call <32 x i16> @llvm.genx.svm.gather.v32i16.v16i1.v16i64(<16 x i1> {{.*}}, i32 1, {{.*}})
-// CHECK_VARYING_I16_SIMD16-NEXT: call <16 x i16> @llvm.genx.rdregioni.v16i16.v32i16.i16(<32 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 undef)
+// CHECK_VARYING_I16_SIMD16-NEXT: call <16 x i16> @llvm.genx.rdregioni.v16i16.v32i16.i16(<32 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 poison)
 // CHECK_VARYING_I16_SIMD8: call <16 x i16> @llvm.genx.svm.gather.v16i16.v8i1.v8i64(<8 x i1> {{.*}}, i32 1, {{.*}})
-// CHECK_VARYING_I16_SIMD8-NEXT: call <8 x i16> @llvm.genx.rdregioni.v8i16.v16i16.i16(<16 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 undef)
+// CHECK_VARYING_I16_SIMD8-NEXT: call <8 x i16> @llvm.genx.rdregioni.v8i16.v16i16.i16(<16 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 poison)
     T b = bIN[i + programIndex/2];
 // CHECK_VARYING: @llvm.genx.svm.scatter
-// CHECK_VARYING_I8_SIMD16: call <64 x i8> @llvm.genx.wrregioni.v64i8.v16i8.i16.v16i1(<64 x i8> undef, <16 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 0, <16 x i1> {{.*}})
+// CHECK_VARYING_I8_SIMD16: call <64 x i8> @llvm.genx.wrregioni.v64i8.v16i8.i16.v16i1(<64 x i8> poison, <16 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 0, <16 x i1> {{.*}})
 // CHECK_VARYING_I8_SIMD16-NEXT: call void @llvm.genx.svm.scatter.v16i1.v16i64.v64i8(<16 x i1> {{.*}}, i32 0, {{.*}})
-// CHECK_VARYING_I8_SIMD8: call <32 x i8> @llvm.genx.wrregioni.v32i8.v8i8.i16.v8i1(<32 x i8> undef, <8 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 0, <8 x i1> {{.*}})
+// CHECK_VARYING_I8_SIMD8: call <32 x i8> @llvm.genx.wrregioni.v32i8.v8i8.i16.v8i1(<32 x i8> poison, <8 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 0, <8 x i1> {{.*}})
 // CHECK_VARYING_I8_SIMD8-NEXT: call void @llvm.genx.svm.scatter.v8i1.v8i64.v32i8(<8 x i1> {{.*}}, i32 0, {{.*}})
-// CHECK_VARYING_I16_SIMD16: call <32 x i16> @llvm.genx.wrregioni.v32i16.v16i16.i16.v16i1(<32 x i16> undef, <16 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 0, <16 x i1> {{.*}})
+// CHECK_VARYING_I16_SIMD16: call <32 x i16> @llvm.genx.wrregioni.v32i16.v16i16.i16.v16i1(<32 x i16> poison, <16 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 0, <16 x i1> {{.*}})
 // CHECK_VARYING_I16_SIMD16-NEXT: call void @llvm.genx.svm.scatter.v16i1.v16i64.v32i16(<16 x i1> {{.*}}, i32 1, {{.*}})
-// CHECK_VARYING_I16_SIMD8: call <16 x i16> @llvm.genx.wrregioni.v16i16.v8i16.i16.v8i1(<16 x i16> undef, <8 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 0, <8 x i1> {{.*}})
+// CHECK_VARYING_I16_SIMD8: call <16 x i16> @llvm.genx.wrregioni.v16i16.v8i16.i16.v8i1(<16 x i16> poison, <8 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 0, <8 x i1> {{.*}})
 // CHECK_VARYING_I16_SIMD8-NEXT: call void @llvm.genx.svm.scatter.v8i1.v8i64.v16i16(<8 x i1> {{.*}}, i32 1, <8 x i64> {{.*}})
     cOUT[i + programIndex] = a + b;
   }
@@ -131,37 +131,37 @@ export void vadd(uniform int n, uniform T aIN[], uniform T bIN[], uniform T cOUT
 // CHECK_MASKED_ST_I8_SIMD16: load <16 x i8>
 // CHECK_MASKED_ST_I8_SIMD16: load <16 x i8>
 // CHECK_MASKED_ST_I8_SIMD16: call <64 x i8> @llvm.genx.svm.gather.v64i8.v16i1.v16i64(<16 x i1> {{.*}}, i32 0, {{.*}})
-// CHECK_MASKED_ST_I8_SIMD16-NEXT: call <16 x i8> @llvm.genx.rdregioni.v16i8.v64i8.i16(<64 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 undef)
+// CHECK_MASKED_ST_I8_SIMD16-NEXT: call <16 x i8> @llvm.genx.rdregioni.v16i8.v64i8.i16(<64 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 poison)
 // CHECK_MASKED_ST_I8_SIMD16: call <64 x i8> @llvm.genx.svm.gather.v64i8.v16i1.v16i64(<16 x i1> {{.*}}, i32 0, {{.*}})
-// CHECK_MASKED_ST_I8_SIMD16-NEXT: call <16 x i8> @llvm.genx.rdregioni.v16i8.v64i8.i16(<64 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 undef)
-// CHECK_MASKED_ST_I8_SIMD16: call <64 x i8> @llvm.genx.wrregioni.v64i8.v16i8.i16.v16i1(<64 x i8> undef, <16 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 0, <16 x i1> {{.*}})
+// CHECK_MASKED_ST_I8_SIMD16-NEXT: call <16 x i8> @llvm.genx.rdregioni.v16i8.v64i8.i16(<64 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 poison)
+// CHECK_MASKED_ST_I8_SIMD16: call <64 x i8> @llvm.genx.wrregioni.v64i8.v16i8.i16.v16i1(<64 x i8> poison, <16 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 0, <16 x i1> {{.*}})
 // CHECK_MASKED_ST_I8_SIMD16: call void @llvm.genx.svm.scatter.v16i1.v16i64.v64i8(<16 x i1> {{.*}}, i32 0, {{.*}})
 
 // CHECK_MASKED_ST_I8_SIMD8-NOT: load <8 x i8>
 // CHECK_MASKED_ST_I8_SIMD8-NOT: load <8 x i8>
 // CHECK_MASKED_ST_I8_SIMD8: call <32 x i8> @llvm.genx.svm.gather.v32i8.v8i1.v8i64(<8 x i1> {{.*}}, i32 0, {{.*}})
-// CHECK_MASKED_ST_I8_SIMD8-NEXT: call <8 x i8> @llvm.genx.rdregioni.v8i8.v32i8.i16(<32 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 undef)
+// CHECK_MASKED_ST_I8_SIMD8-NEXT: call <8 x i8> @llvm.genx.rdregioni.v8i8.v32i8.i16(<32 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 poison)
 // CHECK_MASKED_ST_I8_SIMD8: call <32 x i8> @llvm.genx.svm.gather.v32i8.v8i1.v8i64(<8 x i1> {{.*}}, i32 0, {{.*}})
-// CHECK_MASKED_ST_I8_SIMD8-NEXT: call <8 x i8> @llvm.genx.rdregioni.v8i8.v32i8.i16(<32 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 undef)
-// CHECK_MASKED_ST_I8_SIMD8: call <32 x i8> @llvm.genx.wrregioni.v32i8.v8i8.i16.v8i1(<32 x i8> undef, <8 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 0, <8 x i1> {{.*}})
+// CHECK_MASKED_ST_I8_SIMD8-NEXT: call <8 x i8> @llvm.genx.rdregioni.v8i8.v32i8.i16(<32 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 poison)
+// CHECK_MASKED_ST_I8_SIMD8: call <32 x i8> @llvm.genx.wrregioni.v32i8.v8i8.i16.v8i1(<32 x i8> poison, <8 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 0, <8 x i1> {{.*}})
 // CHECK_MASKED_ST_I8_SIMD8-NEXT: call void @llvm.genx.svm.scatter.v8i1.v8i64.v32i8(<8 x i1> {{.*}}, i32 0, {{.*}})
 
 // CHECK_MASKED_ST_I16_SIMD16: load <16 x i16>
 // CHECK_MASKED_ST_I16_SIMD16: load <16 x i16>
 // CHECK_MASKED_ST_I16_SIMD16: call <32 x i16> @llvm.genx.svm.gather.v32i16.v16i1.v16i64(<16 x i1> {{.*}}, i32 1, {{.*}})
-// CHECK_MASKED_ST_I16_SIMD16-NEXT: call <16 x i16> @llvm.genx.rdregioni.v16i16.v32i16.i16(<32 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 undef)
+// CHECK_MASKED_ST_I16_SIMD16-NEXT: call <16 x i16> @llvm.genx.rdregioni.v16i16.v32i16.i16(<32 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 poison)
 // CHECK_MASKED_ST_I16_SIMD16: call <32 x i16> @llvm.genx.svm.gather.v32i16.v16i1.v16i64(<16 x i1> {{.*}}, i32 1, {{.*}})
-// CHECK_MASKED_ST_I16_SIMD16-NEXT: call <16 x i16> @llvm.genx.rdregioni.v16i16.v32i16.i16(<32 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 undef)
-// CHECK_MASKED_ST_I16_SIMD16: call <32 x i16> @llvm.genx.wrregioni.v32i16.v16i16.i16.v16i1(<32 x i16> undef, <16 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 0, <16 x i1> {{.*}})
+// CHECK_MASKED_ST_I16_SIMD16-NEXT: call <16 x i16> @llvm.genx.rdregioni.v16i16.v32i16.i16(<32 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 poison)
+// CHECK_MASKED_ST_I16_SIMD16: call <32 x i16> @llvm.genx.wrregioni.v32i16.v16i16.i16.v16i1(<32 x i16> poison, <16 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 0, <16 x i1> {{.*}})
 // CHECK_MASKED_ST_I16_SIMD16: call void @llvm.genx.svm.scatter.v16i1.v16i64.v32i16(<16 x i1> {{.*}}, i32 1, {{.*}})
 
 // CHECK_MASKED_ST_I16_SIMD8: load <8 x i16>
 // CHECK_MASKED_ST_I16_SIMD8: load <8 x i16>
 // CHECK_MASKED_ST_I16_SIMD8: call <16 x i16> @llvm.genx.svm.gather.v16i16.v8i1.v8i64(<8 x i1> {{.*}}, i32 1, {{.*}})
-// CHECK_MASKED_ST_I16_SIMD8-NEXT: call <8 x i16> @llvm.genx.rdregioni.v8i16.v16i16.i16(<16 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 undef)
+// CHECK_MASKED_ST_I16_SIMD8-NEXT: call <8 x i16> @llvm.genx.rdregioni.v8i16.v16i16.i16(<16 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 poison)
 // CHECK_MASKED_ST_I16_SIMD8: call <16 x i16> @llvm.genx.svm.gather.v16i16.v8i1.v8i64(<8 x i1> {{.*}}, i32 1, {{.*}})
-// CHECK_MASKED_ST_I16_SIMD8-NEXT: call <8 x i16> @llvm.genx.rdregioni.v8i16.v16i16.i16(<16 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 undef)
-// CHECK_MASKED_ST_I16_SIMD8: call <16 x i16> @llvm.genx.wrregioni.v16i16.v8i16.i16.v8i1(<16 x i16> undef, <8 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 0, <8 x i1> {{.*}})
+// CHECK_MASKED_ST_I16_SIMD8-NEXT: call <8 x i16> @llvm.genx.rdregioni.v8i16.v16i16.i16(<16 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 poison)
+// CHECK_MASKED_ST_I16_SIMD8: call <16 x i16> @llvm.genx.wrregioni.v16i16.v8i16.i16.v8i1(<16 x i16> poison, <8 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 0, <8 x i1> {{.*}})
 // CHECK_MASKED_ST_I16_SIMD8: call void @llvm.genx.svm.scatter.v8i1.v8i64.v16i16(<8 x i1> {{.*}}, i32 1, <8 x i64> {{.*}})
 
 // CHECK_MASKED_ST_UNSAFE: load
@@ -172,25 +172,25 @@ export void vadd(uniform int n, uniform T aIN[], uniform T bIN[], uniform T cOUT
 // CHECK_MASKED_ST_UNSAFE_I8_SIMD16: load <16 x i8>
 // CHECK_MASKED_ST_UNSAFE_I8_SIMD16: load <16 x i8>
 // CHECK_MASKED_ST_UNSAFE_I8_SIMD16-NOT: @llvm.genx.svm.gather
-// CHECK_MASKED_ST_UNSAFE_I8_SIMD16: call <64 x i8> @llvm.genx.wrregioni.v64i8.v16i8.i16.v16i1(<64 x i8> undef, <16 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 0, <16 x i1> {{.*}})
+// CHECK_MASKED_ST_UNSAFE_I8_SIMD16: call <64 x i8> @llvm.genx.wrregioni.v64i8.v16i8.i16.v16i1(<64 x i8> poison, <16 x i8> {{.*}}, i32 0, i32 16, i32 4, i16 0, i32 0, <16 x i1> {{.*}})
 // CHECK_MASKED_ST_UNSAFE_I8_SIMD16: call void @llvm.genx.svm.scatter.v16i1.v16i64.v64i8(<16 x i1> {{.*}}, i32 0, {{.*}})
 
 // CHECK_MASKED_ST_UNSAFE_I8_SIMD8: load <8 x i8>
 // CHECK_MASKED_ST_UNSAFE_I8_SIMD8: load <8 x i8>
 // CHECK_MASKED_ST_UNSAFE_I8_SIMD8-NOT: @llvm.genx.svm.gather
-// CHECK_MASKED_ST_UNSAFE_I8_SIMD8: call <32 x i8> @llvm.genx.wrregioni.v32i8.v8i8.i16.v8i1(<32 x i8> undef, <8 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 0, <8 x i1> {{.*}})
+// CHECK_MASKED_ST_UNSAFE_I8_SIMD8: call <32 x i8> @llvm.genx.wrregioni.v32i8.v8i8.i16.v8i1(<32 x i8> poison, <8 x i8> {{.*}}, i32 0, i32 8, i32 4, i16 0, i32 0, <8 x i1> {{.*}})
 // CHECK_MASKED_ST_UNSAFE_I8_SIMD8: call void @llvm.genx.svm.scatter.v8i1.v8i64.v32i8(<8 x i1> {{.*}}, i32 0, {{.*}})
 
 // CHECK_MASKED_ST_UNSAFE_I16_SIMD16: load <16 x i16>
 // CHECK_MASKED_ST_UNSAFE_I16_SIMD16: load <16 x i16>
 // CHECK_MASKED_ST_UNSAFE_I16_SIMD16-NOT: @llvm.genx.svm.gather
-// CHECK_MASKED_ST_UNSAFE_I16_SIMD16: call <32 x i16> @llvm.genx.wrregioni.v32i16.v16i16.i16.v16i1(<32 x i16> undef, <16 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 0, <16 x i1> {{.*}})
+// CHECK_MASKED_ST_UNSAFE_I16_SIMD16: call <32 x i16> @llvm.genx.wrregioni.v32i16.v16i16.i16.v16i1(<32 x i16> poison, <16 x i16> {{.*}}, i32 0, i32 16, i32 2, i16 0, i32 0, <16 x i1> {{.*}})
 // CHECK_MASKED_ST_UNSAFE_I16_SIMD16: call void @llvm.genx.svm.scatter.v16i1.v16i64.v32i16(<16 x i1> {{.*}}, i32 1, {{.*}})
 
 // CHECK_MASKED_ST_UNSAFE_I16_SIMD8: load <8 x i16>
 // CHECK_MASKED_ST_UNSAFE_I16_SIMD8: load <8 x i16>
 // CHECK_MASKED_ST_UNSAFE_I16_SIMD8-NOT: @llvm.genx.svm.gather
-// CHECK_MASKED_ST_UNSAFE_I16_SIMD8: call <16 x i16> @llvm.genx.wrregioni.v16i16.v8i16.i16.v8i1(<16 x i16> undef, <8 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 0, <8 x i1> {{.*}})
+// CHECK_MASKED_ST_UNSAFE_I16_SIMD8: call <16 x i16> @llvm.genx.wrregioni.v16i16.v8i16.i16.v8i1(<16 x i16> poison, <8 x i16> {{.*}}, i32 0, i32 8, i32 2, i16 0, i32 0, <8 x i1> {{.*}})
 // CHECK_MASKED_ST_UNSAFE_I16_SIMD8: call void @llvm.genx.svm.scatter.v8i1.v8i64.v16i16(<8 x i1> {{.*}}, i32 1, <8 x i64> {{.*}})
 
     T a = aIN[i + programIndex];


### PR DESCRIPTION
## Description
Replace all occurrences of the deprecated undef keyword with poison in ISPC's built-in IR library files (builtins/*.ll) and M4 macro files (builtins/util.m4, builtins/util-xe.m4, builtins/svml.m4). 

https://github.com/ispc/ispc/issues/3782
## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed