### PR TITLE
Fix missing reference to roundeven + fix bad round call on double-precision

### DIFF
--- a/builtins/generic.ispc
+++ b/builtins/generic.ispc
@@ -447,10 +447,66 @@ EXT READNONE uniform double __floor_uniform_double(uniform double x) { return @l
 EXT READNONE uniform float __floor_uniform_float(uniform float x) { return @llvm.floor(x); }
 EXT READNONE varying double __floor_varying_double(varying double x) { return @llvm.floor(x); }
 EXT READNONE varying float __floor_varying_float(varying float x) { return @llvm.floor(x); }
-EXT READNONE uniform double __round_uniform_double(uniform double x) { return @llvm.roundeven(x); }
-EXT READNONE uniform float __round_uniform_float(uniform float x) { return @llvm.roundeven(x); }
-EXT READNONE varying double __round_varying_double(varying double x) { return @llvm.roundeven(x); }
-EXT READNONE varying float __round_varying_float(varying float x) { return @llvm.roundeven(x); }
+
+// There are not any rounding instructions in SSE2 and the roundeven function
+// (defined in C23) is not defined in the MSVC's CRT yet.
+// Thus, calling llvm.roundeven on SSE2 systems would results in an error. 
+// So we have to emulate the functionality with multiple instructions...
+// This code is initially comming from the SSE2 target file.
+EXT READNONE uniform float __round_uniform_float(uniform float x) {
+    uniform uint32 ix = __intbits_uniform_float(x);
+    const uniform uint32 sign = ix & 0x80000000lu;
+    ix ^= sign;
+    x = __floatbits_uniform_int32(ix);
+    x += 0x1.0p23f;
+    x -= 0x1.0p23f;
+    ix = __intbits_uniform_float(x);
+    ix ^= sign;
+    x = __floatbits_uniform_int32(ix);
+    return x;
+}
+
+// See __round_uniform_float for more information
+EXT READNONE varying float __round_varying_float(varying float x) {
+    uint32 ix = __intbits_varying_float(x);
+    const uint32 sign = ix & 0x80000000lu;
+    ix ^= sign;
+    x = __floatbits_varying_int32(ix);
+    x += 0x1.0p23f;
+    x -= 0x1.0p23f;
+    ix = __intbits_varying_float(x);
+    ix ^= sign;
+    x = __floatbits_varying_int32(ix);
+    return x;
+}
+
+// See __round_uniform_float for more information
+EXT READNONE uniform double __round_uniform_double(uniform double x) {
+    uniform uint64 ix = __intbits_uniform_double(x);
+    const uniform uint64 sign = ix & 0x8000000000000000llu;
+    ix ^= sign;
+    x = __doublebits_uniform_int64(ix);
+    x += 0x1.0p52d;
+    x -= 0x1.0p52d;
+    ix = __intbits_uniform_double(x);
+    ix ^= sign;
+    x = __doublebits_uniform_int64(ix);
+    return x;
+}
+
+// See __round_uniform_float for more information
+EXT READNONE varying double __round_varying_double(varying double x) {
+    uint64 ix = __intbits_varying_double(x);
+    const uint64 sign = ix & 0x8000000000000000llu;
+    ix ^= sign;
+    x = __doublebits_varying_int64(ix);
+    x += 0x1.0p52d;
+    x -= 0x1.0p52d;
+    ix = __intbits_varying_double(x);
+    ix ^= sign;
+    x = __doublebits_varying_int64(ix);
+    return x;
+}
 
 // rcp
 EXT READNONE uniform float __rcp_fast_uniform_float(uniform float x) { return 1 / x; }

--- a/builtins/generic.ispc
+++ b/builtins/generic.ispc
@@ -450,7 +450,7 @@ EXT READNONE varying float __floor_varying_float(varying float x) { return @llvm
 
 // There are not any rounding instructions in SSE2 and the roundeven function
 // (defined in C23) is not defined in the MSVC's CRT yet.
-// Thus, calling llvm.roundeven on SSE2 systems would results in an error. 
+// Thus, calling llvm.roundeven on SSE2 systems would results in an error.
 // So we have to emulate the functionality with multiple instructions...
 // This code is initially comming from the SSE2 target file.
 EXT READNONE uniform float __round_uniform_float(uniform float x) {

--- a/builtins/target-avx512-utils.ll
+++ b/builtins/target-avx512-utils.ll
@@ -100,6 +100,14 @@ define double @__max_uniform_double(double, double) nounwind readnone alwaysinli
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; round
+
+define double @__round_uniform_double(double) nounwind readonly alwaysinline {
+  %res = call double @llvm.roundeven(double %0)
+  ret double %res
+}
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rsqrt
 
 define(`rsqrt14_uniform', `

--- a/builtins/target-avx512-utils.ll
+++ b/builtins/target-avx512-utils.ll
@@ -102,6 +102,11 @@ define double @__max_uniform_double(double, double) nounwind readnone alwaysinli
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; round
 
+define float @__round_uniform_float(float) nounwind readonly alwaysinline {
+  %res = call float @llvm.roundeven(float %0)
+  ret float %res
+}
+
 define double @__round_uniform_double(double) nounwind readonly alwaysinline {
   %res = call double @llvm.roundeven(double %0)
   ret double %res

--- a/builtins/target-avx512skx-x16-nozmm.ll
+++ b/builtins/target-avx512skx-x16-nozmm.ll
@@ -268,6 +268,19 @@ define <16 x double> @__max_varying_double(<16 x double>, <16 x double>) nounwin
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; round
+
+define <16 x float> @__round_varying_float(<16 x float>) nounwind readonly alwaysinline {
+  %res = call <16 x float> @llvm.roundeven(<16 x float> %0)
+  ret <16 x float> %res
+}
+
+define <16 x double> @__round_varying_double(<16 x double>) nounwind readonly alwaysinline {
+  %res = call <16 x double> @llvm.roundeven(<16 x double> %0)
+  ret <16 x double> %res
+}
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; sqrt
 
 declare <8 x float> @llvm.x86.avx512.mask.sqrt.ps.256(<8 x float>, <8 x float>, i8) nounwind readnone

--- a/builtins/target-avx512skx-x16.ll
+++ b/builtins/target-avx512skx-x16.ll
@@ -360,6 +360,19 @@ define <16 x double> @__max_varying_double(<16 x double>, <16 x double>) nounwin
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; round
+
+define <16 x float> @__round_varying_float(<16 x float>) nounwind readonly alwaysinline {
+  %res = call <16 x float> @llvm.roundeven(<16 x float> %0)
+  ret <16 x float> %res
+}
+
+define <16 x double> @__round_varying_double(<16 x double>) nounwind readonly alwaysinline {
+  %res = call <16 x double> @llvm.roundeven(<16 x double> %0)
+  ret <16 x double> %res
+}
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; sqrt
 
 declare <16 x float> @llvm.x86.avx512.mask.sqrt.ps.512(<16 x float>, <16 x float>, i16, i32) nounwind readnone

--- a/builtins/target-avx512skx-x32.ll
+++ b/builtins/target-avx512skx-x32.ll
@@ -352,6 +352,19 @@ define <WIDTH x float> @__max_varying_float(<WIDTH x float>,
   ret <WIDTH x float> %r
 }
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; round
+
+define <WIDTH x float> @__round_varying_float(<WIDTH x float>) nounwind readonly alwaysinline {
+  %res = call <WIDTH x float> @llvm.roundeven(<WIDTH x float> %0)
+  ret <WIDTH x float> %res
+}
+
+define <WIDTH x double> @__round_varying_double(<WIDTH x double>) nounwind readonly alwaysinline {
+  %res = call <WIDTH x double> @llvm.roundeven(<WIDTH x double> %0)
+  ret <WIDTH x double> %res
+}
+
 ;; sqrt/rsqrt/rcp
 ;; TODO: need to use intrinsics and N-R approximation.
 

--- a/builtins/target-avx512skx-x4.ll
+++ b/builtins/target-avx512skx-x4.ll
@@ -311,6 +311,19 @@ define <4 x double> @__max_varying_double(<4 x double>, <4 x double>) nounwind r
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; round
+
+define <4 x float> @__round_varying_float(<4 x float>) nounwind readonly alwaysinline {
+  %res = call <4 x float> @llvm.roundeven(<4 x float> %0)
+  ret <4 x float> %res
+}
+
+define <4 x double> @__round_varying_double(<4 x double>) nounwind readonly alwaysinline {
+  %res = call <4 x double> @llvm.roundeven(<4 x double> %0)
+  ret <4 x double> %res
+}
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; sqrt
 
 declare <4 x float> @llvm.x86.avx512.mask.sqrt.ps.128(<4 x float>, <4 x float>, i8) nounwind readnone

--- a/builtins/target-avx512skx-x64.ll
+++ b/builtins/target-avx512skx-x64.ll
@@ -330,6 +330,19 @@ define <WIDTH x float> @__max_varying_float(<WIDTH x float>,
   ret <WIDTH x float> %r
 }
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; round
+
+define <WIDTH x float> @__round_varying_float(<WIDTH x float>) nounwind readonly alwaysinline {
+  %res = call <WIDTH x float> @llvm.roundeven(<WIDTH x float> %0)
+  ret <WIDTH x float> %res
+}
+
+define <WIDTH x double> @__round_varying_double(<WIDTH x double>) nounwind readonly alwaysinline {
+  %res = call <WIDTH x double> @llvm.roundeven(<WIDTH x double> %0)
+  ret <WIDTH x double> %res
+}
+
 ;; sqrt/rsqrt/rcp
 ;; TODO: need to use intrinsics and N-R approximation.
 

--- a/builtins/target-avx512skx-x8.ll
+++ b/builtins/target-avx512skx-x8.ll
@@ -341,6 +341,19 @@ define <8 x double> @__max_varying_double(<8 x double>, <8 x double>) nounwind r
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; round
+
+define <8 x float> @__round_varying_float(<8 x float>) nounwind readonly alwaysinline {
+  %res = call <8 x float> @llvm.roundeven(<8 x float> %0)
+  ret <8 x float> %res
+}
+
+define <8 x double> @__round_varying_double(<8 x double>) nounwind readonly alwaysinline {
+  %res = call <8 x double> @llvm.roundeven(<8 x double> %0)
+  ret <8 x double> %res
+}
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; sqrt
 
 declare <8 x float> @llvm.x86.avx512.mask.sqrt.ps.256(<8 x float>, <8 x float>, i8) nounwind readnone

--- a/builtins/target-neon-common.ll
+++ b/builtins/target-neon-common.ll
@@ -75,6 +75,29 @@ define i16 @__float_to_half_uniform(float %v) nounwind readnone alwaysinline {
 ')
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; round
+
+define float @__round_uniform_float(float) nounwind readonly alwaysinline {
+  %res = call float @llvm.roundeven(float %0)
+  ret float %res
+}
+
+define double @__round_uniform_double(double) nounwind readonly alwaysinline {
+  %res = call double @llvm.roundeven(double %0)
+  ret double %res
+}
+
+define <WIDTH x float> @__round_varying_float(<WIDTH x float>) nounwind readonly alwaysinline {
+  %res = call <WIDTH x float> @llvm.roundeven(<WIDTH x float> %0)
+  ret <WIDTH x float> %res
+}
+
+define <WIDTH x double> @__round_varying_double(<WIDTH x double>) nounwind readonly alwaysinline {
+  %res = call <WIDTH x double> @llvm.roundeven(<WIDTH x double> %0)
+  ret <WIDTH x double> %res
+}
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; math
 
 define(`math_flags_functions',

--- a/builtins/target-sse2-common.ll
+++ b/builtins/target-sse2-common.ll
@@ -236,23 +236,37 @@ define float @__ceil_uniform_float(float) nounwind readonly alwaysinline {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rounding doubles
 
-declare double @round(double)
-declare double @floor(double)
-declare double @ceil(double)
-
 define double @__round_uniform_double(double) nounwind readonly alwaysinline {
-  %r = call double @round(double %0)
-  ret double %r
+  %double_to_int_bitcast.i.i.i.i = bitcast double %0 to i64
+  %bitop.i.i = and i64 %double_to_int_bitcast.i.i.i.i, -9223372036854775808
+  %bitop.i = xor i64 %bitop.i.i, %double_to_int_bitcast.i.i.i.i
+  %int64_to_double_bitcast.i.i40.i = bitcast i64 %bitop.i to double
+  %binop.i = fadd double %int64_to_double_bitcast.i.i40.i, 0x4330000000000000
+  %binop21.i = fadd double %binop.i, 0xC330000000000000
+  %double_to_int_bitcast.i.i.i = bitcast double %binop21.i to i64
+  %bitop31.i = xor i64 %double_to_int_bitcast.i.i.i, %bitop.i.i
+  %int64_to_double_bitcast.i.i.i = bitcast i64 %bitop31.i to double
+  ret double %int64_to_double_bitcast.i.i.i
 }
 
 define double @__floor_uniform_double(double) nounwind readonly alwaysinline {
-  %r = call double @floor(double %0)
-  ret double %r
+  %calltmp.i = tail call double @__round_uniform_double(double %0) nounwind
+  %bincmp.i = fcmp ogt double %calltmp.i, %0
+  %selectexpr.i = sext i1 %bincmp.i to i64
+  %bitop.i = and i64 %selectexpr.i, -4616189618054758400
+  %int64_to_double_bitcast.i.i.i = bitcast i64 %bitop.i to double
+  %binop.i = fadd double %calltmp.i, %int64_to_double_bitcast.i.i.i
+  ret double %binop.i
 }
 
 define double @__ceil_uniform_double(double) nounwind readonly alwaysinline {
-  %r = call double @ceil(double %0)
-  ret double %r
+  %calltmp.i = tail call double @__round_uniform_double(double %0) nounwind
+  %bincmp.i = fcmp olt double %calltmp.i, %0
+  %selectexpr.i = sext i1 %bincmp.i to i64
+  %bitop.i = and i64 %selectexpr.i, 4607182418800017408
+  %int64_to_double_bitcast.i.i.i = bitcast i64 %bitop.i to double
+  %binop.i = fadd double %calltmp.i, %int64_to_double_bitcast.i.i.i
+  ret double %binop.i
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/builtins/target-sse2-i32x4.ll
+++ b/builtins/target-sse2-i32x4.ll
@@ -103,15 +103,36 @@ define <4 x float> @__ceil_varying_float(<4 x float>) nounwind readonly alwaysin
 ;; rounding doubles
 
 define <4 x double> @__round_varying_double(<4 x double>) nounwind readonly alwaysinline {
-  unary1to4(double, @round)
+  %double_to_int_bitcast.i.i.i.i = bitcast <4 x double> %0 to <4 x i64>
+  %bitop.i.i = and <4 x i64> %double_to_int_bitcast.i.i.i.i, splat (i64 -9223372036854775808)
+  %bitop.i = xor <4 x i64> %double_to_int_bitcast.i.i.i.i, %bitop.i.i
+  %int64_to_double_bitcast.i.i40.i = bitcast <4 x i64> %bitop.i to <4 x double>
+  %binop.i = fadd <4 x double> %int64_to_double_bitcast.i.i40.i, splat (double 0x4330000000000000)
+  %binop21.i = fadd <4 x double> %binop.i, splat (double 0xC330000000000000)
+  %double_to_int_bitcast.i.i.i = bitcast <4 x double> %binop21.i to <4 x i64>
+  %bitop31.i = xor <4 x i64> %double_to_int_bitcast.i.i.i, %bitop.i.i
+  %int64_to_double_bitcast.i.i.i = bitcast <4 x i64> %bitop31.i to <4 x double>
+  ret <4 x double> %int64_to_double_bitcast.i.i.i
 }
 
 define <4 x double> @__floor_varying_double(<4 x double>) nounwind readonly alwaysinline {
-  unary1to4(double, @floor)
+  %calltmp.i = tail call <4 x double> @__round_varying_double(<4 x double> %0) nounwind
+  %bincmp.i = fcmp ogt <4 x double> %calltmp.i, %0
+  %val_to_boolvec64.i = sext <4 x i1> %bincmp.i to <4 x i64>
+  %bitop.i = and <4 x i64> %val_to_boolvec64.i, splat (i64 -4616189618054758400)
+  %int64_to_double_bitcast.i.i.i = bitcast <4 x i64> %bitop.i to <4 x double>
+  %binop.i = fadd <4 x double> %calltmp.i, %int64_to_double_bitcast.i.i.i
+  ret <4 x double> %binop.i
 }
 
 define <4 x double> @__ceil_varying_double(<4 x double>) nounwind readonly alwaysinline {
-  unary1to4(double, @ceil)
+  %calltmp.i = tail call <4 x double> @__round_varying_double(<4 x double> %0) nounwind
+  %bincmp.i = fcmp olt <4 x double> %calltmp.i, %0
+  %val_to_boolvec64.i = sext <4 x i1> %bincmp.i to <4 x i64>
+  %bitop.i = and <4 x i64> %val_to_boolvec64.i, splat (i64 4607182418800017408)
+  %int64_to_double_bitcast.i.i.i = bitcast <4 x i64> %bitop.i to <4 x double>
+  %binop.i = fadd <4 x double> %calltmp.i, %int64_to_double_bitcast.i.i.i
+  ret <4 x double> %binop.i
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/builtins/target-sse2-i32x8.ll
+++ b/builtins/target-sse2-i32x8.ll
@@ -378,15 +378,36 @@ define <8 x float> @__ceil_varying_float(<8 x float>) nounwind readonly alwaysin
 ;; rounding doubles
 
 define <8 x double> @__round_varying_double(<8 x double>) nounwind readonly alwaysinline {
-  unary1to8(double, @round)
+  %double_to_int_bitcast.i.i.i.i = bitcast <8 x double> %0 to <8 x i64>
+  %bitop.i.i = and <8 x i64> %double_to_int_bitcast.i.i.i.i, splat (i64 -9223372036854775808)
+  %bitop.i = xor <8 x i64> %double_to_int_bitcast.i.i.i.i, %bitop.i.i
+  %int64_to_double_bitcast.i.i40.i = bitcast <8 x i64> %bitop.i to <8 x double>
+  %binop.i = fadd <8 x double> %int64_to_double_bitcast.i.i40.i, splat (double 0x4330000000000000)
+  %binop21.i = fadd <8 x double> %binop.i, splat (double 0xC330000000000000)
+  %double_to_int_bitcast.i.i.i = bitcast <8 x double> %binop21.i to <8 x i64>
+  %bitop31.i = xor <8 x i64> %double_to_int_bitcast.i.i.i, %bitop.i.i
+  %int64_to_double_bitcast.i.i.i = bitcast <8 x i64> %bitop31.i to <8 x double>
+  ret <8 x double> %int64_to_double_bitcast.i.i.i
 }
 
 define <8 x double> @__floor_varying_double(<8 x double>) nounwind readonly alwaysinline {
-  unary1to8(double, @floor)
+  %calltmp.i = tail call <8 x double> @__round_varying_double(<8 x double> %0) nounwind
+  %bincmp.i = fcmp ogt <8 x double> %calltmp.i, %0
+  %val_to_boolvec64.i = sext <8 x i1> %bincmp.i to <8 x i64>
+  %bitop.i = and <8 x i64> %val_to_boolvec64.i, splat (i64 -4616189618054758400)
+  %int64_to_double_bitcast.i.i.i = bitcast <8 x i64> %bitop.i to <8 x double>
+  %binop.i = fadd <8 x double> %calltmp.i, %int64_to_double_bitcast.i.i.i
+  ret <8 x double> %binop.i
 }
 
 define <8 x double> @__ceil_varying_double(<8 x double>) nounwind readonly alwaysinline {
-  unary1to8(double, @ceil)
+  %calltmp.i = tail call <8 x double> @__round_varying_double(<8 x double> %0) nounwind
+  %bincmp.i = fcmp olt <8 x double> %calltmp.i, %0
+  %val_to_boolvec64.i = sext <8 x i1> %bincmp.i to <8 x i64>
+  %bitop.i = and <8 x i64> %val_to_boolvec64.i, splat (i64 4607182418800017408)
+  %int64_to_double_bitcast.i.i.i = bitcast <8 x i64> %bitop.i to <8 x double>
+  %binop.i = fadd <8 x double> %calltmp.i, %int64_to_double_bitcast.i.i.i
+  ret <8 x double> %binop.i
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/tests/func-tests/round-float-uniform.ispc
+++ b/tests/func-tests/round-float-uniform.ispc
@@ -1,5 +1,4 @@
 #include "test_static.isph"
-// rule: skip on target=generic.*
 // rule: run on OS=!windows
 
 task void f_f(uniform float RET[], uniform float aFOO[]) {

--- a/tests/func-tests/round-float-varying.ispc
+++ b/tests/func-tests/round-float-varying.ispc
@@ -1,5 +1,4 @@
 #include "test_static.isph"
-// rule: skip on target=generic.*
 // rule: run on OS=!windows
 // rule: skip on arch=ppc64le
 

--- a/tests/lit-tests/2780-1.ispc
+++ b/tests/lit-tests/2780-1.ispc
@@ -1,4 +1,5 @@
 // RUN: %{ispc} --pic --target=avx512skx-x8 -h %t.h %s -o %t.o
+// RUN: %{ispc} --pic --target=avx2-i32x8 -h %t.h %s -o %t.o
 // RUN: %{cc} -x c -c %s -o %t.c.o --include %t.h
 // RUN: %{cc} %t.o %t.c.o -o %t.c.bin
 // RUN: %t.c.bin | FileCheck %s

--- a/tests/lit-tests/2780-2.ispc
+++ b/tests/lit-tests/2780-2.ispc
@@ -1,0 +1,22 @@
+// RUN: %{ispc} --pic --target=neon-i32x4 %s --x86-asm-syntax=intel --emit-asm -o - | FileCheck %s
+
+// REQUIRES: ARM_ENABLED
+
+// CHECK-LABEL: RoundToInt___vyf:{{.*}}
+// CHECK-NEXT: // %bb.0:
+// CHECK-NEXT: frintn  v0.4s, v0.4s
+// CHECK-NEXT: ret
+float RoundToInt(float x)
+{
+    return round(x);
+}
+
+// CHECK-LABEL: RoundToInt___vyd:{{.*}}
+// CHECK-NEXT: // %bb.0:
+// CHECK-NEXT: frintn  v0.2d, v0.2d
+// CHECK-NEXT: frintn  v1.2d, v1.2d
+// CHECK-NEXT: ret
+double RoundToInt(double x)
+{
+    return round(x);
+}

--- a/tests/lit-tests/2780-2.ispc
+++ b/tests/lit-tests/2780-2.ispc
@@ -3,7 +3,7 @@
 // REQUIRES: ARM_ENABLED
 
 // CHECK-LABEL: RoundToInt___vyf:{{.*}}
-// CHECK-NEXT: // %bb.0:
+// CHECK-NEXT: {{.*}}%bb.0:
 // CHECK-NEXT: frintn  v0.4s, v0.4s
 // CHECK-NEXT: ret
 float RoundToInt(float x)
@@ -12,7 +12,7 @@ float RoundToInt(float x)
 }
 
 // CHECK-LABEL: RoundToInt___vyd:{{.*}}
-// CHECK-NEXT: // %bb.0:
+// CHECK-NEXT: {{.*}}%bb.0:
 // CHECK-NEXT: frintn  v0.2d, v0.2d
 // CHECK-NEXT: frintn  v1.2d, v1.2d
 // CHECK-NEXT: ret

--- a/tests/lit-tests/2780-2.ispc
+++ b/tests/lit-tests/2780-2.ispc
@@ -1,4 +1,4 @@
-// RUN: %{ispc} --pic --target=neon-i32x4 %s --x86-asm-syntax=intel --emit-asm -o - | FileCheck %s
+// RUN: %{ispc} --pic --target=neon-i32x4 %s --emit-asm -o - | FileCheck %s
 
 // REQUIRES: ARM_ENABLED
 

--- a/tests/lit-tests/2780-2.ispc
+++ b/tests/lit-tests/2780-2.ispc
@@ -3,8 +3,7 @@
 // REQUIRES: ARM_ENABLED
 
 // CHECK-LABEL: RoundToInt___vyf:{{.*}}
-// CHECK-NEXT: {{.*}}%bb.0:
-// CHECK-NEXT: frintn  v0.4s, v0.4s
+// CHECK: frintn{{.*4s.*}}
 // CHECK-NEXT: ret
 float RoundToInt(float x)
 {
@@ -12,9 +11,8 @@ float RoundToInt(float x)
 }
 
 // CHECK-LABEL: RoundToInt___vyd:{{.*}}
-// CHECK-NEXT: {{.*}}%bb.0:
-// CHECK-NEXT: frintn  v0.2d, v0.2d
-// CHECK-NEXT: frintn  v1.2d, v1.2d
+// CHECK: frintn{{.*2d.*}}
+// CHECK-NEXT: frintn{{.*2d.*}}
 // CHECK-NEXT: ret
 double RoundToInt(double x)
 {

--- a/tests/lit-tests/2780.ispc
+++ b/tests/lit-tests/2780.ispc
@@ -11,3 +11,13 @@ float RoundToInt(float x)
 {
     return round(x);
 }
+
+// CHECK-LABEL: RoundToInt___vyd:
+// CHECK-NEXT: # %bb.0:
+// CHECK-NEXT: vroundpd        ymm0, {{.*}}, 8
+// CHECK-NEXT: vroundpd        ymm1, {{.*}}, 8
+// CHECK-NEXT: ret
+double RoundToInt(double x)
+{
+    return round(x);
+}

--- a/tests/lit-tests/2780.ispc
+++ b/tests/lit-tests/2780.ispc
@@ -1,4 +1,5 @@
 // RUN: %{ispc} --pic --target=avx512skx-x8 %s --x86-asm-syntax=intel --emit-asm -o - | FileCheck %s
+// RUN: %{ispc} --pic --target=avx2-i32x8 %s --x86-asm-syntax=intel --emit-asm -o - | FileCheck %s
 
 // REQUIRES: !MACOS_HOST && X86_ENABLED
 


### PR DESCRIPTION
Everything is in the name. This PR fix the issue detected #3818 (in tests filing on Windows).

I did not test this thoroughly yet. Please note that the IR code has been modified manually and has not been automatically  generated (it matter for the review).
As discussed in #3818, this probably impact performance of rounding operations on targets using generic targets like RISC-V and POWER.

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [ ] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed