### PR TITLE
CI: update SDE to version 10.8

### DIFF
--- a/.github/workflows/scripts/init-env.ps1
+++ b/.github/workflows/scripts/init-env.ps1
@@ -5,7 +5,7 @@ if (-not $env:SDE_REPO) {
   echo "SDE_REPO=$env:SDE_REPO" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 }
 if (-not $env:SDE_TAR_NAME) {
-  $env:SDE_TAR_NAME = "sde-external-9.58.0-2025-06-16"
+  $env:SDE_TAR_NAME = "sde-external-10.8.0-2026-03-15"
   echo "SDE_TAR_NAME=$env:SDE_TAR_NAME" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 }
 if (-not $env:LLVM_REPO) { $env:LLVM_REPO = "https://github.com/ispc/ispc.dependencies" }

--- a/.github/workflows/scripts/init-env.sh
+++ b/.github/workflows/scripts/init-env.sh
@@ -3,7 +3,7 @@
 # Define some widely used environment variables in one place
 
 SDE_REPO=${SDE_REPO:-"https://github.com/ispc/ispc.dependencies"}
-SDE_TAR_NAME=${SDE_TAR_NAME:-"sde-external-9.58.0-2025-06-16"}
+SDE_TAR_NAME=${SDE_TAR_NAME:-"sde-external-10.8.0-2026-03-15"}
 LLVM_REPO=${LLVM_REPO:-"https://github.com/ispc/ispc.dependencies"}
 LLVM_VERSION=${LLVM_VERSION:-"22.1"}
 echo "LLVM_VERSION=${LLVM_VERSION}" >> "${GITHUB_ENV}"

--- a/.github/workflows/scripts/install-test-deps.ps1
+++ b/.github/workflows/scripts/install-test-deps.ps1
@@ -25,6 +25,11 @@ wget -q --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 5 "$
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 7z.exe x -txz ${env:SDE_TAR_NAME}-win.tar.xz
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-7z.exe x -ttar ${env:SDE_TAR_NAME}-win.tar
+# Extract SDE outside the default workspace ($pwd is D:\a\ispc\ispc). SDE 10.8+
+# fails to start when its install path contains a single-character folder (the
+# "\a\" segment), so unpack it into a path with no single-character component.
+# See https://community.intel.com/t5/Intel-ISA-Extensions/SDE-10-8-fails-to-start-depending-on-the-installation-folder/td-p/1746386
+$SDE_INSTALL_DIR = "C:\projects\sde"
+7z.exe x -ttar ${env:SDE_TAR_NAME}-win.tar -o"$SDE_INSTALL_DIR"
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-echo "$pwd\${env:SDE_TAR_NAME}-win" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+echo "$SDE_INSTALL_DIR\${env:SDE_TAR_NAME}-win" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append


### PR DESCRIPTION
## Description
Update to newer SDE version. 
Full testing is [here](https://github.com/ispc/ispc/actions/runs/27289707021).

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed