### PR TITLE
Fix #3860: Adapt to LLVM trunk API change in IITDescriptor

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -417,20 +417,16 @@ static llvm::Function *lGetISPCIntrinsicsFuncDecl(llvm::Module *M, std::string n
 
 bool lIsAnyArgumentKind(const IITDesc &D) {
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
-    if (D.Kind != IITDesc::Overloaded) {
-        return false;
-    }
-
-    unsigned Kind = D.getOverloadKind();
+    return D.Kind == IITDesc::Overloaded;
 #else
     if (D.Kind != IITDesc::Argument) {
         return false;
     }
 
     unsigned Kind = D.getArgumentKind();
-#endif
     return Kind == IITDesc::AK_Any || Kind == IITDesc::AK_AnyInteger || Kind == IITDesc::AK_AnyFloat ||
            Kind == IITDesc::AK_AnyVector || Kind == IITDesc::AK_AnyPointer;
+#endif
 }
 
 bool lIsArgDesc(const IITDesc &D) {


### PR DESCRIPTION
LLVM commit 0579490 (PR #203506) removed getOverloadKind() and the AK_* enum values, replacing them with separate constraint enums. In the new API, all "any type" descriptors have Kind == Overloaded, while Match is now a distinct Kind.

This simplifies lIsAnyArgumentKind() for LLVM 23+ to just check for IITDesc::Overloaded. The pre-LLVM-23 branch remains unchanged for backward compatibility.

## Description
Brief description of changes

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed