### PR TITLE
Fix build with LLVM trunk: cast CreateIntrinsic result to CallInst

### DIFF
--- a/src/opt/LowerAMXBuiltinsPass.cpp
+++ b/src/opt/LowerAMXBuiltinsPass.cpp
@@ -122,7 +122,8 @@ static llvm::CallInst *lLowerAMXTileZeroBuiltin(llvm::CallInst *CI) {
 
     if (auto *CTile = lValidateAMXTileArgument(CI, TileOp)) {
         llvm::SmallVector<llvm::Value *, 1> Ops({CTile});
-        return builder.CreateIntrinsic(llvm::Type::getVoidTy(builder.getContext()), llvm::Intrinsic::x86_tilezero, Ops);
+        return llvm::cast<llvm::CallInst>(
+            builder.CreateIntrinsic(llvm::Type::getVoidTy(builder.getContext()), llvm::Intrinsic::x86_tilezero, Ops));
     } else {
         return nullptr;
     }
@@ -150,7 +151,8 @@ static llvm::CallInst *lLowerAMXLoadStoreBuiltin(llvm::CallInst *CI) {
     }
 
     llvm::SmallVector<llvm::Value *, 3> Ops({CTile, CI->getArgOperand(1), CI->getArgOperand(2)});
-    return builder.CreateIntrinsic(llvm::Type::getVoidTy(builder.getContext()), LoadStoreID, Ops);
+    return llvm::cast<llvm::CallInst>(
+        builder.CreateIntrinsic(llvm::Type::getVoidTy(builder.getContext()), LoadStoreID, Ops));
 }
 
 static llvm::CallInst *lLowerAMXDotProductBuiltin(llvm::CallInst *CI) {
@@ -184,7 +186,8 @@ static llvm::CallInst *lLowerAMXDotProductBuiltin(llvm::CallInst *CI) {
     }
 
     llvm::SmallVector<llvm::Value *, 3> Ops({DstTile, Src1Tile, Src2Tile});
-    return builder.CreateIntrinsic(llvm::Type::getVoidTy(builder.getContext()), DotProdID, Ops);
+    return llvm::cast<llvm::CallInst>(
+        builder.CreateIntrinsic(llvm::Type::getVoidTy(builder.getContext()), DotProdID, Ops));
 }
 
 static bool lRunOnBasicBlock(llvm::BasicBlock &BB) {


### PR DESCRIPTION
LLVM trunk changed IRBuilder::CreateIntrinsic to return Value* instead of CallInst* to allow constant folding. Cast the result back to CallInst* which is safe for these void AMX intrinsics that are never folded.

## Related Issue
- [ ] Fixes #3864 

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed