### PR TITLE
Add --opt=disable-apx and automatic Windows x64 unwind v3 for APX EGPR

### DIFF
--- a/.github/workflows/ispc-ci.yml
+++ b/.github/workflows/ispc-ci.yml
@@ -42,7 +42,8 @@ env:
                       "avx512skx-x4", "avx512skx-x8", "avx512skx-x16", "avx512skx-x64", "avx512skx-x32",
                       "avx512icl-x4", "avx512icl-x8", "avx512icl-x16", "avx512icl-x64", "avx512icl-x32",
                       "avx512spr-x4", "avx512spr-x8", "avx512spr-x16", "avx512spr-x64", "avx512spr-x32",
-                      "avx512gnr-x4", "avx512gnr-x8", "avx512gnr-x16", "avx512gnr-x64", "avx512gnr-x32"]'
+                      "avx512gnr-x4", "avx512gnr-x8", "avx512gnr-x16", "avx512gnr-x64", "avx512gnr-x32",
+                      "avx10.2dmr-x4", "avx10.2dmr-x8", "avx10.2dmr-x16", "avx10.2dmr-x32", "avx10.2dmr-x64"]'
   TARGETS_FULL_ARM: '["neon-i32x4", "neon-i32x8", "neon-i8x16", "neon-i16x8", "neon-i8x32", "neon-i16x16"]'
   OPTSETS_FULL: "-O0 -O1 -O2"
   ISPC_ANDROID_NDK_PATH: "/usr/local/share/android-ndk"
@@ -129,6 +130,9 @@ jobs:
           - version: "22.1"
             full_version: "22.1.6"
             short_version: 22
+          - version: "23.1"
+            full_version: "23.1.0"
+            short_version: 23
     uses: ./.github/workflows/reusable.ispc.build.yml
     with:
       platform: linux
@@ -197,7 +201,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: [20, 21, 22]
+        llvm: [20, 21, 22, 23]
         arch: [x86, x86-64]
     uses: ./.github/workflows/reusable.ispc.test.yml
     with:
@@ -278,6 +282,24 @@ jobs:
       targets: ${{ matrix.targets }}
       optsets: ${{ needs.define-flow.outputs.tests_optsets }}
       ispc_extra_flags: ${{ matrix.extra_flags }}
+
+  # nvl (Nova Lake) targets require LLVM 22, so they are tested in a dedicated
+  # job on LLVM 22 and 23 and excluded from the LLVM 20/21 test matrix.
+  linux-test-llvm22-plus:
+    needs: [define-flow, linux-build-ispc]
+    if: ${{ needs.define-flow.outputs.flow_type == 'full' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        llvm: [22, 23]
+        arch: [x86, x86-64]
+    uses: ./.github/workflows/reusable.ispc.test.yml
+    with:
+      platform: linux
+      architecture: ${{ matrix.arch }}
+      artifact_name: ispc_llvm${{ matrix.llvm }}_linux
+      targets: '["avx10.2nvl-x4", "avx10.2nvl-x8", "avx10.2nvl-x16", "avx10.2nvl-x32", "avx10.2nvl-x64"]'
+      optsets: ${{ needs.define-flow.outputs.tests_optsets }}
 
   linux-test-llvm22-lto:
     needs: [define-flow, linux-build-ispc-llvm22-lto]
@@ -395,6 +417,9 @@ jobs:
           - version: "22.1"
             full_version: "22.1.6"
             short_version: 22
+          - version: "23.1"
+            full_version: "23.1.0"
+            short_version: 23
     uses: ./.github/workflows/reusable.ispc.build.yml
     with:
       platform: macos
@@ -419,7 +444,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: [20, 21, 22]
+        llvm: [20, 21, 22, 23]
     uses: ./.github/workflows/reusable.ispc.test.yml
     with:
       platform: macos
@@ -487,6 +512,10 @@ jobs:
             full_version: "22.1.6"
             short_version: 22
             vs_version: "vs2022"
+          - version: "23.1"
+            full_version: "23.1.0"
+            short_version: 23
+            vs_version: "vs2022"
     uses: ./.github/workflows/reusable.ispc.build.yml
     with:
       platform: windows
@@ -533,7 +562,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: [20, 21, 22]
+        llvm: [20, 21, 22, 23]
         arch: [x86, x86-64]
     uses: ./.github/workflows/reusable.ispc.test.yml
     with:

--- a/docs/ispc.rst
+++ b/docs/ispc.rst
@@ -296,6 +296,27 @@ ISPC Targets:
   checked the same way AVX-512 already is: the CPU must advertise the feature in
   CPUID and the OS must manage its XSAVE state.
 
+New Options:
+
+* A new ``--opt=disable-apx[=<list>]`` option allows disabling x86 APX
+  (Advanced Performance Extensions) sub-features, which are enabled by default
+  on APX-capable targets such as ``avx10.2dmr`` and ``avx10.2nvl``. With no
+  list it disables all APX sub-features; otherwise it accepts a comma-separated
+  subset of ``egpr``, ``ndd``, ``push2pop2``, ``ppx``, ``ccmp``, ``cf``,
+  ``nf``, ``zu``, and ``jmpabs``.
+
+Windows x64 Stack Unwinding For APX:
+
+* On Windows x64, code that uses the APX extended general purpose registers
+  (``egpr``, R16-R31) cannot be described by the legacy v1/v2 SEH unwind
+  encodings, which have no register-number field for registers beyond R15.
+  When targeting Windows on an APX-capable target (the ``avx10.2dmr`` and
+  ``avx10.2nvl`` families) with ``egpr`` enabled, ISPC now automatically
+  requests Windows x64 unwind information version 3 by setting the
+  ``winx64-eh-unwind`` module flag, mirroring what Clang does. If you need
+  compatibility with an older unwinder, disable the extended registers with
+  ``--opt=disable-apx=egpr``, which also drops the unwind v3 request.
+
 Updating ISPC Programs For Changes In ISPC 1.30.0
 -------------------------------------------------
 
@@ -1665,6 +1686,21 @@ controlled via command-line flags. These options can be specified using the
 `--opt=<option>` flag. Below is a list of available optimization options:
 
 Available options:
+
+- ``disable-apx[=<list>]``
+
+  Disable x86 APX (Advanced Performance Extensions) sub-features. APX
+  sub-features are enabled by default on APX-capable targets such as
+  ``avx10.2dmr`` and ``avx10.2nvl``. With no list, all APX sub-features are
+  disabled; otherwise the value is a comma-separated subset of the sub-feature
+  names: ``egpr`` (extended general purpose registers R16-R31), ``ndd``
+  (non-destructive destination), ``push2pop2`` (PUSH2/POP2 instructions),
+  ``ppx`` (push-pop acceleration), ``ccmp`` (conditional compare and test),
+  ``cf`` (conditional faulting), ``nf`` (no-flags ALU variants), ``zu``
+  (zero-upper SETcc/IMUL), and ``jmpabs`` (64-bit absolute JMP). The
+  sub-features are independent, so any combination can be disabled. The exact
+  set of sub-features a given ISPC build accepts depends on its LLVM backend;
+  run ``ispc --help`` to see the list supported by your build.
 
 - ``disable-assertions``
 

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -50,6 +50,21 @@ static void lPrintVersion() {
 #endif
 }
 
+// Build a comma-separated list of the APX sub-feature names this build accepts,
+// e.g. "egpr, ndd, push2pop2, ppx, ccmp, cf, nf, zu". Used in the help text and
+// in error messages so the advertised set always matches the actual build. The
+// accepted set is the single source of truth in Opt::APXFeatureTable().
+static std::string lAPXFeatureList() {
+    std::string list;
+    for (auto const &f : Opt::APXFeatureTable()) {
+        if (!list.empty()) {
+            list += ", ";
+        }
+        list += f.first;
+    }
+    return list;
+}
+
 static ArgsParseResult usage() {
     lPrintVersion();
     printf("\nusage: ispc\n");
@@ -137,6 +152,9 @@ static ArgsParseResult usage() {
     printf("        disable-loop-unroll\t\tDisable loop unrolling\n");
     printf("        disable-zmm\t\t\tDisable using zmm registers for avx512skx-x16, avx512icl-x16 targets in favor of "
            "ymm. This also affects ABI\n");
+    printf("        disable-apx[=<list>]\t\tDisable x86 APX sub-features (enabled by default on avx10.2dmr, "
+           "avx10.2nvl targets). With no list, disables all; otherwise a comma-separated subset of: %s\n",
+           lAPXFeatureList().c_str());
 #ifdef ISPC_XE_ENABLED
     printf("        emit-xe-hardware-mask\t\tEnable emitting of Xe implicit hardware mask\n");
     printf("        enable-xe-foreach-varying\t\tEnable experimental foreach support inside varying control flow\n");
@@ -564,6 +582,38 @@ static void lParseInclude(const char *path) {
     }
 }
 
+// Parse the value of --opt=disable-apx[=<comma-separated-list>].  An empty list
+// disables all APX sub-features.  Returns true on success; on an unknown
+// sub-feature name it reports an error via errorHandler and returns false.
+static bool lParseDisableAPX(const char *features, ArgErrors &errorHandler) {
+    if (*features == 0) {
+        g->opt.disableAPX |= Opt::APX_all;
+        return true;
+    }
+    bool ok = true;
+    std::stringstream ss(features);
+    for (std::string item; std::getline(ss, item, ',');) {
+        // Tolerate empty tokens from leading/embedded/trailing commas.
+        if (item.empty()) {
+            continue;
+        }
+        bool found = false;
+        for (auto const &f : Opt::APXFeatureTable()) {
+            if (item == f.first) {
+                g->opt.disableAPX |= f.second;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            errorHandler.AddError("Unknown APX sub-feature \"%s\" in --opt=disable-apx. Valid sub-features are: %s.",
+                                  item.c_str(), lAPXFeatureList().c_str());
+            ok = false;
+        }
+    }
+    return ok;
+}
+
 // Forward declarations for functions used in ParseCommandLineArgs
 extern void printBinaryType();
 
@@ -875,6 +925,15 @@ ArgsParseResult ispc::ParseCommandLineArgs(int argc, char *argv[], std::string &
                 g->opt.disableFMA = true;
             } else if (!strcmp(opt, "disable-zmm")) {
                 g->opt.disableZMM = true;
+            } else if (!strcmp(opt, "disable-apx") || !strncmp(opt, "disable-apx=", 12)) {
+                const char *apxOpt = opt + 11;
+                if (*apxOpt == 0) {
+                    // No list given: disable all APX sub-features.
+                    g->opt.disableAPX |= Opt::APX_all;
+                } else {
+                    // *apxOpt == '=', so parse the comma-separated list that follows.
+                    lParseDisableAPX(apxOpt + 1, errorHandler);
+                }
             } else if (!strcmp(opt, "force-aligned-memory")) {
                 g->opt.forceAlignedMemory = true;
             } else if (!strcmp(opt, "reset-ftz-daz")) {
@@ -1255,6 +1314,25 @@ ArgsParseResult ispc::ParseCommandLineArgs(int argc, char *argv[], std::string &
                         "--opt=disable-zmm can only be used with avx512skx-x16, avx512icl-x16 or generic-i32x16, "
                         "generic-i1x16, generic-i1x32, generic-i1x64 targets.");
             }
+        }
+    }
+
+    // Validate --opt=disable-apx usage. APX sub-features are only enabled on
+    // APX-capable targets (currently the avx10.2dmr and avx10.2nvl families).
+    // The option is meaningful in a multi-target build as long as at least one
+    // such target is present, so warn only when none of the targets is
+    // APX-capable (i.e. the option is entirely ineffective).
+    if (g->opt.disableAPX) {
+        bool anyAPXTarget = false;
+        for (auto target : targets) {
+            if (ISPCTargetIsApxCapable(target)) {
+                anyAPXTarget = true;
+                break;
+            }
+        }
+        if (!anyAPXTarget) {
+            Warning(SourcePos(), "--opt=disable-apx has no effect: none of the selected targets is APX-capable. "
+                                 "APX sub-features are only enabled on targets such as avx10.2dmr and avx10.2nvl.");
         }
     }
 

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -1317,25 +1317,6 @@ ArgsParseResult ispc::ParseCommandLineArgs(int argc, char *argv[], std::string &
         }
     }
 
-    // Validate --opt=disable-apx usage. APX sub-features are only enabled on
-    // APX-capable targets (currently the avx10.2dmr and avx10.2nvl families).
-    // The option is meaningful in a multi-target build as long as at least one
-    // such target is present, so warn only when none of the targets is
-    // APX-capable (i.e. the option is entirely ineffective).
-    if (g->opt.disableAPX) {
-        bool anyAPXTarget = false;
-        for (auto target : targets) {
-            if (ISPCTargetIsApxCapable(target)) {
-                anyAPXTarget = true;
-                break;
-            }
-        }
-        if (!anyAPXTarget) {
-            Warning(SourcePos(), "--opt=disable-apx has no effect: none of the selected targets is APX-capable. "
-                                 "APX sub-features are only enabled on targets such as avx10.2dmr and avx10.2nvl.");
-        }
-    }
-
     if ((output.type == Module::Asm) && (intelAsmSyntax != nullptr)) {
         std::vector<const char *> Args(3);
         Args[0] = "ispc (LLVM option parsing)";

--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -2415,6 +2415,26 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
             featuresString += "+longlong";
         }
 
+        // Disable any x86 APX sub-features the user requested via
+        // --opt=disable-apx. The APX sub-features are enabled by default on
+        // APX-capable targets (e.g. avx10.2dmr, avx10.2nvl) through the CPU
+        // name; appending "-<feature>" to the LLVM feature string turns them
+        // off. They are independent in the LLVM X86 backend, so any
+        // combination can be disabled. This is a no-op on targets that do not
+        // enable APX in the first place. The accepted set is the single source
+        // of truth in Opt::APXFeatureTable().
+        if (g->opt.disableAPX && ISPCTargetIsX86(m_ispc_target)) {
+            for (auto const &f : Opt::APXFeatureTable()) {
+                if (g->opt.disableAPX & f.second) {
+                    if (!featuresString.empty()) {
+                        featuresString += ",";
+                    }
+                    featuresString += "-";
+                    featuresString += f.first;
+                }
+            }
+        }
+
         if (g->opt.disableFMA == false) {
             options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
         }
@@ -3306,6 +3326,21 @@ bool Target::hasXePrefetch() const {
 ///////////////////////////////////////////////////////////////////////////
 // Opt
 
+const std::vector<std::pair<const char *, Opt::APXFeature>> &Opt::APXFeatureTable() {
+    // All APX sub-features are recognized by the LLVM X86 backend on the LLVM
+    // versions ISPC supports except jmpabs, which is only recognized from
+    // LLVM 23.0 on (so its bit is never set in disableAPX before then).
+    static const std::vector<std::pair<const char *, Opt::APXFeature>> table = {
+        {"egpr", APX_egpr},     {"ndd", APX_ndd},   {"push2pop2", APX_push2pop2},
+        {"ppx", APX_ppx},       {"ccmp", APX_ccmp}, {"cf", APX_cf},
+        {"nf", APX_nf},         {"zu", APX_zu},
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+        {"jmpabs", APX_jmpabs},
+#endif
+    };
+    return table;
+}
+
 Opt::Opt() {
     level = 2;
     fastMath = FastMathMode::None;
@@ -3330,6 +3365,7 @@ Opt::Opt() {
     disableUniformMemoryOptimizations = false;
     disableCoalescing = false;
     disableZMM = false;
+    disableAPX = 0;
     resetFTZ_DAZ = false;
 #ifdef ISPC_XE_ENABLED
     disableXeGatherCoalescing = false;

--- a/src/ispc.h
+++ b/src/ispc.h
@@ -660,6 +660,38 @@ struct Opt {
         Affects only >= 512 bit wide targets and only if avx512vl is available */
     bool disableZMM;
 
+    /** Bitmask of x86 APX (Advanced Performance Extensions) sub-features to
+        disable.  The APX sub-features are enabled by default on APX-capable
+        targets (e.g. avx10.2dmr, avx10.2nvl); setting a bit here appends the
+        corresponding "-<feature>" entry to the LLVM target feature string so
+        that the feature is turned off.  The sub-features are independent in the
+        LLVM X86 backend, so any combination can be disabled.  A value of 0
+        means no APX feature is disabled (the default).  Only meaningful for
+        x86 targets; all sub-features are available on LLVM 20+ except
+        APX_jmpabs, which requires LLVM 23.0+. */
+    enum APXFeature {
+        APX_egpr = 1 << 0,
+        APX_ndd = 1 << 1,
+        APX_push2pop2 = 1 << 2,
+        APX_ppx = 1 << 3,
+        APX_ccmp = 1 << 4,
+        APX_cf = 1 << 5,
+        APX_nf = 1 << 6,
+        APX_zu = 1 << 7,
+        APX_jmpabs = 1 << 8,
+        APX_all = APX_egpr | APX_ndd | APX_push2pop2 | APX_ppx | APX_ccmp | APX_cf | APX_nf |
+                  APX_zu
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+                  // jmpabs is only known to the LLVM X86 backend from 23.0 on.
+                  | APX_jmpabs
+#endif
+    };
+    unsigned int disableAPX;
+
+    /** Mmapping x86 APX sub-feature names (as used by the LLVM X86 backend)
+        to their APXFeature bit. */
+    static const std::vector<std::pair<const char *, APXFeature>> &APXFeatureTable();
+
     /** Set FTZ/DAZ flags on the extern function entrance and restore them.
         upon return to "host" code.*/
     bool resetFTZ_DAZ;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -231,6 +231,20 @@ Module::Module(const char *fn) : srcFile(fn) {
     lSetCodeModel(module);
     lSetPICLevel(module);
 
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+    // On Windows x64, code that uses the APX extended general purpose registers
+    // (EGPR, R16-R31) cannot be described by the legacy v1/v2 SEH unwind
+    // encodings, so the LLVM X86 backend errors out unless the module opts in
+    // to unwind v3. EGPR is enabled by default on APX-capable targets (the
+    // avx10.2dmr and avx10.2nvl families) unless the user turned it off via
+    // --opt=disable-apx. Mirror clang by selecting unwind v3 in that case.
+    // The value 3 is llvm::WinX64EHUnwindMode::V3 (only defined on LLVM 23+).
+    if (g->target_os == TargetOS::windows && g->target->getArch() == Arch::x86_64 &&
+        ISPCTargetIsApxCapable(g->target->getISPCTarget()) && !(g->opt.disableAPX & Opt::APX_egpr)) {
+        module->addModuleFlag(llvm::Module::Warning, "winx64-eh-unwind", 3);
+    }
+#endif
+
 #if ISPC_LLVM_VERSION < ISPC_LLVM_21_0
     // LLVM is transitioning to new debug info representation, use "old" style for now.
     module->setIsNewDbgInfoFormat(false);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2781,6 +2781,27 @@ static Module::Output lCreateTargetOutputs(Module::Output &output, ISPCTarget ta
     return targetOutputs;
 }
 
+// Validate --opt=disable-apx usage against the *resolved* targets. APX
+// sub-features are only enabled on APX-capable targets (currently the
+// avx10.2dmr and avx10.2nvl families). The option is meaningful in a
+// multi-target build as long as at least one such target is present, so warn
+// only when none of the resolved targets is APX-capable (i.e. the option is
+// entirely ineffective). This check must run after target resolution because
+// targets derived from --cpu or --target=host (rather than spelled out via
+// --target) are only known once the Target objects are constructed.
+static void lWarnIfDisableAPXHasNoEffect(const std::vector<ISPCTarget> &resolvedTargets) {
+    if (!g->opt.disableAPX) {
+        return;
+    }
+    for (auto target : resolvedTargets) {
+        if (ISPCTargetIsApxCapable(target)) {
+            return;
+        }
+    }
+    Warning(SourcePos(), "--opt=disable-apx has no effect: none of the selected targets is APX-capable. "
+                         "APX sub-features are only enabled on targets such as avx10.2dmr and avx10.2nvl.");
+}
+
 // Compiles the given source file for multiple target ISAs and creates a dispatch module.
 int Module::CompileMultipleTargets(const char *srcFile, Arch arch, const char *cpu, std::vector<ISPCTarget> &targets,
                                    Output &output) {
@@ -2800,6 +2821,7 @@ int Module::CompileMultipleTargets(const char *srcFile, Arch arch, const char *c
     // when the function returns.
     std::vector<std::unique_ptr<Module>> modules;
     std::vector<std::unique_ptr<Target>> targetsPtrs;
+    std::vector<ISPCTarget> resolvedTargets;
 
     for (unsigned int i = 0; i < targets.size(); ++i) {
         auto targetPtr = Target::Create(arch, cpu, targets[i], output.flags.getPICLevel(), output.flags.getMCModel(),
@@ -2807,6 +2829,7 @@ int Module::CompileMultipleTargets(const char *srcFile, Arch arch, const char *c
         if (!targetPtr) {
             return 1;
         }
+        resolvedTargets.push_back(targetPtr->getISPCTarget());
 
         // Here, we transfer the ownership of the target to the vector, i.e.,
         // the lifetime of the target objects is tied to the function scope.
@@ -2834,6 +2857,8 @@ int Module::CompileMultipleTargets(const char *srcFile, Arch arch, const char *c
         lResetTargetAndModule();
     }
 
+    lWarnIfDisableAPXHasNoEffect(resolvedTargets);
+
     // Generate the dispatch module
     return GenerateDispatch(srcFile, targets, modules, targetsPtrs, output);
 }
@@ -2859,6 +2884,7 @@ int Module::CompileAndOutput(const char *srcFile, Arch arch, const char *cpu, st
         if (!targetPtr) {
             return 1;
         }
+        lWarnIfDisableAPXHasNoEffect({targetPtr->getISPCTarget()});
         auto modulePtr = Module::Create(srcFile, output);
 
         return m->CompileSingleTarget(arch, cpu, target);

--- a/src/target_enums.cpp
+++ b/src/target_enums.cpp
@@ -890,6 +890,29 @@ bool ISPCTargetIsX86(ISPCTarget target) {
     }
 }
 
+// Targets that enable x86 APX (Advanced Performance Extensions) by default,
+// i.e. the avx10.2dmr and avx10.2nvl families. APX sub-features such as the
+// extended general purpose registers (EGPR, R16-R31) are only emitted for
+// these targets, so APX-specific handling (e.g. --opt=disable-apx and Windows
+// unwind v3) is gated on this set.
+bool ISPCTargetIsApxCapable(ISPCTarget target) {
+    switch (target) {
+    case ISPCTarget::avx10_2dmr_x4:
+    case ISPCTarget::avx10_2dmr_x8:
+    case ISPCTarget::avx10_2dmr_x16:
+    case ISPCTarget::avx10_2dmr_x32:
+    case ISPCTarget::avx10_2dmr_x64:
+    case ISPCTarget::avx10_2nvl_x4:
+    case ISPCTarget::avx10_2nvl_x8:
+    case ISPCTarget::avx10_2nvl_x16:
+    case ISPCTarget::avx10_2nvl_x32:
+    case ISPCTarget::avx10_2nvl_x64:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool ISPCTargetIsNeon(ISPCTarget target) {
     switch (target) {
     case ISPCTarget::neon_i8x16:

--- a/src/target_enums.h
+++ b/src/target_enums.h
@@ -137,6 +137,7 @@ ISPCTarget ParseISPCTarget(std::string target);
 std::pair<std::vector<ISPCTarget>, std::string> ParseISPCTargets(const char *target);
 std::string ISPCTargetToString(ISPCTarget target);
 bool ISPCTargetIsX86(ISPCTarget target);
+bool ISPCTargetIsApxCapable(ISPCTarget target);
 bool ISPCTargetIsNeon(ISPCTarget target);
 bool ISPCTargetIsRiscV(ISPCTarget target);
 bool ISPCTargetIsWasm(ISPCTarget target);

--- a/tests/lit-tests/3758.ispc
+++ b/tests/lit-tests/3758.ispc
@@ -1,0 +1,58 @@
+// By default APX is on: EGPR (R16-R31) is allocated and {nf} forms are emitted.
+//; RUN: %{ispc} %s --target=avx10.2dmr-x16 --nowrap --emit-asm -o - | FileCheck %s --check-prefix=APX-ON
+
+// Disabling only egpr removes EGPR usage (the #3758 workaround) but keeps the
+// other APX sub-features such as {nf}.
+//; RUN: %{ispc} %s --target=avx10.2dmr-x16 --opt=disable-apx=egpr --nowrap --emit-asm -o - | FileCheck %s --check-prefix=NO-EGPR
+
+// Disabling all APX sub-features removes both EGPR and {nf} forms.
+//; RUN: %{ispc} %s --target=avx10.2dmr-x16 --opt=disable-apx --nowrap --emit-asm -o - | FileCheck %s --check-prefix=NO-APX
+
+// Reproduce the original multi-target + debug-info (-g) compilation from the
+// issue.
+//; RUN: %{ispc} %s --target=sse4-i32x8,avx2-i32x16,avx512skx-x16,avx10.2dmr-x16 -g --opt=disable-apx=egpr --nowrap --emit-asm -o %t.s
+//; RUN: FileCheck %s --check-prefix=MULTI-G --input-file %t_avx10_2dmr.s
+
+// Exact LLVM target feature strings for each option variant.
+//; RUN: %{ispc} %s --target=avx10.2dmr-x16 --opt=disable-apx --print-target -o /dev/null | FileCheck %s --check-prefix=FEAT-ALL
+//; RUN: %{ispc} %s --target=avx10.2dmr-x16 --opt=disable-apx=egpr --print-target -o /dev/null | FileCheck %s --check-prefix=FEAT-EGPR
+//; RUN: %{ispc} %s --target=avx10.2dmr-x16 --opt=disable-apx=ndd,nf --print-target -o /dev/null | FileCheck %s --check-prefix=FEAT-NDD-NF
+
+// REQUIRES: X86_ENABLED && !MACOS_HOST && LLVM_20_0+
+
+// APX-ON: {nf}
+// APX-ON: %r1{{[6-9]}}
+
+// Only egpr is disabled, so {nf} forms must still be present while no EGPR
+// (R16-R31) is allocated.
+// NO-EGPR: {nf}
+// NO-EGPR-NOT: %r{{(1[6-9]|2[0-9]|3[01])}}
+
+// All APX sub-features are disabled: the function still compiles, but no EGPR
+// and no {nf} forms appear.
+// NO-APX: crunch
+// NO-APX-NOT: %r{{(1[6-9]|2[0-9]|3[01])}}
+// NO-APX-NOT: {nf}
+
+// In the multi-target build the avx10.2dmr variant is compiled and contains no
+// EGPR despite -g being enabled.
+// MULTI-G: crunch
+// MULTI-G-NOT: %r{{(1[6-9]|2[0-9]|3[01])}}
+
+// jmpabs is only known to the LLVM X86 backend from 23.0 on, so it is appended
+// to the feature string only there.
+// FEAT-ALL: Target Feature String: -egpr,-ndd,-push2pop2,-ppx,-ccmp,-cf,-nf,-zu{{(,-jmpabs)?}}
+// FEAT-EGPR: Target Feature String: -egpr
+// FEAT-NDD-NF: Target Feature String: -ndd,-nf
+
+uniform int64 crunch(uniform int64 a, uniform int64 b, uniform int64 c, uniform int64 d, uniform int64 e,
+                     uniform int64 f, uniform int64 g, uniform int64 h, uniform int64 i, uniform int64 j,
+                     uniform int64 k, uniform int64 l) {
+    uniform int64 r = a * b + c * d;
+    r = r * e + f * g;
+    r = r * h + i * j;
+    r = r * k + l * a;
+    r = r ^ (b * c) ^ (d * e);
+    r = r + (f ^ g) * (h ^ i);
+    return r * j + k * l;
+}

--- a/tests/lit-tests/apx-win-unwindv3.ispc
+++ b/tests/lit-tests/apx-win-unwindv3.ispc
@@ -1,0 +1,27 @@
+// On Windows x64, APX-capable targets enable the EGPR registers (R16-R31) by
+// default, which cannot be described by the legacy v1/v2 SEH unwind encodings.
+// ISPC mirrors clang by selecting unwind v3 (the "winx64-eh-unwind" module
+// flag with value 3) so the X86 backend does not error out.
+
+// EGPR enabled (default): the v3 unwind module flag is set.
+//; RUN: %{ispc} %s --target=avx10.2dmr-x16 --arch=x86-64 --target-os=windows --emit-llvm-text -o - | FileCheck %s --check-prefix=V3
+
+// EGPR disabled: no v3 flag is needed.
+//; RUN: %{ispc} %s --target=avx10.2dmr-x16 --arch=x86-64 --target-os=windows --opt=disable-apx=egpr --emit-llvm-text -o - | FileCheck %s --check-prefix=NO-V3
+
+// Non-APX target: no v3 flag.
+//; RUN: %{ispc} %s --target=avx512skx-x16 --arch=x86-64 --target-os=windows --emit-llvm-text -o - | FileCheck %s --check-prefix=NO-V3
+
+// Linux: unwind v3 is Windows-only, so the flag is never set.
+//; RUN: %{ispc} %s --target=avx10.2dmr-x16 --arch=x86-64 --target-os=linux --emit-llvm-text -o - | FileCheck %s --check-prefix=NO-V3
+
+// REQUIRES: X86_ENABLED && WINDOWS_ENABLED && LLVM_23_0+
+
+// V3: !{i32 2, !"winx64-eh-unwind", i32 3}
+
+// NO-V3-NOT: winx64-eh-unwind
+
+void foo(uniform int a[], uniform int n) {
+    for (uniform int i = 0; i < n; ++i)
+        a[i] = a[i] + 1;
+}

--- a/tests/lit-tests/disable-apx-nvl.ispc
+++ b/tests/lit-tests/disable-apx-nvl.ispc
@@ -1,0 +1,21 @@
+// On the avx10.2nvl target (LLVM 23.0+), --opt=disable-apx with no list turns
+// off the whole APX sub-feature set, including jmpabs, even with -g enabled.
+
+//; RUN: %{ispc} %s --target=avx10.2nvl-x16 -g --opt=disable-apx --print-target -o /dev/null | FileCheck %s --check-prefix=FEAT
+//; RUN: %{ispc} %s --target=avx10.2nvl-x16 -g --opt=disable-apx --nowrap --emit-asm -o - | FileCheck %s --check-prefix=ASM
+
+// REQUIRES: X86_ENABLED && !MACOS_HOST && LLVM_23_0+
+
+// FEAT: Target Feature String: -egpr,-ndd,-push2pop2,-ppx,-ccmp,-cf,-nf,-zu,-jmpabs
+
+// All APX sub-features are disabled: no EGPR (R16-R31) and no {nf} forms.
+// ASM: crunch
+// ASM-NOT: %r{{(1[6-9]|2[0-9]|3[01])}}
+// ASM-NOT: {nf}
+
+uniform int64 crunch(uniform int64 a, uniform int64 b, uniform int64 c, uniform int64 d, uniform int64 e,
+                     uniform int64 f, uniform int64 g, uniform int64 h) {
+    uniform int64 r = a * b + c * d;
+    r = r * e + f * g;
+    return r * h + a * b;
+}

--- a/tests/lit-tests/disable-apx.ispc
+++ b/tests/lit-tests/disable-apx.ispc
@@ -1,0 +1,38 @@
+// Tests for the --opt=disable-apx option that turns off x86 APX sub-features.
+
+// An unknown sub-feature name is rejected with a helpful message.
+//; RUN: not %{ispc} %s --target=avx10.2dmr-x16 --opt=disable-apx=egpr,bogus --nowrap -o /dev/null 2>&1 | FileCheck %s --check-prefix=BAD-NAME
+
+// Using the option when no target is APX-capable is a no-op and warns once.
+//; RUN: %{ispc} %s --target=avx2-i32x8 --opt=disable-apx --nowrap -o /dev/null 2>&1 | FileCheck %s --check-prefix=NOOP
+
+// In a multi-target build with at least one APX-capable target the option is
+// effective, so no "no effect" warning is emitted.
+//; RUN: %{ispc} %s --target=avx2-i32x8,avx10.2dmr-x16 --opt=disable-apx --nowrap -o %t.o 2>&1 | FileCheck %s --check-prefix=MULTI --allow-empty
+
+// In a multi-target build where no target is APX-capable the warning is emitted
+// exactly once, not once per target.
+//; RUN: %{ispc} %s --target=sse4-i32x8,avx2-i32x8,avx512skx-x16 --opt=disable-apx --nowrap -o %t.o 2>&1 | FileCheck %s --check-prefix=ONCE
+
+// Empty tokens from leading/embedded commas are tolerated, not rejected.
+//; RUN: %{ispc} %s --target=avx10.2dmr-x16 --opt=disable-apx=,egpr,,nf --print-target -o /dev/null | FileCheck %s --check-prefix=EMPTY-TOK
+
+// REQUIRES: X86_ENABLED && !MACOS_HOST && LLVM_20_0+
+
+// BAD-NAME: Error: Unknown APX sub-feature "bogus" in --opt=disable-apx.
+
+// NOOP: Warning: --opt=disable-apx has no effect: none of the selected targets is APX-capable.
+
+// MULTI-NOT: --opt=disable-apx has no effect
+
+// The warning must appear exactly once regardless of how many non-APX targets
+// are selected.
+// ONCE-COUNT-1: --opt=disable-apx has no effect
+// ONCE-NOT: --opt=disable-apx has no effect
+
+// EMPTY-TOK: Target Feature String: -egpr,-nf
+
+void foo(uniform int a[], uniform int n) {
+    for (uniform int i = 0; i < n; ++i)
+        a[i] = a[i] + 1;
+}

--- a/tests/lit-tests/disable-apx.ispc
+++ b/tests/lit-tests/disable-apx.ispc
@@ -14,6 +14,14 @@
 // exactly once, not once per target.
 //; RUN: %{ispc} %s --target=sse4-i32x8,avx2-i32x8,avx512skx-x16 --opt=disable-apx --nowrap -o %t.o 2>&1 | FileCheck %s --check-prefix=ONCE
 
+// When the APX-capable target is derived from --cpu rather than spelled out
+// with --target, the option is still effective, so no "no effect" warning is
+// emitted (regression test: the check must run after target resolution).
+//; RUN: %{ispc} %s --cpu=dmr --opt=disable-apx --nowrap -o %t.o 2>&1 | FileCheck %s --check-prefix=CPU-DERIVED --allow-empty
+
+// Conversely, a non-APX target derived from --cpu still warns.
+//; RUN: %{ispc} %s --cpu=skx --opt=disable-apx --nowrap -o %t.o 2>&1 | FileCheck %s --check-prefix=CPU-NOOP
+
 // Empty tokens from leading/embedded commas are tolerated, not rejected.
 //; RUN: %{ispc} %s --target=avx10.2dmr-x16 --opt=disable-apx=,egpr,,nf --print-target -o /dev/null | FileCheck %s --check-prefix=EMPTY-TOK
 
@@ -24,6 +32,10 @@
 // NOOP: Warning: --opt=disable-apx has no effect: none of the selected targets is APX-capable.
 
 // MULTI-NOT: --opt=disable-apx has no effect
+
+// CPU-DERIVED-NOT: --opt=disable-apx has no effect
+
+// CPU-NOOP: Warning: --opt=disable-apx has no effect: none of the selected targets is APX-capable.
 
 // The warning must appear exactly once regardless of how many non-APX targets
 // are selected.


### PR DESCRIPTION
## Description

Adds a knob to disable x86 APX sub-features and makes ISPC emit the correct Windows x64 stack-unwind information when APX extended registers are in use.

Changes

  - `--opt=disable-apx[=<list>]` — disables x86 APX sub-features (egpr, ndd, push2pop2, ppx, ccmp, cf, nf, zu, and jmpabs on LLVM 23+), which are on by default for APX-capable targets (avx10.2dmr, avx10.2nvl). With no list it disables all; otherwise a comma-separated subset.
  - Windows x64 unwind v3 — on Windows, when an APX-capable target has egpr enabled, ISPC now sets the `winx64-eh-unwind` module flag to v3, mirroring Clang. The legacy v1/v2 SEH encodings cannot describe R16-R31, and the LLVM X86 backend errors out otherwise. --opt=disable-apx=egpr restores compatibility with older unwinders and drops the v3 request. Gated on LLVM 23.0+.

Plus CI and docs updates.

## Related Issue
- [x] Fixes #3758 

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [x] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed