### PR TITLE
Bump ISPC version

### DIFF
--- a/common/version.h
+++ b/common/version.h
@@ -11,6 +11,6 @@
 #pragma once
 
 #define ISPC_VERSION_MAJOR 1
-#define ISPC_VERSION_MINOR 31
+#define ISPC_VERSION_MINOR 32
 #define ISPC_VERSION_PATCH 0
-#define ISPC_VERSION "1.31.0dev"
+#define ISPC_VERSION "1.32.0dev"

--- a/docker/ubuntu/18.04/xpu_ispc_build/Dockerfile
+++ b/docker/ubuntu/18.04/xpu_ispc_build/Dockerfile
@@ -57,19 +57,17 @@ RUN if [[ $(uname -m) =~ "x86" ]]; then \
 # intrinsics (-mwaitpkg, _tpause), but Ubuntu 18.04's binutils 2.30 assembler
 # does not know the 'tpause' instruction (needs >= 2.32), so a GCC 11 build
 # fails to assemble. GCC 7 does not enable that code path.
-RUN if [ "$XE_DEPS" == "ON" ]; then \
-        git clone --depth 1 --branch v2021.13.0 https://github.com/oneapi-src/oneTBB.git /tmp/oneTBB && \
-        cmake -S /tmp/oneTBB -B /tmp/oneTBB/build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DTBB_TEST=OFF \
-            -DCMAKE_C_COMPILER=gcc-7 \
-            -DCMAKE_CXX_COMPILER=g++-7 \
-            -DCMAKE_INSTALL_PREFIX=/opt/intel/oneapi/tbb/2021.13 && \
-        cmake --build /tmp/oneTBB/build -j"$(nproc)" && \
-        cmake --install /tmp/oneTBB/build && \
-        rm -rf /tmp/oneTBB && \
-        ln -s /opt/intel/oneapi/tbb/2021.13 /opt/intel/oneapi/tbb/latest; \
-    fi
+RUN git clone --depth 1 --branch v2021.13.0 https://github.com/oneapi-src/oneTBB.git /tmp/oneTBB && \
+    cmake -S /tmp/oneTBB -B /tmp/oneTBB/build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DTBB_TEST=OFF \
+        -DCMAKE_C_COMPILER=gcc-7 \
+        -DCMAKE_CXX_COMPILER=g++-7 \
+        -DCMAKE_INSTALL_PREFIX=/opt/intel/oneapi/tbb/2021.13 && \
+    cmake --build /tmp/oneTBB/build -j"$(nproc)" && \
+    cmake --install /tmp/oneTBB/build && \
+    rm -rf /tmp/oneTBB && \
+    ln -s /opt/intel/oneapi/tbb/2021.13 /opt/intel/oneapi/tbb/latest
 
 # Set TBB_ROOT to point to oneAPI TBB installation
 ENV TBB_ROOT=/opt/intel/oneapi/tbb/latest

--- a/docker/v1.31.0/ubuntu18.04/Dockerfile
+++ b/docker/v1.31.0/ubuntu18.04/Dockerfile
@@ -60,19 +60,17 @@ RUN if [[ $(uname -m) =~ "x86" ]]; then \
 # intrinsics (-mwaitpkg, _tpause), but Ubuntu 18.04's binutils 2.30 assembler
 # does not know the 'tpause' instruction (needs >= 2.32), so a GCC 11 build
 # fails to assemble. GCC 7 does not enable that code path.
-RUN if [ "$XE_DEPS" == "ON" ]; then \
-        git clone --depth 1 --branch v2021.13.0 https://github.com/oneapi-src/oneTBB.git /tmp/oneTBB && \
-        cmake -S /tmp/oneTBB -B /tmp/oneTBB/build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DTBB_TEST=OFF \
-            -DCMAKE_C_COMPILER=gcc-7 \
-            -DCMAKE_CXX_COMPILER=g++-7 \
-            -DCMAKE_INSTALL_PREFIX=/opt/intel/oneapi/tbb/2021.13 && \
-        cmake --build /tmp/oneTBB/build -j"$(nproc)" && \
-        cmake --install /tmp/oneTBB/build && \
-        rm -rf /tmp/oneTBB && \
-        ln -s /opt/intel/oneapi/tbb/2021.13 /opt/intel/oneapi/tbb/latest; \
-    fi
+RUN git clone --depth 1 --branch v2021.13.0 https://github.com/oneapi-src/oneTBB.git /tmp/oneTBB && \
+    cmake -S /tmp/oneTBB -B /tmp/oneTBB/build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DTBB_TEST=OFF \
+        -DCMAKE_C_COMPILER=gcc-7 \
+        -DCMAKE_CXX_COMPILER=g++-7 \
+        -DCMAKE_INSTALL_PREFIX=/opt/intel/oneapi/tbb/2021.13 && \
+    cmake --build /tmp/oneTBB/build -j"$(nproc)" && \
+    cmake --install /tmp/oneTBB/build && \
+    rm -rf /tmp/oneTBB && \
+    ln -s /opt/intel/oneapi/tbb/2021.13 /opt/intel/oneapi/tbb/latest
 
 # Set TBB_ROOT to point to oneAPI TBB installation
 ENV TBB_ROOT=/opt/intel/oneapi/tbb/latest


### PR DESCRIPTION
## Description
Bump ISPC version to v1.32.0dev and cherry-pick a docker aarch64 fix from release branch.

## Related Issue
- [ ] Linked to relevant issue(s)

## Checklist
- [ ] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [ ] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed