### PR TITLE
Add rebuild LLVM 23 workflow and version to superbuild

### DIFF
--- a/.github/workflows/rebuild-llvm23.yml
+++ b/.github/workflows/rebuild-llvm23.yml
@@ -1,0 +1,40 @@
+# Copyright 2026 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Rebuild LLVM 23.1
+
+permissions: read-all
+
+on:
+  push:
+    branches:
+      - main
+      - '**rebuild_llvm**'
+    paths:
+      - "llvm_patches/*23_1*"
+      - "scripts/alloy.py"
+      - "superbuild/*"
+      - ".github/workflows/rebuild-llvm23.yml"
+      - ".github/workflows/reusable.rebuild.yml"
+  workflow_dispatch:
+
+jobs:
+  llvm22:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.lto }}-${{ matrix.asserts }}-${{ matrix.arch }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        lto: ['ON', 'OFF']
+        asserts: ['ON', 'OFF']
+        arch: ['x86', 'aarch64']
+    uses: ./.github/workflows/reusable.rebuild.yml
+    with:
+      version: '23.1'
+      full_version: '23.1.0'
+      lto: ${{ matrix.lto }}
+      asserts: ${{ matrix.asserts }}
+      arch: ${{ matrix.arch }}
+      ubuntu: '22.04'
+      win_sdk: '10.0.18362.0'

--- a/scripts/alloy.py
+++ b/scripts/alloy.py
@@ -91,8 +91,19 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     # Identify the version
     # An example of using branch (instead of final tag) is the following (for 16.0):
     # git: "release/16.x"
+    # GIT_TAG_IS_SHA marks GIT_TAG as a raw commit SHA rather than a branch/tag
+    # name. A SHA cannot be passed to "git clone --branch" and is not reachable in
+    # a shallow clone, so such versions are cloned and then checked out explicitly.
+    GIT_TAG_IS_SHA=False
     if  version_LLVM == "trunk":
         GIT_TAG="main"
+    elif  version_LLVM == "23_1":
+        # LLVM 23 is not released yet. We pin to a specific trunk SHA rather than
+        # a release tag because we need recent trunk fixes for proper APX support.
+        # TODO: replace this SHA with the llvmorg-23.1.x release tag once LLVM 23
+        # is released. Keep this SHA in sync with LLVM_TAG in superbuild/CMakeLists.txt.
+        GIT_TAG="5a52d68d6b030b155580ff03f5f8ad0cc9dc2fd9"
+        GIT_TAG_IS_SHA=True
     elif  version_LLVM == "22_1":
         GIT_TAG="llvmorg-22.1.6"
     elif  version_LLVM == "21_1":
@@ -134,10 +145,19 @@ def checkout_LLVM(component, version_LLVM, target_dir, from_validation, verbose)
     else:
         alloy_error("Unsupported llvm version: " + version_LLVM, 1)
 
-    depth = "" if options.full_checkout else "--depth=1 --shallow-submodules"
-    git_clone_cmd = f"git clone {depth} --branch {GIT_TAG} {GIT_REPO_BASE} {target_dir}"
-    try_do_LLVM(f"clone {component} with tag {GIT_TAG} from {GIT_REPO_BASE} to {target_dir}",
-                git_clone_cmd, from_validation, verbose)
+    if GIT_TAG_IS_SHA:
+        # A raw SHA is not reachable via "--branch" nor in a shallow clone, so do a
+        # full clone of the default branch and then check the commit out explicitly.
+        git_clone_cmd = f"git clone {GIT_REPO_BASE} {target_dir}"
+        try_do_LLVM(f"clone {component} from {GIT_REPO_BASE} to {target_dir}",
+                    git_clone_cmd, from_validation, verbose)
+        try_do_LLVM(f"checkout {component} at commit {GIT_TAG}",
+                    f"git -C {target_dir} checkout {GIT_TAG}", from_validation, verbose)
+    else:
+        depth = "" if options.full_checkout else "--depth=1 --shallow-submodules"
+        git_clone_cmd = f"git clone {depth} --branch {GIT_TAG} {GIT_REPO_BASE} {target_dir}"
+        try_do_LLVM(f"clone {component} with tag {GIT_TAG} from {GIT_REPO_BASE} to {target_dir}",
+                    git_clone_cmd, from_validation, verbose)
 
 def get_llvm_disable_assertions_switch(llvm_disable_assertions):
     if llvm_disable_assertions == True:
@@ -641,7 +661,7 @@ def validation_run(only, only_targets, reference_branch, number, update, speed_n
             archs.append("x86-64")
         if "native" in only:
             sde_targets_t = []
-        for i in ["6.0", "7.0", "8.0", "9.0", "10.0", "11.0", "12.0", "13.0", "14.0", "15.0", "16.0", "17.0", "18.1", "19.1", "20.1", "21.1", "22.1", "trunk"]:
+        for i in ["6.0", "7.0", "8.0", "9.0", "10.0", "11.0", "12.0", "13.0", "14.0", "15.0", "16.0", "17.0", "18.1", "19.1", "20.1", "21.1", "22.1", "23.1", "trunk"]:
             if i in only:
                 LLVM.append(i)
         if "current" in only:
@@ -974,7 +994,7 @@ if __name__ == '__main__':
     llvm_group = OptionGroup(parser, "Options for building LLVM",
                     "These options must be used with -b option.")
     llvm_group.add_option('--version', dest='version',
-        help='version of llvm to build: 6.0-22.1 trunk. Default: trunk', default="trunk")
+        help='version of llvm to build: 6.0-23.1 trunk. Default: trunk', default="trunk")
     llvm_group.add_option('--full-checkout', dest='full_checkout', action='store_true', default=False,
         help=('Disable a shallow clone and checkout a whole LLVM repository.\n'
               'By default it clones LLVM with --depth=1 to save space and time'))
@@ -1027,7 +1047,7 @@ if __name__ == '__main__':
     run_group.add_option('--only', dest='only',
         help='set types of tests. Possible values:\n' +
             '-O0, -O1, -O2, x86, x86-64, stability (test only stability), performance (test only performance),\n' +
-            'build (only build with different LLVM), 6.0-22.1, trunk, native (do not use SDE),\n' +
+            'build (only build with different LLVM), 6.0-23.1, trunk, native (do not use SDE),\n' +
             'current (do not rebuild ISPC), debug (only with debug info), nodebug (only without debug info, default).',
             default="")
     run_group.add_option('--perf_LLVM', dest='perf_llvm',

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -212,7 +212,13 @@ string(APPEND LIT_TOOLS_DIR ${GNUWIN32} "/bin")
 unset(LLVM_TAG)
 unset(LLVM_VERSION_DOTTED)
 string(REPLACE "." "_" LLVM_VERSION "${LLVM_VERSION}")
-if (${LLVM_VERSION} STREQUAL 22_1)
+if (${LLVM_VERSION} STREQUAL 23_1)
+    # LLVM 23 is not released yet. We pin to a specific trunk SHA rather than a
+    # release tag because we need recent trunk fixes for proper APX support.
+    # TODO: replace this SHA with the llvmorg-23.1.x release tag once LLVM 23 is
+    # released. Keep this SHA in sync with the LLVM_TAG in scripts/alloy.py.
+    set(LLVM_TAG    5a52d68d6b030b155580ff03f5f8ad0cc9dc2fd9)
+elseif (${LLVM_VERSION} STREQUAL 22_1)
     set(LLVM_TAG    llvmorg-22.1.6)
 elseif (${LLVM_VERSION} STREQUAL 21_1)
     set(LLVM_TAG    llvmorg-21.1.8)
@@ -263,6 +269,11 @@ if (DEFINED LLVM_SHA AND NOT "${LLVM_SHA}" STREQUAL "")
     # Disable shallow clone when a specific SHA is provided to avoid race conditions
     # where the SHA may not be available in a shallow clone if LLVM main has moved forward
     set(LLVM_GIT_SHALLOW OFF)
+elseif (${LLVM_VERSION} STREQUAL 23_1)
+    # LLVM 23 is pinned to a raw trunk SHA (see above). A shallow clone only
+    # fetches the tip of the default branch, which will not contain an arbitrary
+    # historical commit, so the checkout would fail. Disable shallow clone here.
+    set(LLVM_GIT_SHALLOW OFF)
 else()
     set(LLVM_GIT_SHALLOW ON)
 endif()
@@ -271,6 +282,13 @@ if (${LLVM_VERSION} STREQUAL trunk)
     set(LLVM_VERSION_DOTTED main)
     set(LLVM_VERSION_MAJOR 0)
     set(LLVM_VERSION_MINOR 0)
+    set(LLVM_VERSION_PATCH 0)
+elseif (${LLVM_VERSION} STREQUAL 23_1)
+    # LLVM 23 is not released yet; LLVM_TAG is pinned to a specific SHA, so the
+    # version components cannot be parsed out of the tag. Set them explicitly.
+    set(LLVM_VERSION_DOTTED 23.1.0)
+    set(LLVM_VERSION_MAJOR 23)
+    set(LLVM_VERSION_MINOR 1)
     set(LLVM_VERSION_PATCH 0)
 else()
     string(SUBSTRING ${LLVM_TAG} 8 -1 LLVM_VERSION_DOTTED)


### PR DESCRIPTION
## Description
Even though LLVM 23 was not branched out yet we need to fix some SHA of latest LLVM for the future ISPC release to get the proper APX support. The LLVM SHA is not finalized yet but I need to land the rebuild workflow to run testing.

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed