### PR TITLE
Fix Ubuntu 18.04 Docker images

### DIFF
--- a/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/18.04/cpu_ispc_build/Dockerfile
@@ -40,25 +40,18 @@ RUN if [[ $(uname -m) =~ "x86" ]]; then \
     wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $CMAKE_URL && \
     sh cmake-*.sh --prefix=/usr/local --skip-license && rm -rf cmake-*.sh
 
-# Install TBB (required for ISPCRT).
-# Use oneAPI TBB on x86 (to avoid enum-constexpr-conversion errors with LLVM 21+)
-# Build TBB from source on ARM64 (Intel apt packages are x86-only)
-RUN if [[ $(uname -m) =~ "x86" ]]; then \
-        wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor -o /usr/share/keyrings/intel-oneapi-archive-keyring.gpg && \
-        echo "deb [signed-by=/usr/share/keyrings/intel-oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list && \
-        apt-get -y update && apt-get --no-install-recommends install -y intel-oneapi-tbb-devel && \
-        rm -rf /var/lib/apt/lists/*; \
-    else \
-        git clone --depth 1 --branch v2021.13.0 https://github.com/oneapi-src/oneTBB.git /tmp/oneTBB && \
-        cmake -S /tmp/oneTBB -B /tmp/oneTBB/build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DTBB_TEST=OFF \
-            -DCMAKE_INSTALL_PREFIX=/opt/intel/oneapi/tbb/2021.13 && \
-        cmake --build /tmp/oneTBB/build -j"$(nproc)" && \
-        cmake --install /tmp/oneTBB/build && \
-        rm -rf /tmp/oneTBB && \
-        ln -s /opt/intel/oneapi/tbb/2021.13 /opt/intel/oneapi/tbb/latest; \
-    fi
+# Install TBB from source (required for ISPCRT).
+# Build from source to avoid certificate issues with Intel apt repo on Ubuntu 18.04
+# and to avoid enum-constexpr-conversion errors with LLVM 21+
+RUN git clone --depth 1 --branch v2021.13.0 https://github.com/oneapi-src/oneTBB.git /tmp/oneTBB && \
+    cmake -S /tmp/oneTBB -B /tmp/oneTBB/build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DTBB_TEST=OFF \
+        -DCMAKE_INSTALL_PREFIX=/opt/intel/oneapi/tbb/2021.13 && \
+    cmake --build /tmp/oneTBB/build -j"$(nproc)" && \
+    cmake --install /tmp/oneTBB/build && \
+    rm -rf /tmp/oneTBB && \
+    ln -s /opt/intel/oneapi/tbb/2021.13 /opt/intel/oneapi/tbb/latest
 
 # Set TBB_ROOT to point to oneAPI TBB installation
 ENV TBB_ROOT=/opt/intel/oneapi/tbb/latest

--- a/docker/ubuntu/18.04/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/18.04/xpu_ispc_build/Dockerfile
@@ -41,26 +41,19 @@ RUN if [[ $(uname -m) =~ "x86" ]]; then \
     wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $CMAKE_URL && \
     sh cmake-*.sh --prefix=/usr/local --skip-license && rm -rf cmake-*.sh
 
-# Install TBB (required for ISPCRT).
-# Use oneAPI TBB on x86 (to avoid enum-constexpr-conversion errors with LLVM 21+)
-# Build TBB from source on ARM64 (Intel apt packages are x86-only)
+# Install TBB from source (required for ISPCRT).
+# Build from source to avoid certificate issues with Intel apt repo on Ubuntu 18.04
+# and to avoid enum-constexpr-conversion errors with LLVM 21+
 RUN if [ "$XE_DEPS" == "ON" ]; then \
-        if [[ $(uname -m) =~ "x86" ]]; then \
-            wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor -o /usr/share/keyrings/intel-oneapi-archive-keyring.gpg && \
-            echo "deb [signed-by=/usr/share/keyrings/intel-oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list && \
-            apt-get -y update && apt-get --no-install-recommends install -y intel-oneapi-tbb-devel && \
-            rm -rf /var/lib/apt/lists/*; \
-        else \
-            git clone --depth 1 --branch v2021.13.0 https://github.com/oneapi-src/oneTBB.git /tmp/oneTBB && \
-            cmake -S /tmp/oneTBB -B /tmp/oneTBB/build -G Ninja \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DTBB_TEST=OFF \
-                -DCMAKE_INSTALL_PREFIX=/opt/intel/oneapi/tbb/2021.13 && \
-            cmake --build /tmp/oneTBB/build -j"$(nproc)" && \
-            cmake --install /tmp/oneTBB/build && \
-            rm -rf /tmp/oneTBB && \
-            ln -s /opt/intel/oneapi/tbb/2021.13 /opt/intel/oneapi/tbb/latest; \
-        fi; \
+        git clone --depth 1 --branch v2021.13.0 https://github.com/oneapi-src/oneTBB.git /tmp/oneTBB && \
+        cmake -S /tmp/oneTBB -B /tmp/oneTBB/build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DTBB_TEST=OFF \
+            -DCMAKE_INSTALL_PREFIX=/opt/intel/oneapi/tbb/2021.13 && \
+        cmake --build /tmp/oneTBB/build -j"$(nproc)" && \
+        cmake --install /tmp/oneTBB/build && \
+        rm -rf /tmp/oneTBB && \
+        ln -s /opt/intel/oneapi/tbb/2021.13 /opt/intel/oneapi/tbb/latest; \
     fi
 
 # Set TBB_ROOT to point to oneAPI TBB installation


### PR DESCRIPTION
Ubuntu 18.04's ca-certificates package is outdated and doesn't include the Sectigo certificate used by apt.repos.intel.com, causing wget to fail when downloading the Intel GPG key. Fix by building TBB from source.

Workflow with applied patch: https://github.com/ispc/ispc/actions/runs/26182624422

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed