### PR TITLE
Fix #3159: Adapt to LLVM 23 API change for AArch64 CPU extensions

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -156,7 +156,13 @@ static std::vector<llvm::StringRef> lGetARMTargetFeatures(Arch arch, const std::
                 return {};
             }
             using CpuExtensionsType = llvm::AArch64::ExtensionBitset;
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+            // LLVM 23 removed CpuInfo::getImpliedExtensions(); access the
+            // DefaultExtensions field directly (llvm/llvm-project#206422).
+            CpuExtensionsType cpuExtensions = cpuInfo->DefaultExtensions;
+#else
             CpuExtensionsType cpuExtensions = cpuInfo->getImpliedExtensions();
+#endif
             llvm::AArch64::getExtensionFeatures(cpuExtensions, targetFeatures);
         } else {
             UNREACHABLE();


### PR DESCRIPTION
LLVM trunk (23.0) removed `CpuInfo::getImpliedExtensions()` method. This PR adds a version guard to:
- Access the `DefaultExtensions` field directly for LLVM 23+
- Maintain backward compatibility with LLVM 22 and earlier

The fix follows the pattern established in the codebase for LLVM version-specific changes.

Generated with [Claude Code](https://claude.ai/code)