### PR TITLE
Add support for Zen6 AMD CPU

### DIFF
--- a/src/ispc.cpp
+++ b/src/ispc.cpp
@@ -375,12 +375,15 @@ typedef enum {
 #if ISPC_LLVM_VERSION >= ISPC_LLVM_22_0
     CPU_NVL,
 #endif
-    // Zen1 to Zen5
+    // Zen1 to Zen6
     CPU_ZNVER1,
     CPU_ZNVER2,
     CPU_ZNVER3,
     CPU_ZNVER4,
     CPU_ZNVER5,
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+    CPU_ZNVER6,
+#endif
 
 // FIXME: LLVM supports a ton of different ARM CPU variants--not just
 // listed below.  We should be able to handle any of them that also
@@ -503,6 +506,9 @@ std::map<DeviceType, std::set<std::string>> CPUFeatures = {
     {CPU_ZNVER3, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2"}},
     {CPU_ZNVER4, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2", "avx512", "avx512_vnni"}},
     {CPU_ZNVER5, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2", "avx512", "avx_vnni", "avx512_vnni"}},
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+    {CPU_ZNVER6, {"mmx", "sse", "sse2", "ssse3", "sse41", "sse42", "avx", "avx2", "avx512", "avx_vnni", "avx512_vnni"}},
+#endif
 // TODO: Add features for remaining CPUs if valid.
 #ifdef ISPC_ARM_ENABLED
     {CPU_CortexA35, {}},
@@ -632,6 +638,9 @@ class AllCPUs {
         names[CPU_ZNVER3].push_back("znver3");
         names[CPU_ZNVER4].push_back("znver4");
         names[CPU_ZNVER5].push_back("znver5");
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+        names[CPU_ZNVER6].push_back("znver6");
+#endif
 
 #ifdef ISPC_ARM_ENABLED
         names[CPU_CortexA35].push_back("cortex-a35");
@@ -722,6 +731,12 @@ class AllCPUs {
         compat[CPU_ICL] =
             Set(CPU_ICL, CPU_x86_64, CPU_Bonnell, CPU_Penryn, CPU_Core2, CPU_Nehalem, CPU_Silvermont, CPU_SandyBridge,
                 CPU_IvyBridge, CPU_Haswell, CPU_Broadwell, CPU_Skylake, CPU_SKX, CPU_None);
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+        compat[CPU_ZNVER6] =
+            Set(CPU_x86_64, CPU_Bonnell, CPU_Penryn, CPU_Core2, CPU_Nehalem, CPU_Silvermont, CPU_SandyBridge,
+                CPU_IvyBridge, CPU_Haswell, CPU_Broadwell, CPU_Skylake, CPU_SKX, CPU_ICL, CPU_ICX, CPU_TGL, CPU_ZNVER1,
+                CPU_ZNVER2, CPU_ZNVER3, CPU_ZNVER4, CPU_ZNVER5, CPU_ZNVER6, CPU_None);
+#endif
         compat[CPU_ZNVER5] =
             Set(CPU_x86_64, CPU_Bonnell, CPU_Penryn, CPU_Core2, CPU_Nehalem, CPU_Silvermont, CPU_SandyBridge,
                 CPU_IvyBridge, CPU_Haswell, CPU_Broadwell, CPU_Skylake, CPU_SKX, CPU_ICL, CPU_ICX, CPU_TGL, CPU_ZNVER1,
@@ -1077,6 +1092,9 @@ Target::Target(Arch arch, const char *cpu, ISPCTarget ispc_target, PICLevel picL
 
         case CPU_ZNVER4:
         case CPU_ZNVER5:
+#if ISPC_LLVM_VERSION >= ISPC_LLVM_23_0
+        case CPU_ZNVER6:
+#endif
         case CPU_TGL:
         case CPU_ICX:
         case CPU_ICL:

--- a/tests/lit-tests/cpus_x86_llvm23_plus.ispc
+++ b/tests/lit-tests/cpus_x86_llvm23_plus.ispc
@@ -1,0 +1,9 @@
+// The test checks that cpu definitions (including all synonyms) are successfully consumed by compiler.
+
+//; RUN: %{ispc} %s -o %t.o --nostdlib --target=avx512icl-x16 --cpu=znver6
+
+// REQUIRES: X86_ENABLED && LLVM_23_0+
+
+uniform int i;
+
+void foo() {}

--- a/tests/lit-tests/znver6-fp16.ispc
+++ b/tests/lit-tests/znver6-fp16.ispc
@@ -1,0 +1,20 @@
+// Zen6 adds AVX512-FP16 on top of Zen5, so float16 arithmetic must lower to
+// native half-precision instructions instead of round-tripping through fp32.
+// The znver5 run is the negative control: same target, so any difference comes
+// from the CPU alone.
+
+// RUN: %{ispc} -O2 %s --target=avx512icl-x16 --cpu=znver6 --nostdlib --nowrap --emit-asm -o - \
+// RUN:   | FileCheck %s --check-prefix=ZNVER6 --implicit-check-not=vcvtph2ps
+// RUN: %{ispc} -O2 %s --target=avx512icl-x16 --cpu=znver5 --nostdlib --nowrap --emit-asm -o - \
+// RUN:   | FileCheck %s --check-prefix=ZNVER5 --implicit-check-not='{{vfmadd[0-9]+ph}}'
+
+// REQUIRES: X86_ENABLED && LLVM_23_0+
+
+// ZNVER6: {{vfmadd[0-9]+ph}}
+// ZNVER5: vcvtph2ps
+
+void fma16(uniform float16 dst[], const uniform float16 a[], const uniform float16 b[], uniform int n) {
+    foreach (i = 0 ... n) {
+        dst[i] = a[i] * b[i] + dst[i];
+    }
+}


### PR DESCRIPTION
## Description
LLVM gained znver6 in 23, so add it as a --cpu=znver6 value guarded by ISPC_LLVM_23_0.

Zen6 is Zen5 plus AVX512-FP16, AVX-VNNI-INT8, AVX-IFMA, AVX-NE-CONVERT and AVX512-BMM. It maps to avx512icl-x16.

No new ISPC target is introduced, but passing the CPU through can be useful: float16 arithmetic on avx512icl-x16 now lowers to native instructions instead of the round-trip through fp32.

## Related Issue
- [X] Linked to relevant issue: #3889 

## Checklist
- [X] Code has been formatted with `clang-format` (e.g., `clang-format -i src/ispc.cpp`)
- [X] Git history has been squashed to meaningful commits (one commit per logical change)
- [X] Compiler changes are covered by [lit tests](https://github.com/ispc/ispc/tree/main/tests/lit-tests)
- [ ] [Documentation](https://github.com/ispc/ispc/tree/main/docs/ispc.rst) updated if needed