### PR TITLE
Use 64-bit hosted VS tools to fix Windows x86 CI linker failures

### DIFF
--- a/.github/workflows/scripts/load-vs-env.ps1
+++ b/.github/workflows/scripts/load-vs-env.ps1
@@ -1,9 +1,13 @@
 if($args[0] -ceq "x86") {
     $arch="x86"
+    # Use 64-bit hosted tools to avoid 32-bit linker memory limitations (LNK1201, LNK1318)
+    $host_arch="x64"
 } elseif($args[0] -ceq "x86-64") {
     $arch="x64"
+    $host_arch="x64"
 } elseif($args[0] -ceq "aarch64") {
     $arch="arm64"
+    $host_arch="arm64"
 } else {
 	Write-Host "Unrecognized architecture - use of these: x86, x86-64."
 	Exit 1
@@ -21,4 +25,4 @@ Write-Output "  <-> VS Install Path: ${VS_INST_PATH}"
 
 # Import DevShell module and enter the dev shell environment
 Import-Module ${VS_INST_PATH}/Common7/Tools/Microsoft.VisualStudio.DevShell.dll
-Enter-VsDevShell -VsInstallPath ${VS_INST_PATH} -SkipAutomaticLocation -DevCmdArguments "-arch=${arch} -no_logo"
+Enter-VsDevShell -VsInstallPath ${VS_INST_PATH} -SkipAutomaticLocation -DevCmdArguments "-arch=${arch} -host_arch=${host_arch} -no_logo"

--- a/.github/workflows/scripts/load-vs-env.ps1
+++ b/.github/workflows/scripts/load-vs-env.ps1
@@ -9,7 +9,7 @@ if($args[0] -ceq "x86") {
     $arch="arm64"
     $host_arch="arm64"
 } else {
-	Write-Host "Unrecognized architecture - use of these: x86, x86-64."
+	Write-Host "Unrecognized architecture - use one of these: x86, x86-64, aarch64."
 	Exit 1
 }
 


### PR DESCRIPTION
The 32-bit linker runs out of heap space when linking test binaries with debug symbols, causing LNK1201 and LNK1318 errors. Adding -host_arch=x64 to the VS DevShell arguments uses the 64-bit hosted cross-compiler toolchain (HostX64\x86) instead of the native 32-bit toolchain (HostX86\x86).

## Description
Brief description of changes

## Related Issue
- [ ] Fixes #3836 

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed