### PR TITLE
Fix #3835: Update lit tests for LLVM trunk changes

### DIFF
--- a/tests/lit-tests/float16_uniform.ispc
+++ b/tests/lit-tests/float16_uniform.ispc
@@ -2,7 +2,7 @@
 
 // Tests float16 constant parsing in *e*f16 form.
 //; CHECK: define half @foo0___unh(half
-//; CHECK: fadd half %{{[a-zA-Z_][a-zA-Z0-9_]*}}, {{0xH011D|1\.670837e-05}}
+//; CHECK: fadd half %{{[a-zA-Z_][a-zA-Z0-9_]*}}, {{0xH011D|1\.698730e-05}}
 uniform float16 foo0(uniform float16 arg0) {
     arg0 = arg0 + 1.7e-5f16;
     return arg0;
@@ -10,7 +10,7 @@ uniform float16 foo0(uniform float16 arg0) {
 
 // Tests float16 constant parsing in *.*F16 form.
 //; CHECK: define void @foo1___REFunhun_3C_unh_3E_
-//; CHECK: store half {{0xH4252|3\.160156e\+00}},
+//; CHECK: store half {{0xH4252|3\.16016[0-9]e\+00}},
 //; CHECK: fmul half %arg
 void foo1(uniform float16 &arg0, uniform float16 *uniform arg1) {
     arg0 = 3.16F16;

--- a/tests/lit-tests/float16_varying.ispc
+++ b/tests/lit-tests/float16_varying.ispc
@@ -2,7 +2,7 @@
 
 // Tests float16 constant parsing in *e*f16 form.
 //; CHECK: define <{{[0-9]*}} x half> @foo0___vyh(<{{[0-9]*}} x half>
-//; CHECK: fadd <{{[0-9]*}} x half> %{{[a-zA-Z_][a-zA-Z0-9_]*}}, {{<half (0xH011D|1\.670837e-05), half (0xH011D|1\.670837e-05)|splat \(half (0xH011D|1\.670837e-05)\)}}
+//; CHECK: fadd <{{[0-9]*}} x half> %{{[a-zA-Z_][a-zA-Z0-9_]*}}, {{<half (0xH011D|1\.698730e-05), half (0xH011D|1\.698730e-05)|splat \(half (0xH011D|1\.698730e-05)\)}}
 varying float16 foo0(varying float16 arg0) {
     arg0 = arg0 + 1.7e-5f16;
     return arg0;

--- a/tests/lit-tests/lit.cfg
+++ b/tests/lit-tests/lit.cfg
@@ -67,6 +67,12 @@ if llvm_version_major >= 22:
 else:
     print("LLVM_22_0+: NO")
 
+if llvm_version_major >= 23:
+    print("LLVM_23_0+: YES")
+    config.available_features.add("LLVM_23_0+")
+else:
+    print("LLVM_23_0+: NO")
+
 # Windows target OS is enabled
 windows_enabled = lit_config.params.get('windows_enabled')
 if windows_enabled == "ON":

--- a/tests/lit-tests/profile_sample_use.ispc
+++ b/tests/lit-tests/profile_sample_use.ispc
@@ -5,9 +5,6 @@
 //
 // Test with profile - should have complete profile metadata:
 // RUN: %{ispc} -O2 --profile-sample-use=%S/test_profile_metadata.prof --target=host --nostdlib --nowrap --emit-llvm-text -o - %s | FileCheck %s --check-prefix=CHECK_WITH_PROFILE
-//
-// Test error handling:
-// RUN: not %{ispc} --profile-sample-use=nonexistent_file.prof --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s --check-prefix=CHECK_ERROR
 
 // WITHOUT PROFILE - should have no profile metadata
 // CHECK_NO_PROFILE-NOT: ProfileSummary
@@ -23,9 +20,6 @@
 // CHECK_WITH_PROFILE: !{{[0-9]+}} = !{!"NumFunctions", i64 3}
 // CHECK_WITH_PROFILE: !{{[0-9]+}} = !{!"IsPartialProfile", i64 0}
 // CHECK_WITH_PROFILE: !{{[0-9]+}} = !{!"DetailedSummary", !{{[0-9]+}}}
-
-// ERROR HANDLING - should report file not found
-// CHECK_ERROR: error: nonexistent_file.prof: Could not open profile
 
 static uniform float hot_helper(uniform float x) {
     return x * 2.0f + 1.0f;

--- a/tests/lit-tests/profile_sample_use_error.ispc
+++ b/tests/lit-tests/profile_sample_use_error.ispc
@@ -1,0 +1,9 @@
+// Test error handling for missing profile file.
+// LLVM 23+ silently ignores missing profile files, so this test is only for older versions.
+//
+// REQUIRES: !LLVM_23_0+
+// RUN: not %{ispc} --profile-sample-use=nonexistent_file.prof --target=host --nostdlib --nowrap --emit-llvm-text -o - %s 2>&1 | FileCheck %s
+
+// CHECK: error: nonexistent_file.prof: Could not open profile
+
+export void dummy() {}


### PR DESCRIPTION
This commit fixes three lit test failures in LLVM trunk nightly builds:

1. float16_uniform.ispc and float16_varying.ispc:
   - Updated expected decimal value from 1.670837e-05 to 1.698730e-05
   - LLVM commit 41c214f0b115 changed float literal output from hex to shortest-roundtrip decimal form
   - Previous value was incorrect single-precision interpretation
   - New value is correct half-precision value for 0xH011D

2. profile_sample_use.ispc:
   - Added LLVM_23_0+ feature flag to lit.cfg
   - Gated error handling test with REQUIRES: !LLVM_23_0+
   - LLVM trunk now silently ignores missing profile files instead of reporting errors (behavior change between May 6-7)

## Related Issue
- [x] Fixes #3835 

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed