### PR TITLE
Fix #3821: Update lit tests for LLVM trunk float16 format change

### DIFF
--- a/tests/lit-tests/2738.ispc
+++ b/tests/lit-tests/2738.ispc
@@ -35,7 +35,7 @@
 
 // FLOAT16-LABEL: @foo___
 // FLOAT16-NEXT: allocas:
-// FLOAT16-NEXT: ret <4 x half> <half 0xH3C00, half 0xH4000, half 0xH4200, half 0xH4400>
+// FLOAT16-NEXT: ret <4 x half> <half {{0xH3C00|1\.000000e\+00}}, half {{0xH4000|2\.000000e\+00}}, half {{0xH4200|3\.000000e\+00}}, half {{0xH4400|4\.000000e\+00}}>
 
 // FLOAT-LABEL: @foo___
 // FLOAT-NEXT: allocas:

--- a/tests/lit-tests/2738_arith_exprs.ispc
+++ b/tests/lit-tests/2738_arith_exprs.ispc
@@ -35,7 +35,7 @@
 
 // FLOAT16-LABEL: @foo___
 // FLOAT16-NEXT: allocas:
-// FLOAT16-NEXT: ret <4 x half> <half 0xH3C00, half 0xH4000, half 0xH4200, half 0xH4400>
+// FLOAT16-NEXT: ret <4 x half> <half {{0xH3C00|1\.000000e\+00}}, half {{0xH4000|2\.000000e\+00}}, half {{0xH4200|3\.000000e\+00}}, half {{0xH4400|4\.000000e\+00}}>
 
 // FLOAT-LABEL: @foo___
 // FLOAT-NEXT: allocas:

--- a/tests/lit-tests/2738_cast_types.ispc
+++ b/tests/lit-tests/2738_cast_types.ispc
@@ -35,7 +35,7 @@
 
 // FLOAT16-LABEL: @foo___
 // FLOAT16-NEXT: allocas:
-// FLOAT16-NEXT: ret <4 x half> <half 0xH3C00, half 0xH4000, half 0xH4200, half 0xH4400>
+// FLOAT16-NEXT: ret <4 x half> <half {{0xH3C00|1\.000000e\+00}}, half {{0xH4000|2\.000000e\+00}}, half {{0xH4200|3\.000000e\+00}}, half {{0xH4400|4\.000000e\+00}}>
 
 // FLOAT-LABEL: @foo___
 // FLOAT-NEXT: allocas:

--- a/tests/lit-tests/2738_mixed_types.ispc
+++ b/tests/lit-tests/2738_mixed_types.ispc
@@ -35,7 +35,7 @@
 
 // FLOAT16-LABEL: @foo___
 // FLOAT16-NEXT: allocas:
-// FLOAT16-NEXT: ret <4 x half> <half 0xH3C00, half 0xH4000, half 0xH4200, half 0xH4400>
+// FLOAT16-NEXT: ret <4 x half> <half {{0xH3C00|1\.000000e\+00}}, half {{0xH4000|2\.000000e\+00}}, half {{0xH4200|3\.000000e\+00}}, half {{0xH4400|4\.000000e\+00}}>
 
 // FLOAT-LABEL: @foo___
 // FLOAT-NEXT: allocas:

--- a/tests/lit-tests/2738_one_init.ispc
+++ b/tests/lit-tests/2738_one_init.ispc
@@ -35,7 +35,7 @@
 
 // FLOAT16-LABEL: @foo___
 // FLOAT16-NEXT: allocas:
-// FLOAT16-NEXT: ret <4 x half> {{<half 0xH4000, half 0xH4000, half 0xH4000, half 0xH4000>|splat \(half 0xH4000\)}}
+// FLOAT16-NEXT: ret <4 x half> {{<half (0xH4000|2\.000000e\+00), half (0xH4000|2\.000000e\+00), half (0xH4000|2\.000000e\+00), half (0xH4000|2\.000000e\+00)>|splat \(half (0xH4000|2\.000000e\+00)\)}}
 
 // FLOAT-LABEL: @foo___
 // FLOAT-NEXT: allocas:

--- a/tests/lit-tests/constant_folding_float16.ispc
+++ b/tests/lit-tests/constant_folding_float16.ispc
@@ -1,37 +1,37 @@
 // RUN: %{ispc} %s -O2 --target=host --emit-llvm-text --nostdlib --opt=fast-math -o - | FileCheck %s
 
 // CHECK: @retAddF16
-// CHECK: ret half 0xH4500
+// CHECK: ret half {{0xH4500|5\.000000e\+00}}
 uniform float16 retAddF16() {
     return 2.0f16 + 3.0f16;
 }
 
 // CHECK: @retSubF16
-// CHECK: ret half 0xH3800
+// CHECK: ret half {{0xH3800|5\.000000e-01}}
 uniform float16 retSubF16() {
     return 3.0f16 - 2.5f16;
 }
 
 // CHECK: @retMulF16
-// CHECK: ret half 0xH4780
+// CHECK: ret half {{0xH4780|7\.500000e\+00}}
 uniform float16 retMulF16() {
     return 3.0f16 * 2.5f16;
 }
 
 // CHECK: @retDivF16
-// CHECK: ret half 0xH4200
+// CHECK: ret half {{0xH4200|3\.000000e\+00}}
 uniform float16 retDivF16() {
     return 7.5f16 / 2.5f16;
 }
 
 // CHECK: @retNegF16
-// CHECK: ret half 0xHC000
+// CHECK: ret half {{0xHC000|-2\.000000e\+00}}
 uniform float16 retNegF16() {
     return -2.0f16;
 }
 
 // CHECK: @retFastMathF16
-// CHECK: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )*}}half %{{[a-zA-Z_][a-zA-Z0-9_]*}}, 0xH3800
+// CHECK: fmul {{((contract|reassoc|arcp|nsz|nnan|ninf|afn|fast) )*}}half %{{[a-zA-Z_][a-zA-Z0-9_]*}}, {{0xH3800|5\.000000e-01}}
 uniform float16 retFastMathF16(uniform float16 arg) {
     return arg / 2.f16;
 }

--- a/tests/lit-tests/float16_uniform.ispc
+++ b/tests/lit-tests/float16_uniform.ispc
@@ -2,7 +2,7 @@
 
 // Tests float16 constant parsing in *e*f16 form.
 //; CHECK: define half @foo0___unh(half
-//; CHECK: fadd half %{{[a-zA-Z_][a-zA-Z0-9_]*}}, 0xH011D
+//; CHECK: fadd half %{{[a-zA-Z_][a-zA-Z0-9_]*}}, {{0xH011D|1\.670837e-05}}
 uniform float16 foo0(uniform float16 arg0) {
     arg0 = arg0 + 1.7e-5f16;
     return arg0;
@@ -10,7 +10,7 @@ uniform float16 foo0(uniform float16 arg0) {
 
 // Tests float16 constant parsing in *.*F16 form.
 //; CHECK: define void @foo1___REFunhun_3C_unh_3E_
-//; CHECK: store half 0xH4252,
+//; CHECK: store half {{0xH4252|3\.160156e\+00}},
 //; CHECK: fmul half %arg
 void foo1(uniform float16 &arg0, uniform float16 *uniform arg1) {
     arg0 = 3.16F16;
@@ -48,10 +48,10 @@ uniform double foo5(uniform float16 arg0) { return arg0; }
 
 // Creates +0, -0, +inf and -inf.
 //; CHECK: define void @foo6
-//; CHECK: store half 0xH0000
-//; CHECK: store half 0xH8000
-//; CHECK: store half 0xH7C00
-//; CHECK: store half 0xHFC00
+//; CHECK: store half {{0xH0000|0\.000000e\+00}}
+//; CHECK: store half {{0xH8000|-0\.000000e\+00}}
+//; CHECK: store half {{0xH7C00|\+inf}}
+//; CHECK: store half {{0xHFC00|-inf}}
 void foo6() {
     uniform float16 pz = +0.f16;
     uniform float16 nz = -0.f16;

--- a/tests/lit-tests/float16_varying.ispc
+++ b/tests/lit-tests/float16_varying.ispc
@@ -2,7 +2,7 @@
 
 // Tests float16 constant parsing in *e*f16 form.
 //; CHECK: define <{{[0-9]*}} x half> @foo0___vyh(<{{[0-9]*}} x half>
-//; CHECK: fadd <{{[0-9]*}} x half> %{{[a-zA-Z_][a-zA-Z0-9_]*}}, {{<half 0xH011D, half 0xH011D|splat \(half 0xH011D\)}}
+//; CHECK: fadd <{{[0-9]*}} x half> %{{[a-zA-Z_][a-zA-Z0-9_]*}}, {{<half (0xH011D|1\.670837e-05), half (0xH011D|1\.670837e-05)|splat \(half (0xH011D|1\.670837e-05)\)}}
 varying float16 foo0(varying float16 arg0) {
     arg0 = arg0 + 1.7e-5f16;
     return arg0;
@@ -36,9 +36,9 @@ varying double foo4(varying float16 arg0) { return arg0; }
 // Creates +0, -0, +inf and -inf.
 //; CHECK: define void @foo5
 //; CHECK: store <{{[0-9]*}} x half> zeroinitializer
-//; CHECK: store <{{[0-9]*}} x half> {{<half 0xH8000|splat \(half 0xH8000\)}}
-//; CHECK: store <{{[0-9]*}} x half> {{<half 0xH7C00|splat \(half 0xH7C00\)}}
-//; CHECK: store <{{[0-9]*}} x half> {{<half 0xHFC00|splat \(half 0xHFC00\)}}
+//; CHECK: store <{{[0-9]*}} x half> {{<half (0xH8000|-0\.000000e\+00)|splat \(half (0xH8000|-0\.000000e\+00)\)}}
+//; CHECK: store <{{[0-9]*}} x half> {{<half (0xH7C00|\+inf)|splat \(half (0xH7C00|\+inf)\)}}
+//; CHECK: store <{{[0-9]*}} x half> {{<half (0xHFC00|-inf)|splat \(half (0xHFC00|-inf)\)}}
 void foo5() {
     float16 pz = +0.f16;
     float16 nz = -0.f16;

--- a/tests/lit-tests/hex_literals.ispc
+++ b/tests/lit-tests/hex_literals.ispc
@@ -9,7 +9,7 @@ uniform uint16 i2 = 0X1234;
 uniform uint32 i3 = 0X12345678;
 uniform uint64 i4 = 0X1234567890abcdef;
 
-// CHECK: global half 0xH4000
+// CHECK: global half {{0xH4000|2\.000000e\+00}}
 // CHECK: global float 2.000000e+00
 // CHECK: global double 2.000000e+00
 uniform float16 f1 = 0X1p1f16;

--- a/tests/lit-tests/ispc-intrinsics.ispc
+++ b/tests/lit-tests/ispc-intrinsics.ispc
@@ -71,7 +71,7 @@ ATTRS uniform double atomicrmw(uniform int8 *uniform ptr, uniform double val) {
 }
 
 // CHECK-LABEL: @bitcast
-// CHECK-DAG:   %calltmp = call half @llvm.ispc.bitcast.i16.f16(i16 {{%x.*}}, half 0xH0000)
+// CHECK-DAG:   %calltmp = call half @llvm.ispc.bitcast.i16.f16(i16 {{%x.*}}, half {{0xH0000|0\.000000e\+00}})
 ATTRS uniform float16 bitcast(uniform int16 x) {
     return @llvm.ispc.bitcast(x, (uniform float16)0);
 }


### PR DESCRIPTION
LLVM trunk commit 41c214f0b115 changed the output syntax of floating-point literals in textual IR. The legacy hex format (e.g., 0xH3C00) is no longer emitted; values now print as decimals (e.g., 1.000000e+00), and special values use +inf/-inf notation.

Updated FileCheck patterns in 10 lit tests to accept both legacy hex and new decimal forms via regex alternations, ensuring tests pass on both stable LLVM (21/22) and trunk (23+).

Files updated:
- tests/lit-tests/2738.ispc
- tests/lit-tests/2738_arith_exprs.ispc
- tests/lit-tests/2738_cast_types.ispc
- tests/lit-tests/2738_mixed_types.ispc
- tests/lit-tests/2738_one_init.ispc
- tests/lit-tests/constant_folding_float16.ispc
- tests/lit-tests/float16_uniform.ispc
- tests/lit-tests/float16_varying.ispc
- tests/lit-tests/hex_literals.ispc
- tests/lit-tests/ispc-intrinsics.ispc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description
Brief description of changes

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed