### PR TITLE
Fix reduce_add functions

### DIFF
--- a/builtins/generic.ispc
+++ b/builtins/generic.ispc
@@ -758,65 +758,62 @@ EXT READNONE varying float16 __pow_varying_half(varying float16 x, varying float
 EXT READNONE uniform float16 __sqrt_uniform_half(uniform float16 x) { return @llvm.sqrt(x); }
 EXT READNONE varying float16 __sqrt_varying_half(varying float16 x) { return @llvm.sqrt(x); }
 
-// 16-bit float reduction
+// 16-bit float add/min/max reductions
 EXT READNONE uniform float16 __reduce_add_half(varying float16 x) { return @llvm.vector.reduce.fadd(-0.0f16, x); }
 EXT READNONE uniform float16 __reduce_max_half(varying float16 x) { return @llvm.vector.reduce.fmax(x); }
 EXT READNONE uniform float16 __reduce_min_half(varying float16 x) { return @llvm.vector.reduce.fmin(x); }
 
-// 16-bit float min and max functions
-EXT READNONE uniform float16 __min_uniform_half(uniform float16 x, uniform float16 y) { return x < y ? x : y; }
-EXT READNONE varying float16 __min_varying_half(varying float16 x, varying float16 y) { return x < y ? x : y; }
-EXT READNONE uniform float16 __max_uniform_half(uniform float16 x, uniform float16 y) { return x > y ? x : y; }
-EXT READNONE varying float16 __max_varying_half(varying float16 x, varying float16 y) { return x > y ? x : y; }
-
-// horizontal int8 ops
-EXT READNONE uniform int16 __reduce_add_int8(varying int8 x) { return @llvm.vector.reduce.add((int16)x); }
-EXT READNONE uniform int8 __reduce_min_int8(varying int8 x) { return @llvm.vector.reduce.smin(x); }
-EXT READNONE uniform int8 __reduce_max_int8(varying int8 x) { return @llvm.vector.reduce.smax(x); }
-
-// horizontal int16 ops
-EXT READNONE uniform int16 __reduce_add_int16(varying int16 x) { return @llvm.vector.reduce.add((int32)x); }
-EXT READNONE uniform int16 __reduce_min_int16(varying int16 x) { return @llvm.vector.reduce.smin(x); }
-EXT READNONE uniform int16 __reduce_max_int16(varying int16 x) { return @llvm.vector.reduce.smax(x); }
-
-// horizontal float ops
+// float add/min/max reductions
 EXT READNONE uniform float __reduce_add_float(varying float x) { return @llvm.vector.reduce.fadd(-0.0f, x); }
 EXT READNONE uniform float __reduce_max_float(varying float x) { return @llvm.vector.reduce.fmax(x); }
 EXT READNONE uniform float __reduce_min_float(varying float x) { return @llvm.vector.reduce.fmin(x); }
 
-// horizontal int32 ops
-// TODO!: don't we lose result with reduce_add having int32 return type?
-EXT READNONE uniform int32 __reduce_add_int32(varying int32 x) { return @llvm.vector.reduce.add((int64)x); }
-EXT READNONE uniform int32 __reduce_min_int32(varying int32 x) { return @llvm.vector.reduce.smin(x); }
-EXT READNONE uniform int32 __reduce_max_int32(varying int32 x) { return @llvm.vector.reduce.smax(x); }
-
-// horizontal uint8 ops
-EXT READNONE uniform uint8 __reduce_min_uint8(varying uint8 x) { return @llvm.vector.reduce.umin(x); }
-EXT READNONE uniform uint8 __reduce_max_uint8(varying uint8 x) { return @llvm.vector.reduce.umax(x); }
-
-// horizontal uint16 ops
-EXT READNONE uniform uint16 __reduce_min_uint16(varying uint16 x) { return @llvm.vector.reduce.umin(x); }
-EXT READNONE uniform uint16 __reduce_max_uint16(varying uint16 x) { return @llvm.vector.reduce.umax(x); }
-
-// horizontal uint32 ops
-EXT READNONE uniform uint32 __reduce_min_uint32(varying uint32 x) { return @llvm.vector.reduce.umin(x); }
-EXT READNONE uniform uint32 __reduce_max_uint32(varying uint32 x) { return @llvm.vector.reduce.umax(x); }
-
-// horizontal double ops
+// double add/min/max reductions
 EXT READNONE uniform double __reduce_add_double(varying double x) { return @llvm.vector.reduce.fadd(-0.0d, x); }
 EXT READNONE uniform double __reduce_min_double(varying double x) { return @llvm.vector.reduce.fmin(x); }
 EXT READNONE uniform double __reduce_max_double(varying double x) { return @llvm.vector.reduce.fmax(x); }
 
-// horizontal int64 ops
+// int8 add/min/max reductions
+EXT READNONE uniform int8 __reduce_add_int8(varying int8 x) { return @llvm.vector.reduce.add(x); }
+EXT READNONE uniform int8 __reduce_min_int8(varying int8 x) { return @llvm.vector.reduce.smin(x); }
+EXT READNONE uniform int8 __reduce_max_int8(varying int8 x) { return @llvm.vector.reduce.smax(x); }
+
+// int16 add/min/max reductions
+EXT READNONE uniform int16 __reduce_add_int16(varying int16 x) { return @llvm.vector.reduce.add(x); }
+EXT READNONE uniform int16 __reduce_min_int16(varying int16 x) { return @llvm.vector.reduce.smin(x); }
+EXT READNONE uniform int16 __reduce_max_int16(varying int16 x) { return @llvm.vector.reduce.smax(x); }
+
+// int32 add/min/max reductions
+EXT READNONE uniform int32 __reduce_add_int32(varying int32 x) { return @llvm.vector.reduce.add(x); }
+EXT READNONE uniform int32 __reduce_min_int32(varying int32 x) { return @llvm.vector.reduce.smin(x); }
+EXT READNONE uniform int32 __reduce_max_int32(varying int32 x) { return @llvm.vector.reduce.smax(x); }
+
+// int64 add/min/max reductions
 EXT READNONE uniform int64 __reduce_add_int64(varying int64 x) { return @llvm.vector.reduce.add(x); }
 EXT READNONE uniform int64 __reduce_min_int64(varying int64 x) { return @llvm.vector.reduce.smin(x); }
 EXT READNONE uniform int64 __reduce_max_int64(varying int64 x) { return @llvm.vector.reduce.smax(x); }
 
-// horizontal uint64 ops
+// uint8 add/min/max reductions
+EXT READNONE uniform uint8 __reduce_add_uint8(varying uint8 x) { return @llvm.vector.reduce.add(x); }
+EXT READNONE uniform uint8 __reduce_min_uint8(varying uint8 x) { return @llvm.vector.reduce.umin(x); }
+EXT READNONE uniform uint8 __reduce_max_uint8(varying uint8 x) { return @llvm.vector.reduce.umax(x); }
+
+// uint16 add/min/max reductions
+EXT READNONE uniform uint16 __reduce_add_uint16(varying uint16 x) { return @llvm.vector.reduce.add(x); }
+EXT READNONE uniform uint16 __reduce_min_uint16(varying uint16 x) { return @llvm.vector.reduce.umin(x); }
+EXT READNONE uniform uint16 __reduce_max_uint16(varying uint16 x) { return @llvm.vector.reduce.umax(x); }
+
+// uint32 add/min/max reductions
+EXT READNONE uniform uint32 __reduce_add_uint32(varying uint32 x) { return @llvm.vector.reduce.add(x); }
+EXT READNONE uniform uint32 __reduce_min_uint32(varying uint32 x) { return @llvm.vector.reduce.umin(x); }
+EXT READNONE uniform uint32 __reduce_max_uint32(varying uint32 x) { return @llvm.vector.reduce.umax(x); }
+
+// uint64 add/min/max reductions
+EXT READNONE uniform uint64 __reduce_add_uint64(varying uint64 x) { return @llvm.vector.reduce.add(x); }
 EXT READNONE uniform uint64 __reduce_min_uint64(varying uint64 x) { return @llvm.vector.reduce.umin(x); }
 EXT READNONE uniform uint64 __reduce_max_uint64(varying uint64 x) { return @llvm.vector.reduce.umax(x); }
 
-// horizontal equality ops
+// equality reductions
 template <typename T> unmasked uniform bool __reduce_equal(varying T x, uniform T *uniform ret, UIntMaskType mask) {
     uniform int first_active = __count_trailing_zeros_uniform_i64(__movmsk(mask));
     uniform T first_val = __extract(x, first_active);
@@ -829,6 +826,15 @@ template <typename T> unmasked uniform bool __reduce_equal(varying T x, uniform 
         return true;
     }
     return false;
+}
+EXT uniform bool __reduce_equal_half(varying float16 val, uniform float16 *uniform ret, UIntMaskType mask) {
+    return __reduce_equal<float16>(val, ret, mask);
+}
+EXT uniform bool __reduce_equal_float(varying float val, uniform float *uniform ret, UIntMaskType mask) {
+    return __reduce_equal<float>(val, ret, mask);
+}
+EXT uniform bool __reduce_equal_double(varying double val, uniform double *uniform ret, UIntMaskType mask) {
+    return __reduce_equal<double>(val, ret, mask);
 }
 EXT uniform bool __reduce_equal_int8(varying int8 val, uniform int8 *uniform ret, UIntMaskType mask) {
     return __reduce_equal<int8>(val, ret, mask);
@@ -854,15 +860,54 @@ EXT uniform bool __reduce_equal_int64(varying int64 val, uniform int64 *uniform 
 EXT uniform bool __reduce_equal_uint64(varying uint64 val, uniform uint64 *uniform ret, UIntMaskType mask) {
     return __reduce_equal<uint64>(val, ret, mask);
 }
-EXT uniform bool __reduce_equal_half(varying float16 val, uniform float16 *uniform ret, UIntMaskType mask) {
-    return __reduce_equal<float16>(val, ret, mask);
-}
-EXT uniform bool __reduce_equal_float(varying float val, uniform float *uniform ret, UIntMaskType mask) {
-    return __reduce_equal<float>(val, ret, mask);
-}
-EXT uniform bool __reduce_equal_double(varying double val, uniform double *uniform ret, UIntMaskType mask) {
-    return __reduce_equal<double>(val, ret, mask);
-}
+
+// 16-bit float min and max functions
+EXT READNONE uniform float16 __min_uniform_half(uniform float16 x, uniform float16 y) { return x < y ? x : y; }
+EXT READNONE varying float16 __min_varying_half(varying float16 x, varying float16 y) { return x < y ? x : y; }
+EXT READNONE uniform float16 __max_uniform_half(uniform float16 x, uniform float16 y) { return x > y ? x : y; }
+EXT READNONE varying float16 __max_varying_half(varying float16 x, varying float16 y) { return x > y ? x : y; }
+
+// float min and max functions
+EXT READNONE uniform float __min_uniform_float(uniform float x, uniform float y) { return @llvm.minnum(x, y); }
+EXT READNONE uniform float __max_uniform_float(uniform float x, uniform float y) { return @llvm.maxnum(x, y); }
+EXT READNONE varying float __min_varying_float(varying float x, varying float y) { return @llvm.minnum(x, y); }
+EXT READNONE varying float __max_varying_float(varying float x, varying float y) { return @llvm.maxnum(x, y); }
+
+// double precision min/max
+EXT READNONE uniform double __min_uniform_double(uniform double x, uniform double y) { return @llvm.minnum(x, y); }
+EXT READNONE uniform double __max_uniform_double(uniform double x, uniform double y) { return @llvm.maxnum(x, y); }
+EXT READNONE varying double __min_varying_double(varying double x, varying double y) { return @llvm.minnum(x, y); }
+EXT READNONE varying double __max_varying_double(varying double x, varying double y) { return @llvm.maxnum(x, y); }
+
+// 8-bit integer min and max functions
+EXT READNONE uniform int8 __min_uniform_int8(uniform int8 x, uniform int8 y) { return x < y ? x : y; }
+EXT READNONE uniform int8 __max_uniform_int8(uniform int8 x, uniform int8 y) { return x > y ? x : y; }
+EXT READNONE uniform uint8 __min_uniform_uint8(uniform uint8 x, uniform uint8 y) { return x < y ? x : y; }
+EXT READNONE uniform uint8 __max_uniform_uint8(uniform uint8 x, uniform uint8 y) { return x > y ? x : y; }
+EXT READNONE varying int8 __min_varying_int8(varying int8 x, varying int8 y) { return x < y ? x : y; }
+EXT READNONE varying int8 __max_varying_int8(varying int8 x, varying int8 y) { return x > y ? x : y; }
+EXT READNONE varying uint8 __min_varying_uint8(varying uint8 x, varying uint8 y) { return x < y ? x : y; }
+EXT READNONE varying uint8 __max_varying_uint8(varying uint8 x, varying uint8 y) { return x > y ? x : y; }
+
+// 16-bit integer min and max functions
+EXT READNONE uniform int16 __min_uniform_int16(uniform int16 x, uniform int16 y) { return x < y ? x : y; }
+EXT READNONE uniform int16 __max_uniform_int16(uniform int16 x, uniform int16 y) { return x > y ? x : y; }
+EXT READNONE uniform uint16 __min_uniform_uint16(uniform uint16 x, uniform uint16 y) { return x < y ? x : y; }
+EXT READNONE uniform uint16 __max_uniform_uint16(uniform uint16 x, uniform uint16 y) { return x > y ? x : y; }
+EXT READNONE varying int16 __min_varying_int16(varying int16 x, varying int16 y) { return x < y ? x : y; }
+EXT READNONE varying int16 __max_varying_int16(varying int16 x, varying int16 y) { return x > y ? x : y; }
+EXT READNONE varying uint16 __min_varying_uint16(varying uint16 x, varying uint16 y) { return x < y ? x : y; }
+EXT READNONE varying uint16 __max_varying_uint16(varying uint16 x, varying uint16 y) { return x > y ? x : y; }
+
+// 32-bit integer min and max functions
+EXT READNONE uniform int32 __min_uniform_int32(uniform int32 x, uniform int32 y) { return x < y ? x : y; }
+EXT READNONE uniform int32 __max_uniform_int32(uniform int32 x, uniform int32 y) { return x > y ? x : y; }
+EXT READNONE uniform uint32 __min_uniform_uint32(uniform uint32 x, uniform uint32 y) { return x < y ? x : y; }
+EXT READNONE uniform uint32 __max_uniform_uint32(uniform uint32 x, uniform uint32 y) { return x > y ? x : y; }
+EXT READNONE varying int32 __min_varying_int32(varying int32 x, varying int32 y) { return x < y ? x : y; }
+EXT READNONE varying int32 __max_varying_int32(varying int32 x, varying int32 y) { return x > y ? x : y; }
+EXT READNONE varying uint32 __min_varying_uint32(varying uint32 x, varying uint32 y) { return x < y ? x : y; }
+EXT READNONE varying uint32 __max_varying_uint32(varying uint32 x, varying uint32 y) { return x > y ? x : y; }
 
 // 64-bit integer min and max functions
 EXT READNONE uniform int64 __min_uniform_int64(uniform int64 x, uniform int64 y) { return x < y ? x : y; }
@@ -873,48 +918,6 @@ EXT READNONE uniform uint64 __min_uniform_uint64(uniform uint64 x, uniform uint6
 EXT READNONE uniform uint64 __max_uniform_uint64(uniform uint64 x, uniform uint64 y) { return x > y ? x : y; }
 EXT READNONE varying uint64 __min_varying_uint64(varying uint64 x, varying uint64 y) { return x < y ? x : y; }
 EXT READNONE varying uint64 __max_varying_uint64(varying uint64 x, varying uint64 y) { return x > y ? x : y; }
-
-// float min/max
-EXT READNONE uniform float __min_uniform_float(uniform float x, uniform float y) { return @llvm.minnum(x, y); }
-EXT READNONE uniform float __max_uniform_float(uniform float x, uniform float y) { return @llvm.maxnum(x, y); }
-EXT READNONE varying float __min_varying_float(varying float x, varying float y) { return @llvm.minnum(x, y); }
-EXT READNONE varying float __max_varying_float(varying float x, varying float y) { return @llvm.maxnum(x, y); }
-
-// int8 min/max
-EXT READNONE uniform int8 __min_uniform_int8(uniform int8 x, uniform int8 y) { return x < y ? x : y; }
-EXT READNONE uniform int8 __max_uniform_int8(uniform int8 x, uniform int8 y) { return x > y ? x : y; }
-EXT READNONE uniform uint8 __min_uniform_uint8(uniform uint8 x, uniform uint8 y) { return x < y ? x : y; }
-EXT READNONE uniform uint8 __max_uniform_uint8(uniform uint8 x, uniform uint8 y) { return x > y ? x : y; }
-EXT READNONE varying int8 __min_varying_int8(varying int8 x, varying int8 y) { return x < y ? x : y; }
-EXT READNONE varying int8 __max_varying_int8(varying int8 x, varying int8 y) { return x > y ? x : y; }
-EXT READNONE varying uint8 __min_varying_uint8(varying uint8 x, varying uint8 y) { return x < y ? x : y; }
-EXT READNONE varying uint8 __max_varying_uint8(varying uint8 x, varying uint8 y) { return x > y ? x : y; }
-
-// int16 min/max
-EXT READNONE uniform int16 __min_uniform_int16(uniform int16 x, uniform int16 y) { return x < y ? x : y; }
-EXT READNONE uniform int16 __max_uniform_int16(uniform int16 x, uniform int16 y) { return x > y ? x : y; }
-EXT READNONE uniform uint16 __min_uniform_uint16(uniform uint16 x, uniform uint16 y) { return x < y ? x : y; }
-EXT READNONE uniform uint16 __max_uniform_uint16(uniform uint16 x, uniform uint16 y) { return x > y ? x : y; }
-EXT READNONE varying int16 __min_varying_int16(varying int16 x, varying int16 y) { return x < y ? x : y; }
-EXT READNONE varying int16 __max_varying_int16(varying int16 x, varying int16 y) { return x > y ? x : y; }
-EXT READNONE varying uint16 __min_varying_uint16(varying uint16 x, varying uint16 y) { return x < y ? x : y; }
-EXT READNONE varying uint16 __max_varying_uint16(varying uint16 x, varying uint16 y) { return x > y ? x : y; }
-
-// unsigned int min/max
-EXT READNONE uniform int32 __min_uniform_int32(uniform int32 x, uniform int32 y) { return x < y ? x : y; }
-EXT READNONE uniform int32 __max_uniform_int32(uniform int32 x, uniform int32 y) { return x > y ? x : y; }
-EXT READNONE uniform uint32 __min_uniform_uint32(uniform uint32 x, uniform uint32 y) { return x < y ? x : y; }
-EXT READNONE uniform uint32 __max_uniform_uint32(uniform uint32 x, uniform uint32 y) { return x > y ? x : y; }
-EXT READNONE varying int32 __min_varying_int32(varying int32 x, varying int32 y) { return x < y ? x : y; }
-EXT READNONE varying int32 __max_varying_int32(varying int32 x, varying int32 y) { return x > y ? x : y; }
-EXT READNONE varying uint32 __min_varying_uint32(varying uint32 x, varying uint32 y) { return x < y ? x : y; }
-EXT READNONE varying uint32 __max_varying_uint32(varying uint32 x, varying uint32 y) { return x > y ? x : y; }
-
-// double precision min/max
-EXT READNONE uniform double __min_uniform_double(uniform double x, uniform double y) { return @llvm.minnum(x, y); }
-EXT READNONE uniform double __max_uniform_double(uniform double x, uniform double y) { return @llvm.maxnum(x, y); }
-EXT READNONE varying double __min_varying_double(varying double x, varying double y) { return @llvm.minnum(x, y); }
-EXT READNONE varying double __max_varying_double(varying double x, varying double y) { return @llvm.maxnum(x, y); }
 
 // int8/int16 avg builtins
 EXT varying uint8 __avg_up_uint8(varying uint8 a, varying uint8 b) { return ((uint16)a + (uint16)b + 1) >> 1; }

--- a/builtins/target-avx1-i32x16.ll
+++ b/builtins/target-avx1-i32x16.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2025, Intel Corporation
+;;  Copyright (c) 2010-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-avx1-i32x16.ll
+++ b/builtins/target-avx1-i32x16.ll
@@ -283,7 +283,10 @@ define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
   reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<16 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<16 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<16 x i16> %0)
+  ret i16 %res
+}
 
 define <16 x i32> @__add_varying_int32(<16 x i32>,
                                        <16 x i32>) nounwind readnone alwaysinline {
@@ -311,7 +314,10 @@ define i32 @__reduce_max_int32(<16 x i32>) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint32 ops
 
-@__reduce_add_uint32 = alias i32 (<16 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<16 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<16 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_uint32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__min_varying_uint32, @__min_uniform_uint32)
@@ -384,7 +390,10 @@ define i64 @__reduce_max_int64(<16 x i64>) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint64 ops
 
-@__reduce_add_uint64 = alias i64 (<16 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<16 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<16 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_uint64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_uint64, @__min_uniform_uint64)

--- a/builtins/target-avx1-i32x16.ll
+++ b/builtins/target-avx1-i32x16.ll
@@ -241,18 +241,6 @@ reduce_equal(16)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
 
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %0,
-                                              <16 x i8> zeroinitializer)
-  %r0 = extractelement <2 x i64> %rv, i32 0
-  %r1 = extractelement <2 x i64> %rv, i32 1
-  %r = add i64 %r0, %r1
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
 define i32 @__reduce_min_int32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__min_varying_int32, @__min_uniform_int32)
 }

--- a/builtins/target-avx1-i32x16.ll
+++ b/builtins/target-avx1-i32x16.ll
@@ -243,21 +243,6 @@ reduce_equal(16)
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define internal <16 x i8> @__add_varying_i8(<16 x i8>,
-                                              <16 x i8>) nounwind readnone alwaysinline {
-  %r = add <16 x i8> %0, %1
-  ret <16 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
-  reduce16(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %0,
                                               <16 x i8> zeroinitializer)
@@ -266,41 +251,6 @@ define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %r = add i64 %r0, %r1
   %r8 = trunc i64 %r to i8
   ret i8 %r8
-}
-
-define internal <16 x i16> @__add_varying_i16(<16 x i16>,
-                                  <16 x i16>) nounwind readnone alwaysinline {
-  %r = add <16 x i16> %0, %1
-  ret <16 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
-  reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<16 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<16 x i16> %0)
-  ret i16 %res
-}
-
-define <16 x i32> @__add_varying_int32(<16 x i32>,
-                                       <16 x i32>) nounwind readnone alwaysinline {
-  %s = add <16 x i32> %0, %1
-  ret <16 x i32> %s
-}
-
-define i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinline {
-  %s = add i32 %0, %1
-  ret i32 %s
-}
-
-define i32 @__reduce_add_int32(<16 x i32>) nounwind readnone alwaysinline {
-  reduce16(i32, @__add_varying_int32, @__add_uniform_int32)
 }
 
 define i32 @__reduce_min_int32(<16 x i32>) nounwind readnone alwaysinline {
@@ -313,11 +263,6 @@ define i32 @__reduce_max_int32(<16 x i32>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint32 ops
-
-define i32 @__reduce_add_uint32(<16 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<16 x i32> %0)
-  ret i32 %res
-}
 
 define i32 @__reduce_min_uint32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__min_varying_uint32, @__min_uniform_uint32)
@@ -364,21 +309,6 @@ define double @__reduce_max_double(<16 x double>) nounwind readnone alwaysinline
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int64 ops
 
-define <16 x i64> @__add_varying_int64(<16 x i64>,
-                                                <16 x i64>) nounwind readnone alwaysinline {
-  %s = add <16 x i64> %0, %1
-  ret <16 x i64> %s
-}
-
-define i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %s = add i64 %0, %1
-  ret i64 %s
-}
-
-define i64 @__reduce_add_int64(<16 x i64>) nounwind readnone alwaysinline {
-  reduce16(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
 define i64 @__reduce_min_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_int64, @__min_uniform_int64)
 }
@@ -389,11 +319,6 @@ define i64 @__reduce_max_int64(<16 x i64>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint64 ops
-
-define i64 @__reduce_add_uint64(<16 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<16 x i64> %0)
-  ret i64 %res
-}
 
 define i64 @__reduce_min_uint64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_uint64, @__min_uniform_uint64)

--- a/builtins/target-avx1-i32x16.ll
+++ b/builtins/target-avx1-i32x16.ll
@@ -243,14 +243,29 @@ reduce_equal(16)
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
+define internal <16 x i8> @__add_varying_i8(<16 x i8>,
+                                              <16 x i8>) nounwind readnone alwaysinline {
+  %r = add <16 x i8> %0, %1
+  ret <16 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
+  reduce16(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %0,
                                               <16 x i8> zeroinitializer)
   %r0 = extractelement <2 x i64> %rv, i32 0
   %r1 = extractelement <2 x i64> %rv, i32 1
   %r = add i64 %r0, %r1
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 define internal <16 x i16> @__add_varying_i16(<16 x i16>,
@@ -268,6 +283,8 @@ define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
   reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
+@__reduce_add_uint16 = alias i16 (<16 x i16>), ptr @__reduce_add_int16
+
 define <16 x i32> @__add_varying_int32(<16 x i32>,
                                        <16 x i32>) nounwind readnone alwaysinline {
   %s = add <16 x i32> %0, %1
@@ -283,29 +300,26 @@ define i32 @__reduce_add_int32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__add_varying_int32, @__add_uniform_int32)
 }
 
-
 define i32 @__reduce_min_int32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__min_varying_int32, @__min_uniform_int32)
 }
-
 
 define i32 @__reduce_max_int32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__max_varying_int32, @__max_uniform_int32)
 }
 
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint32 ops
+
+@__reduce_add_uint32 = alias i32 (<16 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_uint32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__min_varying_uint32, @__min_uniform_uint32)
 }
 
-
 define i32 @__reduce_max_uint32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__max_varying_uint32, @__max_uniform_uint32)
 }
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal double ops
@@ -341,7 +355,6 @@ define double @__reduce_max_double(<16 x double>) nounwind readnone alwaysinline
   reduce16(double, @__max_varying_double, @__max_uniform_double)
 }
 
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int64 ops
 
@@ -360,29 +373,26 @@ define i64 @__reduce_add_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
-
 define i64 @__reduce_min_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_int64, @__min_uniform_int64)
 }
-
 
 define i64 @__reduce_max_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__max_varying_int64, @__max_uniform_int64)
 }
 
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint64 ops
+
+@__reduce_add_uint64 = alias i64 (<16 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_uint64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_uint64, @__min_uniform_uint64)
 }
 
-
 define i64 @__reduce_max_uint64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__max_varying_uint64, @__max_uniform_uint64)
 }
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; unaligned loads/loads+broadcasts

--- a/builtins/target-avx1-i32x8.ll
+++ b/builtins/target-avx1-i32x8.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2025, Intel Corporation
+;;  Copyright (c) 2010-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-avx1-i32x8.ll
+++ b/builtins/target-avx1-i32x8.ll
@@ -254,21 +254,6 @@ define double @__reduce_max_double(<8 x double>) nounwind readnone alwaysinline 
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define internal <8 x i8> @__add_varying_i8(<8 x i8>,
-                                              <8 x i8>) nounwind readnone alwaysinline {
-  %r = add <8 x i8> %0, %1
-  ret <8 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
-  reduce8(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %wide8 = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
       <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
@@ -283,53 +268,9 @@ define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; horizontal int16 ops
-
-define internal <8 x i16> @__add_varying_i16(<8 x i16>,
-                                  <8 x i16>) nounwind readnone alwaysinline {
-  %r = add <8 x i16> %0, %1
-  ret <8 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
-  reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<8 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<8 x i16> %0)
-  ret i16 %res
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
 
-;; helper functions
-define <8 x i32> @__add_varying_int32(<8 x i32>,
-                                      <8 x i32>) nounwind readnone alwaysinline {
-  %s = add <8 x i32> %0, %1
-  ret <8 x i32> %s
-}
-
-define i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinline {
-  %s = add i32 %0, %1
-  ret i32 %s
-}
-
 ;; reduction functions
-define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone alwaysinline {
-  reduce8(i32, @__add_varying_int32, @__add_uniform_int32)
-}
-
-define i32 @__reduce_add_uint32(<8 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<8 x i32> %0)
-  ret i32 %res
-}
-
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8(i32, @__min_varying_int32, @__min_uniform_int32)
 }
@@ -346,32 +287,10 @@ define i32 @__reduce_max_uint32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8(i32, @__max_varying_uint32, @__max_uniform_uint32)
 }
 
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int64 ops
 
-;; helper functions
-define <8 x i64> @__add_varying_int64(<8 x i64>,
-                                      <8 x i64>) nounwind readnone alwaysinline {
-  %s = add <8 x i64> %0, %1
-  ret <8 x i64> %s
-}
-
-define i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %s = add i64 %0, %1
-  ret i64 %s
-}
-
 ;; reduction functions
-define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone alwaysinline {
-  reduce8(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
-define i64 @__reduce_add_uint64(<8 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<8 x i64> %0)
-  ret i64 %res
-}
-
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone alwaysinline {
   reduce8(i64, @__min_varying_int64, @__min_uniform_int64)
 }

--- a/builtins/target-avx1-i32x8.ll
+++ b/builtins/target-avx1-i32x8.ll
@@ -250,24 +250,6 @@ define double @__reduce_max_double(<8 x double>) nounwind readnone alwaysinline 
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; horizontal int8 ops
-
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
-  %wide8 = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
-      <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-                  i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8>
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %wide8,
-                                              <16 x i8> zeroinitializer)
-  %r0 = extractelement <2 x i64> %rv, i32 0
-  %r1 = extractelement <2 x i64> %rv, i32 1
-  %r = add i64 %r0, %r1
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
 
 ;; reduction functions

--- a/builtins/target-avx1-i32x8.ll
+++ b/builtins/target-avx1-i32x8.ll
@@ -300,7 +300,10 @@ define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
   reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<8 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<8 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<8 x i16> %0)
+  ret i16 %res
+}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
@@ -322,7 +325,10 @@ define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8(i32, @__add_varying_int32, @__add_uniform_int32)
 }
 
-@__reduce_add_uint32 = alias i32 (<8 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<8 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<8 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -361,7 +367,10 @@ define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone alwaysinline {
   reduce8(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
-@__reduce_add_uint64 = alias i64 (<8 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<8 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<8 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone alwaysinline {
   reduce8(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx1-i32x8.ll
+++ b/builtins/target-avx1-i32x8.ll
@@ -254,7 +254,22 @@ define double @__reduce_max_double(<8 x double>) nounwind readnone alwaysinline 
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
+define internal <8 x i8> @__add_varying_i8(<8 x i8>,
+                                              <8 x i8>) nounwind readnone alwaysinline {
+  %r = add <8 x i8> %0, %1
+  ret <8 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
+  reduce8(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %wide8 = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
       <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                   i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8>
@@ -263,8 +278,8 @@ define i16 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
   %r0 = extractelement <2 x i64> %rv, i32 0
   %r1 = extractelement <2 x i64> %rv, i32 1
   %r = add i64 %r0, %r1
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -285,6 +300,8 @@ define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
   reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
+@__reduce_add_uint16 = alias i16 (<8 x i16>), ptr @__reduce_add_int16
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
 
@@ -304,6 +321,8 @@ define i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinline {
 define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8(i32, @__add_varying_int32, @__add_uniform_int32)
 }
+
+@__reduce_add_uint32 = alias i32 (<8 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -342,21 +361,19 @@ define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone alwaysinline {
   reduce8(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
+@__reduce_add_uint64 = alias i64 (<8 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone alwaysinline {
   reduce8(i64, @__min_varying_int64, @__min_uniform_int64)
 }
 
-
 define i64 @__reduce_max_int64(<8 x i64>) nounwind readnone alwaysinline {
   reduce8(i64, @__max_varying_int64, @__max_uniform_int64)
 }
 
-
 define i64 @__reduce_min_uint64(<8 x i64>) nounwind readnone alwaysinline {
   reduce8(i64, @__min_varying_uint64, @__min_uniform_uint64)
 }
-
 
 define i64 @__reduce_max_uint64(<8 x i64>) nounwind readnone alwaysinline {
   reduce8(i64, @__max_varying_uint64, @__max_uniform_uint64)

--- a/builtins/target-avx1-i64x4.ll
+++ b/builtins/target-avx1-i64x4.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2013-2025, Intel Corporation
+;;  Copyright (c) 2013-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-avx1-i64x4.ll
+++ b/builtins/target-avx1-i64x4.ll
@@ -279,74 +279,7 @@ define float @__reduce_max_float(<4 x float>) nounwind readnone {
 reduce_equal(4)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; horizontal int8 ops
-
-define internal <4 x i8> @__add_varying_i8(<4 x i8>,
-                                              <4 x i8>) nounwind readnone alwaysinline {
-  %r = add <4 x i8> %0, %1
-  ret <4 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
-  reduce4(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
-; Calling psadbw does not worth it for only 4 items
-define i8 @__reduce_add_uint8(<4 x i8>) nounwind readnone alwaysinline {
-  %res = call i8 @__reduce_add_int8(<4 x i8> %0)
-  ret i8 %res
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; horizontal int16 ops
-
-define internal <4 x i16> @__add_varying_i16(<4 x i16>,
-                                  <4 x i16>) nounwind readnone alwaysinline {
-  %r = add <4 x i16> %0, %1
-  ret <4 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
-  reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<4 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<4 x i16> %0)
-  ret i16 %res
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
-
-define <4 x i32> @__add_varying_int32(<4 x i32>,
-                                      <4 x i32>) nounwind readnone alwaysinline {
-  %s = add <4 x i32> %0, %1
-  ret <4 x i32> %s
-}
-
-define i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinline {
-  %s = add i32 %0, %1
-  ret i32 %s
-}
-
-define i32 @__reduce_add_int32(<4 x i32>) nounwind readnone alwaysinline {
-  reduce4(i32, @__add_varying_int32, @__add_uniform_int32)
-}
-
-define i32 @__reduce_add_uint32(<4 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<4 x i32> %0)
-  ret i32 %res
-}
 
 define i32 @__reduce_min_int32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -396,26 +329,6 @@ define double @__reduce_max_double(<4 x double>) nounwind readnone alwaysinline 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int64 ops
-
-define <4 x i64> @__add_varying_int64(<4 x i64>,
-                                      <4 x i64>) nounwind readnone alwaysinline {
-  %s = add <4 x i64> %0, %1
-  ret <4 x i64> %s
-}
-
-define i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %s = add i64 %0, %1
-  ret i64 %s
-}
-
-define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone alwaysinline {
-  reduce4(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
-define i64 @__reduce_add_uint64(<4 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<4 x i64> %0)
-  ret i64 %res
-}
 
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx1-i64x4.ll
+++ b/builtins/target-avx1-i64x4.ll
@@ -297,7 +297,10 @@ define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
 }
 
 ; Calling psadbw does not worth it for only 4 items
-@__reduce_add_uint8 = alias i8 (<4 x i8>), ptr @__reduce_add_int8
+define i8 @__reduce_add_uint8(<4 x i8>) nounwind readnone alwaysinline {
+  %res = call i8 @__reduce_add_int8(<4 x i8> %0)
+  ret i8 %res
+}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int16 ops
@@ -317,7 +320,10 @@ define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
   reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<4 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<4 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<4 x i16> %0)
+  ret i16 %res
+}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
@@ -337,7 +343,10 @@ define i32 @__reduce_add_int32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__add_varying_int32, @__add_uniform_int32)
 }
 
-@__reduce_add_uint32 = alias i32 (<4 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<4 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<4 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_int32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -403,7 +412,10 @@ define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
-@__reduce_add_uint64 = alias i64 (<4 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<4 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<4 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx1-i64x4.ll
+++ b/builtins/target-avx1-i64x4.ll
@@ -281,21 +281,23 @@ reduce_equal(4)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int8 ops
 
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i16 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline 
-{
-  %wide8 = shufflevector <4 x i8> %0, <4 x i8> zeroinitializer,
-      <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 4, i32 4, i32 4,
-                  i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4>
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %wide8,
-                                              <16 x i8> zeroinitializer)
-  %r0 = extractelement <2 x i64> %rv, i32 0
-  %r1 = extractelement <2 x i64> %rv, i32 1
-  %r = add i64 %r0, %r1
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+define internal <4 x i8> @__add_varying_i8(<4 x i8>,
+                                              <4 x i8>) nounwind readnone alwaysinline {
+  %r = add <4 x i8> %0, %1
+  ret <4 x i8> %r
 }
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
+  reduce4(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+; Calling psadbw does not worth it for only 4 items
+@__reduce_add_uint8 = alias i8 (<4 x i8>), ptr @__reduce_add_int8
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int16 ops
@@ -315,6 +317,8 @@ define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
   reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
+@__reduce_add_uint16 = alias i16 (<4 x i16>), ptr @__reduce_add_int16
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
 
@@ -333,11 +337,11 @@ define i32 @__reduce_add_int32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__add_varying_int32, @__add_uniform_int32)
 }
 
+@__reduce_add_uint32 = alias i32 (<4 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_int32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__min_varying_int32, @__min_uniform_int32)
 }
-
 
 define i32 @__reduce_max_int32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__max_varying_int32, @__max_uniform_int32)
@@ -399,26 +403,23 @@ define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
+@__reduce_add_uint64 = alias i64 (<4 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_int64, @__min_uniform_int64)
 }
 
-
 define i64 @__reduce_max_int64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__max_varying_int64, @__max_uniform_int64)
 }
-
 
 define i64 @__reduce_min_uint64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_uint64, @__min_uniform_uint64)
 }
 
-
 define i64 @__reduce_max_uint64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__max_varying_uint64, @__max_uniform_uint64)
 }
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; unaligned loads/loads+broadcasts

--- a/builtins/target-avx2-i16x16.ll
+++ b/builtins/target-avx2-i16x16.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2025, Intel Corporation
+;;  Copyright (c) 2020-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-avx2-i16x16.ll
+++ b/builtins/target-avx2-i16x16.ll
@@ -518,21 +518,6 @@ svml(ISA)
 ;; 8 bit
 declare <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8>, <32 x i8>) nounwind readnone
 
-define internal <16 x i8> @__add_varying_i8(<16 x i8>,
-                                              <16 x i8>) nounwind readnone alwaysinline {
-  %r = add <16 x i8> %0, %1
-  ret <16 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
-  reduce16(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %ext = shufflevector <16 x i8> %0, <16 x i8> undef,
       <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
@@ -544,50 +529,6 @@ define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %r = add i64 %r0, %r1
   %r8 = trunc i64 %r to i8
   ret i8 %r8
-}
-
-;; 16 bit
-;; TODO: why returning i16?
-define internal <16 x i16> @__add_varying_i16(<16 x i16>,
-                                              <16 x i16>) nounwind readnone alwaysinline {
-  %r = add <16 x i16> %0, %1
-  ret <16 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
-  reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<16 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<16 x i16> %0)
-  ret i16 %res
-}
-
-;; 32 bit
-;; TODO: why returning i32?
-define internal <16 x i32> @__add_varying_int32(<16 x i32>,
-                                                <16 x i32>) nounwind readnone alwaysinline {
-  %s = add <16 x i32> %0, %1
-  ret <16 x i32> %s
-}
-
-define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinline {
-  %s = add i32 %0, %1
-  ret i32 %s
-}
-
-define i32 @__reduce_add_int32(<16 x i32>) nounwind readnone alwaysinline {
-  reduce16(i32, @__add_varying_int32, @__add_uniform_int32)
-}
-
-define i32 @__reduce_add_uint32(<16 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<16 x i32> %0)
-  ret i32 %res
 }
 
 ;; float
@@ -659,26 +600,6 @@ define double @__reduce_max_double(<16 x double>) nounwind readnone alwaysinline
 }
 
 ;; int64
-
-define internal <16 x i64> @__add_varying_int64(<16 x i64>,
-                                                <16 x i64>) nounwind readnone alwaysinline {
-  %s = add <16 x i64> %0, %1
-  ret <16 x i64> %s
-}
-
-define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %s = add i64 %0, %1
-  ret i64 %s
-}
-
-define i64 @__reduce_add_int64(<16 x i64>) nounwind readnone alwaysinline {
-  reduce16(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
-define i64 @__reduce_add_uint64(<16 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<16 x i64> %0)
-  ret i64 %res
-}
 
 define i64 @__reduce_min_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx2-i16x16.ll
+++ b/builtins/target-avx2-i16x16.ll
@@ -563,7 +563,10 @@ define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
   reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<16 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<16 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<16 x i16> %0)
+  ret i16 %res
+}
 
 ;; 32 bit
 ;; TODO: why returning i32?
@@ -582,7 +585,10 @@ define i32 @__reduce_add_int32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__add_varying_int32, @__add_uniform_int32)
 }
 
-@__reduce_add_uint32 = alias i32 (<16 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<16 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<16 x i32> %0)
+  ret i32 %res
+}
 
 ;; float
 ;; TODO: __reduce_add_float may use hadd
@@ -669,7 +675,10 @@ define i64 @__reduce_add_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
-@__reduce_add_uint64 = alias i64 (<16 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<16 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<16 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx2-i16x16.ll
+++ b/builtins/target-avx2-i16x16.ll
@@ -518,7 +518,22 @@ svml(ISA)
 ;; 8 bit
 declare <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8>, <32 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
+define internal <16 x i8> @__add_varying_i8(<16 x i8>,
+                                              <16 x i8>) nounwind readnone alwaysinline {
+  %r = add <16 x i8> %0, %1
+  ret <16 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
+  reduce16(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %ext = shufflevector <16 x i8> %0, <16 x i8> undef,
       <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
                  i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
@@ -527,8 +542,8 @@ define i16 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
   %r0 = extractelement <4 x i64> %rv, i32 0
   %r1 = extractelement <4 x i64> %rv, i32 1
   %r = add i64 %r0, %r1
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 ;; 16 bit
@@ -548,6 +563,8 @@ define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
   reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
+@__reduce_add_uint16 = alias i16 (<16 x i16>), ptr @__reduce_add_int16
+
 ;; 32 bit
 ;; TODO: why returning i32?
 define internal <16 x i32> @__add_varying_int32(<16 x i32>,
@@ -564,6 +581,8 @@ define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinlin
 define i32 @__reduce_add_int32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__add_varying_int32, @__add_uniform_int32)
 }
+
+@__reduce_add_uint32 = alias i32 (<16 x i32>), ptr @__reduce_add_int32
 
 ;; float
 ;; TODO: __reduce_add_float may use hadd
@@ -649,6 +668,8 @@ define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinlin
 define i64 @__reduce_add_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__add_varying_int64, @__add_uniform_int64)
 }
+
+@__reduce_add_uint64 = alias i64 (<16 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx2-i16x16.ll
+++ b/builtins/target-avx2-i16x16.ll
@@ -515,22 +515,6 @@ svml(ISA)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; reductions
 
-;; 8 bit
-declare <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8>, <32 x i8>) nounwind readnone
-
-define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
-  %ext = shufflevector <16 x i8> %0, <16 x i8> undef,
-      <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
-                 i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
-  %rv = call <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8> %ext,
-                                                    <32 x i8> zeroinitializer)
-  %r0 = extractelement <4 x i64> %rv, i32 0
-  %r1 = extractelement <4 x i64> %rv, i32 1
-  %r = add i64 %r0, %r1
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
 ;; float
 ;; TODO: __reduce_add_float may use hadd
 define internal <16 x float> @__add_varying_float(<16 x float>,

--- a/builtins/target-avx2-i8x32.ll
+++ b/builtins/target-avx2-i8x32.ll
@@ -541,7 +541,22 @@ svml(ISA)
 ;; 8 bit
 declare <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8>, <32 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<32 x i8>) nounwind readnone alwaysinline {
+define internal <32 x i8> @__add_varying_i8(<32 x i8>,
+                                              <32 x i8>) nounwind readnone alwaysinline {
+  %r = add <32 x i8> %0, %1
+  ret <32 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<32 x i8>) nounwind readnone alwaysinline {
+  reduce32(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+define i8 @__reduce_add_uint8(<32 x i8>) nounwind readnone alwaysinline {
   %rv = call <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8> %0,
                                                     <32 x i8> zeroinitializer)
   %r0 = extractelement <4 x i64> %rv, i32 0
@@ -551,12 +566,11 @@ define i16 @__reduce_add_int8(<32 x i8>) nounwind readnone alwaysinline {
   %r01 = add i64 %r0, %r1
   %r23 = add i64 %r2, %r3
   %r = add i64 %r01, %r23
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 ;; 16 bit
-;; TODO: why returning i16?
 define internal <32 x i16> @__add_varying_i16(<32 x i16>,
                                               <32 x i16>) nounwind readnone alwaysinline {
   %r = add <32 x i16> %0, %1
@@ -572,8 +586,9 @@ define i16 @__reduce_add_int16(<32 x i16>) nounwind readnone alwaysinline {
   reduce32(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
+@__reduce_add_uint16 = alias i16 (<32 x i16>), ptr @__reduce_add_int16
+
 ;; 32 bit
-;; TODO: why returning i32?
 define internal <32 x i32> @__add_varying_int32(<32 x i32>,
                                                 <32 x i32>) nounwind readnone alwaysinline {
   %s = add <32 x i32> %0, %1
@@ -588,6 +603,8 @@ define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinlin
 define i32 @__reduce_add_int32(<32 x i32>) nounwind readnone alwaysinline {
   reduce32(i32, @__add_varying_int32, @__add_uniform_int32)
 }
+
+@__reduce_add_uint32 = alias i32 (<32 x i32>), ptr @__reduce_add_int32
 
 ;; float
 ;; TODO: __reduce_add_float may use hadd
@@ -673,6 +690,8 @@ define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinlin
 define i64 @__reduce_add_int64(<32 x i64>) nounwind readnone alwaysinline {
   reduce32(i64, @__add_varying_int64, @__add_uniform_int64)
 }
+
+@__reduce_add_uint64 = alias i64 (<32 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<32 x i64>) nounwind readnone alwaysinline {
   reduce32(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx2-i8x32.ll
+++ b/builtins/target-avx2-i8x32.ll
@@ -538,23 +538,6 @@ svml(ISA)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; reductions
 
-;; 8 bit
-declare <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8>, <32 x i8>) nounwind readnone
-
-define i8 @__reduce_add_uint8(<32 x i8>) nounwind readnone alwaysinline {
-  %rv = call <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8> %0,
-                                                    <32 x i8> zeroinitializer)
-  %r0 = extractelement <4 x i64> %rv, i32 0
-  %r1 = extractelement <4 x i64> %rv, i32 1
-  %r2 = extractelement <4 x i64> %rv, i32 2
-  %r3 = extractelement <4 x i64> %rv, i32 3
-  %r01 = add i64 %r0, %r1
-  %r23 = add i64 %r2, %r3
-  %r = add i64 %r01, %r23
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
 ;; float
 ;; TODO: __reduce_add_float may use hadd
 define internal <32 x float> @__add_varying_float(<32 x float>,

--- a/builtins/target-avx2-i8x32.ll
+++ b/builtins/target-avx2-i8x32.ll
@@ -541,21 +541,6 @@ svml(ISA)
 ;; 8 bit
 declare <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8>, <32 x i8>) nounwind readnone
 
-define internal <32 x i8> @__add_varying_i8(<32 x i8>,
-                                              <32 x i8>) nounwind readnone alwaysinline {
-  %r = add <32 x i8> %0, %1
-  ret <32 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<32 x i8>) nounwind readnone alwaysinline {
-  reduce32(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 define i8 @__reduce_add_uint8(<32 x i8>) nounwind readnone alwaysinline {
   %rv = call <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8> %0,
                                                     <32 x i8> zeroinitializer)
@@ -568,48 +553,6 @@ define i8 @__reduce_add_uint8(<32 x i8>) nounwind readnone alwaysinline {
   %r = add i64 %r01, %r23
   %r8 = trunc i64 %r to i8
   ret i8 %r8
-}
-
-;; 16 bit
-define internal <32 x i16> @__add_varying_i16(<32 x i16>,
-                                              <32 x i16>) nounwind readnone alwaysinline {
-  %r = add <32 x i16> %0, %1
-  ret <32 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<32 x i16>) nounwind readnone alwaysinline {
-  reduce32(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<32 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<32 x i16> %0)
-  ret i16 %res
-}
-
-;; 32 bit
-define internal <32 x i32> @__add_varying_int32(<32 x i32>,
-                                                <32 x i32>) nounwind readnone alwaysinline {
-  %s = add <32 x i32> %0, %1
-  ret <32 x i32> %s
-}
-
-define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinline {
-  %s = add i32 %0, %1
-  ret i32 %s
-}
-
-define i32 @__reduce_add_int32(<32 x i32>) nounwind readnone alwaysinline {
-  reduce32(i32, @__add_varying_int32, @__add_uniform_int32)
-}
-
-define i32 @__reduce_add_uint32(<32 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<32 x i32> %0)
-  ret i32 %res
 }
 
 ;; float
@@ -681,26 +624,6 @@ define double @__reduce_max_double(<32 x double>) nounwind readnone alwaysinline
 }
 
 ;; int64
-
-define internal <32 x i64> @__add_varying_int64(<32 x i64>,
-                                                <32 x i64>) nounwind readnone alwaysinline {
-  %s = add <32 x i64> %0, %1
-  ret <32 x i64> %s
-}
-
-define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %s = add i64 %0, %1
-  ret i64 %s
-}
-
-define i64 @__reduce_add_int64(<32 x i64>) nounwind readnone alwaysinline {
-  reduce32(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
-define i64 @__reduce_add_uint64(<32 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<32 x i64> %0)
-  ret i64 %res
-}
 
 define i64 @__reduce_min_int64(<32 x i64>) nounwind readnone alwaysinline {
   reduce32(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx2-i8x32.ll
+++ b/builtins/target-avx2-i8x32.ll
@@ -586,7 +586,10 @@ define i16 @__reduce_add_int16(<32 x i16>) nounwind readnone alwaysinline {
   reduce32(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<32 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<32 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<32 x i16> %0)
+  ret i16 %res
+}
 
 ;; 32 bit
 define internal <32 x i32> @__add_varying_int32(<32 x i32>,
@@ -604,7 +607,10 @@ define i32 @__reduce_add_int32(<32 x i32>) nounwind readnone alwaysinline {
   reduce32(i32, @__add_varying_int32, @__add_uniform_int32)
 }
 
-@__reduce_add_uint32 = alias i32 (<32 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<32 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<32 x i32> %0)
+  ret i32 %res
+}
 
 ;; float
 ;; TODO: __reduce_add_float may use hadd
@@ -691,7 +697,10 @@ define i64 @__reduce_add_int64(<32 x i64>) nounwind readnone alwaysinline {
   reduce32(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
-@__reduce_add_uint64 = alias i64 (<32 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<32 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<32 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<32 x i64>) nounwind readnone alwaysinline {
   reduce32(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx512skx-x16-nozmm.ll
+++ b/builtins/target-avx512skx-x16-nozmm.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2016-2025, Intel Corporation
+;;  Copyright (c) 2016-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-avx512skx-x16-nozmm.ll
+++ b/builtins/target-avx512skx-x16-nozmm.ll
@@ -334,14 +334,29 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
+define internal <16 x i8> @__add_varying_i8(<16 x i8>,
+                                              <16 x i8>) nounwind readnone alwaysinline {
+  %r = add <16 x i8> %0, %1
+  ret <16 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
+  reduce16(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %0,
                                               <16 x i8> zeroinitializer)
   %r0 = extractelement <2 x i64> %rv, i32 0
   %r1 = extractelement <2 x i64> %rv, i32 1
   %r = add i64 %r0, %r1
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 define internal <16 x i16> @__add_varying_i16(<16 x i16>,
@@ -358,6 +373,8 @@ define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline 
 define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
   reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
 }
+
+@__reduce_add_uint16 = alias i16 (<16 x i16>), ptr @__reduce_add_int16
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal float ops
@@ -403,6 +420,8 @@ define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinlin
 define i32 @__reduce_add_int32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__add_varying_int32, @__add_uniform_int32)
 }
+
+@__reduce_add_uint32 = alias i32 (<16 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_int32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -473,6 +492,8 @@ define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinlin
 define i64 @__reduce_add_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__add_varying_int64, @__add_uniform_int64)
 }
+
+@__reduce_add_uint64 = alias i64 (<16 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx512skx-x16-nozmm.ll
+++ b/builtins/target-avx512skx-x16-nozmm.ll
@@ -330,21 +330,6 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; horizontal int8/16 ops
-
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %0,
-                                              <16 x i8> zeroinitializer)
-  %r0 = extractelement <2 x i64> %rv, i32 0
-  %r1 = extractelement <2 x i64> %rv, i32 1
-  %r = add i64 %r0, %r1
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal float ops
 
 declare <8 x float> @llvm.x86.avx.hadd.ps.256(<8 x float>, <8 x float>) nounwind readnone

--- a/builtins/target-avx512skx-x16-nozmm.ll
+++ b/builtins/target-avx512skx-x16-nozmm.ll
@@ -334,21 +334,6 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define internal <16 x i8> @__add_varying_i8(<16 x i8>,
-                                              <16 x i8>) nounwind readnone alwaysinline {
-  %r = add <16 x i8> %0, %1
-  ret <16 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
-  reduce16(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %0,
                                               <16 x i8> zeroinitializer)
@@ -357,26 +342,6 @@ define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %r = add i64 %r0, %r1
   %r8 = trunc i64 %r to i8
   ret i8 %r8
-}
-
-define internal <16 x i16> @__add_varying_i16(<16 x i16>,
-                                  <16 x i16>) nounwind readnone alwaysinline {
-  %r = add <16 x i16> %0, %1
-  ret <16 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
-  reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<16 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<16 x i16> %0)
-  ret i16 %res
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -408,26 +373,6 @@ define float @__reduce_max_float(<16 x float>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
-
-define internal <16 x i32> @__add_varying_int32(<16 x i32>,
-                                       <16 x i32>) nounwind readnone alwaysinline {
-  %s = add <16 x i32> %0, %1
-  ret <16 x i32> %s
-}
-
-define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinline {
-  %s = add i32 %0, %1
-  ret i32 %s
-}
-
-define i32 @__reduce_add_int32(<16 x i32>) nounwind readnone alwaysinline {
-  reduce16(i32, @__add_varying_int32, @__add_uniform_int32)
-}
-
-define i32 @__reduce_add_uint32(<16 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<16 x i32> %0)
-  ret i32 %res
-}
 
 define i32 @__reduce_min_int32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -483,26 +428,6 @@ define double @__reduce_max_double(<16 x double>) nounwind readnone alwaysinline
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int64 ops
-
-define internal <16 x i64> @__add_varying_int64(<16 x i64>,
-                                                <16 x i64>) nounwind readnone alwaysinline {
-  %s = add <16 x i64> %0, %1
-  ret <16 x i64> %s
-}
-
-define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %s = add i64 %0, %1
-  ret i64 %s
-}
-
-define i64 @__reduce_add_int64(<16 x i64>) nounwind readnone alwaysinline {
-  reduce16(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
-define i64 @__reduce_add_uint64(<16 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<16 x i64> %0)
-  ret i64 %res
-}
 
 define i64 @__reduce_min_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx512skx-x16-nozmm.ll
+++ b/builtins/target-avx512skx-x16-nozmm.ll
@@ -374,7 +374,10 @@ define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
   reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<16 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<16 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<16 x i16> %0)
+  ret i16 %res
+}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal float ops
@@ -421,7 +424,10 @@ define i32 @__reduce_add_int32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__add_varying_int32, @__add_uniform_int32)
 }
 
-@__reduce_add_uint32 = alias i32 (<16 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<16 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<16 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_int32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -493,7 +499,10 @@ define i64 @__reduce_add_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
-@__reduce_add_uint64 = alias i64 (<16 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<16 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<16 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx512skx-x16.ll
+++ b/builtins/target-avx512skx-x16.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2016-2025, Intel Corporation
+;;  Copyright (c) 2016-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-avx512skx-x16.ll
+++ b/builtins/target-avx512skx-x16.ll
@@ -426,14 +426,29 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
+define internal <16 x i8> @__add_varying_i8(<16 x i8>,
+                                              <16 x i8>) nounwind readnone alwaysinline {
+  %r = add <16 x i8> %0, %1
+  ret <16 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
+  reduce16(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %0,
                                               <16 x i8> zeroinitializer)
   %r0 = extractelement <2 x i64> %rv, i32 0
   %r1 = extractelement <2 x i64> %rv, i32 1
   %r = add i64 %r0, %r1
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 define internal <16 x i16> @__add_varying_i16(<16 x i16>,
@@ -450,6 +465,8 @@ define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline 
 define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
   reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
 }
+
+@__reduce_add_uint16 = alias i16 (<16 x i16>), ptr @__reduce_add_int16
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal float ops
@@ -506,6 +523,8 @@ define i32 @__reduce_max_int32(<16 x i32>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint32 ops
+
+@__reduce_add_uint32 = alias i32 (<16 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_uint32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__min_varying_uint32, @__min_uniform_uint32)
@@ -576,6 +595,8 @@ define i64 @__reduce_max_int64(<16 x i64>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint64 ops
+
+@__reduce_add_uint64 = alias i64 (<16 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_uint64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_uint64, @__min_uniform_uint64)

--- a/builtins/target-avx512skx-x16.ll
+++ b/builtins/target-avx512skx-x16.ll
@@ -422,21 +422,6 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; horizontal int8/16 ops
-
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %0,
-                                              <16 x i8> zeroinitializer)
-  %r0 = extractelement <2 x i64> %rv, i32 0
-  %r1 = extractelement <2 x i64> %rv, i32 1
-  %r = add i64 %r0, %r1
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal float ops
 
 declare <8 x float> @llvm.x86.avx.hadd.ps.256(<8 x float>, <8 x float>) nounwind readnone

--- a/builtins/target-avx512skx-x16.ll
+++ b/builtins/target-avx512skx-x16.ll
@@ -426,21 +426,6 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define internal <16 x i8> @__add_varying_i8(<16 x i8>,
-                                              <16 x i8>) nounwind readnone alwaysinline {
-  %r = add <16 x i8> %0, %1
-  ret <16 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
-  reduce16(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %0,
                                               <16 x i8> zeroinitializer)
@@ -449,26 +434,6 @@ define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %r = add i64 %r0, %r1
   %r8 = trunc i64 %r to i8
   ret i8 %r8
-}
-
-define internal <16 x i16> @__add_varying_i16(<16 x i16>,
-                                  <16 x i16>) nounwind readnone alwaysinline {
-  %r = add <16 x i16> %0, %1
-  ret <16 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
-  reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<16 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<16 x i16> %0)
-  ret i16 %res
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -501,21 +466,6 @@ define float @__reduce_max_float(<16 x float>) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
 
-define internal <16 x i32> @__add_varying_int32(<16 x i32>,
-                                       <16 x i32>) nounwind readnone alwaysinline {
-  %s = add <16 x i32> %0, %1
-  ret <16 x i32> %s
-}
-
-define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinline {
-  %s = add i32 %0, %1
-  ret i32 %s
-}
-
-define i32 @__reduce_add_int32(<16 x i32>) nounwind readnone alwaysinline {
-  reduce16(i32, @__add_varying_int32, @__add_uniform_int32)
-}
-
 define i32 @__reduce_min_int32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__min_varying_int32, @__min_uniform_int32)
 }
@@ -526,11 +476,6 @@ define i32 @__reduce_max_int32(<16 x i32>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint32 ops
-
-define i32 @__reduce_add_uint32(<16 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<16 x i32> %0)
-  ret i32 %res
-}
 
 define i32 @__reduce_min_uint32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__min_varying_uint32, @__min_uniform_uint32)
@@ -576,21 +521,6 @@ define double @__reduce_max_double(<16 x double>) nounwind readnone alwaysinline
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int64 ops
 
-define internal <16 x i64> @__add_varying_int64(<16 x i64>,
-                                                <16 x i64>) nounwind readnone alwaysinline {
-  %s = add <16 x i64> %0, %1
-  ret <16 x i64> %s
-}
-
-define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %s = add i64 %0, %1
-  ret i64 %s
-}
-
-define i64 @__reduce_add_int64(<16 x i64>) nounwind readnone alwaysinline {
-  reduce16(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
 define i64 @__reduce_min_int64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_int64, @__min_uniform_int64)
 }
@@ -601,11 +531,6 @@ define i64 @__reduce_max_int64(<16 x i64>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint64 ops
-
-define i64 @__reduce_add_uint64(<16 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<16 x i64> %0)
-  ret i64 %res
-}
 
 define i64 @__reduce_min_uint64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_uint64, @__min_uniform_uint64)

--- a/builtins/target-avx512skx-x16.ll
+++ b/builtins/target-avx512skx-x16.ll
@@ -466,7 +466,10 @@ define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
   reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<16 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<16 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<16 x i16> %0)
+  ret i16 %res
+}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal float ops
@@ -524,7 +527,10 @@ define i32 @__reduce_max_int32(<16 x i32>) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint32 ops
 
-@__reduce_add_uint32 = alias i32 (<16 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<16 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<16 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_uint32(<16 x i32>) nounwind readnone alwaysinline {
   reduce16(i32, @__min_varying_uint32, @__min_uniform_uint32)
@@ -596,7 +602,10 @@ define i64 @__reduce_max_int64(<16 x i64>) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint64 ops
 
-@__reduce_add_uint64 = alias i64 (<16 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<16 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<16 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_uint64(<16 x i64>) nounwind readnone alwaysinline {
   reduce16(i64, @__min_varying_uint64, @__min_uniform_uint64)

--- a/builtins/target-avx512skx-x32.ll
+++ b/builtins/target-avx512skx-x32.ll
@@ -367,21 +367,6 @@ svml(ISA)
 ;; 8 bit
 declare <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8>, <32 x i8>) nounwind readnone
 
-define internal <32 x i8> @__add_varying_i8(<32 x i8>,
-                                              <32 x i8>) nounwind readnone alwaysinline {
-  %r = add <32 x i8> %0, %1
-  ret <32 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<32 x i8>) nounwind readnone alwaysinline {
-  reduce32(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 define i8 @__reduce_add_uint8(<32 x i8>) nounwind readnone alwaysinline {
   %rv = call <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8> %0,
                                                     <32 x i8> zeroinitializer)
@@ -394,50 +379,6 @@ define i8 @__reduce_add_uint8(<32 x i8>) nounwind readnone alwaysinline {
   %r = add i64 %r01, %r23
   %r8 = trunc i64 %r to i8
   ret i8 %r8
-}
-
-;; 16 bit
-;; TODO: why returning i16?
-define internal <32 x i16> @__add_varying_i16(<32 x i16>,
-                                              <32 x i16>) nounwind readnone alwaysinline {
-  %r = add <32 x i16> %0, %1
-  ret <32 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<32 x i16>) nounwind readnone alwaysinline {
-  reduce32(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<32 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<32 x i16> %0)
-  ret i16 %res
-}
-
-;; 32 bit
-;; TODO: why returning i32?
-define internal <32 x i32> @__add_varying_int32(<32 x i32>,
-                                                <32 x i32>) nounwind readnone alwaysinline {
-  %s = add <32 x i32> %0, %1
-  ret <32 x i32> %s
-}
-
-define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinline {
-  %s = add i32 %0, %1
-  ret i32 %s
-}
-
-define i32 @__reduce_add_int32(<32 x i32>) nounwind readnone alwaysinline {
-  reduce32(i32, @__add_varying_int32, @__add_uniform_int32)
-}
-
-define i32 @__reduce_add_uint32(<32 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<32 x i32> %0)
-  ret i32 %res
 }
 
 ;; float
@@ -509,26 +450,6 @@ define double @__reduce_max_double(<32 x double>) nounwind readnone alwaysinline
 }
 
 ;; int64
-
-define internal <32 x i64> @__add_varying_int64(<32 x i64>,
-                                                <32 x i64>) nounwind readnone alwaysinline {
-  %s = add <32 x i64> %0, %1
-  ret <32 x i64> %s
-}
-
-define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %s = add i64 %0, %1
-  ret i64 %s
-}
-
-define i64 @__reduce_add_int64(<32 x i64>) nounwind readnone alwaysinline {
-  reduce32(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
-define i64 @__reduce_add_uint64(<32 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<32 x i64> %0)
-  ret i64 %res
-}
 
 define i64 @__reduce_min_int64(<32 x i64>) nounwind readnone alwaysinline {
   reduce32(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx512skx-x32.ll
+++ b/builtins/target-avx512skx-x32.ll
@@ -367,7 +367,22 @@ svml(ISA)
 ;; 8 bit
 declare <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8>, <32 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<32 x i8>) nounwind readnone alwaysinline {
+define internal <32 x i8> @__add_varying_i8(<32 x i8>,
+                                              <32 x i8>) nounwind readnone alwaysinline {
+  %r = add <32 x i8> %0, %1
+  ret <32 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<32 x i8>) nounwind readnone alwaysinline {
+  reduce32(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+define i8 @__reduce_add_uint8(<32 x i8>) nounwind readnone alwaysinline {
   %rv = call <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8> %0,
                                                     <32 x i8> zeroinitializer)
   %r0 = extractelement <4 x i64> %rv, i32 0
@@ -377,8 +392,8 @@ define i16 @__reduce_add_int8(<32 x i8>) nounwind readnone alwaysinline {
   %r01 = add i64 %r0, %r1
   %r23 = add i64 %r2, %r3
   %r = add i64 %r01, %r23
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 ;; 16 bit
@@ -398,6 +413,8 @@ define i16 @__reduce_add_int16(<32 x i16>) nounwind readnone alwaysinline {
   reduce32(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
+@__reduce_add_uint16 = alias i16 (<32 x i16>), ptr @__reduce_add_int16
+
 ;; 32 bit
 ;; TODO: why returning i32?
 define internal <32 x i32> @__add_varying_int32(<32 x i32>,
@@ -414,6 +431,8 @@ define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinlin
 define i32 @__reduce_add_int32(<32 x i32>) nounwind readnone alwaysinline {
   reduce32(i32, @__add_varying_int32, @__add_uniform_int32)
 }
+
+@__reduce_add_uint32 = alias i32 (<32 x i32>), ptr @__reduce_add_int32
 
 ;; float
 ;; TODO: __reduce_add_float may use hadd
@@ -499,6 +518,8 @@ define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinlin
 define i64 @__reduce_add_int64(<32 x i64>) nounwind readnone alwaysinline {
   reduce32(i64, @__add_varying_int64, @__add_uniform_int64)
 }
+
+@__reduce_add_uint64 = alias i64 (<32 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<32 x i64>) nounwind readnone alwaysinline {
   reduce32(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx512skx-x32.ll
+++ b/builtins/target-avx512skx-x32.ll
@@ -364,23 +364,6 @@ svml(ISA)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; reductions
 
-;; 8 bit
-declare <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8>, <32 x i8>) nounwind readnone
-
-define i8 @__reduce_add_uint8(<32 x i8>) nounwind readnone alwaysinline {
-  %rv = call <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8> %0,
-                                                    <32 x i8> zeroinitializer)
-  %r0 = extractelement <4 x i64> %rv, i32 0
-  %r1 = extractelement <4 x i64> %rv, i32 1
-  %r2 = extractelement <4 x i64> %rv, i32 2
-  %r3 = extractelement <4 x i64> %rv, i32 3
-  %r01 = add i64 %r0, %r1
-  %r23 = add i64 %r2, %r3
-  %r = add i64 %r01, %r23
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
 ;; float
 ;; TODO: __reduce_add_float may use hadd
 define internal <32 x float> @__add_varying_float(<32 x float>,

--- a/builtins/target-avx512skx-x32.ll
+++ b/builtins/target-avx512skx-x32.ll
@@ -413,7 +413,10 @@ define i16 @__reduce_add_int16(<32 x i16>) nounwind readnone alwaysinline {
   reduce32(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<32 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<32 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<32 x i16> %0)
+  ret i16 %res
+}
 
 ;; 32 bit
 ;; TODO: why returning i32?
@@ -432,7 +435,10 @@ define i32 @__reduce_add_int32(<32 x i32>) nounwind readnone alwaysinline {
   reduce32(i32, @__add_varying_int32, @__add_uniform_int32)
 }
 
-@__reduce_add_uint32 = alias i32 (<32 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<32 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<32 x i32> %0)
+  ret i32 %res
+}
 
 ;; float
 ;; TODO: __reduce_add_float may use hadd
@@ -519,7 +525,10 @@ define i64 @__reduce_add_int64(<32 x i64>) nounwind readnone alwaysinline {
   reduce32(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
-@__reduce_add_uint64 = alias i64 (<32 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<32 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<32 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<32 x i64>) nounwind readnone alwaysinline {
   reduce32(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx512skx-x4.ll
+++ b/builtins/target-avx512skx-x4.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2016-2025, Intel Corporation
+;;  Copyright (c) 2016-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-avx512skx-x4.ll
+++ b/builtins/target-avx512skx-x4.ll
@@ -374,18 +374,23 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int8/16 ops
 
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i16 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
-  %ri = shufflevector <4 x i8> %0, <4 x i8> zeroinitializer,
-                         <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-                         i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7>
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %ri,
-                                              <16 x i8> zeroinitializer)
-  %r = extractelement <2 x i64> %rv, i32 0
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+define internal <4 x i8> @__add_varying_i8(<4 x i8>,
+                                              <4 x i8>) nounwind readnone alwaysinline {
+  %r = add <4 x i8> %0, %1
+  ret <4 x i8> %r
 }
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
+  reduce4(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+; Calling psadbw does not worth it for only 4 items
+@__reduce_add_uint8 = alias i8 (<4 x i8>), ptr @__reduce_add_int8
 
 define internal <4 x i16> @__add_varying_i16(<4 x i16>,
                                   <4 x i16>) nounwind readnone alwaysinline {
@@ -401,6 +406,8 @@ define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline 
 define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
   reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
 }
+
+@__reduce_add_uint16 = alias i16 (<4 x i16>), ptr @__reduce_add_int16
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal float ops
@@ -449,6 +456,8 @@ define i32 @__reduce_max_int32(<4 x i32>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint32 ops
+
+@__reduce_add_uint32 = alias i32 (<4 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_uint32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__min_varying_uint32, @__min_uniform_uint32)
@@ -506,6 +515,8 @@ define i64 @__reduce_max_int64(<4 x i64>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint64 ops
+
+@__reduce_add_uint64 = alias i64 (<4 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_uint64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_uint64, @__min_uniform_uint64)

--- a/builtins/target-avx512skx-x4.ll
+++ b/builtins/target-avx512skx-x4.ll
@@ -390,7 +390,10 @@ define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
 }
 
 ; Calling psadbw does not worth it for only 4 items
-@__reduce_add_uint8 = alias i8 (<4 x i8>), ptr @__reduce_add_int8
+define i8 @__reduce_add_uint8(<4 x i8>) nounwind readnone alwaysinline {
+  %res = call i8 @__reduce_add_int8(<4 x i8> %0)
+  ret i8 %res
+}
 
 define internal <4 x i16> @__add_varying_i16(<4 x i16>,
                                   <4 x i16>) nounwind readnone alwaysinline {
@@ -407,7 +410,10 @@ define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
   reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<4 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<4 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<4 x i16> %0)
+  ret i16 %res
+}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal float ops
@@ -457,7 +463,10 @@ define i32 @__reduce_max_int32(<4 x i32>) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint32 ops
 
-@__reduce_add_uint32 = alias i32 (<4 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<4 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<4 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_uint32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__min_varying_uint32, @__min_uniform_uint32)
@@ -516,7 +525,10 @@ define i64 @__reduce_max_int64(<4 x i64>) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint64 ops
 
-@__reduce_add_uint64 = alias i64 (<4 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<4 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<4 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_uint64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_uint64, @__min_uniform_uint64)

--- a/builtins/target-avx512skx-x4.ll
+++ b/builtins/target-avx512skx-x4.ll
@@ -372,50 +372,6 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; horizontal int8/16 ops
-
-define internal <4 x i8> @__add_varying_i8(<4 x i8>,
-                                              <4 x i8>) nounwind readnone alwaysinline {
-  %r = add <4 x i8> %0, %1
-  ret <4 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
-  reduce4(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
-; Calling psadbw does not worth it for only 4 items
-define i8 @__reduce_add_uint8(<4 x i8>) nounwind readnone alwaysinline {
-  %res = call i8 @__reduce_add_int8(<4 x i8> %0)
-  ret i8 %res
-}
-
-define internal <4 x i16> @__add_varying_i16(<4 x i16>,
-                                  <4 x i16>) nounwind readnone alwaysinline {
-  %r = add <4 x i16> %0, %1
-  ret <4 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
-  reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<4 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<4 x i16> %0)
-  ret i16 %res
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal float ops
 
 declare <4 x float> @llvm.x86.sse3.hadd.ps(<4 x float>, <4 x float>) nounwind readnone
@@ -438,20 +394,6 @@ define float @__reduce_max_float(<4 x float>) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
 
-define internal <4 x i32> @__add_varying_int32(<4 x i32>, <4 x i32>) nounwind readnone alwaysinline {
-  %s = add <4 x i32> %0, %1
-  ret <4 x i32> %s
-}
-
-define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinline {
-  %s = add i32 %0, %1
-  ret i32 %s
-}
-
-define i32 @__reduce_add_int32(<4 x i32>) nounwind readnone alwaysinline {
-  reduce4(i32, @__add_varying_int32, @__add_uniform_int32)
-}
-
 define i32 @__reduce_min_int32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__min_varying_int32, @__min_uniform_int32)
 }
@@ -462,11 +404,6 @@ define i32 @__reduce_max_int32(<4 x i32>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint32 ops
-
-define i32 @__reduce_add_uint32(<4 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<4 x i32> %0)
-  ret i32 %res
-}
 
 define i32 @__reduce_min_uint32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__min_varying_uint32, @__min_uniform_uint32)
@@ -500,20 +437,6 @@ define double @__reduce_max_double(<4 x double>) nounwind readnone alwaysinline 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int64 ops
 
-define internal <4 x i64> @__add_varying_int64(<4 x i64>, <4 x i64>) nounwind readnone alwaysinline {
-  %s = add <4 x i64> %0, %1
-  ret <4 x i64> %s
-}
-
-define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %s = add i64 %0, %1
-  ret i64 %s
-}
-
-define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone alwaysinline {
-  reduce4(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_int64, @__min_uniform_int64)
 }
@@ -524,11 +447,6 @@ define i64 @__reduce_max_int64(<4 x i64>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint64 ops
-
-define i64 @__reduce_add_uint64(<4 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<4 x i64> %0)
-  ret i64 %res
-}
 
 define i64 @__reduce_min_uint64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_uint64, @__min_uniform_uint64)

--- a/builtins/target-avx512skx-x64.ll
+++ b/builtins/target-avx512skx-x64.ll
@@ -345,21 +345,6 @@ svml(ISA)
 ;; 8 bit
 declare <8 x i64> @llvm.x86.avx512.psad.bw.512(<64 x i8>, <64 x i8>) nounwind readnone
 
-define internal <64 x i8> @__add_varying_i8(<64 x i8>,
-                                              <64 x i8>) nounwind readnone alwaysinline {
-  %r = add <64 x i8> %0, %1
-  ret <64 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<64 x i8>) nounwind readnone alwaysinline {
-  reduce64(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 ; TODO: optimize this further with a shuffle/permute
 define i8 @__reduce_add_uint8(<64 x i8>) nounwind readnone alwaysinline {
   %rv = call <8 x i64> @llvm.x86.avx512.psad.bw.512(<64 x i8> %0,
@@ -381,48 +366,6 @@ define i8 @__reduce_add_uint8(<64 x i8>) nounwind readnone alwaysinline {
   %r = add i64 %r0123, %r4567
   %r8 = trunc i64 %r to i8
   ret i8 %r8
-}
-
-;; 16 bit
-define internal <64 x i16> @__add_varying_i16(<64 x i16>,
-                                              <64 x i16>) nounwind readnone alwaysinline {
-  %r = add <64 x i16> %0, %1
-  ret <64 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<64 x i16>) nounwind readnone alwaysinline {
-  reduce64(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<64 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<64 x i16> %0)
-  ret i16 %res
-}
-
-;; 32 bit
-define internal <64 x i32> @__add_varying_int32(<64 x i32>,
-                                                <64 x i32>) nounwind readnone alwaysinline {
-  %s = add <64 x i32> %0, %1
-  ret <64 x i32> %s
-}
-
-define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinline {
-  %s = add i32 %0, %1
-  ret i32 %s
-}
-
-define i32 @__reduce_add_int32(<64 x i32>) nounwind readnone alwaysinline {
-  reduce64(i32, @__add_varying_int32, @__add_uniform_int32)
-}
-
-define i32 @__reduce_add_uint32(<64 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<64 x i32> %0)
-  ret i32 %res
 }
 
 ;; float
@@ -494,26 +437,6 @@ define double @__reduce_max_double(<64 x double>) nounwind readnone alwaysinline
 }
 
 ;; int64
-
-define internal <64 x i64> @__add_varying_int64(<64 x i64>,
-                                                <64 x i64>) nounwind readnone alwaysinline {
-  %s = add <64 x i64> %0, %1
-  ret <64 x i64> %s
-}
-
-define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %s = add i64 %0, %1
-  ret i64 %s
-}
-
-define i64 @__reduce_add_int64(<64 x i64>) nounwind readnone alwaysinline {
-  reduce64(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
-define i64 @__reduce_add_uint64(<64 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<64 x i64> %0)
-  ret i64 %res
-}
 
 define i64 @__reduce_min_int64(<64 x i64>) nounwind readnone alwaysinline {
   reduce64(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx512skx-x64.ll
+++ b/builtins/target-avx512skx-x64.ll
@@ -342,32 +342,6 @@ svml(ISA)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; reductions
 
-;; 8 bit
-declare <8 x i64> @llvm.x86.avx512.psad.bw.512(<64 x i8>, <64 x i8>) nounwind readnone
-
-; TODO: optimize this further with a shuffle/permute
-define i8 @__reduce_add_uint8(<64 x i8>) nounwind readnone alwaysinline {
-  %rv = call <8 x i64> @llvm.x86.avx512.psad.bw.512(<64 x i8> %0,
-                                                    <64 x i8> zeroinitializer)
-  %r0 = extractelement <8 x i64> %rv, i32 0
-  %r1 = extractelement <8 x i64> %rv, i32 1
-  %r2 = extractelement <8 x i64> %rv, i32 2
-  %r3 = extractelement <8 x i64> %rv, i32 3
-  %r4 = extractelement <8 x i64> %rv, i32 4
-  %r5 = extractelement <8 x i64> %rv, i32 5
-  %r6 = extractelement <8 x i64> %rv, i32 6
-  %r7 = extractelement <8 x i64> %rv, i32 7
-  %r01 = add i64 %r0, %r1
-  %r23 = add i64 %r2, %r3
-  %r45 = add i64 %r4, %r5
-  %r67 = add i64 %r6, %r7
-  %r0123 = add i64 %r01, %r23
-  %r4567 = add i64 %r45, %r67
-  %r = add i64 %r0123, %r4567
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
 ;; float
 ;; TODO: __reduce_add_float may use hadd
 define internal <64 x float> @__add_varying_float(<64 x float>,

--- a/builtins/target-avx512skx-x64.ll
+++ b/builtins/target-avx512skx-x64.ll
@@ -399,7 +399,10 @@ define i16 @__reduce_add_int16(<64 x i16>) nounwind readnone alwaysinline {
   reduce64(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<64 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<64 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<64 x i16> %0)
+  ret i16 %res
+}
 
 ;; 32 bit
 define internal <64 x i32> @__add_varying_int32(<64 x i32>,
@@ -417,7 +420,10 @@ define i32 @__reduce_add_int32(<64 x i32>) nounwind readnone alwaysinline {
   reduce64(i32, @__add_varying_int32, @__add_uniform_int32)
 }
 
-@__reduce_add_uint32 = alias i32 (<64 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<64 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<64 x i32> %0)
+  ret i32 %res
+}
 
 ;; float
 ;; TODO: __reduce_add_float may use hadd
@@ -504,7 +510,10 @@ define i64 @__reduce_add_int64(<64 x i64>) nounwind readnone alwaysinline {
   reduce64(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
-@__reduce_add_uint64 = alias i64 (<64 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<64 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<64 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<64 x i64>) nounwind readnone alwaysinline {
   reduce64(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx512skx-x64.ll
+++ b/builtins/target-avx512skx-x64.ll
@@ -345,7 +345,23 @@ svml(ISA)
 ;; 8 bit
 declare <8 x i64> @llvm.x86.avx512.psad.bw.512(<64 x i8>, <64 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<64 x i8>) nounwind readnone alwaysinline {
+define internal <64 x i8> @__add_varying_i8(<64 x i8>,
+                                              <64 x i8>) nounwind readnone alwaysinline {
+  %r = add <64 x i8> %0, %1
+  ret <64 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<64 x i8>) nounwind readnone alwaysinline {
+  reduce64(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+; TODO: optimize this further with a shuffle/permute
+define i8 @__reduce_add_uint8(<64 x i8>) nounwind readnone alwaysinline {
   %rv = call <8 x i64> @llvm.x86.avx512.psad.bw.512(<64 x i8> %0,
                                                     <64 x i8> zeroinitializer)
   %r0 = extractelement <8 x i64> %rv, i32 0
@@ -363,12 +379,11 @@ define i16 @__reduce_add_int8(<64 x i8>) nounwind readnone alwaysinline {
   %r0123 = add i64 %r01, %r23
   %r4567 = add i64 %r45, %r67
   %r = add i64 %r0123, %r4567
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 ;; 16 bit
-;; TODO: why returning i16?
 define internal <64 x i16> @__add_varying_i16(<64 x i16>,
                                               <64 x i16>) nounwind readnone alwaysinline {
   %r = add <64 x i16> %0, %1
@@ -384,8 +399,9 @@ define i16 @__reduce_add_int16(<64 x i16>) nounwind readnone alwaysinline {
   reduce64(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
+@__reduce_add_uint16 = alias i16 (<64 x i16>), ptr @__reduce_add_int16
+
 ;; 32 bit
-;; TODO: why returning i32?
 define internal <64 x i32> @__add_varying_int32(<64 x i32>,
                                                 <64 x i32>) nounwind readnone alwaysinline {
   %s = add <64 x i32> %0, %1
@@ -400,6 +416,8 @@ define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinlin
 define i32 @__reduce_add_int32(<64 x i32>) nounwind readnone alwaysinline {
   reduce64(i32, @__add_varying_int32, @__add_uniform_int32)
 }
+
+@__reduce_add_uint32 = alias i32 (<64 x i32>), ptr @__reduce_add_int32
 
 ;; float
 ;; TODO: __reduce_add_float may use hadd
@@ -485,6 +503,8 @@ define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinlin
 define i64 @__reduce_add_int64(<64 x i64>) nounwind readnone alwaysinline {
   reduce64(i64, @__add_varying_int64, @__add_uniform_int64)
 }
+
+@__reduce_add_uint64 = alias i64 (<64 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<64 x i64>) nounwind readnone alwaysinline {
   reduce64(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-avx512skx-x8.ll
+++ b/builtins/target-avx512skx-x8.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2016-2025, Intel Corporation
+;;  Copyright (c) 2016-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-avx512skx-x8.ll
+++ b/builtins/target-avx512skx-x8.ll
@@ -412,21 +412,6 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define internal <8 x i8> @__add_varying_i8(<8 x i8>,
-                                              <8 x i8>) nounwind readnone alwaysinline {
-  %r = add <8 x i8> %0, %1
-  ret <8 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
-  reduce8(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %ri = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
                          <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
@@ -436,26 +421,6 @@ define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %r = extractelement <2 x i64> %rv, i32 0
   %r8 = trunc i64 %r to i8
   ret i8 %r8
-}
-
-define internal <8 x i16> @__add_varying_i16(<8 x i16>,
-                                  <8 x i16>) nounwind readnone alwaysinline {
-  %r = add <8 x i16> %0, %1
-  ret <8 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
-  reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<8 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<8 x i16> %0)
-  ret i16 %res
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -483,21 +448,6 @@ define float @__reduce_max_float(<8 x float>) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
 
-define internal <8 x i32> @__add_varying_int32(<8 x i32>,
-                                       <8 x i32>) nounwind readnone alwaysinline {
-  %s = add <8 x i32> %0, %1
-  ret <8 x i32> %s
-}
-
-define internal i32 @__add_uniform_int32(i32, i32) nounwind readnone alwaysinline {
-  %s = add i32 %0, %1
-  ret i32 %s
-}
-
-define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone alwaysinline {
-  reduce8(i32, @__add_varying_int32, @__add_uniform_int32)
-}
-
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8(i32, @__min_varying_int32, @__min_uniform_int32)
 }
@@ -508,11 +458,6 @@ define i32 @__reduce_max_int32(<8 x i32>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint32 ops
-
-define i32 @__reduce_add_uint32(<8 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<8 x i32> %0)
-  ret i32 %res
-}
 
 define i32 @__reduce_min_uint32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8(i32, @__min_varying_uint32, @__min_uniform_uint32)
@@ -551,21 +496,6 @@ define double @__reduce_max_double(<8 x double>) nounwind readnone alwaysinline 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int64 ops
 
-define internal <8 x i64> @__add_varying_int64(<8 x i64>,
-                                                <8 x i64>) nounwind readnone alwaysinline {
-  %s = add <8 x i64> %0, %1
-  ret <8 x i64> %s
-}
-
-define internal i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %s = add i64 %0, %1
-  ret i64 %s
-}
-
-define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone alwaysinline {
-  reduce8(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone alwaysinline {
   reduce8(i64, @__min_varying_int64, @__min_uniform_int64)
 }
@@ -576,11 +506,6 @@ define i64 @__reduce_max_int64(<8 x i64>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint64 ops
-
-define i64 @__reduce_add_uint64(<8 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<8 x i64> %0)
-  ret i64 %res
-}
 
 define i64 @__reduce_min_uint64(<8 x i64>) nounwind readnone alwaysinline {
   reduce8(i64, @__min_varying_uint64, @__min_uniform_uint64)

--- a/builtins/target-avx512skx-x8.ll
+++ b/builtins/target-avx512skx-x8.ll
@@ -412,15 +412,30 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
+define internal <8 x i8> @__add_varying_i8(<8 x i8>,
+                                              <8 x i8>) nounwind readnone alwaysinline {
+  %r = add <8 x i8> %0, %1
+  ret <8 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
+  reduce8(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %ri = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
                          <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                          i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %ri,
                                               <16 x i8> zeroinitializer)
   %r = extractelement <2 x i64> %rv, i32 0
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 define internal <8 x i16> @__add_varying_i16(<8 x i16>,
@@ -437,6 +452,8 @@ define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline 
 define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
   reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
 }
+
+@__reduce_add_uint16 = alias i16 (<8 x i16>), ptr @__reduce_add_int16
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal float ops
@@ -488,6 +505,8 @@ define i32 @__reduce_max_int32(<8 x i32>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint32 ops
+
+@__reduce_add_uint32 = alias i32 (<8 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_uint32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8(i32, @__min_varying_uint32, @__min_uniform_uint32)
@@ -551,6 +570,8 @@ define i64 @__reduce_max_int64(<8 x i64>) nounwind readnone alwaysinline {
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint64 ops
+
+@__reduce_add_uint64 = alias i64 (<8 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_uint64(<8 x i64>) nounwind readnone alwaysinline {
   reduce8(i64, @__min_varying_uint64, @__min_uniform_uint64)

--- a/builtins/target-avx512skx-x8.ll
+++ b/builtins/target-avx512skx-x8.ll
@@ -453,7 +453,10 @@ define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
   reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<8 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<8 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<8 x i16> %0)
+  ret i16 %res
+}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal float ops
@@ -506,7 +509,10 @@ define i32 @__reduce_max_int32(<8 x i32>) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint32 ops
 
-@__reduce_add_uint32 = alias i32 (<8 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<8 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<8 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_uint32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8(i32, @__min_varying_uint32, @__min_uniform_uint32)
@@ -571,7 +577,10 @@ define i64 @__reduce_max_int64(<8 x i64>) nounwind readnone alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; horizontal uint64 ops
 
-@__reduce_add_uint64 = alias i64 (<8 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<8 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<8 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_uint64(<8 x i64>) nounwind readnone alwaysinline {
   reduce8(i64, @__min_varying_uint64, @__min_uniform_uint64)

--- a/builtins/target-avx512skx-x8.ll
+++ b/builtins/target-avx512skx-x8.ll
@@ -408,22 +408,6 @@ define i1 @__none(<WIDTH x MASK> %mask) nounwind readnone alwaysinline {
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; horizontal int8/16 ops
-
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
-  %ri = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
-                         <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-                         i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %ri,
-                                              <16 x i8> zeroinitializer)
-  %r = extractelement <2 x i64> %rv, i32 0
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal float ops
 
 declare <8 x float> @llvm.x86.avx.hadd.ps.256(<8 x float>, <8 x float>) nounwind readnone

--- a/builtins/target-sse2-i32x4.ll
+++ b/builtins/target-sse2-i32x4.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2025, Intel Corporation
+;;  Copyright (c) 2010-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-sse2-i32x4.ll
+++ b/builtins/target-sse2-i32x4.ll
@@ -152,47 +152,6 @@ define i1 @__none(<4 x i32>) nounwind readnone alwaysinline {
   ret i1 %cmp
 }
 
-define internal <4 x i8> @__add_varying_i8(<4 x i8>,
-                                              <4 x i8>) nounwind readnone alwaysinline {
-  %r = add <4 x i8> %0, %1
-  ret <4 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
-  reduce4(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
-; Calling psadbw does not worth it for only 4 items
-define i8 @__reduce_add_uint8(<4 x i8>) nounwind readnone alwaysinline {
-  %res = call i8 @__reduce_add_int8(<4 x i8> %0)
-  ret i8 %res
-}
-
-define internal <4 x i16> @__add_varying_i16(<4 x i16>,
-                                  <4 x i16>) nounwind readnone alwaysinline {
-  %r = add <4 x i16> %0, %1
-  ret <4 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
-  reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<4 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<4 x i16> %0)
-  ret i16 %res
-}
-
 define float @__reduce_add_float(<4 x float> %v) nounwind readonly alwaysinline {
   %v1 = shufflevector <4 x float> %v, <4 x float> undef,
                       <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
@@ -209,21 +168,6 @@ define float @__reduce_min_float(<4 x float>) nounwind readnone {
 
 define float @__reduce_max_float(<4 x float>) nounwind readnone {
   reduce4(float, @__max_varying_float, @__max_uniform_float)
-}
-
-define i32 @__reduce_add_int32(<4 x i32> %v) nounwind readnone {
-  %v1 = shufflevector <4 x i32> %v, <4 x i32> undef,
-                      <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
-  %m1 = add <4 x i32> %v1, %v
-  %m1a = extractelement <4 x i32> %m1, i32 0
-  %m1b = extractelement <4 x i32> %m1, i32 1
-  %sum = add i32 %m1a, %m1b
-  ret i32 %sum
-}
-
-define i32 @__reduce_add_uint32(<4 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<4 x i32> %0)
-  ret i32 %res
 }
 
 define i32 @__reduce_min_int32(<4 x i32>) nounwind readnone {
@@ -261,23 +205,6 @@ define double @__reduce_min_double(<4 x double>) nounwind readnone {
 
 define double @__reduce_max_double(<4 x double>) nounwind readnone {
   reduce4(double, @__max_varying_double, @__max_uniform_double)
-}
-
-define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone {
-  %v0 = shufflevector <4 x i64> %0, <4 x i64> undef,
-                      <2 x i32> <i32 0, i32 1>
-  %v1 = shufflevector <4 x i64> %0, <4 x i64> undef,
-                      <2 x i32> <i32 2, i32 3>
-  %sum = add <2 x i64> %v0, %v1
-  %e0 = extractelement <2 x i64> %sum, i32 0
-  %e1 = extractelement <2 x i64> %sum, i32 1
-  %m = add i64 %e0, %e1
-  ret i64 %m
-}
-
-define i64 @__reduce_add_uint64(<4 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<4 x i64> %0)
-  ret i64 %res
 }
 
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone {

--- a/builtins/target-sse2-i32x4.ll
+++ b/builtins/target-sse2-i32x4.ll
@@ -168,7 +168,10 @@ define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
 }
 
 ; Calling psadbw does not worth it for only 4 items
-@__reduce_add_uint8 = alias i8 (<4 x i8>), ptr @__reduce_add_int8
+define i8 @__reduce_add_uint8(<4 x i8>) nounwind readnone alwaysinline {
+  %res = call i8 @__reduce_add_int8(<4 x i8> %0)
+  ret i8 %res
+}
 
 define internal <4 x i16> @__add_varying_i16(<4 x i16>,
                                   <4 x i16>) nounwind readnone alwaysinline {
@@ -185,7 +188,10 @@ define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
   reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<4 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<4 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<4 x i16> %0)
+  ret i16 %res
+}
 
 define float @__reduce_add_float(<4 x float> %v) nounwind readonly alwaysinline {
   %v1 = shufflevector <4 x float> %v, <4 x float> undef,
@@ -215,7 +221,10 @@ define i32 @__reduce_add_int32(<4 x i32> %v) nounwind readnone {
   ret i32 %sum
 }
 
-@__reduce_add_uint32 = alias i32 (<4 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<4 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<4 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_int32(<4 x i32>) nounwind readnone {
   reduce4(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -266,7 +275,10 @@ define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone {
   ret i64 %m
 }
 
-@__reduce_add_uint64 = alias i64 (<4 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<4 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<4 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone {
   reduce4(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-sse2-i32x4.ll
+++ b/builtins/target-sse2-i32x4.ll
@@ -152,20 +152,23 @@ define i1 @__none(<4 x i32>) nounwind readnone alwaysinline {
   ret i1 %cmp
 }
 
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i16 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
-  %wide8 = shufflevector <4 x i8> %0, <4 x i8> zeroinitializer,
-      <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 4, i32 4, i32 4,
-                  i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4>
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %wide8,
-                                              <16 x i8> zeroinitializer)
-  %r0 = extractelement <2 x i64> %rv, i32 0
-  %r1 = extractelement <2 x i64> %rv, i32 1
-  %r = add i64 %r0, %r1
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+define internal <4 x i8> @__add_varying_i8(<4 x i8>,
+                                              <4 x i8>) nounwind readnone alwaysinline {
+  %r = add <4 x i8> %0, %1
+  ret <4 x i8> %r
 }
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
+  reduce4(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+; Calling psadbw does not worth it for only 4 items
+@__reduce_add_uint8 = alias i8 (<4 x i8>), ptr @__reduce_add_int8
 
 define internal <4 x i16> @__add_varying_i16(<4 x i16>,
                                   <4 x i16>) nounwind readnone alwaysinline {
@@ -181,6 +184,8 @@ define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline 
 define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
   reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
 }
+
+@__reduce_add_uint16 = alias i16 (<4 x i16>), ptr @__reduce_add_int16
 
 define float @__reduce_add_float(<4 x float> %v) nounwind readonly alwaysinline {
   %v1 = shufflevector <4 x float> %v, <4 x float> undef,
@@ -209,6 +214,8 @@ define i32 @__reduce_add_int32(<4 x i32> %v) nounwind readnone {
   %sum = add i32 %m1a, %m1b
   ret i32 %sum
 }
+
+@__reduce_add_uint32 = alias i32 (<4 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_int32(<4 x i32>) nounwind readnone {
   reduce4(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -258,6 +265,8 @@ define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone {
   %m = add i64 %e0, %e1
   ret i64 %m
 }
+
+@__reduce_add_uint64 = alias i64 (<4 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone {
   reduce4(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-sse2-i32x8.ll
+++ b/builtins/target-sse2-i32x8.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2025, Intel Corporation
+;;  Copyright (c) 2010-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-sse2-i32x8.ll
+++ b/builtins/target-sse2-i32x8.ll
@@ -181,7 +181,22 @@ define i1 @__none(<8 x i32>) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
+define internal <8 x i8> @__add_varying_i8(<8 x i8>,
+                                              <8 x i8>) nounwind readnone alwaysinline {
+  %r = add <8 x i8> %0, %1
+  ret <8 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
+  reduce8(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %wide8 = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
       <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                   i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8>
@@ -190,8 +205,8 @@ define i16 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
   %r0 = extractelement <2 x i64> %rv, i32 0
   %r1 = extractelement <2 x i64> %rv, i32 1
   %r = add i64 %r0, %r1
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 define internal <8 x i16> @__add_varying_i16(<8 x i16>,
@@ -208,6 +223,8 @@ define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline 
 define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
   reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
 }
+
+@__reduce_add_uint16 = alias i16 (<8 x i16>), ptr @__reduce_add_int16
 
 define <4 x float> @__vec4_add_float(<4 x float> %v0,
                                      <4 x float> %v1) nounwind readnone alwaysinline {
@@ -248,6 +265,8 @@ define i32 @__add_int32(i32, i32) nounwind readnone alwaysinline {
 define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8by4(i32, @__vec4_add_int32, @__add_int32)
 }
+
+@__reduce_add_uint32 = alias i32 (<8 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -302,6 +321,8 @@ define i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
 define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone {
   reduce8by4(i64, @__add_varying_int64, @__add_uniform_int64)
 }
+
+@__reduce_add_uint64 = alias i64 (<8 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone {
   reduce8(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-sse2-i32x8.ll
+++ b/builtins/target-sse2-i32x8.ll
@@ -181,21 +181,6 @@ define i1 @__none(<8 x i32>) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define internal <8 x i8> @__add_varying_i8(<8 x i8>,
-                                              <8 x i8>) nounwind readnone alwaysinline {
-  %r = add <8 x i8> %0, %1
-  ret <8 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
-  reduce8(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %wide8 = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
       <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
@@ -207,26 +192,6 @@ define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %r = add i64 %r0, %r1
   %r8 = trunc i64 %r to i8
   ret i8 %r8
-}
-
-define internal <8 x i16> @__add_varying_i16(<8 x i16>,
-                                  <8 x i16>) nounwind readnone alwaysinline {
-  %r = add <8 x i16> %0, %1
-  ret <8 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
-  reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<8 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<8 x i16> %0)
-  ret i16 %res
 }
 
 define <4 x float> @__vec4_add_float(<4 x float> %v0,
@@ -250,28 +215,6 @@ define float @__reduce_min_float(<8 x float>) nounwind readnone alwaysinline {
 
 define float @__reduce_max_float(<8 x float>) nounwind readnone alwaysinline {
   reduce8(float, @__max_varying_float, @__max_uniform_float)
-}
-
-; helper function for reduce_add_int32
-define <4 x i32> @__vec4_add_int32(<4 x i32> %v0,
-                                   <4 x i32> %v1) nounwind readnone alwaysinline {
-  %v = add <4 x i32> %v0, %v1
-  ret <4 x i32> %v
-}
-
-; helper function for reduce_add_int32
-define i32 @__add_int32(i32, i32) nounwind readnone alwaysinline {
-  %v = add i32 %0, %1
-  ret i32 %v
-}
-
-define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone alwaysinline {
-  reduce8by4(i32, @__vec4_add_int32, @__add_int32)
-}
-
-define i32 @__reduce_add_uint32(<8 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<8 x i32> %0)
-  ret i32 %res
 }
 
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone alwaysinline {
@@ -311,26 +254,6 @@ define double @__reduce_min_double(<8 x double>) nounwind readnone {
 
 define double @__reduce_max_double(<8 x double>) nounwind readnone {
   reduce8(double, @__max_varying_double, @__max_uniform_double)
-}
-
-define <4 x i64> @__add_varying_int64(<4 x i64>,
-                                      <4 x i64>) nounwind readnone alwaysinline {
-  %r = add <4 x i64> %0, %1
-  ret <4 x i64> %r
-}
-
-define i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %r = add i64 %0, %1
-  ret i64 %r
-}
-
-define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone {
-  reduce8by4(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
-define i64 @__reduce_add_uint64(<8 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<8 x i64> %0)
-  ret i64 %res
 }
 
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone {

--- a/builtins/target-sse2-i32x8.ll
+++ b/builtins/target-sse2-i32x8.ll
@@ -179,21 +179,6 @@ define i1 @__none(<8 x i32>) nounwind readnone alwaysinline {
   ret i1 %cmp
 }
 
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
-  %wide8 = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
-      <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-                  i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8>
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %wide8,
-                                              <16 x i8> zeroinitializer)
-  %r0 = extractelement <2 x i64> %rv, i32 0
-  %r1 = extractelement <2 x i64> %rv, i32 1
-  %r = add i64 %r0, %r1
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
 define <4 x float> @__vec4_add_float(<4 x float> %v0,
                                      <4 x float> %v1) nounwind readnone alwaysinline {
   %v = fadd <4 x float> %v0, %v1

--- a/builtins/target-sse2-i32x8.ll
+++ b/builtins/target-sse2-i32x8.ll
@@ -224,7 +224,10 @@ define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
   reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<8 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<8 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<8 x i16> %0)
+  ret i16 %res
+}
 
 define <4 x float> @__vec4_add_float(<4 x float> %v0,
                                      <4 x float> %v1) nounwind readnone alwaysinline {
@@ -266,7 +269,10 @@ define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8by4(i32, @__vec4_add_int32, @__add_int32)
 }
 
-@__reduce_add_uint32 = alias i32 (<8 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<8 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<8 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -322,7 +328,10 @@ define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone {
   reduce8by4(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
-@__reduce_add_uint64 = alias i64 (<8 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<8 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<8 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone {
   reduce8(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-sse4-i16x8.ll
+++ b/builtins/target-sse4-i16x8.ll
@@ -1,5 +1,5 @@
-;;  Copyright (c) 2013, 2015, Google, Inc.
-;;  Copyright(c) 2019-2024, Intel Corporation
+;;  Copyright(c) 2013, 2015, Google, Inc.
+;;  Copyright(c) 2019-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-sse4-i16x8.ll
+++ b/builtins/target-sse4-i16x8.ll
@@ -273,7 +273,10 @@ define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
   reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<8 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<8 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<8 x i16> %0)
+  ret i16 %res
+}
 
 define internal <8 x float> @__add_varying_float(<8 x float>, <8 x float>) {
   %r = fadd <8 x float> %0, %1
@@ -311,7 +314,10 @@ define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone {
   reduce8(i32, @__add_varying_int32, @__add_uniform_int32)
 }
 
-@__reduce_add_uint32 = alias i32 (<8 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<8 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<8 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone {
   reduce8(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -365,7 +371,10 @@ define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone {
   reduce8(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
-@__reduce_add_uint64 = alias i64 (<8 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<8 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<8 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone {
   reduce8(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-sse4-i16x8.ll
+++ b/builtins/target-sse4-i16x8.ll
@@ -228,21 +228,6 @@ define i1 @__none(<8 x MASK>) nounwind readnone alwaysinline {
   ret i1 %meq
 }
 
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
-  %wide8 = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
-      <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-                  i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8>
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %wide8,
-                                              <16 x i8> zeroinitializer)
-  %r0 = extractelement <2 x i64> %rv, i32 0
-  %r1 = extractelement <2 x i64> %rv, i32 1
-  %r = add i64 %r0, %r1
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
 define internal <8 x float> @__add_varying_float(<8 x float>, <8 x float>) {
   %r = fadd <8 x float> %0, %1
   ret <8 x float> %r

--- a/builtins/target-sse4-i16x8.ll
+++ b/builtins/target-sse4-i16x8.ll
@@ -230,21 +230,6 @@ define i1 @__none(<8 x MASK>) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define internal <8 x i8> @__add_varying_i8(<8 x i8>,
-                                              <8 x i8>) nounwind readnone alwaysinline {
-  %r = add <8 x i8> %0, %1
-  ret <8 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
-  reduce8(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %wide8 = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
       <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
@@ -256,26 +241,6 @@ define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %r = add i64 %r0, %r1
   %r8 = trunc i64 %r to i8
   ret i8 %r8
-}
-
-define internal <8 x i16> @__add_varying_i16(<8 x i16>,
-                                  <8 x i16>) nounwind readnone alwaysinline {
-  %r = add <8 x i16> %0, %1
-  ret <8 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
-  reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<8 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<8 x i16> %0)
-  ret i16 %res
 }
 
 define internal <8 x float> @__add_varying_float(<8 x float>, <8 x float>) {
@@ -298,25 +263,6 @@ define float @__reduce_min_float(<8 x float>) nounwind readnone {
 
 define float @__reduce_max_float(<8 x float>) nounwind readnone {
   reduce8(float, @__max_varying_float, @__max_uniform_float)
-}
-
-define internal <8 x i32> @__add_varying_int32(<8 x i32>, <8 x i32>) {
-  %r = add <8 x i32> %0, %1
-  ret <8 x i32> %r
-}
-
-define internal i32 @__add_uniform_int32(i32, i32) {
-  %r = add i32 %0, %1
-  ret i32 %r
-}
-
-define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone {
-  reduce8(i32, @__add_varying_int32, @__add_uniform_int32)
-}
-
-define i32 @__reduce_add_uint32(<8 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<8 x i32> %0)
-  ret i32 %res
 }
 
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone {
@@ -355,25 +301,6 @@ define double @__reduce_min_double(<8 x double>) nounwind readnone {
 
 define double @__reduce_max_double(<8 x double>) nounwind readnone {
   reduce8(double, @__max_varying_double, @__max_uniform_double)
-}
-
-define internal <8 x i64> @__add_varying_int64(<8 x i64>, <8 x i64>) {
-  %r = add <8 x i64> %0, %1
-  ret <8 x i64> %r
-}
-
-define internal i64 @__add_uniform_int64(i64, i64) {
-  %r = add i64 %0, %1
-  ret i64 %r
-}
-
-define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone {
-  reduce8(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
-define i64 @__reduce_add_uint64(<8 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<8 x i64> %0)
-  ret i64 %res
 }
 
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone {

--- a/builtins/target-sse4-i16x8.ll
+++ b/builtins/target-sse4-i16x8.ll
@@ -230,7 +230,22 @@ define i1 @__none(<8 x MASK>) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
+define internal <8 x i8> @__add_varying_i8(<8 x i8>,
+                                              <8 x i8>) nounwind readnone alwaysinline {
+  %r = add <8 x i8> %0, %1
+  ret <8 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
+  reduce8(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %wide8 = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
       <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                   i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8>
@@ -239,8 +254,8 @@ define i16 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
   %r0 = extractelement <2 x i64> %rv, i32 0
   %r1 = extractelement <2 x i64> %rv, i32 1
   %r = add i64 %r0, %r1
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 define internal <8 x i16> @__add_varying_i16(<8 x i16>,
@@ -257,6 +272,8 @@ define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline 
 define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
   reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
 }
+
+@__reduce_add_uint16 = alias i16 (<8 x i16>), ptr @__reduce_add_int16
 
 define internal <8 x float> @__add_varying_float(<8 x float>, <8 x float>) {
   %r = fadd <8 x float> %0, %1
@@ -293,6 +310,8 @@ define internal i32 @__add_uniform_int32(i32, i32) {
 define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone {
   reduce8(i32, @__add_varying_int32, @__add_uniform_int32)
 }
+
+@__reduce_add_uint32 = alias i32 (<8 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone {
   reduce8(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -345,6 +364,8 @@ define internal i64 @__add_uniform_int64(i64, i64) {
 define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone {
   reduce8(i64, @__add_varying_int64, @__add_uniform_int64)
 }
+
+@__reduce_add_uint64 = alias i64 (<8 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone {
   reduce8(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-sse4-i32x4.ll
+++ b/builtins/target-sse4-i32x4.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2024, Intel Corporation
+;;  Copyright (c) 2010-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-sse4-i32x4.ll
+++ b/builtins/target-sse4-i32x4.ll
@@ -278,71 +278,9 @@ define double @__reduce_max_double(<4 x double>) nounwind readnone alwaysinline 
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; horizontal int8 ops
-
-define internal <4 x i8> @__add_varying_i8(<4 x i8>,
-                                              <4 x i8>) nounwind readnone alwaysinline {
-  %r = add <4 x i8> %0, %1
-  ret <4 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
-  reduce4(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
-; Calling psadbw does not worth it for only 4 items
-define i8 @__reduce_add_uint8(<4 x i8>) nounwind readnone alwaysinline {
-  %res = call i8 @__reduce_add_int8(<4 x i8> %0)
-  ret i8 %res
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; horizontal int16 ops
-
-define internal <4 x i16> @__add_varying_i16(<4 x i16>,
-                                  <4 x i16>) nounwind readnone alwaysinline {
-  %r = add <4 x i16> %0, %1
-  ret <4 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
-  reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<4 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<4 x i16> %0)
-  ret i16 %res
-}
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
 
 ;; reduction functions
-define i32 @__reduce_add_int32(<4 x i32> %v) nounwind readnone alwaysinline {
-  %v1 = shufflevector <4 x i32> %v, <4 x i32> undef,
-                      <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
-  %m1 = add <4 x i32> %v1, %v
-  %m1a = extractelement <4 x i32> %m1, i32 0
-  %m1b = extractelement <4 x i32> %m1, i32 1
-  %sum = add i32 %m1a, %m1b
-  ret i32 %sum
-}
-
-define i32 @__reduce_add_uint32(<4 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<4 x i32> %0)
-  ret i32 %res
-}
-
 define i32 @__reduce_min_int32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__min_varying_int32, @__min_uniform_int32)
 }
@@ -363,23 +301,6 @@ define i32 @__reduce_max_uint32(<4 x i32>) nounwind readnone alwaysinline {
 ;; horizontal int64 ops
 
 ;; reduction functions
-define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone alwaysinline {
-  %v0 = shufflevector <4 x i64> %0, <4 x i64> undef,
-                      <2 x i32> <i32 0, i32 1>
-  %v1 = shufflevector <4 x i64> %0, <4 x i64> undef,
-                      <2 x i32> <i32 2, i32 3>
-  %sum = add <2 x i64> %v0, %v1
-  %e0 = extractelement <2 x i64> %sum, i32 0
-  %e1 = extractelement <2 x i64> %sum, i32 1
-  %m = add i64 %e0, %e1
-  ret i64 %m
-}
-
-define i64 @__reduce_add_uint64(<4 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<4 x i64> %0)
-  ret i64 %res
-}
-
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_int64, @__min_uniform_int64)
 }

--- a/builtins/target-sse4-i32x4.ll
+++ b/builtins/target-sse4-i32x4.ll
@@ -280,20 +280,23 @@ define double @__reduce_max_double(<4 x double>) nounwind readnone alwaysinline 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int8 ops
 
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i16 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
-  %wide8 = shufflevector <4 x i8> %0, <4 x i8> zeroinitializer,
-      <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 4, i32 4, i32 4,
-                  i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4>
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %wide8,
-                                              <16 x i8> zeroinitializer)
-  %r0 = extractelement <2 x i64> %rv, i32 0
-  %r1 = extractelement <2 x i64> %rv, i32 1
-  %r = add i64 %r0, %r1
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+define internal <4 x i8> @__add_varying_i8(<4 x i8>,
+                                              <4 x i8>) nounwind readnone alwaysinline {
+  %r = add <4 x i8> %0, %1
+  ret <4 x i8> %r
 }
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
+  reduce4(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+; Calling psadbw does not worth it for only 4 items
+@__reduce_add_uint8 = alias i8 (<4 x i8>), ptr @__reduce_add_int8
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int16 ops
@@ -313,6 +316,8 @@ define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
   reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
+@__reduce_add_uint16 = alias i16 (<4 x i16>), ptr @__reduce_add_int16
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
 
@@ -326,6 +331,8 @@ define i32 @__reduce_add_int32(<4 x i32> %v) nounwind readnone alwaysinline {
   %sum = add i32 %m1a, %m1b
   ret i32 %sum
 }
+
+@__reduce_add_uint32 = alias i32 (<4 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_int32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -358,6 +365,8 @@ define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone alwaysinline {
   %m = add i64 %e0, %e1
   ret i64 %m
 }
+
+@__reduce_add_uint64 = alias i64 (<4 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-sse4-i32x4.ll
+++ b/builtins/target-sse4-i32x4.ll
@@ -296,7 +296,10 @@ define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
 }
 
 ; Calling psadbw does not worth it for only 4 items
-@__reduce_add_uint8 = alias i8 (<4 x i8>), ptr @__reduce_add_int8
+define i8 @__reduce_add_uint8(<4 x i8>) nounwind readnone alwaysinline {
+  %res = call i8 @__reduce_add_int8(<4 x i8> %0)
+  ret i8 %res
+}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int16 ops
@@ -316,7 +319,10 @@ define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
   reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<4 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<4 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<4 x i16> %0)
+  ret i16 %res
+}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; horizontal int32 ops
@@ -332,7 +338,10 @@ define i32 @__reduce_add_int32(<4 x i32> %v) nounwind readnone alwaysinline {
   ret i32 %sum
 }
 
-@__reduce_add_uint32 = alias i32 (<4 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<4 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<4 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_int32(<4 x i32>) nounwind readnone alwaysinline {
   reduce4(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -366,7 +375,10 @@ define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone alwaysinline {
   ret i64 %m
 }
 
-@__reduce_add_uint64 = alias i64 (<4 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<4 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<4 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-sse4-i32x8.ll
+++ b/builtins/target-sse4-i32x8.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2010-2024, Intel Corporation
+;;  Copyright (c) 2010-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-sse4-i32x8.ll
+++ b/builtins/target-sse4-i32x8.ll
@@ -209,7 +209,22 @@ define i1 @__none(<8 x i32>) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
+define internal <8 x i8> @__add_varying_i8(<8 x i8>,
+                                              <8 x i8>) nounwind readnone alwaysinline {
+  %r = add <8 x i8> %0, %1
+  ret <8 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
+  reduce8(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %wide8 = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
       <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
                   i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8>
@@ -218,8 +233,8 @@ define i16 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
   %r0 = extractelement <2 x i64> %rv, i32 0
   %r1 = extractelement <2 x i64> %rv, i32 1
   %r = add i64 %r0, %r1
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 define internal <8 x i16> @__add_varying_i16(<8 x i16>,
@@ -236,6 +251,8 @@ define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline 
 define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
   reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
 }
+
+@__reduce_add_uint16 = alias i16 (<8 x i16>), ptr @__reduce_add_int16
 
 define float @__reduce_min_float(<8 x float>) nounwind readnone alwaysinline {
   reduce8by4(float, @llvm.x86.sse.min.ps, @__min_uniform_float)
@@ -261,6 +278,8 @@ define i32 @__add_int32(i32, i32) nounwind readnone alwaysinline {
 define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8by4(i32, @__vec4_add_int32, @__add_int32)
 }
+
+@__reduce_add_uint32 = alias i32 (<8 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8by4(i32, @llvm.x86.sse41.pminsd, @__min_uniform_int32)
@@ -315,6 +334,8 @@ define i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
 define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone {
   reduce8by4(i64, @__add_varying_int64, @__add_uniform_int64)
 }
+
+@__reduce_add_uint64 = alias i64 (<8 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone {
   reduce8(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-sse4-i32x8.ll
+++ b/builtins/target-sse4-i32x8.ll
@@ -209,21 +209,6 @@ define i1 @__none(<8 x i32>) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define internal <8 x i8> @__add_varying_i8(<8 x i8>,
-                                              <8 x i8>) nounwind readnone alwaysinline {
-  %r = add <8 x i8> %0, %1
-  ret <8 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<8 x i8>) nounwind readnone alwaysinline {
-  reduce8(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   %wide8 = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
       <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
@@ -237,54 +222,12 @@ define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
   ret i8 %r8
 }
 
-define internal <8 x i16> @__add_varying_i16(<8 x i16>,
-                                  <8 x i16>) nounwind readnone alwaysinline {
-  %r = add <8 x i16> %0, %1
-  ret <8 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
-  reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<8 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<8 x i16> %0)
-  ret i16 %res
-}
-
 define float @__reduce_min_float(<8 x float>) nounwind readnone alwaysinline {
   reduce8by4(float, @llvm.x86.sse.min.ps, @__min_uniform_float)
 }
 
 define float @__reduce_max_float(<8 x float>) nounwind readnone alwaysinline {
   reduce8by4(float, @llvm.x86.sse.max.ps, @__max_uniform_float)
-}
-
-; helper function for reduce_add_int32
-define <4 x i32> @__vec4_add_int32(<4 x i32> %v0,
-                                   <4 x i32> %v1) nounwind readnone alwaysinline {
-  %v = add <4 x i32> %v0, %v1
-  ret <4 x i32> %v
-}
-
-; helper function for reduce_add_int32
-define i32 @__add_int32(i32, i32) nounwind readnone alwaysinline {
-  %v = add i32 %0, %1
-  ret i32 %v
-}
-
-define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone alwaysinline {
-  reduce8by4(i32, @__vec4_add_int32, @__add_int32)
-}
-
-define i32 @__reduce_add_uint32(<8 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<8 x i32> %0)
-  ret i32 %res
 }
 
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone alwaysinline {
@@ -324,26 +267,6 @@ define double @__reduce_min_double(<8 x double>) nounwind readnone {
 
 define double @__reduce_max_double(<8 x double>) nounwind readnone {
   reduce8(double, @__max_varying_double, @__max_uniform_double)
-}
-
-define <4 x i64> @__add_varying_int64(<4 x i64>,
-                                      <4 x i64>) nounwind readnone alwaysinline {
-  %r = add <4 x i64> %0, %1
-  ret <4 x i64> %r
-}
-
-define i64 @__add_uniform_int64(i64, i64) nounwind readnone alwaysinline {
-  %r = add i64 %0, %1
-  ret i64 %r
-}
-
-define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone {
-  reduce8by4(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
-define i64 @__reduce_add_uint64(<8 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<8 x i64> %0)
-  ret i64 %res
 }
 
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone {

--- a/builtins/target-sse4-i32x8.ll
+++ b/builtins/target-sse4-i32x8.ll
@@ -207,21 +207,6 @@ define i1 @__none(<8 x i32>) nounwind readnone alwaysinline {
   ret i1 %cmp
 }
 
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i8 @__reduce_add_uint8(<8 x i8>) nounwind readnone alwaysinline {
-  %wide8 = shufflevector <8 x i8> %0, <8 x i8> zeroinitializer,
-      <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
-                  i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8>
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %wide8,
-                                              <16 x i8> zeroinitializer)
-  %r0 = extractelement <2 x i64> %rv, i32 0
-  %r1 = extractelement <2 x i64> %rv, i32 1
-  %r = add i64 %r0, %r1
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
 define float @__reduce_min_float(<8 x float>) nounwind readnone alwaysinline {
   reduce8by4(float, @llvm.x86.sse.min.ps, @__min_uniform_float)
 }

--- a/builtins/target-sse4-i32x8.ll
+++ b/builtins/target-sse4-i32x8.ll
@@ -252,7 +252,10 @@ define i16 @__reduce_add_int16(<8 x i16>) nounwind readnone alwaysinline {
   reduce8(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<8 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<8 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<8 x i16> %0)
+  ret i16 %res
+}
 
 define float @__reduce_min_float(<8 x float>) nounwind readnone alwaysinline {
   reduce8by4(float, @llvm.x86.sse.min.ps, @__min_uniform_float)
@@ -279,7 +282,10 @@ define i32 @__reduce_add_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8by4(i32, @__vec4_add_int32, @__add_int32)
 }
 
-@__reduce_add_uint32 = alias i32 (<8 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<8 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<8 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_int32(<8 x i32>) nounwind readnone alwaysinline {
   reduce8by4(i32, @llvm.x86.sse41.pminsd, @__min_uniform_int32)
@@ -335,7 +341,10 @@ define i64 @__reduce_add_int64(<8 x i64>) nounwind readnone {
   reduce8by4(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
-@__reduce_add_uint64 = alias i64 (<8 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<8 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<8 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<8 x i64>) nounwind readnone {
   reduce8(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-sse4-i8x16.ll
+++ b/builtins/target-sse4-i8x16.ll
@@ -1,5 +1,5 @@
-;;  Copyright (c) 2013, 2015, Google, Inc.
-;;  Copyright(c) 2019-2024, Intel Corporation
+;;  Copyright(c) 2013, 2015, Google, Inc.
+;;  Copyright(c) 2019-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-sse4-i8x16.ll
+++ b/builtins/target-sse4-i8x16.ll
@@ -234,21 +234,6 @@ define i1 @__none(<16 x i8>) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define internal <16 x i8> @__add_varying_i8(<16 x i8>,
-                                              <16 x i8>) nounwind readnone alwaysinline {
-  %r = add <16 x i8> %0, %1
-  ret <16 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
-  reduce16(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
 define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %0,
                                               <16 x i8> zeroinitializer)
@@ -257,26 +242,6 @@ define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %r = add i64 %r0, %r1
   %r8 = trunc i64 %r to i8
   ret i8 %r8
-}
-
-define internal <16 x i16> @__add_varying_i16(<16 x i16>,
-                                  <16 x i16>) nounwind readnone alwaysinline {
-  %r = add <16 x i16> %0, %1
-  ret <16 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
-  reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<16 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<16 x i16> %0)
-  ret i16 %res
 }
 
 define internal <16 x float> @__add_varying_float(<16 x float>, <16 x float>) {
@@ -299,25 +264,6 @@ define float @__reduce_min_float(<16 x float>) nounwind readnone {
 
 define float @__reduce_max_float(<16 x float>) nounwind readnone {
   reduce16(float, @__max_varying_float, @__max_uniform_float)
-}
-
-define internal <16 x i32> @__add_varying_int32(<16 x i32>, <16 x i32>) {
-  %r = add <16 x i32> %0, %1
-  ret <16 x i32> %r
-}
-
-define internal i32 @__add_uniform_int32(i32, i32) {
-  %r = add i32 %0, %1
-  ret i32 %r
-}
-
-define i32 @__reduce_add_int32(<16 x i32>) nounwind readnone {
-  reduce16(i32, @__add_varying_int32, @__add_uniform_int32)
-}
-
-define i32 @__reduce_add_uint32(<16 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<16 x i32> %0)
-  ret i32 %res
 }
 
 define i32 @__reduce_min_int32(<16 x i32>) nounwind readnone {
@@ -356,25 +302,6 @@ define double @__reduce_min_double(<16 x double>) nounwind readnone {
 
 define double @__reduce_max_double(<16 x double>) nounwind readnone {
   reduce16(double, @__max_varying_double, @__max_uniform_double)
-}
-
-define internal <16 x i64> @__add_varying_int64(<16 x i64>, <16 x i64>) {
-  %r = add <16 x i64> %0, %1
-  ret <16 x i64> %r
-}
-
-define internal i64 @__add_uniform_int64(i64, i64) {
-  %r = add i64 %0, %1
-  ret i64 %r
-}
-
-define i64 @__reduce_add_int64(<16 x i64>) nounwind readnone {
-  reduce16(i64, @__add_varying_int64, @__add_uniform_int64)
-}
-
-define i64 @__reduce_add_uint64(<16 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<16 x i64> %0)
-  ret i64 %res
 }
 
 define i64 @__reduce_min_int64(<16 x i64>) nounwind readnone {

--- a/builtins/target-sse4-i8x16.ll
+++ b/builtins/target-sse4-i8x16.ll
@@ -232,18 +232,6 @@ define i1 @__none(<16 x i8>) nounwind readnone alwaysinline {
   ret i1 %meq
 }
 
-declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
-
-define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
-  %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %0,
-                                              <16 x i8> zeroinitializer)
-  %r0 = extractelement <2 x i64> %rv, i32 0
-  %r1 = extractelement <2 x i64> %rv, i32 1
-  %r = add i64 %r0, %r1
-  %r8 = trunc i64 %r to i8
-  ret i8 %r8
-}
-
 define internal <16 x float> @__add_varying_float(<16 x float>, <16 x float>) {
   %r = fadd <16 x float> %0, %1
   ret <16 x float> %r

--- a/builtins/target-sse4-i8x16.ll
+++ b/builtins/target-sse4-i8x16.ll
@@ -234,14 +234,29 @@ define i1 @__none(<16 x i8>) nounwind readnone alwaysinline {
 
 declare <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8>, <16 x i8>) nounwind readnone
 
-define i16 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
+define internal <16 x i8> @__add_varying_i8(<16 x i8>,
+                                              <16 x i8>) nounwind readnone alwaysinline {
+  %r = add <16 x i8> %0, %1
+  ret <16 x i8> %r
+}
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<16 x i8>) nounwind readnone alwaysinline {
+  reduce16(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+define i8 @__reduce_add_uint8(<16 x i8>) nounwind readnone alwaysinline {
   %rv = call <2 x i64> @llvm.x86.sse2.psad.bw(<16 x i8> %0,
                                               <16 x i8> zeroinitializer)
   %r0 = extractelement <2 x i64> %rv, i32 0
   %r1 = extractelement <2 x i64> %rv, i32 1
   %r = add i64 %r0, %r1
-  %r16 = trunc i64 %r to i16
-  ret i16 %r16
+  %r8 = trunc i64 %r to i8
+  ret i8 %r8
 }
 
 define internal <16 x i16> @__add_varying_i16(<16 x i16>,
@@ -258,6 +273,8 @@ define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline 
 define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
   reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
 }
+
+@__reduce_add_uint16 = alias i16 (<16 x i16>), ptr @__reduce_add_int16
 
 define internal <16 x float> @__add_varying_float(<16 x float>, <16 x float>) {
   %r = fadd <16 x float> %0, %1
@@ -294,6 +311,8 @@ define internal i32 @__add_uniform_int32(i32, i32) {
 define i32 @__reduce_add_int32(<16 x i32>) nounwind readnone {
   reduce16(i32, @__add_varying_int32, @__add_uniform_int32)
 }
+
+@__reduce_add_uint32 = alias i32 (<16 x i32>), ptr @__reduce_add_int32
 
 define i32 @__reduce_min_int32(<16 x i32>) nounwind readnone {
   reduce16(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -346,6 +365,8 @@ define internal i64 @__add_uniform_int64(i64, i64) {
 define i64 @__reduce_add_int64(<16 x i64>) nounwind readnone {
   reduce16(i64, @__add_varying_int64, @__add_uniform_int64)
 }
+
+@__reduce_add_uint64 = alias i64 (<16 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<16 x i64>) nounwind readnone {
   reduce16(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-sse4-i8x16.ll
+++ b/builtins/target-sse4-i8x16.ll
@@ -274,7 +274,10 @@ define i16 @__reduce_add_int16(<16 x i16>) nounwind readnone alwaysinline {
   reduce16(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<16 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<16 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<16 x i16> %0)
+  ret i16 %res
+}
 
 define internal <16 x float> @__add_varying_float(<16 x float>, <16 x float>) {
   %r = fadd <16 x float> %0, %1
@@ -312,7 +315,10 @@ define i32 @__reduce_add_int32(<16 x i32>) nounwind readnone {
   reduce16(i32, @__add_varying_int32, @__add_uniform_int32)
 }
 
-@__reduce_add_uint32 = alias i32 (<16 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<16 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<16 x i32> %0)
+  ret i32 %res
+}
 
 define i32 @__reduce_min_int32(<16 x i32>) nounwind readnone {
   reduce16(i32, @__min_varying_int32, @__min_uniform_int32)
@@ -366,7 +372,10 @@ define i64 @__reduce_add_int64(<16 x i64>) nounwind readnone {
   reduce16(i64, @__add_varying_int64, @__add_uniform_int64)
 }
 
-@__reduce_add_uint64 = alias i64 (<16 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<16 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<16 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<16 x i64>) nounwind readnone {
   reduce16(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-wasm-i32x4.ll
+++ b/builtins/target-wasm-i32x4.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2020-2025, Intel Corporation
+;;  Copyright (c) 2020-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-wasm-i32x4.ll
+++ b/builtins/target-wasm-i32x4.ll
@@ -676,7 +676,10 @@ define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
   reduce4(i8, @__add_varying_i8, @__add_uniform_i8)
 }
 
-@__reduce_add_uint8 = alias i8 (<4 x i8>), ptr @__reduce_add_int8
+define i8 @__reduce_add_uint8(<4 x i8>) nounwind readnone alwaysinline {
+  %res = call i8 @__reduce_add_int8(<4 x i8> %0)
+  ret i8 %res
+}
 
 define internal <4 x i16> @__add_varying_i16(<4 x i16>,
                                   <4 x i16>) nounwind readnone alwaysinline {
@@ -693,7 +696,10 @@ define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
   reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
 }
 
-@__reduce_add_uint16 = alias i16 (<4 x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<4 x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<4 x i16> %0)
+  ret i16 %res
+}
 
 define float @__reduce_add_float(<4 x float> %v) nounwind readonly alwaysinline {
   %v1 = shufflevector <4 x float> %v, <4 x float> undef,
@@ -723,7 +729,10 @@ define i32 @__reduce_add_int32(<4 x i32> %v) nounwind readnone alwaysinline {
   ret i32 %sum
 }
 
-@__reduce_add_uint32 = alias i32 (<4 x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<4 x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<4 x i32> %0)
+  ret i32 %res
+}
 
 define double @__reduce_add_double(<4 x double>) nounwind readnone {
   %v0 = shufflevector <4 x double> %0, <4 x double> undef,
@@ -849,7 +858,10 @@ define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone alwaysinline {
   ret i64 %m
 }
 
-@__reduce_add_uint64 = alias i64 (<4 x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<4 x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<4 x i64> %0)
+  ret i64 %res
+}
 
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-wasm-i32x4.ll
+++ b/builtins/target-wasm-i32x4.ll
@@ -661,21 +661,22 @@ gen_scatter(double)
 packed_load_and_store(FALSE)
 define_prefetches()
 
-define i16 @__reduce_add_int8(<4 x i8> %v) {
-entry:
-  %vecext = extractelement <4 x i8> %v, i32 0
-  %conv = sext i8 %vecext to i16
-  %vecext.1 = extractelement <4 x i8> %v, i32 1
-  %conv.1 = sext i8 %vecext.1 to i16
-  %add.1 = add nsw i16 %conv, %conv.1
-  %vecext.2 = extractelement <4 x i8> %v, i32 2
-  %conv.2 = sext i8 %vecext.2 to i16
-  %add.2 = add nsw i16 %add.1, %conv.2
-  %vecext.3 = extractelement <4 x i8> %v, i32 3
-  %conv.3 = sext i8 %vecext.3 to i16
-  %add.3 = add nsw i16 %add.2, %conv.3
-  ret i16 %add.3
+define internal <4 x i8> @__add_varying_i8(<4 x i8>,
+                                              <4 x i8>) nounwind readnone alwaysinline {
+  %r = add <4 x i8> %0, %1
+  ret <4 x i8> %r
 }
+
+define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
+  %r = add i8 %0, %1
+  ret i8 %r
+}
+
+define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
+  reduce4(i8, @__add_varying_i8, @__add_uniform_i8)
+}
+
+@__reduce_add_uint8 = alias i8 (<4 x i8>), ptr @__reduce_add_int8
 
 define internal <4 x i16> @__add_varying_i16(<4 x i16>,
                                   <4 x i16>) nounwind readnone alwaysinline {
@@ -691,6 +692,8 @@ define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline 
 define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
   reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
 }
+
+@__reduce_add_uint16 = alias i16 (<4 x i16>), ptr @__reduce_add_int16
 
 define float @__reduce_add_float(<4 x float> %v) nounwind readonly alwaysinline {
   %v1 = shufflevector <4 x float> %v, <4 x float> undef,
@@ -719,6 +722,8 @@ define i32 @__reduce_add_int32(<4 x i32> %v) nounwind readnone alwaysinline {
   %sum = add i32 %m1a, %m1b
   ret i32 %sum
 }
+
+@__reduce_add_uint32 = alias i32 (<4 x i32>), ptr @__reduce_add_int32
 
 define double @__reduce_add_double(<4 x double>) nounwind readnone {
   %v0 = shufflevector <4 x double> %0, <4 x double> undef,
@@ -843,6 +848,8 @@ define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone alwaysinline {
   %m = add i64 %e0, %e1
   ret i64 %m
 }
+
+@__reduce_add_uint64 = alias i64 (<4 x i64>), ptr @__reduce_add_int64
 
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone alwaysinline {
   reduce4(i64, @__min_varying_int64, @__min_uniform_int64)

--- a/builtins/target-wasm-i32x4.ll
+++ b/builtins/target-wasm-i32x4.ll
@@ -661,46 +661,6 @@ gen_scatter(double)
 packed_load_and_store(FALSE)
 define_prefetches()
 
-define internal <4 x i8> @__add_varying_i8(<4 x i8>,
-                                              <4 x i8>) nounwind readnone alwaysinline {
-  %r = add <4 x i8> %0, %1
-  ret <4 x i8> %r
-}
-
-define internal i8 @__add_uniform_i8(i8, i8) nounwind readnone alwaysinline {
-  %r = add i8 %0, %1
-  ret i8 %r
-}
-
-define i8 @__reduce_add_int8(<4 x i8>) nounwind readnone alwaysinline {
-  reduce4(i8, @__add_varying_i8, @__add_uniform_i8)
-}
-
-define i8 @__reduce_add_uint8(<4 x i8>) nounwind readnone alwaysinline {
-  %res = call i8 @__reduce_add_int8(<4 x i8> %0)
-  ret i8 %res
-}
-
-define internal <4 x i16> @__add_varying_i16(<4 x i16>,
-                                  <4 x i16>) nounwind readnone alwaysinline {
-  %r = add <4 x i16> %0, %1
-  ret <4 x i16> %r
-}
-
-define internal i16 @__add_uniform_i16(i16, i16) nounwind readnone alwaysinline {
-  %r = add i16 %0, %1
-  ret i16 %r
-}
-
-define i16 @__reduce_add_int16(<4 x i16>) nounwind readnone alwaysinline {
-  reduce4(i16, @__add_varying_i16, @__add_uniform_i16)
-}
-
-define i16 @__reduce_add_uint16(<4 x i16>) nounwind readnone alwaysinline {
-  %res = call i16 @__reduce_add_int16(<4 x i16> %0)
-  ret i16 %res
-}
-
 define float @__reduce_add_float(<4 x float> %v) nounwind readonly alwaysinline {
   %v1 = shufflevector <4 x float> %v, <4 x float> undef,
                       <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
@@ -717,21 +677,6 @@ define float @__reduce_min_float(<4 x float>) nounwind readnone {
 
 define float @__reduce_max_float(<4 x float>) nounwind readnone {
   reduce4(float, @__max_varying_float, @__max_uniform_float)
-}
-
-define i32 @__reduce_add_int32(<4 x i32> %v) nounwind readnone alwaysinline {
-  %v1 = shufflevector <4 x i32> %v, <4 x i32> undef,
-                      <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
-  %m1 = add <4 x i32> %v1, %v
-  %m1a = extractelement <4 x i32> %m1, i32 0
-  %m1b = extractelement <4 x i32> %m1, i32 1
-  %sum = add i32 %m1a, %m1b
-  ret i32 %sum
-}
-
-define i32 @__reduce_add_uint32(<4 x i32>) nounwind readnone alwaysinline {
-  %res = call i32 @__reduce_add_int32(<4 x i32> %0)
-  ret i32 %res
 }
 
 define double @__reduce_add_double(<4 x double>) nounwind readnone {
@@ -844,23 +789,6 @@ define  float @__rcp_uniform_float(float) nounwind readonly alwaysinline {
 define  float @__rcp_fast_uniform_float(float) nounwind readonly alwaysinline {
   %r = fdiv float 1.,%0
   ret float %r
-}
-
-define i64 @__reduce_add_int64(<4 x i64>) nounwind readnone alwaysinline {
-  %v0 = shufflevector <4 x i64> %0, <4 x i64> undef,
-                      <2 x i32> <i32 0, i32 1>
-  %v1 = shufflevector <4 x i64> %0, <4 x i64> undef,
-                      <2 x i32> <i32 2, i32 3>
-  %sum = add <2 x i64> %v0, %v1
-  %e0 = extractelement <2 x i64> %sum, i32 0
-  %e1 = extractelement <2 x i64> %sum, i32 1
-  %m = add i64 %e0, %e1
-  ret i64 %m
-}
-
-define i64 @__reduce_add_uint64(<4 x i64>) nounwind readnone alwaysinline {
-  %res = call i64 @__reduce_add_int64(<4 x i64> %0)
-  ret i64 %res
 }
 
 define i64 @__reduce_min_int64(<4 x i64>) nounwind readnone alwaysinline {

--- a/builtins/target-xe.ll
+++ b/builtins/target-xe.ll
@@ -1,4 +1,4 @@
-;;  Copyright (c) 2019-2025, Intel Corporation
+;;  Copyright (c) 2019-2026, Intel Corporation
 ;;
 ;;  SPDX-License-Identifier: BSD-3-Clause
 

--- a/builtins/target-xe.ll
+++ b/builtins/target-xe.ll
@@ -792,7 +792,8 @@ define internal $1 @__add_uniform_$2($1, $1) nounwind readnone alwaysinline {
 }
 ')
 
-xe_add(i16, i16)
+xe_add(i16, int8)
+xe_add(i16, int16)
 xe_add(i32, int32)
 xe_add(i64, int64)
 
@@ -823,24 +824,27 @@ define(`reducexe_func',
         WIDTH, `16', `reducexe16($1, $2, $3, $4, $5)',
                      `reducexe8($1, $2, $3, $4, $5)')')
 
-define i16 @__reduce_add_int8(<WIDTH x i8>) nounwind readnone alwaysinline {
-  %ext = zext <WIDTH x i8> %0 to <WIDTH x i16>
-  reduce_func(i16, @__add_varying_i16, @__add_uniform_i16, %ext)
+define i8 @__reduce_add_int8(<WIDTH x i8>) nounwind readnone alwaysinline {
+  reduce_func(i8, @__add_varying_int8, @__add_uniform_int8, %0)
 }
 
-define i32 @__reduce_add_int16(<WIDTH x i16>) nounwind readnone alwaysinline {
-  %ext = zext <WIDTH x i16> %0 to <WIDTH x i32>
-  reduce_func(i32, @__add_varying_int32, @__add_uniform_int32, %ext)
+@__reduce_add_uint8 = alias i8 (<WIDTH x i8>), ptr @__reduce_add_int8
+
+define i16 @__reduce_add_int16(<WIDTH x i16>) nounwind readnone alwaysinline {
+  reduce_func(i16, @__add_varying_int16, @__add_uniform_int16, %0)
 }
+
+@__reduce_add_uint16 = alias i16 (<WIDTH x i16>), ptr @__reduce_add_int16
 
 define half @__reduce_add_half(<WIDTH x half>) nounwind readonly alwaysinline {
   reduce_func(half, @__fadd_varying_half, @__fadd_uniform_half, %0)
 }
 
-define i64 @__reduce_add_int32(<WIDTH x i32>) nounwind readnone {
-  %ext = zext <WIDTH x i32> %0 to <WIDTH x i64>
-  reduce_func(i64, @__add_varying_int64, @__add_uniform_int64, %ext)
+define i32 @__reduce_add_int32(<WIDTH x i32>) nounwind readnone {
+  reduce_func(i32, @__add_varying_int32, @__add_uniform_int32, %0)
 }
+
+@__reduce_add_uint32 = alias i32 (<WIDTH x i32>), ptr @__reduce_add_int32
 
 define float @__reduce_add_float(<WIDTH x float>) nounwind readonly alwaysinline {
   reduce_func(float, @__fadd_varying_float, @__fadd_uniform_float, %0)
@@ -853,6 +857,8 @@ define double @__reduce_add_double(<WIDTH x double>) nounwind readnone {
 define i64 @__reduce_add_int64(<WIDTH x i64>) nounwind readnone {
   reduce_func(i64, @__add_varying_int64, @__add_uniform_int64, %0)
 }
+
+@__reduce_add_uint64 = alias i64 (<WIDTH x i64>), ptr @__reduce_add_int64
 
 define i8 @__reduce_min_int8(<WIDTH x i8>) nounwind readnone {
   reduce_func(i8, @__min_varying_int8, @__min_uniform_int8, %0)

--- a/builtins/target-xe.ll
+++ b/builtins/target-xe.ll
@@ -828,13 +828,19 @@ define i8 @__reduce_add_int8(<WIDTH x i8>) nounwind readnone alwaysinline {
   reduce_func(i8, @__add_varying_int8, @__add_uniform_int8, %0)
 }
 
-@__reduce_add_uint8 = alias i8 (<WIDTH x i8>), ptr @__reduce_add_int8
+define i8 @__reduce_add_uint8(<WIDTH x i8>) nounwind readnone alwaysinline {
+  %res = call i8 @__reduce_add_int8(<WIDTH x i8> %0)
+  ret i8 %res
+}
 
 define i16 @__reduce_add_int16(<WIDTH x i16>) nounwind readnone alwaysinline {
   reduce_func(i16, @__add_varying_int16, @__add_uniform_int16, %0)
 }
 
-@__reduce_add_uint16 = alias i16 (<WIDTH x i16>), ptr @__reduce_add_int16
+define i16 @__reduce_add_uint16(<WIDTH x i16>) nounwind readnone alwaysinline {
+  %res = call i16 @__reduce_add_int16(<WIDTH x i16> %0)
+  ret i16 %res
+}
 
 define half @__reduce_add_half(<WIDTH x half>) nounwind readonly alwaysinline {
   reduce_func(half, @__fadd_varying_half, @__fadd_uniform_half, %0)
@@ -844,7 +850,10 @@ define i32 @__reduce_add_int32(<WIDTH x i32>) nounwind readnone {
   reduce_func(i32, @__add_varying_int32, @__add_uniform_int32, %0)
 }
 
-@__reduce_add_uint32 = alias i32 (<WIDTH x i32>), ptr @__reduce_add_int32
+define i32 @__reduce_add_uint32(<WIDTH x i32>) nounwind readnone alwaysinline {
+  %res = call i32 @__reduce_add_int32(<WIDTH x i32> %0)
+  ret i32 %res
+}
 
 define float @__reduce_add_float(<WIDTH x float>) nounwind readonly alwaysinline {
   reduce_func(float, @__fadd_varying_float, @__fadd_uniform_float, %0)
@@ -858,7 +867,10 @@ define i64 @__reduce_add_int64(<WIDTH x i64>) nounwind readnone {
   reduce_func(i64, @__add_varying_int64, @__add_uniform_int64, %0)
 }
 
-@__reduce_add_uint64 = alias i64 (<WIDTH x i64>), ptr @__reduce_add_int64
+define i64 @__reduce_add_uint64(<WIDTH x i64>) nounwind readnone alwaysinline {
+  %res = call i64 @__reduce_add_int64(<WIDTH x i64> %0)
+  ret i64 %res
+}
 
 define i8 @__reduce_min_int8(<WIDTH x i8>) nounwind readnone {
   reduce_func(i8, @__min_varying_int8, @__min_uniform_int8, %0)

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -281,10 +281,16 @@ New Features:
 
 Standard Library Changes:
 
-* **Breaking change**: the return type of the ``reduce_add()`` functions is now
-  the same than the input type. Users should now cast the inpout to a wider type
-  themselves so to prevent overflows. Any code relying on the widened return
-  type needs to be updated!
+* **Breaking change**: ``reduce_add()`` now returns the same type as its
+    input. Previously the signatures widened the result, but the
+    implementation was inconsistent and partially incorrect. The new
+    same-type convention also matches the prevailing convention in other
+    SIMD/SPMD ecosystems and is consistent with ``reduce_min()`` /
+    ``reduce_max()`` in ISPC. For overflow-safe accumulation, cast the
+    input to a wider type explicitly, e.g. ``reduce_add((int32)x)`` for an
+    ``int16`` ``x``. Any code that relied on the previous widened return
+    type must be updated.
+
 * The Gauss error function ``erf`` and the complementary error function ``erfc``
   have been added to the standard library.
 * The ``expm1`` function (meant to compute ``exp(x)-1`` accurately), and the

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -269,12 +269,18 @@ New Architecture Support:
   included in official ISPC binaries. To use it, build ISPC from source with
   the `PPC64_ENABLED=ON` CMake option. Usage: `ispc --arch=ppc64le
   --target=generic-i32x4 foo.ispc -o foo.o`.
+
+New Features:
+
 * Implementation of two new fast-math modes: ``balanced`` and ``aggressive``.
   These modes bring more aggressive optimizations compared to the default
   ``legacy`` mode. The latter was the mode provided so far in previous ISPC
   versions. It is still available and left unchanged. The fast-math mode can be
   specified with the option ``--opt=fast-math:<mode>``. See the optimization
   settings section for more information about the new modes.
+
+Standard Library Changes:
+
 * The Gauss error function ``erf`` and the complementary error function ``erfc``
   have been added to the standard library.
 * The ``expm1`` function (meant to compute ``exp(x)-1`` accurately), and the
@@ -282,6 +288,9 @@ New Architecture Support:
   added to the standard library.
 * The hyperbolic functions ``sinh``, ``cosh`` and ``tanh`` have also been added
   to the standard library.
+* The return type of the ``reduce_add()`` functions is now the same than the
+  input type. Users should now cast the inpout to a wider type themselves so to
+  prevent overflows.
 
 ISPC Targets:
 
@@ -6726,12 +6735,12 @@ instances are added together by the ``reduce_add()`` function.
 
 ::
 
-    uniform int16 reduce_add(int8 x)
-    uniform unsigned int16 reduce_add(unsigned int8 x)
-    uniform int32 reduce_add(int16 x)
-    uniform unsigned int32 reduce_add(unsigned int16 x)
-    uniform int64 reduce_add(int32 x)
-    uniform unsigned int64 reduce_add(unsigned int32 x)
+    uniform int8 reduce_add(int8 x)
+    uniform unsigned int8 reduce_add(unsigned int8 x)
+    uniform int16 reduce_add(int16 x)
+    uniform unsigned int16 reduce_add(unsigned int16 x)
+    uniform int32 reduce_add(int32 x)
+    uniform unsigned int32 reduce_add(unsigned int32 x)
     uniform int64 reduce_add(int64 x)
     uniform unsigned int64 reduce_add(unsigned int64 x)
 

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -281,6 +281,10 @@ New Features:
 
 Standard Library Changes:
 
+* **Breaking change**: the return type of the ``reduce_add()`` functions is now
+  the same than the input type. Users should now cast the inpout to a wider type
+  themselves so to prevent overflows. Any code relying on the widened return
+  type needs to be updated!
 * The Gauss error function ``erf`` and the complementary error function ``erfc``
   have been added to the standard library.
 * The ``expm1`` function (meant to compute ``exp(x)-1`` accurately), and the
@@ -288,9 +292,6 @@ Standard Library Changes:
   added to the standard library.
 * The hyperbolic functions ``sinh``, ``cosh`` and ``tanh`` have also been added
   to the standard library.
-* The return type of the ``reduce_add()`` functions is now the same than the
-  input type. Users should now cast the inpout to a wider type themselves so to
-  prevent overflows.
 
 ISPC Targets:
 

--- a/stdlib/include/builtins.isph
+++ b/stdlib/include/builtins.isph
@@ -459,36 +459,28 @@ EXT inline void __memmove64(uniform int8 *uniform, uniform int8 *uniform, unifor
 EXT inline void __memset32(uniform int8 *uniform, uniform int8, uniform int32);
 EXT inline void __memset64(uniform int8 *uniform, uniform int8, uniform int64);
 
-// TODO: check types with sign version of functions
 // reduction functions
-EXT inline READNONE uniform double __reduce_add_double(varying double);
-EXT inline READNONE uniform float __reduce_add_float(varying float);
 EXT inline READNONE uniform float16 __reduce_add_half(varying float16);
+EXT inline READNONE uniform float __reduce_add_float(varying float);
+EXT inline READNONE uniform double __reduce_add_double(varying double);
+EXT inline READNONE uniform int8 __reduce_add_int8(varying int8);
 EXT inline READNONE uniform int16 __reduce_add_int16(varying int16);
 EXT inline READNONE uniform int32 __reduce_add_int32(varying int32);
 EXT inline READNONE uniform int64 __reduce_add_int64(varying int64);
-EXT inline READNONE uniform int16 __reduce_add_int8(varying int8);
-EXT inline uniform bool __reduce_equal_double(varying double, uniform int8 *uniform, UIntMaskType);
-EXT inline uniform bool __reduce_equal_float(varying float, uniform int8 *uniform, UIntMaskType);
+EXT inline READNONE uniform uint8 __reduce_add_uint8(varying uint8);
+EXT inline READNONE uniform uint16 __reduce_add_uint16(varying uint16);
+EXT inline READNONE uniform uint32 __reduce_add_uint32(varying uint32);
+EXT inline READNONE uniform uint64 __reduce_add_uint64(varying uint64);
 EXT inline uniform bool __reduce_equal_half(varying float16, uniform int8 *uniform, UIntMaskType);
+EXT inline uniform bool __reduce_equal_float(varying float, uniform int8 *uniform, UIntMaskType);
+EXT inline uniform bool __reduce_equal_double(varying double, uniform int8 *uniform, UIntMaskType);
 EXT inline uniform bool __reduce_equal_int8(varying int8, uniform int8 *uniform, UIntMaskType);
 EXT inline uniform bool __reduce_equal_int16(varying int16, uniform int8 *uniform, UIntMaskType);
 EXT inline uniform bool __reduce_equal_int32(varying int32, uniform int8 *uniform, UIntMaskType);
 EXT inline uniform bool __reduce_equal_int64(varying int64, uniform int8 *uniform, UIntMaskType);
-EXT inline READNONE uniform double __reduce_max_double(varying double);
-EXT inline READNONE uniform float __reduce_max_float(varying float);
-EXT inline READNONE uniform float16 __reduce_max_half(varying float16);
-EXT inline READNONE uniform int8 __reduce_max_int8(varying int8);
-EXT inline READNONE uniform int16 __reduce_max_int16(varying int16);
-EXT inline READNONE uniform int32 __reduce_max_int32(varying int32);
-EXT inline READNONE uniform int64 __reduce_max_int64(varying int64);
-EXT inline READNONE uniform uint8 __reduce_max_uint8(varying uint8);
-EXT inline READNONE uniform uint16 __reduce_max_uint16(varying uint16);
-EXT inline READNONE uniform uint32 __reduce_max_uint32(varying uint32);
-EXT inline READNONE uniform uint64 __reduce_max_uint64(varying uint64);
-EXT inline READNONE uniform double __reduce_min_double(varying double);
-EXT inline READNONE uniform float __reduce_min_float(varying float);
 EXT inline READNONE uniform float16 __reduce_min_half(varying float16);
+EXT inline READNONE uniform float __reduce_min_float(varying float);
+EXT inline READNONE uniform double __reduce_min_double(varying double);
 EXT inline READNONE uniform int8 __reduce_min_int8(varying int8);
 EXT inline READNONE uniform int16 __reduce_min_int16(varying int16);
 EXT inline READNONE uniform int32 __reduce_min_int32(varying int32);
@@ -497,6 +489,17 @@ EXT inline READNONE uniform uint8 __reduce_min_uint8(varying uint8);
 EXT inline READNONE uniform uint16 __reduce_min_uint16(varying uint16);
 EXT inline READNONE uniform uint32 __reduce_min_uint32(varying uint32);
 EXT inline READNONE uniform uint64 __reduce_min_uint64(varying uint64);
+EXT inline READNONE uniform float16 __reduce_max_half(varying float16);
+EXT inline READNONE uniform float __reduce_max_float(varying float);
+EXT inline READNONE uniform double __reduce_max_double(varying double);
+EXT inline READNONE uniform int8 __reduce_max_int8(varying int8);
+EXT inline READNONE uniform int16 __reduce_max_int16(varying int16);
+EXT inline READNONE uniform int32 __reduce_max_int32(varying int32);
+EXT inline READNONE uniform int64 __reduce_max_int64(varying int64);
+EXT inline READNONE uniform uint8 __reduce_max_uint8(varying uint8);
+EXT inline READNONE uniform uint16 __reduce_max_uint16(varying uint16);
+EXT inline READNONE uniform uint32 __reduce_max_uint32(varying uint32);
+EXT inline READNONE uniform uint64 __reduce_max_uint64(varying uint64);
 
 // TODO: move implementation to stdlib.ispc
 // rdrand

--- a/stdlib/include/stdlib.isph
+++ b/stdlib/include/stdlib.isph
@@ -266,41 +266,52 @@ __declspec(safe, cost1) inline double select(uniform bool cond, double t, double
 __declspec(safe, cost1) inline uniform double select(uniform bool cond, uniform double t, uniform double f);
 
 ///////////////////////////////////////////////////////////////////////////
-// Horizontal ops / reductions
+// Horizontal reduce_add
 
-__declspec(safe) inline uniform int16 reduce_add(int8 x);
-__declspec(safe) inline uniform int8 reduce_min(int8 x);
-__declspec(safe) inline uniform int8 reduce_max(int8 x);
-__declspec(safe) inline uniform unsigned int16 reduce_add(unsigned int8 x);
-__declspec(safe) inline uniform unsigned int8 reduce_min(unsigned int8 x);
-__declspec(safe) inline uniform unsigned int8 reduce_max(unsigned int8 x);
-__declspec(safe) inline uniform int32 reduce_add(int16 x);
-__declspec(safe) inline uniform int16 reduce_min(int16 x);
-__declspec(safe) inline uniform int16 reduce_max(int16 x);
-__declspec(safe) inline uniform unsigned int32 reduce_add(unsigned int16 x);
-__declspec(safe) inline uniform unsigned int16 reduce_min(unsigned int16 x);
-__declspec(safe) inline uniform unsigned int16 reduce_max(unsigned int16 x);
+__declspec(safe) inline uniform int8 reduce_add(int8 x);
+__declspec(safe) inline uniform unsigned int8 reduce_add(unsigned int8 x);
+__declspec(safe) inline uniform int16 reduce_add(int16 x);
+__declspec(safe) inline uniform unsigned int16 reduce_add(unsigned int16 x);
 __declspec(safe) inline uniform float16 reduce_add(float16 x);
-__declspec(safe) inline uniform float16 reduce_min(float16 v);
-__declspec(safe) inline uniform float16 reduce_max(float16 v);
 __declspec(safe) inline uniform float reduce_add(float x);
-__declspec(safe) inline uniform float reduce_min(float v);
-__declspec(safe) inline uniform float reduce_max(float v);
-__declspec(safe) inline uniform int64 reduce_add(int32 x);
-__declspec(safe) inline uniform int reduce_min(int v);
-__declspec(safe) inline uniform int reduce_max(int v);
-__declspec(safe) inline uniform unsigned int64 reduce_add(unsigned int32 x);
-__declspec(safe) inline uniform unsigned int reduce_min(unsigned int v);
-__declspec(safe) inline uniform unsigned int reduce_max(unsigned int v);
+__declspec(safe) inline uniform int32 reduce_add(int32 x);
+__declspec(safe) inline uniform unsigned int32 reduce_add(unsigned int32 x);
 __declspec(safe) inline uniform double reduce_add(double x);
-__declspec(safe) inline uniform double reduce_min(double v);
-__declspec(safe) inline uniform double reduce_max(double v);
 __declspec(safe) inline uniform int64 reduce_add(int64 x);
-__declspec(safe) inline uniform int64 reduce_min(int64 v);
-__declspec(safe) inline uniform int64 reduce_max(int64 v);
 __declspec(safe) inline uniform unsigned int64 reduce_add(unsigned int64 x);
+
+///////////////////////////////////////////////////////////////////////////
+// Horizontal reduce_min
+
+__declspec(safe) inline uniform int8 reduce_min(int8 x);
+__declspec(safe) inline uniform unsigned int8 reduce_min(unsigned int8 x);
+__declspec(safe) inline uniform int16 reduce_min(int16 x);
+__declspec(safe) inline uniform unsigned int16 reduce_min(unsigned int16 x);
+__declspec(safe) inline uniform float16 reduce_min(float16 v);
+__declspec(safe) inline uniform float reduce_min(float v);
+__declspec(safe) inline uniform int32 reduce_min(int32 v);
+__declspec(safe) inline uniform unsigned int32 reduce_min(unsigned int32 v);
+__declspec(safe) inline uniform double reduce_min(double v);
+__declspec(safe) inline uniform int64 reduce_min(int64 v);
 __declspec(safe) inline uniform unsigned int64 reduce_min(unsigned int64 v);
+
+///////////////////////////////////////////////////////////////////////////
+// Horizontal reduce_max
+
+__declspec(safe) inline uniform int8 reduce_max(int8 x);
+__declspec(safe) inline uniform unsigned int8 reduce_max(unsigned int8 x);
+__declspec(safe) inline uniform int16 reduce_max(int16 x);
+__declspec(safe) inline uniform unsigned int16 reduce_max(unsigned int16 x);
+__declspec(safe) inline uniform float16 reduce_max(float16 v);
+__declspec(safe) inline uniform float reduce_max(float v);
+__declspec(safe) inline uniform int32 reduce_max(int32 v);
+__declspec(safe) inline uniform unsigned int32 reduce_max(unsigned int32 v);
+__declspec(safe) inline uniform double reduce_max(double v);
+__declspec(safe) inline uniform int64 reduce_max(int64 v);
 __declspec(safe) inline uniform unsigned int64 reduce_max(unsigned int64 v);
+
+///////////////////////////////////////////////////////////////////////////
+// Horizontal reduce_equal
 
 #define REDUCE_EQUAL_DECL(TYPE, FUNCTYPE, MASKTYPE)                                                                    \
     __declspec(safe) inline uniform bool reduce_equal(TYPE v);                                                         \
@@ -319,6 +330,9 @@ REDUCE_EQUAL_DECL(unsigned int64, int64, UUIntMaskType)
 REDUCE_EQUAL_DECL(double, double, UIntMaskType)
 
 #undef REDUCE_EQUAL_DECL
+
+///////////////////////////////////////////////////////////////////////////
+// Horizontal exclusive_scan_*
 
 inline float16 exclusive_scan_add(float16 v);
 inline int8 exclusive_scan_add(int8 v);

--- a/stdlib/stdlib.ispc
+++ b/stdlib/stdlib.ispc
@@ -1477,72 +1477,59 @@ __declspec(safe, cost1) static inline uniform double select(uniform bool cond, u
 }
 
 ///////////////////////////////////////////////////////////////////////////
-// Horizontal ops / reductions
-
-__declspec(safe) static inline uniform int16 reduce_add(int8 x) { return __reduce_add_int8(__mask ? x : (int8)0); }
-
-__declspec(safe) static inline uniform int8 reduce_min(int8 v) {
-    // Set values for non-running lanes to the maximum int8 value so
-    // they don't affect the result.
-    return __reduce_min_int8(__mask ? v : INT8_MAX);
-}
-
-__declspec(safe) static inline uniform int8 reduce_max(int8 v) {
-    // Set values for non-running lanes to the minimum int8 value so
-    // they don't affect the result.
-    return __reduce_max_int8(__mask ? v : INT8_MIN);
-}
-
-__declspec(safe) static inline uniform unsigned int16 reduce_add(unsigned int8 x) {
-    return __reduce_add_int8(__mask ? x : (int8)0);
-}
-
-__declspec(safe) static inline uniform unsigned int8 reduce_min(unsigned int8 v) {
-    // Set values for non-running lanes to the maximum uint8 value so
-    // they don't affect the result.
-    return __reduce_min_uint8(__mask ? v : UINT8_MAX);
-}
-
-__declspec(safe) static inline uniform unsigned int8 reduce_max(unsigned int8 v) {
-    // Set values for non-running lanes to zero so they don't affect the
-    // result.
-    return __reduce_max_uint8(__mask ? v : 0);
-}
-
-__declspec(safe) static inline uniform int32 reduce_add(int16 x) { return __reduce_add_int16(__mask ? x : (int16)0); }
-
-__declspec(safe) static inline uniform int16 reduce_min(int16 v) {
-    // Set values for non-running lanes to the maximum int8 value so
-    // they don't affect the result.
-    return __reduce_min_int16(__mask ? v : INT16_MAX);
-}
-
-__declspec(safe) static inline uniform int16 reduce_max(int16 v) {
-    // Set values for non-running lanes to the minimum int8 value so
-    // they don't affect the result.
-    return __reduce_max_int16(__mask ? v : INT16_MIN);
-}
-
-__declspec(safe) static inline uniform unsigned int32 reduce_add(unsigned int16 x) {
-    return __reduce_add_int16(__mask ? x : (int16)0);
-}
-
-__declspec(safe) static inline uniform unsigned int16 reduce_min(unsigned int16 v) {
-    // Set values for non-running lanes to the maximum uint8 value so
-    // they don't affect the result.
-    return __reduce_min_uint16(__mask ? v : UINT16_MAX);
-}
-
-__declspec(safe) static inline uniform unsigned int16 reduce_max(unsigned int16 v) {
-    // Set values for non-running lanes to zero so they don't affect the
-    // result.
-    return __reduce_max_uint16(__mask ? v : 0);
-}
+// Horizontal reduce_add
 
 __declspec(safe) static inline uniform float16 reduce_add(float16 x) {
     // zero the lanes where the mask is off
     return __reduce_add_half(__mask ? x : 0.0f16);
 }
+
+__declspec(safe) static inline uniform float reduce_add(float x) {
+    // zero the lanes where the mask is off
+    return __reduce_add_float(__mask ? x : 0.);
+}
+
+__declspec(safe) static inline uniform double reduce_add(double x) {
+    // zero the lanes where the mask is off
+    return __reduce_add_double(__mask ? x : 0.);
+}
+
+__declspec(safe) static inline uniform int8 reduce_add(int8 x) { return __reduce_add_int8(__mask ? x : (int8)0); }
+
+__declspec(safe) static inline uniform unsigned int8 reduce_add(unsigned int8 x) {
+    return __reduce_add_uint8(__mask ? x : (unsigned int8)0);
+}
+
+__declspec(safe) static inline uniform int16 reduce_add(int16 x) { return __reduce_add_int16(__mask ? x : (int16)0); }
+
+__declspec(safe) static inline uniform unsigned int16 reduce_add(unsigned int16 x) {
+    return __reduce_add_uint16(__mask ? x : (unsigned int16)0);
+}
+
+__declspec(safe) static inline uniform int32 reduce_add(int32 x) {
+    // Zero out the values for lanes that aren't running
+    return __reduce_add_int32(__mask ? x : 0l);
+}
+
+__declspec(safe) static inline uniform unsigned int32 reduce_add(unsigned int32 x) {
+    // Set values for non-running lanes to zero so they don't affect the
+    // result.
+    return __reduce_add_uint32(__mask ? x : 0ul);
+}
+
+__declspec(safe) static inline uniform int64 reduce_add(int64 x) {
+    // Zero out the values for lanes that aren't running
+    return __reduce_add_int64(__mask ? x : 0ll);
+}
+
+__declspec(safe) static inline uniform unsigned int64 reduce_add(unsigned int64 x) {
+    // Set values for non-running lanes to zero so they don't affect the
+    // result.
+    return __reduce_add_uint64(__mask ? x : 0ull);
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Horizontal reduce_min
 
 __declspec(safe) static inline uniform float16 reduce_min(float16 v) {
     // For the lanes where the mask is off, replace the given value with
@@ -1556,23 +1543,6 @@ __declspec(safe) static inline uniform float16 reduce_min(float16 v) {
     return result;
 }
 
-__declspec(safe) static inline uniform float16 reduce_max(float16 v) {
-    // For the lanes where the mask is off, replace the given value with
-    // negative infinity, so that it doesn't affect the result.
-    const int16 iflt_neg_max = 0xfc00; // -infinity
-    // unmasked block is needed to make sure that argument for unmasked
-    // function __reduce_max_half() are calculated without a mask.
-    bool test = __mask;
-    uniform float16 result;
-    unmasked { result = __reduce_max_half(test ? v : float16bits(iflt_neg_max)); }
-    return result;
-}
-
-__declspec(safe) static inline uniform float reduce_add(float x) {
-    // zero the lanes where the mask is off
-    return __reduce_add_float(__mask ? x : 0.);
-}
-
 __declspec(safe) static inline uniform float reduce_min(float v) {
     // For the lanes where the mask is off, replace the given value with
     // infinity, so that it doesn't affect the result.
@@ -1582,6 +1552,79 @@ __declspec(safe) static inline uniform float reduce_min(float v) {
     bool test = __mask;
     uniform float result;
     unmasked { result = __reduce_min_float(test ? v : floatbits(iflt_max)); }
+    return result;
+}
+
+__declspec(safe) static inline uniform double reduce_min(double v) {
+    int64 iflt_max = 0x7ff0000000000000; // infinity
+    // unmasked block is needed to make sure that argument for unmasked
+    // function __reduce_min_double() are calculated without a mask.
+    bool test = __mask;
+    uniform double result;
+    unmasked { result = __reduce_min_double(test ? v : doublebits(iflt_max)); }
+    return result;
+}
+
+__declspec(safe) static inline uniform int8 reduce_min(int8 v) {
+    // Set values for non-running lanes to the maximum int8 value so
+    // they don't affect the result.
+    return __reduce_min_int8(__mask ? v : INT8_MAX);
+}
+
+__declspec(safe) static inline uniform unsigned int8 reduce_min(unsigned int8 v) {
+    // Set values for non-running lanes to the maximum uint8 value so
+    // they don't affect the result.
+    return __reduce_min_uint8(__mask ? v : UINT8_MAX);
+}
+
+__declspec(safe) static inline uniform int16 reduce_min(int16 v) {
+    // Set values for non-running lanes to the maximum int8 value so
+    // they don't affect the result.
+    return __reduce_min_int16(__mask ? v : INT16_MAX);
+}
+
+__declspec(safe) static inline uniform unsigned int16 reduce_min(unsigned int16 v) {
+    // Set values for non-running lanes to the maximum uint8 value so
+    // they don't affect the result.
+    return __reduce_min_uint16(__mask ? v : UINT16_MAX);
+}
+
+__declspec(safe) static inline uniform int32 reduce_min(int32 v) {
+    // Set values for non-running lanes to the maximum integer value so
+    // they don't affect the result.
+    return __reduce_min_int32(__mask ? v : INT32_MAX);
+}
+
+__declspec(safe) static inline uniform unsigned int32 reduce_min(unsigned int32 v) {
+    // Set values for non-running lanes to the maximum unsigned integer
+    // value so they don't affect the result.
+    return __reduce_min_uint32(__mask ? v : UINT32_MAX);
+}
+
+__declspec(safe) static inline uniform int64 reduce_min(int64 v) {
+    // Set values for non-running lanes to the maximum integer value so
+    // they don't affect the result.
+    return __reduce_min_int64(__mask ? v : INT64_MAX);
+}
+
+__declspec(safe) static inline uniform unsigned int64 reduce_min(unsigned int64 v) {
+    // Set values for non-running lanes to the maximum unsigned integer
+    // value so they don't affect the result.
+    return __reduce_min_uint64(__mask ? v : UINT64_MAX);
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Horizontal reduce_max
+
+__declspec(safe) static inline uniform float16 reduce_max(float16 v) {
+    // For the lanes where the mask is off, replace the given value with
+    // negative infinity, so that it doesn't affect the result.
+    const int16 iflt_neg_max = 0xfc00; // -infinity
+    // unmasked block is needed to make sure that argument for unmasked
+    // function __reduce_max_half() are calculated without a mask.
+    bool test = __mask;
+    uniform float16 result;
+    unmasked { result = __reduce_max_half(test ? v : float16bits(iflt_neg_max)); }
     return result;
 }
 
@@ -1597,56 +1640,6 @@ __declspec(safe) static inline uniform float reduce_max(float v) {
     return result;
 }
 
-__declspec(safe) static inline uniform int64 reduce_add(int32 x) {
-    // Zero out the values for lanes that aren't running
-    return __reduce_add_int32(__mask ? x : 0);
-}
-
-__declspec(safe) static inline uniform int reduce_min(int v) {
-    // Set values for non-running lanes to the maximum integer value so
-    // they don't affect the result.
-    return __reduce_min_int32(__mask ? v : INT32_MAX);
-}
-
-__declspec(safe) static inline uniform int reduce_max(int v) {
-    // Set values for non-running lanes to the minimum integer value so
-    // they don't affect the result.
-    return __reduce_max_int32(__mask ? v : INT32_MIN);
-}
-
-__declspec(safe) static inline uniform unsigned int64 reduce_add(unsigned int32 x) {
-    // Set values for non-running lanes to zero so they don't affect the
-    // result.
-    return __reduce_add_int32(__mask ? x : 0);
-}
-
-__declspec(safe) static inline uniform unsigned int reduce_min(unsigned int v) {
-    // Set values for non-running lanes to the maximum unsigned integer
-    // value so they don't affect the result.
-    return __reduce_min_uint32(__mask ? v : UINT32_MAX);
-}
-
-__declspec(safe) static inline uniform unsigned int reduce_max(unsigned int v) {
-    // Set values for non-running lanes to zero so they don't affect the
-    // result.
-    return __reduce_max_uint32(__mask ? v : 0);
-}
-
-__declspec(safe) static inline uniform double reduce_add(double x) {
-    // zero the lanes where the mask is off
-    return __reduce_add_double(__mask ? x : 0.);
-}
-
-__declspec(safe) static inline uniform double reduce_min(double v) {
-    int64 iflt_max = 0x7ff0000000000000; // infinity
-    // unmasked block is needed to make sure that argument for unmasked
-    // function __reduce_min_double() are calculated without a mask.
-    bool test = __mask;
-    uniform double result;
-    unmasked { result = __reduce_min_double(test ? v : doublebits(iflt_max)); }
-    return result;
-}
-
 __declspec(safe) static inline uniform double reduce_max(double v) {
     const int64 iflt_neg_max = 0xfff0000000000000; // -infinity
     // unmasked block is needed to make sure that argument for unmasked
@@ -1657,15 +1650,40 @@ __declspec(safe) static inline uniform double reduce_max(double v) {
     return result;
 }
 
-__declspec(safe) static inline uniform int64 reduce_add(int64 x) {
-    // Zero out the values for lanes that aren't running
-    return __reduce_add_int64(__mask ? x : 0);
+__declspec(safe) static inline uniform int8 reduce_max(int8 v) {
+    // Set values for non-running lanes to the minimum int8 value so
+    // they don't affect the result.
+    return __reduce_max_int8(__mask ? v : INT8_MIN);
 }
 
-__declspec(safe) static inline uniform int64 reduce_min(int64 v) {
-    // Set values for non-running lanes to the maximum integer value so
+__declspec(safe) static inline uniform unsigned int8 reduce_max(unsigned int8 v) {
+    // Set values for non-running lanes to zero so they don't affect the
+    // result.
+    return __reduce_max_uint8(__mask ? v : 0);
+}
+
+__declspec(safe) static inline uniform int16 reduce_max(int16 v) {
+    // Set values for non-running lanes to the minimum int8 value so
     // they don't affect the result.
-    return __reduce_min_int64(__mask ? v : INT64_MAX);
+    return __reduce_max_int16(__mask ? v : INT16_MIN);
+}
+
+__declspec(safe) static inline uniform unsigned int16 reduce_max(unsigned int16 v) {
+    // Set values for non-running lanes to zero so they don't affect the
+    // result.
+    return __reduce_max_uint16(__mask ? v : 0);
+}
+
+__declspec(safe) static inline uniform int32 reduce_max(int32 v) {
+    // Set values for non-running lanes to the minimum integer value so
+    // they don't affect the result.
+    return __reduce_max_int32(__mask ? v : INT32_MIN);
+}
+
+__declspec(safe) static inline uniform unsigned int32 reduce_max(unsigned int32 v) {
+    // Set values for non-running lanes to zero so they don't affect the
+    // result.
+    return __reduce_max_uint32(__mask ? v : 0);
 }
 
 __declspec(safe) static inline uniform int64 reduce_max(int64 v) {
@@ -1674,23 +1692,14 @@ __declspec(safe) static inline uniform int64 reduce_max(int64 v) {
     return __reduce_max_int64(__mask ? v : INT64_MIN);
 }
 
-__declspec(safe) static inline uniform unsigned int64 reduce_add(unsigned int64 x) {
-    // Set values for non-running lanes to zero so they don't affect the
-    // result.
-    return __reduce_add_int64(__mask ? x : 0);
-}
-
-__declspec(safe) static inline uniform unsigned int64 reduce_min(unsigned int64 v) {
-    // Set values for non-running lanes to the maximum unsigned integer
-    // value so they don't affect the result.
-    return __reduce_min_uint64(__mask ? v : UINT64_MAX);
-}
-
 __declspec(safe) static inline uniform unsigned int64 reduce_max(unsigned int64 v) {
     // Set values for non-running lanes to zero so they don't affect the
     // result.
     return __reduce_max_uint64(__mask ? v : 0);
 }
+
+///////////////////////////////////////////////////////////////////////////
+// Horizontal reduce_equal
 
 #define REDUCE_EQUAL(TYPE, FUNCTYPE, MASKTYPE)                                                                         \
     __declspec(safe) static inline uniform bool reduce_equal(TYPE v) {                                                 \
@@ -1712,6 +1721,11 @@ REDUCE_EQUAL(float, float, IntMaskType)
 REDUCE_EQUAL(int64, int64, IntMaskType)
 REDUCE_EQUAL(unsigned int64, int64, UIntMaskType)
 REDUCE_EQUAL(double, double, IntMaskType)
+
+#undef REDUCE_EQUAL
+
+///////////////////////////////////////////////////////////////////////////
+// Horizontal exclusive_scan_*
 
 static float16 exclusive_scan_add(float16 v) { return __exclusive_scan_add_half(v, __mask); }
 

--- a/tests/func-tests/3834.ispc
+++ b/tests/func-tests/3834.ispc
@@ -2,15 +2,15 @@
 
 task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
   int8 db = b - 4;
-  int8 iv = (programIndex + db - 19) % 7;
-  int8 m = reduce_add(iv);
+  uint8 iv = (uint8)((programIndex + db - 19) % 7);
+  uint8 m = reduce_add(iv);
   RET[programIndex] = m;
 }
 
 task void result(uniform float RET[]) {
-    uniform int8 x = 0;
+    uniform uint8 x = 0;
     for (uniform int i = 1; i <= programCount; ++i){
-        x += (i - 19) % 7;
+        x += (uint8)((i - 19) % 7);
     }
     RET[programIndex] = x;
 }

--- a/tests/func-tests/reduce-add-int8-1.ispc
+++ b/tests/func-tests/reduce-add-int8-1.ispc
@@ -1,16 +1,18 @@
 #include "test_static.isph"
+
 task void f_fu(uniform float RET[], uniform float aFOO[], uniform float b) {
     float v = aFOO[programIndex];
     uniform float m;
     int8 iv = (int)v;
     if (iv & 1)
-        m = reduce_add(iv);
+        m = reduce_add((iv % 11) - 5);
     RET[programIndex] = m;
 }
 
 task void result(uniform float RET[]) {
-    uniform int x = 0;
-    for (uniform int i = 1; i <= programCount; i += 2)
-        x += i;
+    uniform int8 x = 0;
+    for (uniform int i = 1; i <= programCount; i += 2) {
+        x += (i % 11) - 5;
+    }
     RET[programIndex] = x;
 }

--- a/tests/lit-tests/2799.ispc
+++ b/tests/lit-tests/2799.ispc
@@ -2,7 +2,7 @@
 
 // REQUIRES: X86_ENABLED
 
-// CHECK: store i64 496, {{.*}} %print_arg
+// CHECK: store i32 496, {{.*}} %print_arg
 
 extern "C" uniform int main() {
   print("%\n", reduce_add(programIndex));

--- a/tests/lit-tests/3846.ispc
+++ b/tests/lit-tests/3846.ispc
@@ -1,0 +1,9 @@
+// Check the unsigned reduce_add call produces the (v)psadbw instruction on x86 targets.
+
+// RUN: %{ispc} -O2 --target=host %s --emit-asm --x86-asm-syntax=intel -o - | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK-LABEL: test_uint8___UM_vyT:
+// CHECK: psadbw
+unmasked uniform uint8 test_uint8(uint8 v) { return reduce_add(v); }


### PR DESCRIPTION
## Description

This PR fixes #3834 . More specifically it:
- Fix reduce_add(int8) for signed (negative) values;
- Implement unsigned versions;
- Change the output type so it is now the same than the input type (no widening) -- most target was not computing this correctly anyway;
- Keep using psadbw in `__reduce_add_uint8` though the output type is now `uint8` instead of `int16` for sake of consistency with other functions.
- Fix the tests and add new ones, especially to catch the issue in `__reduce_add_int8` and check the unsigned versions.

I think it would be great to add more stdlib functions with widened output type later. Indeed, it would be more efficient on x86 CPU for `uint8` when the user want a `int16`/`uint16` result (no `uint8` wrap-around). On x86, I think we could also use the instruction `pmaddwd` for computing `reduce_add(int16) -> int32` (AFAIK not yet done previously). AFAIK, RISC and SVE (SVE2?) targets could also provide better implementations than naive ones (though SVE is not supported yet and RISC is certainly used by very few people). It is not critical since SIMD reductions are known to be a bit expensive and they rarely are on a hot path anyway.

Please note that I also reorganized the order of some function for sake of clarity. I also added a missing `undef` (minor).

PS: updating the IR of the 19 targets is pretty tedious and bug prone.

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [x] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [x] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed