### PR TITLE
Fix #3882: Avoid UB in float-to-unsigned constant conversion causing …

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1071,8 +1071,9 @@ static llvm::Constant *lLLVMConstantValue(const Type *type, llvm::LLVMContext *c
             return isUniform ? LLVMInt8(i) : LLVMInt8Vector(i);
         }
         case AtomicType::TYPE_UINT8: {
-            unsigned int i = (unsigned int)value;
-            return isUniform ? LLVMUInt8(i) : LLVMUInt8Vector(i);
+            int i = (int)value;
+            Assert((double)i == value);
+            return isUniform ? LLVMUInt8((uint8_t)i) : LLVMUInt8Vector((uint8_t)i);
         }
         case AtomicType::TYPE_INT16: {
             int i = (int)value;
@@ -1080,8 +1081,9 @@ static llvm::Constant *lLLVMConstantValue(const Type *type, llvm::LLVMContext *c
             return isUniform ? LLVMInt16(i) : LLVMInt16Vector(i);
         }
         case AtomicType::TYPE_UINT16: {
-            unsigned int i = (unsigned int)value;
-            return isUniform ? LLVMUInt16(i) : LLVMUInt16Vector(i);
+            int i = (int)value;
+            Assert((double)i == value);
+            return isUniform ? LLVMUInt16((uint16_t)i) : LLVMUInt16Vector((uint16_t)i);
         }
         case AtomicType::TYPE_INT32: {
             int i = (int)value;
@@ -1089,8 +1091,9 @@ static llvm::Constant *lLLVMConstantValue(const Type *type, llvm::LLVMContext *c
             return isUniform ? LLVMInt32(i) : LLVMInt32Vector(i);
         }
         case AtomicType::TYPE_UINT32: {
-            unsigned int i = (unsigned int)value;
-            return isUniform ? LLVMUInt32(i) : LLVMUInt32Vector(i);
+            int64_t i = (int64_t)value;
+            Assert((double)i == value);
+            return isUniform ? LLVMUInt32((uint32_t)i) : LLVMUInt32Vector((uint32_t)i);
         }
         case AtomicType::TYPE_INT64: {
             int64_t i = (int64_t)value;
@@ -1098,9 +1101,9 @@ static llvm::Constant *lLLVMConstantValue(const Type *type, llvm::LLVMContext *c
             return isUniform ? LLVMInt64(i) : LLVMInt64Vector(i);
         }
         case AtomicType::TYPE_UINT64: {
-            uint64_t i = (uint64_t)value;
-            Assert(value == (int64_t)i);
-            return isUniform ? LLVMUInt64(i) : LLVMUInt64Vector(i);
+            int64_t i = (int64_t)value;
+            Assert((double)i == value);
+            return isUniform ? LLVMUInt64((uint64_t)i) : LLVMUInt64Vector((uint64_t)i);
         }
         case AtomicType::TYPE_FLOAT16: {
             llvm::APFloat apf16 = lCreateAPFloat(value, LLVMTypes::Float16Type);

--- a/tests/lit-tests/3882.ispc
+++ b/tests/lit-tests/3882.ispc
@@ -5,7 +5,7 @@
 // RUN: %{ispc} %s --target=host --nostdlib --nowrap --emit-llvm-text -o - | FileCheck %s
 
 // CHECK-LABEL: @u8_predec___
-// CHECK-NOT: zeroinitializer
+// CHECK-NOT: add {{.*}}, zeroinitializer
 // CHECK: add <[[WIDTH:.*]] x i8> {{.*}}, splat (i8 -1)
 void u8_predec(unsigned int8 v[]) {
     unsigned int8 x = v[programIndex];
@@ -14,7 +14,7 @@ void u8_predec(unsigned int8 v[]) {
 }
 
 // CHECK-LABEL: @u8_postdec___
-// CHECK-NOT: zeroinitializer
+// CHECK-NOT: add {{.*}}, zeroinitializer
 // CHECK: add <[[WIDTH]] x i8> {{.*}}, splat (i8 -1)
 void u8_postdec(unsigned int8 v[]) {
     unsigned int8 x = v[programIndex];
@@ -23,7 +23,7 @@ void u8_postdec(unsigned int8 v[]) {
 }
 
 // CHECK-LABEL: @u16_predec___
-// CHECK-NOT: zeroinitializer
+// CHECK-NOT: add {{.*}}, zeroinitializer
 // CHECK: add <[[WIDTH]] x i16> {{.*}}, splat (i16 -1)
 void u16_predec(unsigned int16 v[]) {
     unsigned int16 x = v[programIndex];
@@ -32,7 +32,7 @@ void u16_predec(unsigned int16 v[]) {
 }
 
 // CHECK-LABEL: @u32_predec___
-// CHECK-NOT: zeroinitializer
+// CHECK-NOT: add {{.*}}, zeroinitializer
 // CHECK: add <[[WIDTH]] x i32> {{.*}}, splat (i32 -1)
 void u32_predec(unsigned int32 v[]) {
     unsigned int32 x = v[programIndex];
@@ -41,7 +41,7 @@ void u32_predec(unsigned int32 v[]) {
 }
 
 // CHECK-LABEL: @u64_predec___
-// CHECK-NOT: zeroinitializer
+// CHECK-NOT: add {{.*}}, zeroinitializer
 // CHECK: add <[[WIDTH]] x i64> {{.*}}, splat (i64 -1)
 void u64_predec(unsigned int64 v[]) {
     unsigned int64 x = v[programIndex];

--- a/tests/lit-tests/3882.ispc
+++ b/tests/lit-tests/3882.ispc
@@ -1,0 +1,50 @@
+// Verifies that pre/post decrement of varying unsigned integers (all widths)
+// emits a subtract-by-1 constant, not a no-op (zeroinitializer). See issue #3882:
+// unsigned decrement was silently miscompiled into `v + 0` due to UB in a
+// negative-double-to-unsigned-integer cast.
+// RUN: %{ispc} %s --target=host --nostdlib --nowrap --emit-llvm-text -o - | FileCheck %s
+
+// CHECK-LABEL: @u8_predec___
+// CHECK-NOT: zeroinitializer
+// CHECK: add <[[WIDTH:.*]] x i8> {{.*}}, splat (i8 -1)
+void u8_predec(unsigned int8 v[]) {
+    unsigned int8 x = v[programIndex];
+    --x;
+    v[programIndex] = x;
+}
+
+// CHECK-LABEL: @u8_postdec___
+// CHECK-NOT: zeroinitializer
+// CHECK: add <[[WIDTH]] x i8> {{.*}}, splat (i8 -1)
+void u8_postdec(unsigned int8 v[]) {
+    unsigned int8 x = v[programIndex];
+    x--;
+    v[programIndex] = x;
+}
+
+// CHECK-LABEL: @u16_predec___
+// CHECK-NOT: zeroinitializer
+// CHECK: add <[[WIDTH]] x i16> {{.*}}, splat (i16 -1)
+void u16_predec(unsigned int16 v[]) {
+    unsigned int16 x = v[programIndex];
+    --x;
+    v[programIndex] = x;
+}
+
+// CHECK-LABEL: @u32_predec___
+// CHECK-NOT: zeroinitializer
+// CHECK: add <[[WIDTH]] x i32> {{.*}}, splat (i32 -1)
+void u32_predec(unsigned int32 v[]) {
+    unsigned int32 x = v[programIndex];
+    --x;
+    v[programIndex] = x;
+}
+
+// CHECK-LABEL: @u64_predec___
+// CHECK-NOT: zeroinitializer
+// CHECK: add <[[WIDTH]] x i64> {{.*}}, splat (i64 -1)
+void u64_predec(unsigned int64 v[]) {
+    unsigned int64 x = v[programIndex];
+    --x;
+    v[programIndex] = x;
+}


### PR DESCRIPTION
…decrement miscompile

lLLVMConstantValue() cast a negative double directly to an unsigned integer type (e.g. (unsigned int)(-1.0)) when emitting the step constant for varying unsigned decrement. This conversion is undefined behavior in C++ for out-of-range values; on aarch64 hosts it saturates to 0, silently turning `--` into a no-op, and for UINT64 it tripped an Assert. Route the conversion through a signed intermediate type first, which is well-defined for -1, then narrow to the unsigned type.

## Description
Brief description of changes

## Related Issue
- [x] Linked to relevant issue(s)

## Checklist
- [x] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [x] Git history has been squashed to meaningful commits (one commit per logical change)
- [x] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] Language/stdlib changes include new [functional tests](https://github.com/ispc/ispc/tree/main/tests/func-tests) for runtime behavior
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed