### PR TITLE
CI: download SDE from ispc.dependencies release mirror

### DIFF
--- a/.github/workflows/scripts/init-env.ps1
+++ b/.github/workflows/scripts/init-env.ps1
@@ -1,16 +1,12 @@
 # Define widely used environment variables
 
-if (-not $env:SDE_MIRROR_ID) {
-  $env:SDE_MIRROR_ID = "859732"
-  echo "SDE_MIRROR_ID=$env:SDE_MIRROR_ID" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+if (-not $env:SDE_REPO) {
+  $env:SDE_REPO = "https://github.com/ispc/ispc.dependencies"
+  echo "SDE_REPO=$env:SDE_REPO" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 }
 if (-not $env:SDE_TAR_NAME) {
   $env:SDE_TAR_NAME = "sde-external-9.58.0-2025-06-16"
   echo "SDE_TAR_NAME=$env:SDE_TAR_NAME" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-}
-if (-not $env:USER_AGENT) {
-  $env:USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
-  echo "USER_AGENT=$env:USER_AGENT" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 }
 if (-not $env:LLVM_REPO) { $env:LLVM_REPO = "https://github.com/ispc/ispc.dependencies" }
 if (-not $env:LLVM_VERSION) { $env:LLVM_VERSION = "22.1" }

--- a/.github/workflows/scripts/init-env.sh
+++ b/.github/workflows/scripts/init-env.sh
@@ -2,9 +2,8 @@
 
 # Define some widely used environment variables in one place
 
-SDE_MIRROR_ID=${SDE_MIRROR_ID:-"859732"}
+SDE_REPO=${SDE_REPO:-"https://github.com/ispc/ispc.dependencies"}
 SDE_TAR_NAME=${SDE_TAR_NAME:-"sde-external-9.58.0-2025-06-16"}
-USER_AGENT=${USER_AGENT:-"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"}
 LLVM_REPO=${LLVM_REPO:-"https://github.com/ispc/ispc.dependencies"}
 LLVM_VERSION=${LLVM_VERSION:-"22.1"}
 echo "LLVM_VERSION=${LLVM_VERSION}" >> "${GITHUB_ENV}"

--- a/.github/workflows/scripts/install-build-deps.sh
+++ b/.github/workflows/scripts/install-build-deps.sh
@@ -75,13 +75,13 @@ do
   fi
 done
 
-# Check if both SDE_MIRROR_ID and USER_AGENT are defined
-if [ -n "$SDE_MIRROR_ID" ] && [ -n "$USER_AGENT" ]; then
-    echo -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
-    wget -q -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
+# Download SDE from the ispc.dependencies release mirror.
+if [ -n "$SDE_REPO" ] && [ -n "$SDE_TAR_NAME" ]; then
+    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 "$SDE_REPO/releases/download/$SDE_TAR_NAME/$SDE_TAR_NAME-lin.tar.xz"
+    file "$SDE_TAR_NAME-lin.tar.xz" | grep -q 'XZ compressed' || { echo "SDE download failed or is not an xz archive"; exit 1; }
     tar xf "$SDE_TAR_NAME"-lin.tar.xz
 else
-    echo "SDE_MIRROR_ID and/or USER_AGENT are not defined. Skipping download."
+    echo "SDE_REPO and/or SDE_TAR_NAME are not defined. Skipping download."
 fi
 
 if [ -n "$INSTALL_COMPUTE_RUNTIME" ]; then
@@ -107,7 +107,7 @@ if [ "$LLVM_VERSION" != "trunk" ]; then
   [ -n "$LLVM_REPO" ] && wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 $LLVM_REPO/releases/download/llvm-$LLVM_VERSION-ispc-dev/$LLVM_TAR
 fi
 tar xf $LLVM_TAR
-if [ -n "$SDE_MIRROR_ID" ] && [ -n "$USER_AGENT" ]; then
+if [ -n "$SDE_REPO" ] && [ -n "$SDE_TAR_NAME" ]; then
   echo "${GITHUB_WORKSPACE}/$SDE_TAR_NAME-lin" >> $GITHUB_PATH
 fi
 echo "${GITHUB_WORKSPACE}/bin-$LLVM_VERSION/bin" >> $GITHUB_PATH

--- a/.github/workflows/scripts/install-svml-test-deps.sh
+++ b/.github/workflows/scripts/install-svml-test-deps.sh
@@ -35,11 +35,12 @@ do
 done
 
 find /usr -name cdefs.h || echo "Find errors were ignored"
-if [ -n "$SDE_MIRROR_ID" ] && [ -n "$USER_AGENT" ]; then
-    wget -q -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
-    tar xf "$SDE_TAR_NAME"-lin.tar.bz2
+if [ -n "$SDE_REPO" ] && [ -n "$SDE_TAR_NAME" ]; then
+    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 "$SDE_REPO/releases/download/$SDE_TAR_NAME/$SDE_TAR_NAME-lin.tar.xz"
+    file "$SDE_TAR_NAME-lin.tar.xz" | grep -q 'XZ compressed' || { echo "SDE download failed or is not an xz archive"; exit 1; }
+    tar xf "$SDE_TAR_NAME"-lin.tar.xz
 else
-    echo "SDE_MIRROR_ID and/or USER_AGENT are not defined, exiting."
+    echo "SDE_REPO and/or SDE_TAR_NAME are not defined, exiting."
     exit 1
 fi
 ISPC_TAR=$(ls ispc-*-linux.tar.gz)

--- a/.github/workflows/scripts/install-test-deps.ps1
+++ b/.github/workflows/scripts/install-test-deps.ps1
@@ -16,12 +16,12 @@ ls
 $ispcDir = Get-ChildItem -Directory -Filter "ispc-*-windows" | Select-Object -First 1
 echo "$pwd\$($ispcDir.Name)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-# Download and unpack SDE
-if (-not $env:USER_AGENT -or -not $env:SDE_MIRROR_ID) {
-    Write-Error "SDE_MIRROR_ID and/or USER_AGENT are not defined, exiting."
+# Download and unpack SDE from the ispc.dependencies release mirror.
+if (-not $env:SDE_REPO -or -not $env:SDE_TAR_NAME) {
+    Write-Error "SDE_REPO and/or SDE_TAR_NAME are not defined, exiting."
     exit 1
 }
-wget -q -U "${env:USER_AGENT}" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/${env:SDE_MIRROR_ID}/${env:SDE_TAR_NAME}-win.tar.xz
+wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 "${env:SDE_REPO}/releases/download/${env:SDE_TAR_NAME}/${env:SDE_TAR_NAME}-win.tar.xz"
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 7z.exe x -txz ${env:SDE_TAR_NAME}-win.tar.xz
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/scripts/install-test-deps.sh
+++ b/.github/workflows/scripts/install-test-deps.sh
@@ -30,15 +30,13 @@ done
 pip install nanobind
 
 find /usr -name cdefs.h || echo "Find errors were ignored"
-# Remark about user agent: it might or might now work with default user agent, but
-# from time to time the settings are changed and browser-like user agent is required to make it work.
-# Check if both SDE_MIRROR_ID and USER_AGENT are defined
-if [ -n "$SDE_MIRROR_ID" ] && [ -n "$USER_AGENT" ]; then
-    echo -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
-    wget -q -U "$USER_AGENT" --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 https://downloadmirror.intel.com/"$SDE_MIRROR_ID"/"$SDE_TAR_NAME"-lin.tar.xz
+# Download SDE from the ispc.dependencies release mirror.
+if [ -n "$SDE_REPO" ] && [ -n "$SDE_TAR_NAME" ]; then
+    wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 "$SDE_REPO/releases/download/$SDE_TAR_NAME/$SDE_TAR_NAME-lin.tar.xz"
+    file "$SDE_TAR_NAME-lin.tar.xz" | grep -q 'XZ compressed' || { echo "SDE download failed or is not an xz archive"; exit 1; }
     tar xf "$SDE_TAR_NAME"-lin.tar.xz
 else
-    echo "SDE_MIRROR_ID and/or USER_AGENT are not defined, exiting."
+    echo "SDE_REPO and/or SDE_TAR_NAME are not defined, exiting."
     exit 1
 fi
 


### PR DESCRIPTION
## Description

downloadmirror.intel.com is now fronted by an AWS WAF bot challenge that returns an empty HTTP 202 to non-browser clients, so unattended wget downloads of Intel SDE produce a 0-byte file that breaks `tar` (exit 2) in the dependency-install step of every Linux/Windows CI job.

Host the SDE tarballs as a release asset on ispc.dependencies and fetch them the same way as LLVM (via the new SDE_REPO variable, parallel to LLVM_REPO). Drop the now-unused SDE_MIRROR_ID and USER_AGENT variables and validate the downloaded file is an xz archive before extracting so a bad download fails loudly instead of feeding garbage to tar. Also fix a latent bug in install-svml-test-deps.sh that untarred a .tar.bz2 from a .tar.xz download.

Requires a matching sde-external-9.58.0-2025-06-16 release with -lin.tar.xz and -win.tar.xz assets on ispc.dependencies.

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed