### PR TITLE
Fix crashing gather index

### DIFF
--- a/src/llvmutil.cpp
+++ b/src/llvmutil.cpp
@@ -11,6 +11,7 @@
 #include "llvmutil.h"
 #include "type.h"
 
+#include <climits>
 #include <cstdlib>
 #include <map>
 #include <set>
@@ -995,6 +996,14 @@ static bool lAllDivBaseEqual(llvm::Value *val, int64_t baseValue, int vectorLeng
         // the addConstants[], mod baseValue.  If we round that up to the
         // next power of 2, we'll have a value that will be no greater than
         // baseValue and sometimes less.
+        //
+        // The requiredAlignment computation below is done in int; if baseValue
+        // is large enough that (addConstants[i] % baseValue) could overflow
+        // int, the alignment could be corrupted and produce a false-positive
+        // equality, so conservatively give up.
+        if (baseValue > INT_MAX) {
+            return false;
+        }
         int maxMod = int(addConstants[0] % baseValue);
         for (int i = 1; i < vectorLength; ++i) {
             maxMod = std::max(maxMod, int(addConstants[i] % baseValue));
@@ -1034,8 +1043,16 @@ static bool lVectorShiftRightAllEqual(llvm::Value *val, llvm::Value *shift, int 
     }
 
     // Now see if the value divided by (1 << shift) can be determined to
-    // have the same value for all vector elements.
-    int pow2 = 1 << shiftAmount[0];
+    // have the same value for all vector elements.  The shift amount must be
+    // within the operand's bit width (a shift at or beyond it is undefined in
+    // LLVM) and small enough that the power-of-two divisor fits in a positive
+    // int64_t.  Otherwise we can't form a valid divisor, so conservatively
+    // give up.
+    unsigned int bitWidth = val->getType()->getScalarSizeInBits();
+    if (shiftAmount[0] < 0 || (uint64_t)shiftAmount[0] >= bitWidth || shiftAmount[0] >= 63) {
+        return false;
+    }
+    int64_t pow2 = (int64_t)1 << shiftAmount[0];
     bool canAdd = true;
     std::vector<llvm::PHINode *> seenPhis;
     bool eq = lAllDivBaseEqual(val, pow2, vectorLength, seenPhis, canAdd);

--- a/tests/lit-tests/2169.ispc
+++ b/tests/lit-tests/2169.ispc
@@ -6,10 +6,6 @@
 // RUN: %t.c.bin | FileCheck %s
 
 // REQUIRES: !MACOS_HOST
-// ISPC assertion failure in lAllDivBaseEqual (llvmutil.cpp) for generic
-// targets: the integer divide optimization passes a non-power-of-2 baseValue.
-// TODO: Fix this ISPC bug for generic targets.
-// XFAIL: PPC64LE_HOST
 
 // CHECK-NOT: Floating point exception
 // CHECK: Correct result

--- a/tests/lit-tests/3881.ispc
+++ b/tests/lit-tests/3881.ispc
@@ -1,0 +1,39 @@
+// Verifies that a gather index derived from 64-bit hash math does not crash
+// the compiler. The gather-index analysis used to compute the power-of-two
+// divisor for a right-shift as a 32-bit int, so shifts of 31/32 on 64-bit
+// values overflowed to a non-positive value and tripped an assertion in
+// lAllDivBaseEqual.
+// See https://github.com/ispc/ispc/issues/3881
+
+// RUN: %{ispc} %s --target=avx2-i32x16 --arch=x86_64 -O2 --nowrap --emit-llvm-text -o - | FileCheck %s
+
+// REQUIRES: X86_ENABLED
+
+// CHECK-LABEL: @repro64
+// CHECK: @llvm.x86.avx2.gather
+export void repro64(uniform int n, uniform int colorCount,
+                    const uniform int* uniform lut, uniform int* uniform result) {
+    foreach (index = 0 ... n) {
+        unsigned int64 z = (unsigned int64)index * 0xD1B54A32D192ED03;
+        z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9;
+        z = z ^ (z >> 31);
+        unsigned int32 r = (unsigned int32)(z >> 32);
+        int lutIdx = (int)(((unsigned int64)r * (unsigned int32)colorCount) >> 32);
+        result[index] = lut[lutIdx];
+    }
+}
+
+// 32-bit variant: a right-shift by 31 of a 32-bit value hit the same
+// `1 << 31 == INT_MIN` overflow in the divisor computation.
+// CHECK-LABEL: @repro32
+// CHECK: @llvm.x86.avx2.gather
+export void repro32(uniform int n, uniform int colorCount,
+                    const uniform int* uniform lut, uniform int* uniform result) {
+    foreach (index = 0 ... n) {
+        unsigned int32 z = (unsigned int32)index * 0x9E3779B1;
+        z = (z ^ (z >> 15)) * 0x85EBCA77;
+        z = z ^ (z >> 31);
+        int lutIdx = (int)(((unsigned int64)z * (unsigned int32)colorCount) >> 32);
+        result[index] = lut[lutIdx];
+    }
+}

--- a/tests/lit-tests/3881.ispc
+++ b/tests/lit-tests/3881.ispc
@@ -5,11 +5,11 @@
 // lAllDivBaseEqual.
 // See https://github.com/ispc/ispc/issues/3881
 
-// RUN: %{ispc} %s --target=avx2-i32x16 --arch=x86_64 -O2 --nowrap --emit-llvm-text -o - | FileCheck %s
+// RUN: %{ispc} %s --target=avx2-i32x16 --arch=x86_64 -O2 --nostdlib --nowrap --emit-llvm-text -o - | FileCheck %s
 
 // REQUIRES: X86_ENABLED
 
-// CHECK-LABEL: @repro64
+// CHECK-LABEL: define {{.*}} @repro64___
 // CHECK: @llvm.x86.avx2.gather
 export void repro64(uniform int n, uniform int colorCount,
                     const uniform int* uniform lut, uniform int* uniform result) {
@@ -25,7 +25,7 @@ export void repro64(uniform int n, uniform int colorCount,
 
 // 32-bit variant: a right-shift by 31 of a 32-bit value hit the same
 // `1 << 31 == INT_MIN` overflow in the divisor computation.
-// CHECK-LABEL: @repro32
+// CHECK-LABEL: define {{.*}} @repro32___
 // CHECK: @llvm.x86.avx2.gather
 export void repro32(uniform int n, uniform int colorCount,
                     const uniform int* uniform lut, uniform int* uniform result) {


### PR DESCRIPTION
## Description
When a gather index came from 64-bit hash math, the compiler crashed. The problem was in lVectorShiftRightAllEqual: it built the shift divisor as a 32-bit int, so a shift by 31 or 32 overflowed and turned negative, which tripped an assertion. The divisor is now int64_t, with a check on the shift amount. There's also a new guard in lAllDivBaseEqual for large baseValue values that weren't possible before. Both places just give up when unsure, so the worst case is that a gather stays a gather, the result is never wrong. Added a regression test with the 64-bit and 32-bit cases that used to crash.

Fixes #3881 

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)