### PR TITLE
Ensure proper alignment for uniform const arrays in AddGlobalVariable

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -606,6 +606,17 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
         alignment = type->GetAlignment();
     }
 
+    // For uniform const arrays, ensure storage alignment matches the
+    // aligned vector loads that may be emitted by LLVM backend optimizations.
+    if (isConst && type->IsUniformType()) {
+        const ArrayType *arrayType = CastType<ArrayType>(type);
+        if (arrayType != nullptr) {
+            const unsigned int requiredAlignment = static_cast<unsigned int>(g->target->getNativeVectorAlignment());
+
+            alignment = std::max<unsigned int>(alignment, requiredAlignment);
+        }
+    }
+
     if (symbolTable->LookupFunction(name.c_str())) {
         Error(pos, "Global variable \"%s\" shadows previously-declared function.", name.c_str());
         return;
@@ -2185,6 +2196,65 @@ static bool lCompatibleTypes(llvm::Type *Ty1, llvm::Type *Ty2) {
 }
 
 /**
+ * Upgrade destination global's alignment to match source if source has stronger alignment.
+ *
+ * In multi-target compilation, target-specific code may emit aligned vector loads
+ * from global const arrays. The dispatcher module owns the actual definitions of
+ * these globals. If alignment is not upgraded when a later target requires stronger
+ * alignment, the final object may have insufficient section alignment, causing runtime
+ * faults (e.g., AVX-512 vmovaps expecting 64-byte alignment on a 16-byte aligned global).
+ *
+ * This helper only modifies alignment, leaving all other attributes unchanged.
+ *
+ * @param dst Destination global variable to upgrade
+ * @param src Source global variable with potentially stronger alignment
+ */
+static void lUpgradeGlobalVariableAlignment(llvm::GlobalVariable *dst, const llvm::GlobalVariable *src) {
+    Assert(dst != nullptr && src != nullptr);
+
+    llvm::MaybeAlign srcAlign = src->getAlign();
+    if (!srcAlign) {
+        return;
+    }
+
+    llvm::MaybeAlign dstAlign = dst->getAlign();
+    if (!dstAlign || dstAlign->value() < srcAlign->value()) {
+        dst->setAlignment(*srcAlign);
+    }
+}
+
+/**
+ * Copy all attributes from source global to destination global, preserving the
+ * maximum alignment between old destination and source.
+ *
+ * When creating a new global in the dispatcher module, we must copy all attributes
+ * from the source global. However, copyAttributesFrom() may overwrite the destination's
+ * alignment in some LLVM versions before we can compare it. This helper explicitly
+ * preserves the strongest alignment.
+ *
+ * @param dst Destination global variable to update
+ * @param src Source global variable to copy attributes from
+ */
+static void lCopyGlobalVariableAttributes(llvm::GlobalVariable *dst, const llvm::GlobalVariable *src) {
+    Assert(dst != nullptr && src != nullptr);
+
+    llvm::MaybeAlign oldDstAlign = dst->getAlign();
+
+    dst->copyAttributesFrom(src);
+
+    // Be explicit about preserving the strongest alignment across LLVM versions
+    // and clone paths.
+    if (oldDstAlign) {
+        llvm::MaybeAlign newDstAlign = dst->getAlign();
+        if (!newDstAlign || newDstAlign->value() < oldDstAlign->value()) {
+            dst->setAlignment(*oldDstAlign);
+        }
+    }
+
+    lUpgradeGlobalVariableAlignment(dst, src);
+}
+
+/**
  * Extract or validate global variables across multiple target modules during
  * multi-target compilation.
  *
@@ -2232,6 +2302,12 @@ static void lExtractOrCheckGlobals(llvm::Module *msrc, llvm::Module *mdst, bool 
                             "targets with differing vector widths.",
                             gv->getName().str().c_str());
                 }
+
+                // Upgrade alignment if the source global requires stronger alignment.
+                // This is critical when the first target creates the dispatcher global
+                // with 16-byte alignment, and a later AVX-512 module validates it but
+                // requires 64-byte alignment.
+                lUpgradeGlobalVariableAlignment(exist, gv);
             }
             // Alternatively, create it anew and make it match the original
             else {
@@ -2241,7 +2317,7 @@ static void lExtractOrCheckGlobals(llvm::Module *msrc, llvm::Module *mdst, bool 
                 VMap[&*iter] = newGlobal;
 
                 newGlobal->setInitializer(llvm::MapValue(iter->getInitializer(), VMap));
-                newGlobal->copyAttributesFrom(gv);
+                lCopyGlobalVariableAttributes(newGlobal, gv);
             }
         }
     }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -608,7 +608,9 @@ void Module::AddGlobalVariable(Declarator *decl, bool isConst) {
 
     // For uniform const arrays, ensure storage alignment matches the
     // aligned vector loads that may be emitted by LLVM backend optimizations.
-    if (isConst && type->IsUniformType()) {
+    // Skip extern declarations: ISPC does not own the definition, so we must
+    // not impose a stronger alignment than the definition in another TU provides.
+    if (isConst && type->IsUniformType() && !storageClass.IsExtern()) {
         const ArrayType *arrayType = CastType<ArrayType>(type);
         if (arrayType != nullptr) {
             const unsigned int requiredAlignment = static_cast<unsigned int>(g->target->getNativeVectorAlignment());

--- a/tests/lit-tests/3826.ispc
+++ b/tests/lit-tests/3826.ispc
@@ -1,0 +1,28 @@
+// REQUIRES: X86_ENABLED
+
+// RUN: %{ispc} %s -O0 --target=sse2-i32x4 --nostdlib --nowrap --emit-llvm-text -o - | FileCheck %s --check-prefix=SSE2
+// RUN: %{ispc} %s -O0 --target=avx2-i32x8 --nostdlib --nowrap --emit-llvm-text -o - | FileCheck %s --check-prefix=AVX2
+// RUN: %{ispc} %s -O0 --target=avx512skx-x16 --nostdlib --nowrap --emit-llvm-text -o - | FileCheck %s --check-prefix=SKX
+// RUN: %{ispc} %s -O0 --target=sse2-i32x4,avx2-i32x8,avx512skx-x16 --nostdlib --nowrap --emit-llvm-text -o %t.ll
+// RUN: FileCheck %s --input-file=%t.ll --check-prefix=DISPATCH
+
+// SSE2: @owned_arr = {{.*}}constant [4 x i32] {{.*}}, align 16
+// SSE2: @ext_arr = external {{.*}}constant [4 x i32]
+// SSE2-NOT: @ext_arr = {{.*}}, align 16
+
+// AVX2: @owned_arr = {{.*}}constant [4 x i32] {{.*}}, align 32
+// AVX2: @ext_arr = external {{.*}}constant [4 x i32]
+// AVX2-NOT: @ext_arr = {{.*}}, align 32
+
+// SKX: @owned_arr = {{.*}}constant [4 x i32] {{.*}}, align 64
+// SKX: @ext_arr = external {{.*}}constant [4 x i32]
+// SKX-NOT: @ext_arr = {{.*}}, align 64
+
+// DISPATCH: @owned_arr = {{.*}}constant [4 x i32] {{.*}}, align 64
+
+const uniform int owned_arr[4] = {1, 2, 3, 4};
+extern const uniform int ext_arr[4];
+
+export void foo(uniform int * uniform out) {
+    *out = owned_arr[0] + ext_arr[0];
+}


### PR DESCRIPTION
This PR ensures that uniform const arrays are aligned to at least the target native vector alignment and that, when globals are merged into the dispatcher module, the strongest alignment seen across all target modules is preserved.

## Description
In multi-target compilation, multiple target-specific modules can share the same global data through the dispatcher module. For uniform const arrays, the dispatcher owns the actual global definition, so its alignment must be good enough for every target that may use it.

When an earlier target such as AVX2 created the dispatcher global with 32-byte alignment, a later wider target such as AVX-512 could reuse that same global without upgrading its alignment. The AVX-512 backend may emit aligned vector loads, for example `vmovaps`, which require 64-byte alignment. If the shared global remains only 32-byte aligned, this can cause a runtime crash due to misaligned access.

## Related Issue
- [x] https://github.com/ispc/ispc/issues/3838

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)